### PR TITLE
Duplicated UID Error Message Improvements

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -824,7 +824,7 @@ function applyProjectChangesToEditor(
 }
 
 export const UTOPIA_DUPLICATE_UID_ERROR_MESSAGE = (dispatchedActions: string) =>
-  `A dispatched action resulted in dupliacted UIDs. Suspicious actions: ${dispatchedActions}`
+  `A dispatched action resulted in duplicated UIDs. Suspicious actions: ${dispatchedActions}`
 function editorDispatchInner(
   boundDispatch: EditorDispatch,
   dispatchedActions: EditorAction[],

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -824,7 +824,7 @@ function applyProjectChangesToEditor(
 }
 
 export const UTOPIA_DUPLICATE_UID_ERROR_MESSAGE = (dispatchedActions: string) =>
-  `Utopia internal error: a dispatched action resulted in dupliacted UIDs. Suspicious actions: ${dispatchedActions}`
+  `A dispatched action resulted in dupliacted UIDs. Suspicious actions: ${dispatchedActions}`
 function editorDispatchInner(
   boundDispatch: EditorDispatch,
   dispatchedActions: EditorAction[],
@@ -943,7 +943,7 @@ function editorDispatchInner(
       // When running in the browser log the error and tell the user to restart the editor.
       console.error(errorMessage)
       const errorToast = EditorActions.addToast(
-        notice(UTOPIA_DUPLICATE_UID_ERROR_MESSAGE(actionNames), 'ERROR', true, 'reload-editor'),
+        notice(UTOPIA_DUPLICATE_UID_ERROR_MESSAGE(actionNames), 'ERROR', false),
       )
       result = {
         ...result,

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -823,7 +823,8 @@ function applyProjectChangesToEditor(
   }
 }
 
-export const UTOPIA_IRRECOVERABLE_ERROR_MESSAGE = `Utopia has suffered from an irrecoverable error, please reload the editor.`
+export const UTOPIA_DUPLICATE_UID_ERROR_MESSAGE = (dispatchedActions: string) =>
+  `Utopia internal error: a dispatched action resulted in dupliacted UIDs. Suspicious actions: ${dispatchedActions}`
 function editorDispatchInner(
   boundDispatch: EditorDispatch,
   dispatchedActions: EditorAction[],
@@ -942,7 +943,7 @@ function editorDispatchInner(
       // When running in the browser log the error and tell the user to restart the editor.
       console.error(errorMessage)
       const errorToast = EditorActions.addToast(
-        notice(UTOPIA_IRRECOVERABLE_ERROR_MESSAGE, 'ERROR', true, 'reload-editor'),
+        notice(UTOPIA_DUPLICATE_UID_ERROR_MESSAGE(actionNames), 'ERROR', true, 'reload-editor'),
       )
       result = {
         ...result,


### PR DESCRIPTION
**Problem:**
<img width="460" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/9c5a74f2-6a47-4d85-bf84-11aef597b6be">
The duplicate UID error message is cryptic, and it persists on the screen even after the project no longer has duplicated UIDs. This makes it hard to turn this into an actionable bug report.

**Context:**
If we can detect that there is a duplicated UID, we _could_ also run code that fixes the UIDs. 
The reason we don't do that today is that it may lead to selection loss, and also it is a performance-costly and memory intensive operation. So we definitely don't want this to be a silent problem with a silent self-healing mechanism because that would lead to silently degraded editor performance.

**Proposal:**
1. try to run an automatic UID fix mitigation, as a fallback, to increase the editor's resilience.
2. Ultimately our goal should be to not have to run the mitigation and instead make sure the actions themselves are not emitting code with duplicated UIDs.

**This PR:**
As a first step, I'd make the error message clearer, and contain the offending action names so we can create bug reports and repro cases. Although this is more noisy in the short term, I hope that in a few days this should weed out a complete list of the problematic actions that have been plaguing us recently:
<img width="386" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/1a0a3db2-5652-482b-a93a-1a22d2ff679f"> 
To reduce noise a bit, I turned these toasts into non-sticky, meaning they disappear after a few seconds.