### PR TITLE
EditorCanvas: handle mouse up on window

### DIFF
--- a/editor/src/components/editor/insertmenu.tsx
+++ b/editor/src/components/editor/insertmenu.tsx
@@ -65,6 +65,8 @@ import { usePossiblyResolvedPackageDependencies } from './npm-dependency/npm-dep
 import { useDispatch } from './store/dispatch-context'
 import { Substores, useEditorState } from './store/store-hook'
 
+export const InsertMenuId = 'insert-menu-inspector-tab'
+
 export const InsertMenuFilterTestId = 'insert-menu-filter'
 
 interface InsertMenuProps {
@@ -626,12 +628,18 @@ const InsertMenuInner = React.memo((props: InsertMenuProps) => {
   }
 
   return (
-    <div style={{ height: '100%' }} onMouseLeave={onMouseLeave} onMouseEnter={onMouseEnter}>
+    <div
+      id={InsertMenuId}
+      style={{ height: '100%' }}
+      onMouseLeave={onMouseLeave}
+      onMouseEnter={onMouseEnter}
+    >
       <WindowedSelect
         autoFocus
         key={'insert-menu-select'}
         value={focusedOption}
         inputValue={filter}
+        // eslint-disable-next-line react/jsx-no-bind
         onInputChange={onFilterChange}
         isMulti={false}
         controlShouldRenderValue={false}
@@ -656,6 +664,7 @@ const InsertMenuInner = React.memo((props: InsertMenuProps) => {
     </div>
   )
 })
+InsertMenuInner.displayName = 'InsertMenuInner'
 
 function addPositionAbsoluteToProps(props: JSXAttributes) {
   const styleAttributes = getJSXAttribute(props, 'style') ?? jsExpressionValue({}, emptyComments)

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -104,6 +104,7 @@ import { CursorComponent } from '../components/canvas/controls/select-mode/curso
 import * as ResizeObserverSyntheticDefault from 'resize-observer-polyfill'
 import { isFeatureEnabled } from '../utils/feature-switches'
 import { getCanvasViewportCenter } from './paste-helpers'
+import { InsertMenuId } from '../components/editor/insertmenu'
 const ResizeObserver = ResizeObserverSyntheticDefault.default ?? ResizeObserverSyntheticDefault
 
 const webFrame = PROBABLY_ELECTRON ? requireElectron().webFrame : null
@@ -805,7 +806,8 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
       (event.nativeEvent != null &&
         event.nativeEvent.srcElement != null &&
         (isTargetContextMenu(event.nativeEvent.target as any) ||
-          isTargetInPopup(event.nativeEvent.srcElement as any, this.props.editor.openPopupId))) ||
+          isTargetInPopup(event.nativeEvent.srcElement as any, this.props.editor.openPopupId) ||
+          isTargetInInsertMenu(event.nativeEvent.target as any))) ||
       this.props.editor.modal !== null
     ) {
       return [] // This is a hack implementing a behavior when context menu blocks the UI
@@ -1395,4 +1397,18 @@ function isTargetInPopup(target: HTMLElement, popupId: string | null): boolean {
     const popupElement = document.getElementById(popupId)
     return popupElement != null && popupElement.contains(target)
   }
+}
+
+function isTargetInInsertMenu(target: HTMLElement | null): boolean {
+  /**
+   * this hack is incredibly sad,
+   * the problem is insertmenu.tsx has non-standard mouse handling.
+   * the real solution would be to rewrite the mouse handling code in the insert menu,
+   * but I don't have the time to do it now
+   *
+   * the way I would change the insert menu is to only start the insert mode if the mouse dragged past a threshold instead of immediately starting it,
+   * plus I would also _enter_ insert mode on click similar to how we enter insert mode from the insert TopMenu
+   */
+  const insertMenu = document.getElementById(InsertMenuId)
+  return insertMenu != null && insertMenu.contains(target)
 }

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -1357,9 +1357,14 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
     }
   }
 
+  handleWindowMouseUp = (event: any) => {
+    this.props.dispatch(this.handleMouseUp(event))
+  }
+
   setupWindowListeners() {
     window.addEventListener('mousemove', this.handleMouseMove, { capture: true }) // we use this event in the capture phase because size-box.ts calls stopPropagation() on mouseMove
     window.addEventListener('mouseleave', this.handleMouseLeave)
+    window.addEventListener('mouseup', this.handleWindowMouseUp, { capture: true })
     window.addEventListener('click', this.handleClick)
     window.addEventListener('dblclick', this.handleDoubleClick)
     ;(window as any).addEventListener('paste', this.handlePaste)
@@ -1368,6 +1373,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
   removeEventListeners() {
     window.removeEventListener('mousemove', this.handleMouseMove, { capture: true })
     window.removeEventListener('mouseleave', this.handleMouseLeave)
+    window.removeEventListener('mouseup', this.handleWindowMouseUp, { capture: true })
     window.removeEventListener('click', this.handleClick)
     window.removeEventListener('dblclick', this.handleDoubleClick)
     ;(window as any).removeEventListener('paste', this.handlePaste)


### PR DESCRIPTION
**Problem:**
For some reason, window.mouseUp was not handled by the big event handler code responsible for Canvas Strategies. This would mean that in canvas interactions such as drag-to-resize or draw-to-insert, the mouse up would ONLY work if the mouse up happened on the canvas. 
The Canvas Strategy interaction would remain stuck if you mouse up'd outside the window, or over a UI element which captures pointer events.

**Fix:**
Add mouse up to the list of window global listeners (mouse move was already among the list)