### PR TITLE
Propagate merge conflicted code to VS Code.

### DIFF
--- a/editor/src/core/shared/github.spec.ts
+++ b/editor/src/core/shared/github.spec.ts
@@ -111,7 +111,10 @@ describe('mergeProjectContentsTree', () => {
     const originContents = projectContentFile('/myfile.txt', codeFile('origin code', null, 0))
     const currentContents = projectContentFile('/myfile.txt', codeFile('current code', null, 1))
     const branchContents = projectContentFile('/myfile.txt', codeFile('origin code', null, 2))
-    const mergedContents = projectContentFile('/myfile.txt', codeFile('current code', null, 3))
+    const mergedContents = projectContentFile(
+      '/myfile.txt',
+      codeFile('current code', null, 3, RevisionsState.CodeAheadButPleaseTellVSCodeAboutIt),
+    )
     const actualResult = mergeProjectContentsTree(
       '/myfile.txt',
       currentContents,
@@ -172,7 +175,10 @@ origin code
 =======
 branch code
 >>>>>>> Branch Changes`
-    const mergedContents = projectContentFile('/myfile.txt', codeFile(mergedCode, null, 3))
+    const mergedContents = projectContentFile(
+      '/myfile.txt',
+      codeFile(mergedCode, null, 3, RevisionsState.CodeAheadButPleaseTellVSCodeAboutIt),
+    )
     const actualResult = mergeProjectContentsTree(
       '/myfile.txt',
       currentContents,

--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -767,7 +767,11 @@ export function mergeProjectContentsTree(
       const updatedTextFile: TextFile = isBranchCode
         ? set(fromField('versionNumber'), latestVersion + 1, branchContents.content)
         : textFile(
-            textFileContents(mergedResult, unparsed, RevisionsState.CodeAhead),
+            textFileContents(
+              mergedResult,
+              unparsed,
+              RevisionsState.CodeAheadButPleaseTellVSCodeAboutIt,
+            ),
             null,
             null,
             latestVersion + 1,

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -624,12 +624,13 @@ export function codeFile(
   fileContents: string,
   lastSavedContents: string | null,
   versionNumber: number = 0,
+  revisionsState: RevisionsStateType = RevisionsState.CodeAhead,
 ): TextFile {
   return textFile(
-    textFileContents(fileContents, unparsed, RevisionsState.CodeAhead),
+    textFileContents(fileContents, unparsed, revisionsState),
     lastSavedContents == null
       ? null
-      : textFileContents(lastSavedContents, unparsed, RevisionsState.CodeAhead),
+      : textFileContents(lastSavedContents, unparsed, revisionsState),
     null,
     versionNumber,
   )


### PR DESCRIPTION
**Problem:**
Merge conflicts in a project caused by local changes conflicting with pulling remote changes don't result in the code being updated in VS Code.

**Cause:**
The logic in `collateProjectChanges` ends up ignoring the file entry as created from the merge because it's marked with `RevisionsState.CodeAhead`, which is ordinarily used when updates _from_ VS Code are made. Then when the parsed version comes back in subsequently (and `collateProjectChanges` is called again) then there are no changes to the code at that point because it has already been updated.

**Fix:**
We now have a slightly more specialised version of `CodeAhead` called `CodeAheadButPleaseTellVSCodeAboutIt`, which `collateProjectChanges` has already been updated to handle appropriately. So the fix was to use that state instead of the regular `CodeAhead` when creating the new entry in `mergeProjectContentsTree`.

**Commit Details:**
- `mergeProjectContentsTree` now when creating a new entry for the merged content uses `CodeAheadButPleaseTellVSCodeAboutIt` for the `RevisionsState` of the newly created `TextFileContents`.
- Added an additional parameter of `RevisionsStateType` to `codeFile`.
