### PR TITLE
ClosedPanels no longer steal mouse events over invisible area

### DIFF
--- a/editor/src/components/editor/closed-panels.tsx
+++ b/editor/src/components/editor/closed-panels.tsx
@@ -110,8 +110,8 @@ export const ClosedPanels = React.memo((props: { side: 'left' | 'right' }) => {
         onMouseUp={stopPropagation}
         style={{
           gap: 10,
-          height: 300,
           width: 32,
+          pointerEvents: 'initial',
         }}
         onMouseEnter={setIsVisibleTrue}
         onMouseLeave={setIsVisibleFalse}

--- a/editor/src/components/editor/closed-panels.tsx
+++ b/editor/src/components/editor/closed-panels.tsx
@@ -97,7 +97,6 @@ export const ClosedPanels = React.memo((props: { side: 'left' | 'right' }) => {
   return (
     <FlexColumn
       style={{
-        pointerEvents: 'initial',
         alignItems: props.side === 'left' ? 'flex-start' : 'flex-end',
         justifyContent: 'space-between',
         height: '100%',
@@ -113,7 +112,6 @@ export const ClosedPanels = React.memo((props: { side: 'left' | 'right' }) => {
           gap: 10,
           height: 300,
           width: 32,
-          pointerEvents: 'initial',
         }}
         onMouseEnter={setIsVisibleTrue}
         onMouseLeave={setIsVisibleFalse}
@@ -150,6 +148,7 @@ export const ClosedPanels = React.memo((props: { side: 'left' | 'right' }) => {
     </FlexColumn>
   )
 })
+ClosedPanels.displayName = 'ClosedPanels'
 
 interface ClosedPanelButtonProps {
   iconType: string


### PR DESCRIPTION
<img width="740" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/6d7bd398-e08c-440c-9259-a8cf3f59bb29">

**Problem:**
The div containing the closed panel reopen buttons accidentally had pointerEvents set to initial

**Fix:**
<img width="178" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/a85fed60-2b82-4f17-9a64-5a3969d635f3">

Only catch the pointer events in this smaller box