### PR TITLE
Options param in property control factory functions

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -173,6 +173,75 @@ describe('registered property controls', () => {
       }
     `)
   })
+  it('Can set property control options using the control factory functions', async () => {
+    const renderResult = await renderTestEditorWithModel(
+      project({
+        ['/utopia/components.utopia.js']: `import { Card } from '../src/card'
+        import * as Utopia from 'utopia-api'
+        
+        const Components = {
+          '/src/card': {
+            Card: {
+              component: Card,
+              supportsChildren: false,
+              properties: {
+                label: Utopia.stringControl('type here', {
+                  required: true,
+                  defaultValue: 'hello',
+                }),
+              },
+              variants: [],
+            },
+          },
+        }
+        
+        export default Components
+        
+  `,
+      }),
+      'await-first-dom-report',
+    )
+    const editorState = renderResult.getEditorState().editor
+
+    expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`
+      Object {
+        "Card": Object {
+          "preferredChildComponents": Array [],
+          "properties": Object {
+            "label": Object {
+              "control": "string-input",
+              "defaultValue": "hello",
+              "placeholder": "type here",
+              "required": true,
+            },
+          },
+          "source": Object {
+            "sourceDescriptorFile": "/utopia/components.utopia.js",
+            "type": "DESCRIPTOR_FILE",
+          },
+          "supportsChildren": false,
+          "variants": Array [
+            Object {
+              "elementToInsert": [Function],
+              "importsToAdd": Object {
+                "/src/card": Object {
+                  "importedAs": null,
+                  "importedFromWithin": Array [
+                    Object {
+                      "alias": "Card",
+                      "name": "Card",
+                    },
+                  ],
+                  "importedWithName": null,
+                },
+              },
+              "insertMenuLabel": "Card",
+            },
+          ],
+        },
+      }
+    `)
+  })
   it('control registration fails when the imported component is undefined', async () => {
     const renderResult = await renderTestEditorWithModel(
       project({

--- a/utopia-api/src/property-controls/factories.ts
+++ b/utopia-api/src/property-controls/factories.ts
@@ -1,5 +1,7 @@
 import type {
+  AllowedEnumType,
   ArrayControlDescription,
+  BasicControlOption,
   BasicControlOptions,
   CheckboxControlDescription,
   ColorControlDescription,
@@ -11,21 +13,27 @@ import type {
   HtmlInputControlDescription,
   ImportType,
   JSXControlDescription,
+  Matrix3,
   Matrix3ControlDescription,
+  Matrix4,
   Matrix4ControlDescription,
   NoneControlDescription,
   NumberInputControlDescription,
   ObjectControlDescription,
   PopUpListControlDescription,
   PropertyControls,
+  PropertyControlsOptions,
   RadioControlDescription,
   RegularControlDescription,
   StringInputControlDescription,
   StyleControlsControlDescription,
   TupleControlDescription,
   UnionControlDescription,
+  Vector2,
   Vector2ControlDescription,
+  Vector3,
   Vector3ControlDescription,
+  Vector4,
   Vector4ControlDescription,
 } from './property-controls'
 
@@ -88,38 +96,68 @@ export function expression<T>(
 
 export function expressionPopupListControl(
   options: ExpressionControlOption<unknown>[],
+  baseOptions?: PropertyControlsOptions<unknown>,
 ): ExpressionPopUpListControlDescription {
   return {
     control: 'expression-popuplist',
     options: options,
+    defaultValue: baseOptions?.defaultValue,
+    label: baseOptions?.label,
+    required: baseOptions?.required,
+    visibleByDefault: baseOptions?.visibleByDefault,
   }
 }
 
-export function eulerControl(): EulerControlDescription {
+export function eulerControl(
+  options?: PropertyControlsOptions<[number, number, number, string]>,
+): EulerControlDescription {
   return {
     control: 'euler',
+    defaultValue: options?.defaultValue,
+    label: options?.label,
+    required: options?.required,
+    visibleByDefault: options?.visibleByDefault,
   }
 }
 
-export function matrix3Control(): Matrix3ControlDescription {
+export function matrix3Control(
+  options?: PropertyControlsOptions<Matrix3>,
+): Matrix3ControlDescription {
   return {
     control: 'matrix3',
+    defaultValue: options?.defaultValue,
+    label: options?.label,
+    required: options?.required,
+    visibleByDefault: options?.visibleByDefault,
   }
 }
 
-export function matrix4Control(): Matrix4ControlDescription {
+export function matrix4Control(
+  options?: PropertyControlsOptions<Matrix4>,
+): Matrix4ControlDescription {
   return {
     control: 'matrix4',
+    defaultValue: options?.defaultValue,
+    label: options?.label,
+    required: options?.required,
+    visibleByDefault: options?.visibleByDefault,
   }
 }
 
-export function noControl(): NoneControlDescription {
+export function noControl(options?: PropertyControlsOptions<number>): NoneControlDescription {
   return {
     control: 'none',
+    defaultValue: options?.defaultValue,
+    label: options?.label,
+    required: options?.required,
+    visibleByDefault: options?.visibleByDefault,
   }
 }
 
-export function numberControl(unit?: string): NumberInputControlDescription {
+export function numberControl(
+  unit?: string,
+  options?: PropertyControlsOptions<number>,
+): NumberInputControlDescription {
   let result: NumberInputControlDescription = {
     control: 'number-input',
   }
@@ -128,22 +166,41 @@ export function numberControl(unit?: string): NumberInputControlDescription {
     result.unit = unit
   }
 
+  if (options != null) {
+    result.defaultValue = options?.defaultValue
+    result.label = options?.label
+    result.required = options?.required
+    result.visibleByDefault = options?.visibleByDefault
+  }
+
   return result
 }
 
 export function popupListControl(
   options: BasicControlOptions<unknown>,
+  baseOptions?: PropertyControlsOptions<AllowedEnumType | BasicControlOption<unknown>>,
 ): PopUpListControlDescription {
   return {
     control: 'popuplist',
     options: options,
+    defaultValue: baseOptions?.defaultValue,
+    label: baseOptions?.label,
+    required: baseOptions?.required,
+    visibleByDefault: baseOptions?.visibleByDefault,
   }
 }
 
-export function radioControl(options: BasicControlOptions<unknown>): RadioControlDescription {
+export function radioControl(
+  options: BasicControlOptions<unknown>,
+  baseOptions?: PropertyControlsOptions<AllowedEnumType | BasicControlOption<unknown>>,
+): RadioControlDescription {
   return {
     control: 'radio',
     options: options,
+    defaultValue: baseOptions?.defaultValue,
+    label: baseOptions?.label,
+    required: baseOptions?.required,
+    visibleByDefault: baseOptions?.visibleByDefault,
   }
 }
 
@@ -152,6 +209,7 @@ export function sliderControl(
   max: number,
   step: number,
   unit?: string,
+  options?: PropertyControlsOptions<number>,
 ): NumberInputControlDescription {
   let result: NumberInputControlDescription = {
     control: 'number-input',
@@ -164,10 +222,20 @@ export function sliderControl(
     result.unit = unit
   }
 
+  if (options != null) {
+    result.defaultValue = options?.defaultValue
+    result.label = options?.label
+    result.required = options?.required
+    result.visibleByDefault = options?.visibleByDefault
+  }
+
   return result
 }
 
-export function stringControl(placeholder?: string): StringInputControlDescription {
+export function stringControl(
+  placeholder?: string,
+  options?: PropertyControlsOptions<string>,
+): StringInputControlDescription {
   let result: StringInputControlDescription = {
     control: 'string-input',
   }
@@ -176,10 +244,20 @@ export function stringControl(placeholder?: string): StringInputControlDescripti
     result.placeholder = placeholder
   }
 
+  if (options != null) {
+    result.defaultValue = options?.defaultValue
+    result.label = options?.label
+    result.required = options?.required
+    result.visibleByDefault = options?.visibleByDefault
+  }
+
   return result
 }
 
-export function htmlControl(placeholder?: string): HtmlInputControlDescription {
+export function htmlControl(
+  placeholder?: string,
+  options?: PropertyControlsOptions<unknown>,
+): HtmlInputControlDescription {
   let result: HtmlInputControlDescription = {
     control: 'html-input',
   }
@@ -188,79 +266,144 @@ export function htmlControl(placeholder?: string): HtmlInputControlDescription {
     result.placeholder = placeholder
   }
 
+  if (options != null) {
+    result.defaultValue = options?.defaultValue
+    result.label = options?.label
+    result.required = options?.required
+    result.visibleByDefault = options?.visibleByDefault
+  }
   return result
 }
 
-export function styleControl(): StyleControlsControlDescription {
+export function styleControl(
+  options?: PropertyControlsOptions<unknown>,
+): StyleControlsControlDescription {
   return {
     control: 'style-controls',
+    defaultValue: options?.defaultValue,
+    label: options?.label,
+    required: options?.required,
+    visibleByDefault: options?.visibleByDefault,
   }
 }
 
-export function vector2Control(): Vector2ControlDescription {
+export function vector2Control(
+  options?: PropertyControlsOptions<Vector2>,
+): Vector2ControlDescription {
   return {
     control: 'vector2',
+    defaultValue: options?.defaultValue,
+    label: options?.label,
+    required: options?.required,
+    visibleByDefault: options?.visibleByDefault,
   }
 }
 
-export function vector3Control(): Vector3ControlDescription {
+export function vector3Control(
+  options?: PropertyControlsOptions<Vector3>,
+): Vector3ControlDescription {
   return {
     control: 'vector3',
+    defaultValue: options?.defaultValue,
+    label: options?.label,
+    required: options?.required,
+    visibleByDefault: options?.visibleByDefault,
   }
 }
 
-export function vector4Control(): Vector4ControlDescription {
+export function vector4Control(
+  options?: PropertyControlsOptions<Vector4>,
+): Vector4ControlDescription {
   return {
     control: 'vector4',
+    defaultValue: options?.defaultValue,
+    label: options?.label,
+    required: options?.required,
+    visibleByDefault: options?.visibleByDefault,
   }
 }
 
-export function jsxControl(): JSXControlDescription {
+export function jsxControl(options?: PropertyControlsOptions<unknown>): JSXControlDescription {
   return {
     control: 'jsx',
+    defaultValue: options?.defaultValue,
+    label: options?.label,
+    required: options?.required,
+    visibleByDefault: options?.visibleByDefault,
   }
 }
 
-export function arrayControl(propertyControl: RegularControlDescription): ArrayControlDescription {
+export function arrayControl(
+  propertyControl: RegularControlDescription,
+  options?: PropertyControlsOptions<Vector2>,
+): ArrayControlDescription {
   return {
     control: 'array',
     propertyControl: propertyControl,
+    defaultValue: options?.defaultValue,
+    label: options?.label,
+    required: options?.required,
+    visibleByDefault: options?.visibleByDefault,
   }
 }
 
 export function fixedSizeArrayControl(
   propertyControl: RegularControlDescription,
   maxCount: number,
+  options?: PropertyControlsOptions<Vector2>,
 ): ArrayControlDescription {
   return {
     control: 'array',
     propertyControl: propertyControl,
     maxCount: maxCount,
+    defaultValue: options?.defaultValue,
+    label: options?.label,
+    required: options?.required,
+    visibleByDefault: options?.visibleByDefault,
   }
 }
 
-export function objectControl(object: {
-  [prop: string]: RegularControlDescription
-}): ObjectControlDescription {
+export function objectControl(
+  object: {
+    [prop: string]: RegularControlDescription
+  },
+  options?: PropertyControlsOptions<unknown>,
+): ObjectControlDescription {
   return {
     control: 'object',
     object: object,
+    defaultValue: options?.defaultValue,
+    label: options?.label,
+    required: options?.required,
+    visibleByDefault: options?.visibleByDefault,
   }
 }
 
 export function tupleControl(
   propertyControls: RegularControlDescription[],
+  options?: PropertyControlsOptions<unknown>,
 ): TupleControlDescription {
   return {
     control: 'tuple',
     propertyControls: propertyControls,
+    defaultValue: options?.defaultValue,
+    label: options?.label,
+    required: options?.required,
+    visibleByDefault: options?.visibleByDefault,
   }
 }
 
-export function unionControl(controls: Array<RegularControlDescription>): UnionControlDescription {
+export function unionControl(
+  controls: Array<RegularControlDescription>,
+  options?: PropertyControlsOptions<unknown>,
+): UnionControlDescription {
   return {
     control: 'union',
     controls: controls,
+    defaultValue: options?.defaultValue,
+    label: options?.label,
+    required: options?.required,
+    visibleByDefault: options?.visibleByDefault,
   }
 }
 

--- a/utopia-api/src/property-controls/factories.ts
+++ b/utopia-api/src/property-controls/factories.ts
@@ -104,21 +104,7 @@ export function expressionPopupListControl(
     options: options,
   }
 
-  if (baseOptions?.defaultValue !== undefined) {
-    result.defaultValue = baseOptions.defaultValue
-  }
-
-  if (baseOptions?.required !== undefined) {
-    result.required = baseOptions.required
-  }
-
-  if (baseOptions?.visibleByDefault !== undefined) {
-    result.visibleByDefault = baseOptions.visibleByDefault
-  }
-
-  if (baseOptions?.label !== undefined) {
-    result.label = baseOptions.label
-  }
+  mutateControlWithOptions(result, baseOptions)
 
   return result
 }
@@ -129,21 +115,7 @@ export function eulerControl(
   let result: EulerControlDescription = {
     control: 'euler',
   }
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
@@ -154,21 +126,7 @@ export function matrix3Control(
   let result: Matrix3ControlDescription = {
     control: 'matrix3',
   }
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
@@ -180,51 +138,23 @@ export function matrix4Control(
     control: 'matrix4',
   }
 
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
 
-export function noControl(options?: PropertyControlsOptions<number>): NoneControlDescription {
+export function noControl(options?: PropertyControlsOptions<unknown>): NoneControlDescription {
   let result: NoneControlDescription = {
     control: 'none',
   }
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
 
 export function numberControl(
   unit?: string,
-  options?: PropertyControlsOptions<number>,
+  options?: PropertyControlsOptions<unknown>,
 ): NumberInputControlDescription {
   let result: NumberInputControlDescription = {
     control: 'number-input',
@@ -234,21 +164,7 @@ export function numberControl(
     result.unit = unit
   }
 
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
@@ -262,21 +178,7 @@ export function popupListControl(
     options: options,
   }
 
-  if (baseOptions?.defaultValue !== undefined) {
-    result.defaultValue = baseOptions.defaultValue
-  }
-
-  if (baseOptions?.required !== undefined) {
-    result.required = baseOptions.required
-  }
-
-  if (baseOptions?.visibleByDefault !== undefined) {
-    result.visibleByDefault = baseOptions.visibleByDefault
-  }
-
-  if (baseOptions?.label !== undefined) {
-    result.label = baseOptions.label
-  }
+  mutateControlWithOptions(result, baseOptions)
 
   return result
 }
@@ -290,21 +192,7 @@ export function radioControl(
     options: options,
   }
 
-  if (baseOptions?.defaultValue !== undefined) {
-    result.defaultValue = baseOptions.defaultValue
-  }
-
-  if (baseOptions?.required !== undefined) {
-    result.required = baseOptions.required
-  }
-
-  if (baseOptions?.visibleByDefault !== undefined) {
-    result.visibleByDefault = baseOptions.visibleByDefault
-  }
-
-  if (baseOptions?.label !== undefined) {
-    result.label = baseOptions.label
-  }
+  mutateControlWithOptions(result, baseOptions)
 
   return result
 }
@@ -314,7 +202,7 @@ export function sliderControl(
   max: number,
   step: number,
   unit?: string,
-  options?: PropertyControlsOptions<number>,
+  options?: PropertyControlsOptions<unknown>,
 ): NumberInputControlDescription {
   let result: NumberInputControlDescription = {
     control: 'number-input',
@@ -327,28 +215,14 @@ export function sliderControl(
     result.unit = unit
   }
 
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
 
 export function stringControl(
   placeholder?: string,
-  options?: PropertyControlsOptions<string>,
+  options?: PropertyControlsOptions<unknown>,
 ): StringInputControlDescription {
   let result: StringInputControlDescription = {
     control: 'string-input',
@@ -358,21 +232,7 @@ export function stringControl(
     result.placeholder = placeholder
   }
 
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
@@ -389,21 +249,7 @@ export function htmlControl(
     result.placeholder = placeholder
   }
 
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
@@ -414,21 +260,7 @@ export function styleControl(
   let result: StyleControlsControlDescription = {
     control: 'style-controls',
   }
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
@@ -440,21 +272,7 @@ export function vector2Control(
     control: 'vector2',
   }
 
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
@@ -466,21 +284,7 @@ export function vector3Control(
     control: 'vector3',
   }
 
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
@@ -492,21 +296,7 @@ export function vector4Control(
     control: 'vector4',
   }
 
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
@@ -515,49 +305,21 @@ export function jsxControl(options?: PropertyControlsOptions<unknown>): JSXContr
   let result: JSXControlDescription = {
     control: 'jsx',
   }
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
 
 export function arrayControl(
   propertyControl: RegularControlDescription,
-  options?: PropertyControlsOptions<Vector2>,
+  options?: PropertyControlsOptions<unknown>,
 ): ArrayControlDescription {
   let result: ArrayControlDescription = {
     control: 'array',
     propertyControl: propertyControl,
   }
 
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
@@ -565,28 +327,14 @@ export function arrayControl(
 export function fixedSizeArrayControl(
   propertyControl: RegularControlDescription,
   maxCount: number,
-  options?: PropertyControlsOptions<Vector2>,
+  options?: PropertyControlsOptions<unknown>,
 ): ArrayControlDescription {
   let result: ArrayControlDescription = {
     control: 'array',
     propertyControl: propertyControl,
     maxCount: maxCount,
   }
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
@@ -602,21 +350,7 @@ export function objectControl(
     object: object,
   }
 
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
@@ -630,21 +364,7 @@ export function tupleControl(
     propertyControls: propertyControls,
   }
 
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
@@ -658,21 +378,7 @@ export function unionControl(
     controls: controls,
   }
 
-  if (options?.defaultValue !== undefined) {
-    result.defaultValue = options.defaultValue
-  }
-
-  if (options?.required !== undefined) {
-    result.required = options.required
-  }
-
-  if (options?.visibleByDefault !== undefined) {
-    result.visibleByDefault = options.visibleByDefault
-  }
-
-  if (options?.label !== undefined) {
-    result.label = options.label
-  }
+  mutateControlWithOptions(result, options)
 
   return result
 }
@@ -684,9 +390,9 @@ export function folderControl(controls: PropertyControls): FolderControlDescript
   }
 }
 
-function mutateControlWithOptions<T extends BaseControlDescription>(
-  control: T,
-  options: PropertyControlsOptions<T>,
+function mutateControlWithOptions<T, U extends PropertyControlsOptions<T>>(
+  control: U,
+  options?: PropertyControlsOptions<T>,
 ) {
   if (options?.defaultValue !== undefined) {
     control.defaultValue = options.defaultValue

--- a/utopia-api/src/property-controls/factories.ts
+++ b/utopia-api/src/property-controls/factories.ts
@@ -1,6 +1,7 @@
 import type {
   AllowedEnumType,
   ArrayControlDescription,
+  BaseControlDescription,
   BasicControlOption,
   BasicControlOptions,
   CheckboxControlDescription,
@@ -98,60 +99,127 @@ export function expressionPopupListControl(
   options: ExpressionControlOption<unknown>[],
   baseOptions?: PropertyControlsOptions<unknown>,
 ): ExpressionPopUpListControlDescription {
-  return {
+  let result: ExpressionPopUpListControlDescription = {
     control: 'expression-popuplist',
     options: options,
-    defaultValue: baseOptions?.defaultValue,
-    label: baseOptions?.label,
-    required: baseOptions?.required,
-    visibleByDefault: baseOptions?.visibleByDefault,
   }
+
+  if (baseOptions?.defaultValue !== undefined) {
+    result.defaultValue = baseOptions.defaultValue
+  }
+
+  if (baseOptions?.required !== undefined) {
+    result.required = baseOptions.required
+  }
+
+  if (baseOptions?.visibleByDefault !== undefined) {
+    result.visibleByDefault = baseOptions.visibleByDefault
+  }
+
+  if (baseOptions?.label !== undefined) {
+    result.label = baseOptions.label
+  }
+
+  return result
 }
 
 export function eulerControl(
   options?: PropertyControlsOptions<[number, number, number, string]>,
 ): EulerControlDescription {
-  return {
+  let result: EulerControlDescription = {
     control: 'euler',
-    defaultValue: options?.defaultValue,
-    label: options?.label,
-    required: options?.required,
-    visibleByDefault: options?.visibleByDefault,
   }
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
+  return result
 }
 
 export function matrix3Control(
   options?: PropertyControlsOptions<Matrix3>,
 ): Matrix3ControlDescription {
-  return {
+  let result: Matrix3ControlDescription = {
     control: 'matrix3',
-    defaultValue: options?.defaultValue,
-    label: options?.label,
-    required: options?.required,
-    visibleByDefault: options?.visibleByDefault,
   }
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
+  return result
 }
 
 export function matrix4Control(
   options?: PropertyControlsOptions<Matrix4>,
 ): Matrix4ControlDescription {
-  return {
+  let result: Matrix4ControlDescription = {
     control: 'matrix4',
-    defaultValue: options?.defaultValue,
-    label: options?.label,
-    required: options?.required,
-    visibleByDefault: options?.visibleByDefault,
   }
+
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
+  return result
 }
 
 export function noControl(options?: PropertyControlsOptions<number>): NoneControlDescription {
-  return {
+  let result: NoneControlDescription = {
     control: 'none',
-    defaultValue: options?.defaultValue,
-    label: options?.label,
-    required: options?.required,
-    visibleByDefault: options?.visibleByDefault,
   }
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
+  return result
 }
 
 export function numberControl(
@@ -166,11 +234,20 @@ export function numberControl(
     result.unit = unit
   }
 
-  if (options != null) {
-    result.defaultValue = options?.defaultValue
-    result.label = options?.label
-    result.required = options?.required
-    result.visibleByDefault = options?.visibleByDefault
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
   }
 
   return result
@@ -180,28 +257,56 @@ export function popupListControl(
   options: BasicControlOptions<unknown>,
   baseOptions?: PropertyControlsOptions<AllowedEnumType | BasicControlOption<unknown>>,
 ): PopUpListControlDescription {
-  return {
+  let result: PopUpListControlDescription = {
     control: 'popuplist',
     options: options,
-    defaultValue: baseOptions?.defaultValue,
-    label: baseOptions?.label,
-    required: baseOptions?.required,
-    visibleByDefault: baseOptions?.visibleByDefault,
   }
+
+  if (baseOptions?.defaultValue !== undefined) {
+    result.defaultValue = baseOptions.defaultValue
+  }
+
+  if (baseOptions?.required !== undefined) {
+    result.required = baseOptions.required
+  }
+
+  if (baseOptions?.visibleByDefault !== undefined) {
+    result.visibleByDefault = baseOptions.visibleByDefault
+  }
+
+  if (baseOptions?.label !== undefined) {
+    result.label = baseOptions.label
+  }
+
+  return result
 }
 
 export function radioControl(
   options: BasicControlOptions<unknown>,
   baseOptions?: PropertyControlsOptions<AllowedEnumType | BasicControlOption<unknown>>,
 ): RadioControlDescription {
-  return {
+  let result: RadioControlDescription = {
     control: 'radio',
     options: options,
-    defaultValue: baseOptions?.defaultValue,
-    label: baseOptions?.label,
-    required: baseOptions?.required,
-    visibleByDefault: baseOptions?.visibleByDefault,
   }
+
+  if (baseOptions?.defaultValue !== undefined) {
+    result.defaultValue = baseOptions.defaultValue
+  }
+
+  if (baseOptions?.required !== undefined) {
+    result.required = baseOptions.required
+  }
+
+  if (baseOptions?.visibleByDefault !== undefined) {
+    result.visibleByDefault = baseOptions.visibleByDefault
+  }
+
+  if (baseOptions?.label !== undefined) {
+    result.label = baseOptions.label
+  }
+
+  return result
 }
 
 export function sliderControl(
@@ -222,11 +327,20 @@ export function sliderControl(
     result.unit = unit
   }
 
-  if (options != null) {
-    result.defaultValue = options?.defaultValue
-    result.label = options?.label
-    result.required = options?.required
-    result.visibleByDefault = options?.visibleByDefault
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
   }
 
   return result
@@ -244,11 +358,20 @@ export function stringControl(
     result.placeholder = placeholder
   }
 
-  if (options != null) {
-    result.defaultValue = options?.defaultValue
-    result.label = options?.label
-    result.required = options?.required
-    result.visibleByDefault = options?.visibleByDefault
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
   }
 
   return result
@@ -266,85 +389,177 @@ export function htmlControl(
     result.placeholder = placeholder
   }
 
-  if (options != null) {
-    result.defaultValue = options?.defaultValue
-    result.label = options?.label
-    result.required = options?.required
-    result.visibleByDefault = options?.visibleByDefault
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
   }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
   return result
 }
 
 export function styleControl(
   options?: PropertyControlsOptions<unknown>,
 ): StyleControlsControlDescription {
-  return {
+  let result: StyleControlsControlDescription = {
     control: 'style-controls',
-    defaultValue: options?.defaultValue,
-    label: options?.label,
-    required: options?.required,
-    visibleByDefault: options?.visibleByDefault,
   }
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
+  return result
 }
 
 export function vector2Control(
   options?: PropertyControlsOptions<Vector2>,
 ): Vector2ControlDescription {
-  return {
+  let result: Vector2ControlDescription = {
     control: 'vector2',
-    defaultValue: options?.defaultValue,
-    label: options?.label,
-    required: options?.required,
-    visibleByDefault: options?.visibleByDefault,
   }
+
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
+  return result
 }
 
 export function vector3Control(
   options?: PropertyControlsOptions<Vector3>,
 ): Vector3ControlDescription {
-  return {
+  let result: Vector3ControlDescription = {
     control: 'vector3',
-    defaultValue: options?.defaultValue,
-    label: options?.label,
-    required: options?.required,
-    visibleByDefault: options?.visibleByDefault,
   }
+
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
+  return result
 }
 
 export function vector4Control(
   options?: PropertyControlsOptions<Vector4>,
 ): Vector4ControlDescription {
-  return {
+  let result: Vector4ControlDescription = {
     control: 'vector4',
-    defaultValue: options?.defaultValue,
-    label: options?.label,
-    required: options?.required,
-    visibleByDefault: options?.visibleByDefault,
   }
+
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
+  return result
 }
 
 export function jsxControl(options?: PropertyControlsOptions<unknown>): JSXControlDescription {
-  return {
+  let result: JSXControlDescription = {
     control: 'jsx',
-    defaultValue: options?.defaultValue,
-    label: options?.label,
-    required: options?.required,
-    visibleByDefault: options?.visibleByDefault,
   }
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
+  return result
 }
 
 export function arrayControl(
   propertyControl: RegularControlDescription,
   options?: PropertyControlsOptions<Vector2>,
 ): ArrayControlDescription {
-  return {
+  let result: ArrayControlDescription = {
     control: 'array',
     propertyControl: propertyControl,
-    defaultValue: options?.defaultValue,
-    label: options?.label,
-    required: options?.required,
-    visibleByDefault: options?.visibleByDefault,
   }
+
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
+  return result
 }
 
 export function fixedSizeArrayControl(
@@ -352,15 +567,28 @@ export function fixedSizeArrayControl(
   maxCount: number,
   options?: PropertyControlsOptions<Vector2>,
 ): ArrayControlDescription {
-  return {
+  let result: ArrayControlDescription = {
     control: 'array',
     propertyControl: propertyControl,
     maxCount: maxCount,
-    defaultValue: options?.defaultValue,
-    label: options?.label,
-    required: options?.required,
-    visibleByDefault: options?.visibleByDefault,
   }
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
+  return result
 }
 
 export function objectControl(
@@ -369,47 +597,110 @@ export function objectControl(
   },
   options?: PropertyControlsOptions<unknown>,
 ): ObjectControlDescription {
-  return {
+  let result: ObjectControlDescription = {
     control: 'object',
     object: object,
-    defaultValue: options?.defaultValue,
-    label: options?.label,
-    required: options?.required,
-    visibleByDefault: options?.visibleByDefault,
   }
+
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
+  return result
 }
 
 export function tupleControl(
   propertyControls: RegularControlDescription[],
   options?: PropertyControlsOptions<unknown>,
 ): TupleControlDescription {
-  return {
+  let result: TupleControlDescription = {
     control: 'tuple',
     propertyControls: propertyControls,
-    defaultValue: options?.defaultValue,
-    label: options?.label,
-    required: options?.required,
-    visibleByDefault: options?.visibleByDefault,
   }
+
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
+  return result
 }
 
 export function unionControl(
   controls: Array<RegularControlDescription>,
   options?: PropertyControlsOptions<unknown>,
 ): UnionControlDescription {
-  return {
+  let result: UnionControlDescription = {
     control: 'union',
     controls: controls,
-    defaultValue: options?.defaultValue,
-    label: options?.label,
-    required: options?.required,
-    visibleByDefault: options?.visibleByDefault,
   }
+
+  if (options?.defaultValue !== undefined) {
+    result.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    result.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    result.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    result.label = options.label
+  }
+
+  return result
 }
 
 export function folderControl(controls: PropertyControls): FolderControlDescription {
   return {
     control: 'folder',
     controls: controls,
+  }
+}
+
+function mutateControlWithOptions<T extends BaseControlDescription>(
+  control: T,
+  options: PropertyControlsOptions<T>,
+) {
+  if (options?.defaultValue !== undefined) {
+    control.defaultValue = options.defaultValue
+  }
+
+  if (options?.required !== undefined) {
+    control.required = options.required
+  }
+
+  if (options?.visibleByDefault !== undefined) {
+    control.visibleByDefault = options.visibleByDefault
+  }
+
+  if (options?.label !== undefined) {
+    control.label = options.label
   }
 }

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -265,12 +265,7 @@ export type BaseControlDescription =
   | Vector4ControlDescription
   | JSXControlDescription
 
-export interface PropertyControlsOptions<T> {
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: T
-}
+export type PropertyControlsOptions<T> = Omit<ControlBaseFields, 'control'> & { defaultField: T }
 
 // Higher Level Controls
 

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -43,22 +43,14 @@ export type BaseControlType =
   | 'vector4'
   | 'jsx'
 
-export interface CheckboxControlDescription {
+export interface CheckboxControlDescription extends PropertyControlsOptions<unknown> {
   control: 'checkbox'
-  label?: string
-  visibleByDefault?: boolean
   disabledTitle?: string
   enabledTitle?: string
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface ColorControlDescription {
+export interface ColorControlDescription extends PropertyControlsOptions<unknown> {
   control: 'color'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
 export type AllowedEnumType = string | boolean | number | undefined | null
@@ -69,13 +61,10 @@ export interface BasicControlOption<T> {
 
 export type BasicControlOptions<T> = AllowedEnumType[] | BasicControlOption<T>[]
 
-export interface PopUpListControlDescription {
+export interface PopUpListControlDescription
+  extends PropertyControlsOptions<AllowedEnumType | BasicControlOption<unknown>> {
   control: 'popuplist'
-  label?: string
-  visibleByDefault?: boolean
   options: BasicControlOptions<unknown>
-  required?: boolean
-  defaultValue?: AllowedEnumType | BasicControlOption<unknown>
 }
 
 export interface ImportType {
@@ -91,29 +80,18 @@ export interface ExpressionControlOption<T> {
   requiredImport?: ImportType
 }
 
-export interface ExpressionPopUpListControlDescription {
+export interface ExpressionPopUpListControlDescription extends PropertyControlsOptions<unknown> {
   control: 'expression-popuplist'
-  label?: string
-  visibleByDefault?: boolean
   options: ExpressionControlOption<unknown>[]
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface EulerControlDescription {
+export interface EulerControlDescription
+  extends PropertyControlsOptions<[number, number, number, string]> {
   control: 'euler'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: [number, number, number, string]
 }
 
-export interface NoneControlDescription {
+export interface NoneControlDescription extends PropertyControlsOptions<unknown> {
   control: 'none'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
 // prettier-ignore
@@ -123,12 +101,8 @@ export type Matrix3 = [
   number, number, number,
 ]
 
-export interface Matrix3ControlDescription {
+export interface Matrix3ControlDescription extends PropertyControlsOptions<Matrix3> {
   control: 'matrix3'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: Matrix3
 }
 
 // prettier-ignore
@@ -139,110 +113,67 @@ export type Matrix4 = [
   number, number, number, number,
 ]
 
-export interface Matrix4ControlDescription {
+export interface Matrix4ControlDescription extends PropertyControlsOptions<Matrix4> {
   control: 'matrix4'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: Matrix4
 }
 
-export interface NumberInputControlDescription {
+export interface NumberInputControlDescription extends PropertyControlsOptions<unknown> {
   control: 'number-input'
-  label?: string
-  visibleByDefault?: boolean
   max?: number
   min?: number
   unit?: string
   step?: number
   displayStepper?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface RadioControlDescription {
+export interface RadioControlDescription
+  extends PropertyControlsOptions<AllowedEnumType | BasicControlOption<unknown>> {
   control: 'radio'
-  label?: string
-  visibleByDefault?: boolean
   options: BasicControlOptions<unknown>
-  required?: boolean
-  defaultValue?: AllowedEnumType | BasicControlOption<unknown>
 }
 
-export interface ExpressionInputControlDescription {
+export interface ExpressionInputControlDescription extends PropertyControlsOptions<unknown> {
   control: 'expression-input'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface StringInputControlDescription {
+export interface StringInputControlDescription extends PropertyControlsOptions<unknown> {
   control: 'string-input'
-  label?: string
-  visibleByDefault?: boolean
   placeholder?: string
   obscured?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface HtmlInputControlDescription {
+export interface HtmlInputControlDescription extends PropertyControlsOptions<unknown> {
   control: 'html-input'
-  label?: string
-  visibleByDefault?: boolean
   placeholder?: string
   obscured?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface StyleControlsControlDescription {
+export interface StyleControlsControlDescription extends PropertyControlsOptions<unknown> {
   control: 'style-controls'
-  label?: string
-  visibleByDefault?: boolean
   placeholder?: CSSProperties
-  required?: boolean
-  defaultValue?: unknown
 }
 
 export type Vector2 = [number, number]
 
-export interface Vector2ControlDescription {
+export interface Vector2ControlDescription extends PropertyControlsOptions<Vector2> {
   control: 'vector2'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: Vector2
 }
 
 export type Vector3 = [number, number, number]
 
-export interface Vector3ControlDescription {
+export interface Vector3ControlDescription extends PropertyControlsOptions<Vector3> {
   control: 'vector3'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: Vector3
 }
 
 export type Vector4 = [number, number, number, number]
 
-export interface Vector4ControlDescription {
+export interface Vector4ControlDescription extends PropertyControlsOptions<Vector4> {
   control: 'vector4'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: Vector4
 }
 
-export interface JSXControlDescription {
+export interface JSXControlDescription extends PropertyControlsOptions<unknown> {
   control: 'jsx'
-  label?: string
-  visibleByDefault?: boolean
   preferredChildComponents?: Array<PreferredChildComponent>
-  required?: boolean
-  defaultValue?: unknown
 }
 
 export type BaseControlDescription =
@@ -278,40 +209,24 @@ export type HigherLevelControlType = 'array' | 'tuple' | 'object' | 'union'
 export type RegularControlType = BaseControlType | HigherLevelControlType
 export type ControlType = RegularControlType | 'folder'
 
-export interface ArrayControlDescription {
+export interface ArrayControlDescription extends PropertyControlsOptions<unknown> {
   control: 'array'
-  label?: string
-  visibleByDefault?: boolean
   propertyControl: RegularControlDescription
   maxCount?: number
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface ObjectControlDescription {
+export interface ObjectControlDescription extends PropertyControlsOptions<unknown> {
   control: 'object'
-  label?: string
-  visibleByDefault?: boolean
   object: { [prop: string]: RegularControlDescription }
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface UnionControlDescription {
+export interface UnionControlDescription extends PropertyControlsOptions<unknown> {
   control: 'union'
-  label?: string
-  visibleByDefault?: boolean
   controls: Array<RegularControlDescription>
-  required?: boolean
-  defaultValue?: unknown
 }
-export interface TupleControlDescription {
+export interface TupleControlDescription extends PropertyControlsOptions<unknown> {
   control: 'tuple'
-  label?: string
-  visibleByDefault?: boolean
   propertyControls: RegularControlDescription[]
-  required?: boolean
-  defaultValue?: unknown
 }
 
 export interface FolderControlDescription {

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -43,14 +43,22 @@ export type BaseControlType =
   | 'vector4'
   | 'jsx'
 
-export interface CheckboxControlDescription extends PropertyControlsOptions<unknown> {
+export interface CheckboxControlDescription {
   control: 'checkbox'
+  label?: string
+  visibleByDefault?: boolean
   disabledTitle?: string
   enabledTitle?: string
+  required?: boolean
+  defaultValue?: unknown
 }
 
-export interface ColorControlDescription extends PropertyControlsOptions<unknown> {
+export interface ColorControlDescription {
   control: 'color'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: unknown
 }
 
 export type AllowedEnumType = string | boolean | number | undefined | null
@@ -61,10 +69,13 @@ export interface BasicControlOption<T> {
 
 export type BasicControlOptions<T> = AllowedEnumType[] | BasicControlOption<T>[]
 
-export interface PopUpListControlDescription
-  extends PropertyControlsOptions<AllowedEnumType | BasicControlOption<unknown>> {
+export interface PopUpListControlDescription {
   control: 'popuplist'
+  label?: string
+  visibleByDefault?: boolean
   options: BasicControlOptions<unknown>
+  required?: boolean
+  defaultValue?: AllowedEnumType | BasicControlOption<unknown>
 }
 
 export interface ImportType {
@@ -80,18 +91,29 @@ export interface ExpressionControlOption<T> {
   requiredImport?: ImportType
 }
 
-export interface ExpressionPopUpListControlDescription extends PropertyControlsOptions<unknown> {
+export interface ExpressionPopUpListControlDescription {
   control: 'expression-popuplist'
+  label?: string
+  visibleByDefault?: boolean
   options: ExpressionControlOption<unknown>[]
+  required?: boolean
+  defaultValue?: unknown
 }
 
-export interface EulerControlDescription
-  extends PropertyControlsOptions<[number, number, number, string]> {
+export interface EulerControlDescription {
   control: 'euler'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: [number, number, number, string]
 }
 
-export interface NoneControlDescription extends PropertyControlsOptions<unknown> {
+export interface NoneControlDescription {
   control: 'none'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: unknown
 }
 
 // prettier-ignore
@@ -101,8 +123,12 @@ export type Matrix3 = [
   number, number, number,
 ]
 
-export interface Matrix3ControlDescription extends PropertyControlsOptions<Matrix3> {
+export interface Matrix3ControlDescription {
   control: 'matrix3'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: Matrix3
 }
 
 // prettier-ignore
@@ -113,67 +139,110 @@ export type Matrix4 = [
   number, number, number, number,
 ]
 
-export interface Matrix4ControlDescription extends PropertyControlsOptions<Matrix4> {
+export interface Matrix4ControlDescription {
   control: 'matrix4'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: Matrix4
 }
 
-export interface NumberInputControlDescription extends PropertyControlsOptions<unknown> {
+export interface NumberInputControlDescription {
   control: 'number-input'
+  label?: string
+  visibleByDefault?: boolean
   max?: number
   min?: number
   unit?: string
   step?: number
   displayStepper?: boolean
+  required?: boolean
+  defaultValue?: unknown
 }
 
-export interface RadioControlDescription
-  extends PropertyControlsOptions<AllowedEnumType | BasicControlOption<unknown>> {
+export interface RadioControlDescription {
   control: 'radio'
+  label?: string
+  visibleByDefault?: boolean
   options: BasicControlOptions<unknown>
+  required?: boolean
+  defaultValue?: AllowedEnumType | BasicControlOption<unknown>
 }
 
-export interface ExpressionInputControlDescription extends PropertyControlsOptions<unknown> {
+export interface ExpressionInputControlDescription {
   control: 'expression-input'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: unknown
 }
 
-export interface StringInputControlDescription extends PropertyControlsOptions<unknown> {
+export interface StringInputControlDescription {
   control: 'string-input'
+  label?: string
+  visibleByDefault?: boolean
   placeholder?: string
   obscured?: boolean
+  required?: boolean
+  defaultValue?: unknown
 }
 
-export interface HtmlInputControlDescription extends PropertyControlsOptions<unknown> {
+export interface HtmlInputControlDescription {
   control: 'html-input'
+  label?: string
+  visibleByDefault?: boolean
   placeholder?: string
   obscured?: boolean
+  required?: boolean
+  defaultValue?: unknown
 }
 
-export interface StyleControlsControlDescription extends PropertyControlsOptions<unknown> {
+export interface StyleControlsControlDescription {
   control: 'style-controls'
+  label?: string
+  visibleByDefault?: boolean
   placeholder?: CSSProperties
+  required?: boolean
+  defaultValue?: unknown
 }
 
 export type Vector2 = [number, number]
 
-export interface Vector2ControlDescription extends PropertyControlsOptions<Vector2> {
+export interface Vector2ControlDescription {
   control: 'vector2'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: Vector2
 }
 
 export type Vector3 = [number, number, number]
 
-export interface Vector3ControlDescription extends PropertyControlsOptions<Vector3> {
+export interface Vector3ControlDescription {
   control: 'vector3'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: Vector3
 }
 
 export type Vector4 = [number, number, number, number]
 
-export interface Vector4ControlDescription extends PropertyControlsOptions<Vector4> {
+export interface Vector4ControlDescription {
   control: 'vector4'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: Vector4
 }
 
-export interface JSXControlDescription extends PropertyControlsOptions<unknown> {
+export interface JSXControlDescription {
   control: 'jsx'
+  label?: string
+  visibleByDefault?: boolean
   preferredChildComponents?: Array<PreferredChildComponent>
+  required?: boolean
+  defaultValue?: unknown
 }
 
 export type BaseControlDescription =
@@ -209,24 +278,40 @@ export type HigherLevelControlType = 'array' | 'tuple' | 'object' | 'union'
 export type RegularControlType = BaseControlType | HigherLevelControlType
 export type ControlType = RegularControlType | 'folder'
 
-export interface ArrayControlDescription extends PropertyControlsOptions<unknown> {
+export interface ArrayControlDescription {
   control: 'array'
+  label?: string
+  visibleByDefault?: boolean
   propertyControl: RegularControlDescription
   maxCount?: number
+  required?: boolean
+  defaultValue?: unknown
 }
 
-export interface ObjectControlDescription extends PropertyControlsOptions<unknown> {
+export interface ObjectControlDescription {
   control: 'object'
+  label?: string
+  visibleByDefault?: boolean
   object: { [prop: string]: RegularControlDescription }
+  required?: boolean
+  defaultValue?: unknown
 }
 
-export interface UnionControlDescription extends PropertyControlsOptions<unknown> {
+export interface UnionControlDescription {
   control: 'union'
+  label?: string
+  visibleByDefault?: boolean
   controls: Array<RegularControlDescription>
+  required?: boolean
+  defaultValue?: unknown
 }
-export interface TupleControlDescription extends PropertyControlsOptions<unknown> {
+export interface TupleControlDescription {
   control: 'tuple'
+  label?: string
+  visibleByDefault?: boolean
   propertyControls: RegularControlDescription[]
+  required?: boolean
+  defaultValue?: unknown
 }
 
 export interface FolderControlDescription {

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -206,28 +206,34 @@ export interface StyleControlsControlDescription {
   defaultValue?: unknown
 }
 
+export type Vector2 = [number, number]
+
 export interface Vector2ControlDescription {
   control: 'vector2'
   label?: string
   visibleByDefault?: boolean
   required?: boolean
-  defaultValue?: [number, number]
+  defaultValue?: Vector2
 }
+
+export type Vector3 = [number, number, number]
 
 export interface Vector3ControlDescription {
   control: 'vector3'
   label?: string
   visibleByDefault?: boolean
   required?: boolean
-  defaultValue?: [number, number, number]
+  defaultValue?: Vector3
 }
+
+export type Vector4 = [number, number, number, number]
 
 export interface Vector4ControlDescription {
   control: 'vector4'
   label?: string
   visibleByDefault?: boolean
   required?: boolean
-  defaultValue?: [number, number, number, number]
+  defaultValue?: Vector4
 }
 
 export interface JSXControlDescription {
@@ -258,6 +264,13 @@ export type BaseControlDescription =
   | Vector3ControlDescription
   | Vector4ControlDescription
   | JSXControlDescription
+
+export interface PropertyControlsOptions<T> {
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: T
+}
 
 // Higher Level Controls
 

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -265,7 +265,7 @@ export type BaseControlDescription =
   | Vector4ControlDescription
   | JSXControlDescription
 
-export type PropertyControlsOptions<T> = Omit<ControlBaseFields, 'control'> & { defaultField: T }
+export type PropertyControlsOptions<T> = Omit<ControlBaseFields, 'control'> & { defaultValue?: T }
 
 // Higher Level Controls
 


### PR DESCRIPTION
**Problem:**
The `defaultValue`, `label`, `required`, and `visibleByDefault` optional properties of property controls are not exposed through the property control factory functions.

**Fix:**
I added a new parameter to each factory function, and extracted the common logic to set these properties into a function called `mutateControlWithOptions`. I also extracted these four properties into a generic base interface (which was necessary to create the typing of `mutateControlWithOptions`).