### PR TITLE
Open editor only for logged in users

### DIFF
--- a/utopia-remix/app/loaders/loggedInProjectLoader.ts
+++ b/utopia-remix/app/loaders/loggedInProjectLoader.ts
@@ -1,0 +1,19 @@
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { ALLOW } from '../handlers/validators'
+import { proxy } from '../util/proxy.server'
+import { getResponseWithValidation, requireUserOrRedirectToLogin } from '../util/api.server'
+
+// due to Remix's current issue with gzip responses (https://github.com/remix-run/remix/issues/6697),
+// we need to remove this header from the response
+const excludeHeaders = new Set(['content-encoding'])
+
+export async function loggedInRequest(args: LoaderFunctionArgs) {
+  await requireUserOrRedirectToLogin(args.request)
+
+  return await getResponseWithValidation(
+    args.request,
+    args.params,
+    (req: Request) => proxy(req, { rawOutput: true }),
+    { validator: ALLOW, excludeHeaders: excludeHeaders },
+  )
+}

--- a/utopia-remix/app/routes-test/p._index.spec.ts
+++ b/utopia-remix/app/routes-test/p._index.spec.ts
@@ -1,0 +1,103 @@
+import { prisma } from '../db.server'
+
+import { createTestSession, createTestUser, newTestRequest, truncateTables } from '../test-util'
+import { loader as p_loader } from '../routes/p._index'
+import { ServerEnvironment } from '../env.server'
+import * as serverProxy from '../util/proxy.server'
+
+describe('handleEditorWithLogin', () => {
+  let pageProxy: jest.SpyInstance
+  beforeAll(async () => {
+    await truncateTables([
+      prisma.projectCollaborator,
+      prisma.userDetails,
+      prisma.persistentSession,
+      prisma.projectID,
+    ])
+  })
+  afterAll(async () => {
+    jest.restoreAllMocks()
+  })
+  afterEach(async () => {
+    await truncateTables([
+      prisma.projectAccess,
+      prisma.projectCollaborator,
+      prisma.userDetails,
+      prisma.persistentSession,
+      prisma.project,
+      prisma.projectID,
+    ])
+    pageProxy.mockClear()
+  })
+
+  beforeEach(async () => {
+    await createTestUser(prisma, { id: 'user1' })
+    await createTestSession(prisma, { key: 'the-key', userId: 'user1' })
+    pageProxy = jest.spyOn(serverProxy, 'proxy')
+    pageProxy.mockImplementation(async (req: Request) => new Response('ok'))
+  })
+  it('should redirect to auth0 login if not logged in', async () => {
+    const request = newTestRequest({
+      method: 'GET',
+      path: '/p',
+    })
+    let response: Response | undefined = undefined
+    try {
+      response = (await p_loader({ request: request, params: {}, context: {} })) as Response
+    } catch (err) {
+      const redirectResponse = err as Response
+      expect(redirectResponse.status).toBe(302)
+      const redirectLocation = redirectResponse.headers.get('Location')
+      const redirectToParam = getParamFromLoginURL(redirectLocation ?? '', 'redirectTo')
+      expect(redirectToParam).toBe(request.url)
+    }
+    expect(response).toBeUndefined()
+  })
+
+  it('should return the page if logged in', async () => {
+    const request = newTestRequest({
+      method: 'GET',
+      path: '/p',
+      authCookie: 'the-key',
+    })
+    const response = (await p_loader({ request: request, params: {}, context: {} })) as Response
+    expect(pageProxy).toHaveBeenCalledWith(request, { rawOutput: true })
+    expect(response.status).toBe(200)
+  })
+
+  it('should redirect to authenticate login with the fakeUser', async () => {
+    const request = newTestRequest({
+      method: 'GET',
+      path: '/p',
+      search: { fakeUser: 'alice' },
+    })
+    let response: Response | undefined = undefined
+    try {
+      response = (await p_loader({ request: request, params: {}, context: {} })) as Response
+    } catch (err) {
+      const redirectResponse = err as Response
+      expect(redirectResponse.status).toBe(302)
+      const redirectLocation = redirectResponse.headers.get('Location')
+      expect(redirectLocation).toContain(`${ServerEnvironment.CORS_ORIGIN}/authenticate`)
+      const redirectToParam = getDecodedParam(redirectLocation, 'redirectTo')
+      const expectedRedirectUrl = new URL(request.url)
+      expectedRedirectUrl.searchParams.delete('fakeUser')
+      expect(redirectToParam).toBe(expectedRedirectUrl.toString())
+      const codeParam = getDecodedParam(redirectLocation, 'code')
+      expect(codeParam).toBe('alice')
+    }
+    expect(response).toBeUndefined()
+  })
+})
+
+function getParamFromLoginURL(url: string, param: string): string | null {
+  const redirect_uri = url.includes(`${ServerEnvironment.AUTH0_ENDPOINT}/authorize`)
+    ? getDecodedParam(url ?? '', 'redirect_uri')
+    : url
+  return getDecodedParam(redirect_uri ?? '', param)
+}
+
+function getDecodedParam(url: string | null, param: string): string | null {
+  const value = new URL(url ?? '').searchParams.get(param)
+  return value ? decodeURIComponent(value) : null
+}

