### PR TITLE
New component descriptor errors

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -707,6 +707,11 @@ export interface SetCodeEditorLintErrors {
   lintErrors: ErrorMessages
 }
 
+export interface SetCodeEditorComponentDescriptorErrors {
+  action: 'SET_CODE_EDITOR_COMPONENT_DESCRIPTOR_ERRORS'
+  componentDescriptorErrors: ErrorMessages
+}
+
 export interface SaveDOMReport {
   action: 'SAVE_DOM_REPORT'
   elementMetadata: ElementInstanceMetadataMap
@@ -1201,6 +1206,7 @@ export type EditorAction =
   | SetMainUIFile
   | SetCodeEditorBuildErrors
   | SetCodeEditorLintErrors
+  | SetCodeEditorComponentDescriptorErrors
   | SaveDOMReport
   | RunDOMWalker
   | TrueUpElements

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -221,6 +221,7 @@ import type {
   SetForking,
   SetCollaborators,
   ExtractPropertyControlsFromDescriptorFiles,
+  SetCodeEditorComponentDescriptorErrors,
 } from '../action-types'
 import type { InsertionSubjectWrapper, Mode } from '../editor-modes'
 import { EditorModes, insertionSubject } from '../editor-modes'
@@ -1199,6 +1200,15 @@ export function setCodeEditorLintErrors(lintErrors: ErrorMessages): SetCodeEdito
   return {
     action: 'SET_CODE_EDITOR_LINT_ERRORS',
     lintErrors: lintErrors,
+  }
+}
+
+export function setCodeEditorComponentDescriptorErrors(
+  componentDescriptorErrors: ErrorMessages,
+): SetCodeEditorComponentDescriptorErrors {
+  return {
+    action: 'SET_CODE_EDITOR_COMPONENT_DESCRIPTOR_ERRORS',
+    componentDescriptorErrors: componentDescriptorErrors,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -67,6 +67,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_CODE_RESULT_CACHE':
     case 'SET_CODE_EDITOR_BUILD_ERRORS':
     case 'SET_CODE_EDITOR_LINT_ERRORS':
+    case 'SET_CODE_EDITOR_COMPONENT_DESCRIPTOR_ERRORS':
     case 'SAVE_DOM_REPORT':
     case 'RUN_DOM_WALKER':
     case 'SET_FILEBROWSER_RENAMING_TARGET':

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -341,6 +341,7 @@ describe('LOAD', () => {
       codeEditorErrors: {
         buildErrors: {},
         lintErrors: {},
+        componentDescriptorErrors: {},
       },
       lastUsedFont: null,
       hiddenInstances: [],

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -331,6 +331,7 @@ import type {
   InsertAttributeOtherJavascriptIntoElement,
   SetCollaborators,
   ExtractPropertyControlsFromDescriptorFiles,
+  SetCodeEditorComponentDescriptorErrors,
 } from '../action-types'
 import { isLoggedIn } from '../action-types'
 import type { Mode } from '../editor-modes'
@@ -376,6 +377,7 @@ import {
   trueUpGroupElementChanged,
   getPackageJsonFromProjectContents,
   modifyUnderlyingTargetJSXElement,
+  getAllComponentDescriptorErrors,
 } from '../store/editor-state'
 import {
   areGeneratedElementsTargeted,
@@ -3529,6 +3531,7 @@ export const UPDATE_FNS = {
           codeEditorErrors: {
             buildErrors: {},
             lintErrors: {},
+            componentDescriptorErrors: {},
           },
           canvas: {
             ...editor.canvas,
@@ -3980,6 +3983,41 @@ export const UPDATE_FNS = {
           },
         }
       }, editor.codeEditorErrors)
+      return {
+        ...editor,
+        codeEditorErrors: updatedCodeEditorErrors,
+      }
+    }
+  },
+  SET_CODE_EDITOR_COMPONENT_DESCRIPTOR_ERRORS: (
+    action: SetCodeEditorComponentDescriptorErrors,
+    editor: EditorModel,
+  ): EditorModel => {
+    const allComponentDescriptorErrorsInState = getAllComponentDescriptorErrors(
+      editor.codeEditorErrors,
+    )
+    const allComponentDescriptorErrorsInAction = Utils.flatMapArray(
+      (filename) => action.componentDescriptorErrors[filename],
+      Object.keys(action.componentDescriptorErrors),
+    )
+    if (
+      allComponentDescriptorErrorsInState.length === 0 &&
+      allComponentDescriptorErrorsInAction.length === 0
+    ) {
+      return editor
+    } else {
+      const updatedCodeEditorErrors = Object.keys(action.componentDescriptorErrors).reduce(
+        (acc, filename) => {
+          return {
+            ...acc,
+            componentDescriptorErrors: {
+              ...acc.componentDescriptorErrors,
+              [filename]: action.componentDescriptorErrors[filename],
+            },
+          }
+        },
+        editor.codeEditorErrors,
+      )
       return {
         ...editor,
         codeEditorErrors: updatedCodeEditorErrors,

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -1041,6 +1041,7 @@ function filterEditorForFiles(editor: EditorState) {
     codeEditorErrors: {
       buildErrors: pick(allFiles, editor.codeEditorErrors.buildErrors),
       lintErrors: pick(allFiles, editor.codeEditorErrors.lintErrors),
+      componentDescriptorErrors: pick(allFiles, editor.codeEditorErrors.componentDescriptorErrors),
     },
   }
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1166,15 +1166,18 @@ export function editorStateHome(visible: boolean): EditorStateHome {
 export interface EditorStateCodeEditorErrors {
   buildErrors: ErrorMessages
   lintErrors: ErrorMessages
+  componentDescriptorErrors: ErrorMessages
 }
 
 export function editorStateCodeEditorErrors(
   buildErrors: ErrorMessages,
   lintErrors: ErrorMessages,
+  componentDescriptorErrors: ErrorMessages,
 ): EditorStateCodeEditorErrors {
   return {
     buildErrors: buildErrors,
     lintErrors: lintErrors,
+    componentDescriptorErrors: componentDescriptorErrors,
   }
 }
 
@@ -2365,6 +2368,7 @@ export interface PersistentModel {
   codeEditorErrors: {
     buildErrors: ErrorMessages
     lintErrors: ErrorMessages
+    componentDescriptorErrors: ErrorMessages
   }
   fileBrowser: {
     minimised: boolean
@@ -2581,6 +2585,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     codeEditorErrors: {
       buildErrors: {},
       lintErrors: {},
+      componentDescriptorErrors: {},
     },
     thumbnailLastGenerated: 0,
     pasteTargetsToIgnore: [],
@@ -3053,6 +3058,7 @@ export function persistentModelForProjectContents(
     codeEditorErrors: {
       buildErrors: {},
       lintErrors: {},
+      componentDescriptorErrors: {},
     },
     lastUsedFont: null,
     hiddenInstances: [],
@@ -3216,7 +3222,10 @@ export function getAllCodeEditorErrors(
 ): Array<ErrorMessage> {
   const allLintErrors = getAllLintErrors(codeEditorErrors)
   const allBuildErrors = getAllBuildErrors(codeEditorErrors)
-  const errorsAndWarnings = skipTsErrors ? allLintErrors : [...allBuildErrors, ...allLintErrors]
+  const allComponentDescriptorErrors = getAllComponentDescriptorErrors(codeEditorErrors)
+  const errorsAndWarnings = skipTsErrors
+    ? [...allLintErrors, ...allComponentDescriptorErrors]
+    : [...allBuildErrors, ...allLintErrors, ...allComponentDescriptorErrors]
   if (minimumSeverity === 'fatal') {
     return errorsAndWarnings.filter((error) => error.severity === 'fatal')
   } else if (minimumSeverity === 'error') {
@@ -3238,6 +3247,12 @@ export function getAllLintErrors(
   codeEditorErrors: EditorStateCodeEditorErrors,
 ): Array<ErrorMessage> {
   return getAllErrorsFromFiles(codeEditorErrors.lintErrors)
+}
+
+export function getAllComponentDescriptorErrors(
+  codeEditorErrors: EditorStateCodeEditorErrors,
+): Array<ErrorMessage> {
+  return getAllErrorsFromFiles(codeEditorErrors.componentDescriptorErrors)
 }
 
 export function getAllErrorsFromFiles(errorsInFiles: ErrorMessages): Array<ErrorMessage> {

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -301,6 +301,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.SET_CODE_EDITOR_BUILD_ERRORS(action, state)
     case 'SET_CODE_EDITOR_LINT_ERRORS':
       return UPDATE_FNS.SET_CODE_EDITOR_LINT_ERRORS(action, state)
+    case 'SET_CODE_EDITOR_COMPONENT_DESCRIPTOR_ERRORS':
+      return UPDATE_FNS.SET_CODE_EDITOR_COMPONENT_DESCRIPTOR_ERRORS(action, state)
     case 'SAVE_DOM_REPORT':
       return UPDATE_FNS.SAVE_DOM_REPORT(action, state, spyCollector)
     case 'TRUE_UP_ELEMENTS':

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -4137,10 +4137,12 @@ export const ErrorMessagesKeepDeepEquality: KeepDeepEqualityCall<ErrorMessages> 
   objectDeepEquality(arrayDeepEquality(ErrorMessageKeepDeepEquality))
 
 export const EditorStateCodeEditorErrorsKeepDeepEquality: KeepDeepEqualityCall<EditorStateCodeEditorErrors> =
-  combine2EqualityCalls(
+  combine3EqualityCalls(
     (errors) => errors.buildErrors,
     ErrorMessagesKeepDeepEquality,
     (errors) => errors.lintErrors,
+    ErrorMessagesKeepDeepEquality,
+    (errors) => errors.componentDescriptorErrors,
     ErrorMessagesKeepDeepEquality,
     editorStateCodeEditorErrors,
   )

--- a/editor/src/components/editor/store/store-hook-substore-helpers.ts
+++ b/editor/src/components/editor/store/store-hook-substore-helpers.ts
@@ -141,6 +141,7 @@ export const EmptyEditorStateForKeysOnly: EditorState = {
   codeEditorErrors: {
     buildErrors: {},
     lintErrors: {},
+    componentDescriptorErrors: {},
   },
   thumbnailLastGenerated: 0,
   pasteTargetsToIgnore: [],

--- a/editor/src/core/model/performance-scripts.tsx
+++ b/editor/src/core/model/performance-scripts.tsx
@@ -111,6 +111,7 @@ async function loadProject(
     codeEditorErrors: {
       buildErrors: {},
       lintErrors: {},
+      componentDescriptorErrors: {},
     },
     fileBrowser: {
       minimised: false,

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -267,7 +267,8 @@ describe('registered property controls', () => {
 
     expect(editorState.codeEditorErrors).toEqual({
       buildErrors: {},
-      lintErrors: {
+      lintErrors: {},
+      componentDescriptorErrors: {
         '/utopia/components.utopia.js': [
           {
             codeSnippet: '',
@@ -277,8 +278,8 @@ describe('registered property controls', () => {
             fileName: '/utopia/components.utopia.js',
             message: "Validation failed: Component registered for key 'Card' is undefined",
             passTime: null,
-            severity: 'fatal',
-            source: 'eslint',
+            severity: 'warning',
+            source: 'component-descriptor',
             startColumn: null,
             startLine: null,
             type: '',
@@ -318,7 +319,8 @@ describe('registered property controls', () => {
 
     expect(editorState.codeEditorErrors).toEqual({
       buildErrors: {},
-      lintErrors: {
+      lintErrors: {},
+      componentDescriptorErrors: {
         '/utopia/components.utopia.js': [
           {
             codeSnippet: '',
@@ -329,8 +331,8 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Component name (Card) does not match the registration key (Cart)',
             passTime: null,
-            severity: 'fatal',
-            source: 'eslint',
+            severity: 'warning',
+            source: 'component-descriptor',
             startColumn: null,
             startLine: null,
             type: '',
@@ -370,7 +372,8 @@ describe('registered property controls', () => {
 
     expect(editorState.codeEditorErrors).toEqual({
       buildErrors: {},
-      lintErrors: {
+      lintErrors: {},
+      componentDescriptorErrors: {
         '/utopia/components.utopia.js': [
           {
             codeSnippet: '',
@@ -381,8 +384,8 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Module name (/src/card) does not match the module key (/src/cardd)',
             passTime: null,
-            severity: 'fatal',
-            source: 'eslint',
+            severity: 'warning',
+            source: 'component-descriptor',
             startColumn: null,
             startLine: null,
             type: '',
@@ -422,7 +425,8 @@ describe('registered property controls', () => {
 
     expect(editorState.codeEditorErrors).toEqual({
       buildErrors: {},
-      lintErrors: {
+      lintErrors: {},
+      componentDescriptorErrors: {
         '/utopia/components.utopia.js': [
           {
             codeSnippet: '',
@@ -433,8 +437,8 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Component name (View) does not match the registration key (Vieww)',
             passTime: null,
-            severity: 'fatal',
-            source: 'eslint',
+            severity: 'warning',
+            source: 'component-descriptor',
             startColumn: null,
             startLine: null,
             type: '',
@@ -474,7 +478,8 @@ describe('registered property controls', () => {
 
     expect(editorState.codeEditorErrors).toEqual({
       buildErrors: {},
-      lintErrors: {
+      lintErrors: {},
+      componentDescriptorErrors: {
         '/utopia/components.utopia.js': [
           {
             codeSnippet: '',
@@ -485,8 +490,8 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Module name (utopia-api) does not match the module key (utopia-apii)',
             passTime: null,
-            severity: 'fatal',
-            source: 'eslint',
+            severity: 'warning',
+            source: 'component-descriptor',
             startColumn: null,
             startLine: null,
             type: '',
@@ -525,7 +530,8 @@ describe('registered property controls', () => {
 
     expect(renderResult.getEditorState().editor.codeEditorErrors).toEqual({
       buildErrors: {},
-      lintErrors: {
+      lintErrors: {},
+      componentDescriptorErrors: {
         '/utopia/components.utopia.js': [
           {
             codeSnippet: '',
@@ -536,8 +542,8 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Component name (Card) does not match the registration key (Cart)',
             passTime: null,
-            severity: 'fatal',
-            source: 'eslint',
+            severity: 'warning',
+            source: 'component-descriptor',
             startColumn: null,
             startLine: null,
             type: '',
@@ -593,7 +599,8 @@ describe('registered property controls', () => {
 
     expect(renderResult.getEditorState().editor.codeEditorErrors).toEqual({
       buildErrors: {},
-      lintErrors: {
+      lintErrors: {},
+      componentDescriptorErrors: {
         '/utopia/components.utopia.js': [],
       },
     })

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -407,7 +407,7 @@ function simpleErrorMessage(fileName: string, error: string): ErrorMessage {
     null,
     null,
     '',
-    'fatal',
+    'warning',
     '',
     error,
     '',

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -72,7 +72,7 @@ import { NO_OP } from '../shared/utils'
 import { createExecutionScope } from '../../components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope'
 import type { EditorDispatch } from '../../components/editor/action-types'
 import {
-  setCodeEditorLintErrors,
+  setCodeEditorComponentDescriptorErrors,
   updatePropertyControlsInfo,
 } from '../../components/editor/actions/action-creators'
 import type { ProjectContentTreeRoot } from '../../components/assets'
@@ -400,7 +400,20 @@ async function getComponentDescriptorPromisesFromParseResult(
 }
 
 function simpleErrorMessage(fileName: string, error: string): ErrorMessage {
-  return errorMessage(fileName, null, null, null, null, '', 'fatal', '', error, '', 'eslint', null)
+  return errorMessage(
+    fileName,
+    null,
+    null,
+    null,
+    null,
+    '',
+    'fatal',
+    '',
+    error,
+    '',
+    'component-descriptor',
+    null,
+  )
 }
 
 function errorsFromComponentRegistration(
@@ -486,7 +499,7 @@ export async function maybeUpdatePropertyControls(
   )
   dispatch([
     updatePropertyControlsInfo(updatedPropertyControlsInfo),
-    setCodeEditorLintErrors(errors),
+    setCodeEditorComponentDescriptorErrors(errors),
   ])
 }
 

--- a/editor/src/core/shared/error-messages.ts
+++ b/editor/src/core/shared/error-messages.ts
@@ -1,6 +1,11 @@
 export type ErrorMessageSeverity = 'fatal' | 'error' | 'warning'
 
-export type ErrorMessageSource = 'eslint' | 'build' | 'utopia-parser' | 'runtime'
+export type ErrorMessageSource =
+  | 'eslint'
+  | 'build'
+  | 'utopia-parser'
+  | 'runtime'
+  | 'component-descriptor'
 
 export interface ErrorMessage {
   fileName: string

--- a/editor/src/core/shared/runtime-report-logs.tsx
+++ b/editor/src/core/shared/runtime-report-logs.tsx
@@ -213,8 +213,15 @@ export function useErrorOverlayRecords(): ErrorOverlayRecords {
   }, [runtimeErrors])
 
   const lintErrors = fatalCodeEditorErrors.filter((e) => e.source === 'eslint')
+  const componentDescriptorErrors = fatalCodeEditorErrors.filter(
+    (e) => e.source === 'component-descriptor',
+  )
   // we start with the lint errors, since those show up the fastest. any subsequent error will go below in the error screen
-  const errorRecords = filterOldPasses([...lintErrors, ...utopiaParserErrors])
+  const errorRecords = filterOldPasses([
+    ...lintErrors,
+    ...utopiaParserErrors,
+    ...componentDescriptorErrors,
+  ])
 
   return { errorRecords, overlayErrors }
 }

--- a/editor/src/test-cases/hydrogen-november.test-utils.ts
+++ b/editor/src/test-cases/hydrogen-november.test-utils.ts
@@ -2,7 +2,7 @@ import type { PersistentModel } from '../components/editor/store/editor-state'
 
 export const HydrogenTestProject: PersistentModel = {
   appID: null,
-  codeEditorErrors: { buildErrors: {}, lintErrors: {} },
+  codeEditorErrors: { buildErrors: {}, lintErrors: {}, componentDescriptorErrors: {} },
   colorSwatches: [],
   dependencyList: { minimised: false },
   exportsInfo: [],

--- a/editor/src/third-party/react-error-overlay/containers/CompileErrorContainer.tsx
+++ b/editor/src/third-party/react-error-overlay/containers/CompileErrorContainer.tsx
@@ -31,7 +31,6 @@ interface CompileErrorContainerProps {
 class CompileErrorContainer extends PureComponent<CompileErrorContainerProps, {}> {
   render() {
     const { currentBuildErrorRecords, editorHandler, onOpenFile } = this.props
-    console.log('currentBuildErrorRecords', currentBuildErrorRecords)
 
     return (
       <ErrorOverlay>

--- a/editor/src/third-party/react-error-overlay/containers/CompileErrorContainer.tsx
+++ b/editor/src/third-party/react-error-overlay/containers/CompileErrorContainer.tsx
@@ -31,6 +31,7 @@ interface CompileErrorContainerProps {
 class CompileErrorContainer extends PureComponent<CompileErrorContainerProps, {}> {
   render() {
     const { currentBuildErrorRecords, editorHandler, onOpenFile } = this.props
+    console.log('currentBuildErrorRecords', currentBuildErrorRecords)
 
     return (
       <ErrorOverlay>


### PR DESCRIPTION
**Problem:**
Component descriptor file errors are registered as eslint errors, even though they are not that.

**Fix:**
- Introduced a new kind of error in `EditorState.codeEditorErrors` called `componentDescriptorErrors`
- Added a new action to set component descriptor errors
- Added these errors to the error overlay
- Introduced a new error source `component-descriptor`
- Modified the errors coming from component descriptor parsing/validation so they contain `component-descriptor` as source
- Changes the error severity of these errors from fatal to warning, so they don't block the canvas from rendering