### PR TITLE
Get project sharing details

### DIFF
--- a/utopia-remix/app/models/project.server.ts
+++ b/utopia-remix/app/models/project.server.ts
@@ -1,5 +1,11 @@
 import { prisma } from '../db.server'
-import type { CollaboratorsByProject, GithubRepository, ProjectListing } from '../types'
+import type {
+  CollaboratorsByProject,
+  GithubRepository,
+  ProjectAccessRequestWithUserDetails,
+  ProjectListing,
+  ProjectSharingDetails,
+} from '../types'
 import {
   AccessLevel,
   AccessRequestStatus,
@@ -81,6 +87,23 @@ export async function getProjectOwnership(
     ownerId: project.owner_id,
     accessLevel: accessLevel,
   }
+}
+
+export async function getProjectSharingDetails(params: {
+  projectId: string
+  userId: string
+}): Promise<ProjectSharingDetails | null> {
+  return prisma.project.findUnique({
+    where: {
+      proj_id: params.projectId,
+      owner_id: params.userId,
+    },
+    select: {
+      proj_id: true,
+      ProjectAccess: true,
+      ProjectAccessRequest: { include: { User: true } },
+    },
+  })
 }
 
 export async function renameProject(params: {

--- a/utopia-remix/app/types.ts
+++ b/utopia-remix/app/types.ts
@@ -18,6 +18,10 @@ export type ProjectListing = ProjectWithoutContentFromDB & {
   hasPendingRequests?: boolean
 }
 
+export type ProjectSharingDetails = Pick<ProjectListing, 'proj_id' | 'ProjectAccess'> & {
+  ProjectAccessRequest: ProjectAccessRequestWithUserDetails[]
+}
+
 // Legacy response
 export interface ProjectListingV1 {
   id: string


### PR DESCRIPTION
This is a prep PR for the editor's share dialog, that will be followed by incremental PRs.

This PR adds a new querier method, `getProjectSharingDetails`, that returns the sharing details for a project (the relevant metadata + access requests). It will be used by the iframe's loader to populate the dialog.