### PR TITLE
Remove collaborator on request destroy

### DIFF
--- a/utopia-remix/app/models/projectAccessRequest.server.spec.ts
+++ b/utopia-remix/app/models/projectAccessRequest.server.spec.ts
@@ -422,5 +422,27 @@ describe('projectAccessRequest', () => {
       })
       expect(current.length).toBe(2)
     })
+    it('removes the user from the collaborators, if present', async () => {
+      await createTestProjectCollaborator(prisma, { projectId: 'two', userId: 'carol' })
+      await createTestProjectCollaborator(prisma, { projectId: 'two', userId: 'bob' })
+      await createTestProjectCollaborator(prisma, { projectId: 'two', userId: 'alice' })
+
+      const existingCollaborators = await prisma.projectCollaborator.findMany({
+        where: { project_id: 'two' },
+      })
+      expect(existingCollaborators.length).toBe(3)
+      expect(existingCollaborators[0].user_id).toBe('carol')
+      expect(existingCollaborators[1].user_id).toBe('bob')
+      expect(existingCollaborators[2].user_id).toBe('alice')
+
+      await destroyAccessRequest({ projectId: 'two', ownerId: 'alice', token: 'token1' })
+
+      const currentCollaborators = await prisma.projectCollaborator.findMany({
+        where: { project_id: 'two' },
+      })
+      expect(currentCollaborators.length).toBe(2)
+      expect(currentCollaborators[0].user_id).toBe('bob')
+      expect(currentCollaborators[1].user_id).toBe('alice')
+    })
   })
 })

--- a/utopia-remix/app/models/projectAccessRequest.server.ts
+++ b/utopia-remix/app/models/projectAccessRequest.server.ts
@@ -165,5 +165,10 @@ export async function destroyAccessRequest(params: {
     })
     // 2. revoke access on FGA
     await permissionsService.revokeAllRolesFromUser(params.projectId, request.user_id)
+    // 3. delete the collaborator, if any
+    await removeFromProjectCollaboratorsWithRunner(tx, {
+      projectId: params.projectId,
+      userId: request.user_id,
+    })
   })
 }


### PR DESCRIPTION
Fix #5172 

**Problem:**

When an access request is destroyed, the related collaborator row (if any, for previously approved requests) should be removed as well.

**Fix:**

1. call `removeFromProjectCollaboratorsWithRunner` inside the destroy transaction
2. test it