### PR TITLE
Remix: show outlet only when the client is ready

### DIFF
--- a/utopia-remix/app/hooks/use-client-ready.tsx
+++ b/utopia-remix/app/hooks/use-client-ready.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+/**
+ * This terrible hook is required to make Remix, zustand, and media queries (e.g. the Radix themes and Sprinkles
+ * conditions) work fine together.
+ *
+ * The first render of Remix does not contain the client-side pieces of information, but the mounted renders do.
+ * So, this hook returns a flag that when true means that the client is ready to display page content.
+ */
+export function useIsClientReady() {
+  const [ready, setReady] = React.useState(false)
+  React.useEffect(() => {
+    setReady(true)
+  }, [])
+  return ready
+}

--- a/utopia-remix/app/root.tsx
+++ b/utopia-remix/app/root.tsx
@@ -25,6 +25,7 @@ import { styles } from './styles/styles.css'
 import type { ErrorWithStatus } from './util/errors'
 import { isErrorWithStatus } from './util/errors'
 import { Status, getStatusName } from './util/statusCodes'
+import { useIsClientReady } from './hooks/use-client-ready'
 
 export const links: LinksFunction = () => [
   ...(cssBundleHref ? [{ rel: 'stylesheet', href: cssBundleHref }] : []),
@@ -64,7 +65,7 @@ export default function App() {
       <body className={styles.root}>
         <AppContext.Provider value={store}>
           <Theme appearance={theme} accentColor='blue' panelBackground='solid'>
-            <Outlet />
+            <OutletWrapper />
           </Theme>
         </AppContext.Provider>
         <ScrollRestoration />
@@ -74,6 +75,16 @@ export default function App() {
     </html>
   )
 }
+
+const OutletWrapper = React.memo(() => {
+  // Only render the outlet if the client is ready.
+  const ready = useIsClientReady()
+  if (!ready) {
+    return null
+  }
+
+  return <Outlet />
+})
 
 export function ErrorBoundary() {
   const routeError = useRouteError()


### PR DESCRIPTION
**Problem:**

The Remix first render does not contain the persisted store, media queries, etc. so it'll flicker when they regulate page layouts.

**Fix:**

Use a (horrible!) hook to make sure mount happened.