### PR TITLE
Move gtag init code to root

### DIFF
--- a/utopia-remix/app/root.tsx
+++ b/utopia-remix/app/root.tsx
@@ -63,6 +63,23 @@ export default function App() {
         <Links />
       </head>
       <body className={styles.root}>
+        <script async src='https://www.googletagmanager.com/gtag/js?id=G-QM0KPN0RNV'></script>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('consent', 'default', {
+			'ad_storage': 'denied',
+			'analytics_storage': 'denied'
+			});
+			gtag('js', new Date());
+			gtag('config', 'G-QM0KPN0RNV', {
+			page_path: window.location.pathname,
+			});
+		`,
+          }}
+        />
         <AppContext.Provider value={store}>
           <Theme appearance={theme} accentColor='blue' panelBackground='solid'>
             <OutletWrapper />

--- a/utopia-remix/app/routes/_index.tsx
+++ b/utopia-remix/app/routes/_index.tsx
@@ -218,23 +218,6 @@ const IndexPage = React.memo(() => {
         <ContactUs />
       </div>
       <CookieConsentBar />
-      <script async src='https://www.googletagmanager.com/gtag/js?id=G-QM0KPN0RNV'></script>
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `
-			window.dataLayer = window.dataLayer || [];
-			function gtag(){dataLayer.push(arguments);}
-			gtag('consent', 'default', {
-			'ad_storage': 'denied',
-			'analytics_storage': 'denied'
-			});
-			gtag('js', new Date());
-			gtag('config', 'G-QM0KPN0RNV', {
-			page_path: window.location.pathname,
-			});
-		`,
-        }}
-      />
     </div>
   )
 })


### PR DESCRIPTION
**Problem:**
Trying to load the root page (i.e `utopia.app` or `utopia.pizza`) and consent to cookies breaks this page forever

**Fix:**
Fix the `gtag` initialization code as per Remix's recommendation:
https://github.com/remix-run/examples/blob/main/google-analytics/app/root.tsx
