### PR TITLE
Fix inserting empty element with no additional imports

### DIFF
--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -5025,6 +5025,47 @@ describe('Navigator', () => {
   })
 
   describe('render props', () => {
+    it('can insert an empty intrinsic element into render prop', async () => {
+      const renderResult = await renderTestEditorWithModel(
+        projectWithRenderProp(''), // <- no render prop
+        'await-first-dom-report',
+      )
+
+      const slotElement = renderResult.renderedDOM.getByTestId(
+        'toggle-render-prop-NavigatorItemTestId-slot_sb/scene/pg:dbc/78c/prop_label_header',
+      )
+
+      await mouseClickAtPoint(slotElement, { x: 3, y: 3 })
+      const renderPropOptionElement = await waitFor(() =>
+        renderResult.renderedDOM.getByText('(empty)'),
+      )
+      await mouseClickAtPoint(renderPropOptionElement, { x: 3, y: 3 })
+
+      expect(
+        renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey),
+      ).toEqual([
+        'regular-sb/scene',
+        'regular-sb/scene/pg',
+        'regular-sb/scene/pg:dbc',
+        'regular-sb/scene/pg:dbc/78c',
+        'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
+        'regular-sb/scene/pg:dbc/78c/pro', // <- the inserted render prop
+        'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
+        'regular-sb/scene/pg:dbc/78c/88b',
+      ])
+      expect(
+        renderResult.getEditorState().derived.visibleNavigatorTargets.map(navigatorEntryToKey),
+      ).toEqual([
+        'regular-sb/scene',
+        'regular-sb/scene/pg',
+        'regular-sb/scene/pg:dbc',
+        'regular-sb/scene/pg:dbc/78c',
+        'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
+        'regular-sb/scene/pg:dbc/78c/pro', // <- the inserted render prop
+        'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
+        'regular-sb/scene/pg:dbc/78c/88b',
+      ])
+    })
     it('can insert an intrinsic element into render prop', async () => {
       const renderResult = await renderTestEditorWithModel(
         projectWithRenderProp(''), // <- no render prop
@@ -5040,6 +5081,8 @@ describe('Navigator', () => {
         renderResult.renderedDOM.getByText('Span with Title'),
       )
       await mouseClickAtPoint(renderPropOptionElement, { x: 3, y: 3 })
+
+      await wait(100000)
 
       expect(
         renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey),

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -5082,8 +5082,6 @@ describe('Navigator', () => {
       )
       await mouseClickAtPoint(renderPropOptionElement, { x: 3, y: 3 })
 
-      await wait(100000)
-
       expect(
         renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey),
       ).toEqual([

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -566,7 +566,10 @@ async function makePreferredChildDescriptor(
   moduleName: string,
   workers: UtopiaTsWorkers,
 ): Promise<Either<string, PreferredChildComponentDescriptor>> {
-  const allRequiredImports = `import { ${componentName} } from '${preferredChild.additionalImports}';`
+  const allRequiredImports =
+    preferredChild.additionalImports == null
+      ? ''
+      : `import { ${componentName} } from '${preferredChild.additionalImports}';`
 
   const parsedParams = await getCachedParseResultForUserStrings(
     workers,


### PR DESCRIPTION
## Problem
if the `(empty)` option is picked from the render prop picker, an error is thrown (`DependencyNotFoundError: Could not find 'undefined` relative to '...'`)

## Cause
Due to how string interpolation works, if a render prop's `preferredChild` doesn't have `additionalImports` filled out, the code adds an `import {...} from 'undefined'` import line

## Fix
Check whether `additionalImports` filled out