--- a/utopia-remix/app/routes/p.$id.tsx
+++ b/utopia-remix/app/routes/p.$id.tsx
@@ -3,7 +3,11 @@ import { validateProjectAccess } from '../handlers/validators'
 import { proxy } from '../util/proxy.server'
 import { UserProjectPermission } from '~/types'
 import { redirect } from '@remix-run/react'
-import { getProjectIdFromParams, getResponseWithValidation } from '../util/api.server'
+import {
+  getProjectIdFromParams,
+  getResponseWithValidation,
+  requireUserOrRedirectToLogin,
+} from '../util/api.server'
 
 const validator = validateProjectAccess(UserProjectPermission.CAN_VIEW_PROJECT, {
   canRequestAccess: true,
@@ -14,6 +18,8 @@ const validator = validateProjectAccess(UserProjectPermission.CAN_VIEW_PROJECT, 
 const excludeHeaders = new Set(['content-encoding'])
 
 export async function loader(args: LoaderFunctionArgs) {
+  await requireUserOrRedirectToLogin(args.request)
+
   try {
     return await getResponseWithValidation(
       args.request,

--- a/utopia-remix/app/routes/p._index.tsx
+++ b/utopia-remix/app/routes/p._index.tsx
@@ -1,0 +1,6 @@
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { loggedInRequest } from '../loaders/loggedInProjectLoader'
+
+export async function loader(args: LoaderFunctionArgs) {
+  return await loggedInRequest(args)
+}

--- a/utopia-remix/app/routes/project._index.tsx
+++ b/utopia-remix/app/routes/project._index.tsx
@@ -1,0 +1,6 @@
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { loggedInRequest } from '../loaders/loggedInProjectLoader'
+
+export async function loader(args: LoaderFunctionArgs) {
+  return await loggedInRequest(args)
+}

--- a/utopia-remix/app/util/api.server.ts
+++ b/utopia-remix/app/util/api.server.ts
@@ -11,6 +11,7 @@ import type { Method } from './methods.server'
 import { Status } from './statusCodes'
 import { ServerEnvironment } from '../env.server'
 import { maybeGetUserFromSession } from '../models/session.server'
+import { auth0LoginURL } from './auth0.server'
 
 interface ErrorResponse {
   error: string
@@ -203,6 +204,19 @@ export async function requireUser(
     }
     throw error
   }
+}
+
+export async function requireUserOrRedirectToLogin(request: Request): Promise<UserDetails | null> {
+  const url = new URL(request.url)
+  const fakeUser = url.searchParams.get('fakeUser')
+  url.searchParams.delete('fakeUser')
+
+  return await requireUser(request, {
+    redirect: auth0LoginURL({
+      redirectTo: url.toString(),
+      fakeUser: fakeUser,
+    }),
+  })
 }
 
 export async function getUser(request: Request): Promise<UserDetails | null> {

--- a/utopia-remix/server.js
+++ b/utopia-remix/server.js
@@ -184,11 +184,6 @@ app.use('/sockjs-node', proxy)
 app.use('/v1/javascript/packager', proxy)
 app.use('/vscode', proxy)
 
-// this will use the proxy only for `/p` and `/project` paths
-// for `/p/{id} and `/project/{id}` we will use Remix routes
-app.use('/p/?$', proxy)
-app.use('/project/?$', proxy)
-
 // other middlewares
 app.use(corsMiddleware)
 


### PR DESCRIPTION
This PR puts the editor behind a login wall (effectively removing the option to create projects anonymously)

- no creation (`/p`, `/project`) is possible before login
- `fakeUser` is supported
- `/p/project-id` is also behind a login wall

<video src="https://github.com/concrete-utopia/utopia/assets/7003853/8aec2f88-6d30-491a-9939-aaa87dde006e" />



