### PR TITLE
Show better error message for evaluation errors

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -325,9 +325,9 @@ describe('registered property controls', () => {
         '/utopia/components.utopia.js': [
           {
             codeSnippet: `  1 | import { Cart } from '../src/card'
-  2 |
+  2 | 
 > 3 | const foo = undefined.foo
-                               ^
+                            ^
   4 | const Components = {
   5 |   '/src/card': {
   6 |     Card: {`,

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -278,10 +278,70 @@ describe('registered property controls', () => {
             fileName: '/utopia/components.utopia.js',
             message: "Validation failed: Component registered for key 'Card' is undefined",
             passTime: null,
-            severity: 'warning',
+            severity: 'fatal',
             source: 'component-descriptor',
             startColumn: null,
             startLine: null,
+            type: '',
+          },
+        ],
+      },
+    })
+
+    const srcCardKey = Object.keys(renderResult.getEditorState().editor.propertyControlsInfo).find(
+      (key) => key === '/src/card',
+    )
+
+    expect(srcCardKey).toBeUndefined()
+  })
+  it('control registration fails when there is an evaluation error', async () => {
+    const renderResult = await renderTestEditorWithModel(
+      project({
+        ['/utopia/components.utopia.js']: `import { Cart } from '../src/card'
+        
+        const foo = undefined.foo
+        const Components = {
+      '/src/card': {
+        Card: {
+          component: Card,
+          supportsChildren: false,
+          properties: { },
+          variants: [ ],
+        },
+      },
+    }
+    
+    export default Components
+  `,
+      }),
+      'await-first-dom-report',
+    )
+    const editorState = renderResult.getEditorState().editor
+
+    expect(editorState.codeEditorErrors).toEqual({
+      buildErrors: {},
+      lintErrors: {},
+      componentDescriptorErrors: {
+        '/utopia/components.utopia.js': [
+          {
+            codeSnippet: `  1 | import { Cart } from '../src/card'
+  2 |
+> 3 | const foo = undefined.foo
+                               ^
+  4 | const Components = {
+  5 |   '/src/card': {
+  6 |     Card: {`,
+            endColumn: null,
+            endLine: null,
+            errorCode: '',
+            fileName: '/utopia/components.utopia.js',
+            message:
+              "Components file evaluation error: TypeError: Cannot read properties of undefined (reading 'foo')",
+            passTime: null,
+            severity: 'fatal',
+            source: 'component-descriptor',
+            startColumn: 25,
+            startLine: 4,
             type: '',
           },
         ],
@@ -331,7 +391,7 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Component name (Card) does not match the registration key (Cart)',
             passTime: null,
-            severity: 'warning',
+            severity: 'fatal',
             source: 'component-descriptor',
             startColumn: null,
             startLine: null,
@@ -384,7 +444,7 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Module name (/src/card) does not match the module key (/src/cardd)',
             passTime: null,
-            severity: 'warning',
+            severity: 'fatal',
             source: 'component-descriptor',
             startColumn: null,
             startLine: null,
@@ -437,7 +497,7 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Component name (View) does not match the registration key (Vieww)',
             passTime: null,
-            severity: 'warning',
+            severity: 'fatal',
             source: 'component-descriptor',
             startColumn: null,
             startLine: null,
@@ -490,7 +550,7 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Module name (utopia-api) does not match the module key (utopia-apii)',
             passTime: null,
-            severity: 'warning',
+            severity: 'fatal',
             source: 'component-descriptor',
             startColumn: null,
             startLine: null,
@@ -542,7 +602,7 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Component name (Card) does not match the registration key (Cart)',
             passTime: null,
-            severity: 'warning',
+            severity: 'fatal',
             source: 'component-descriptor',
             startColumn: null,
             startLine: null,

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -920,7 +920,7 @@ function printScriptLines(scriptLines: Array<ScriptLine>, columnNumber: number |
         // so we can highlight the actual column with a ^
         let extraLine = ''
         if (c.highlight && columnNumber != null) {
-          extraLine = `\n${Array(columnNumber + maxLineNumberLength + 5)
+          extraLine = `\n${Array(columnNumber + maxLineNumberLength + 2)
             .fill(' ')
             .join('')}^`
         }

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -409,7 +409,7 @@ function simpleErrorMessage(fileName: string, error: string): ErrorMessage {
     null,
     null,
     '',
-    'warning',
+    'fatal',
     '',
     error,
     '',
@@ -432,9 +432,9 @@ function errorsFromComponentRegistration(
       case 'evaluation-error':
         if ((error.evaluationError as FancyError).hasOwnProperty('stackFrames')) {
           const fancyError = error.evaluationError as FancyError
-          const errorFromFancyError = fancyErrorToErrorMessage(fancyError)
-          if (errorFromFancyError != null) {
-            return errorFromFancyError
+          const errorMsgFromFancyError = fancyErrorToErrorMessage(fancyError)
+          if (errorMsgFromFancyError != null) {
+            return errorMsgFromFancyError
           }
         }
         return [
@@ -892,7 +892,7 @@ function fancyErrorToErrorMessage(error: FancyError): ErrorMessage | null {
       null,
       null,
       code,
-      'warning',
+      'fatal',
       '',
       `Components file evaluation error: ${error}`,
       '',

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -80,6 +80,8 @@ import { isIntrinsicHTMLElement } from '../shared/element-template'
 import type { ErrorMessage } from '../shared/error-messages'
 import { errorMessage } from '../shared/error-messages'
 import { dropFileExtension } from '../shared/file-utils'
+import type { FancyError } from '../shared/code-exec-utils'
+import type { ScriptLine } from '../../third-party/react-error-overlay/utils/stack-frame'
 
 async function parseInsertOption(
   insertOption: ComponentInsertOption,
@@ -428,6 +430,13 @@ function errorsFromComponentRegistration(
       case 'file-parse-failure':
         return error.parseErrorMessages
       case 'evaluation-error':
+        if ((error.evaluationError as FancyError).hasOwnProperty('stackFrames')) {
+          const fancyError = error.evaluationError as FancyError
+          const errorFromFancyError = fancyErrorToErrorMessage(fancyError)
+          if (errorFromFancyError != null) {
+            return errorFromFancyError
+          }
+        }
         return [
           simpleErrorMessage(
             fileName,
@@ -870,4 +879,55 @@ export function getThirdPartyControlsIntrinsic(
     return propertyControlsInfo[foundPackageWithElement]?.[elementName]?.properties
   }
   return null
+}
+
+function fancyErrorToErrorMessage(error: FancyError): ErrorMessage | null {
+  const frames = error.stackFrames
+  if (frames != null && frames.length > 0) {
+    const code = printScriptLines(frames[0]._originalScriptCode ?? [], frames[0].columnNumber)
+    return errorMessage(
+      frames[0]._originalFileName ?? '',
+      frames[0].lineNumber,
+      frames[0].columnNumber,
+      null,
+      null,
+      code,
+      'warning',
+      '',
+      `Components file evaluation error: ${error}`,
+      '',
+      'component-descriptor',
+      null,
+    )
+  }
+  return null
+}
+
+function printScriptLines(scriptLines: Array<ScriptLine>, columnNumber: number | null): string {
+  const maxLineNumberLength = Math.max(...scriptLines.map((c) => c.lineNumber.toString().length))
+  const printedCode =
+    scriptLines
+      .map((c) => {
+        const prefix = c.highlight ? `> ` : '  '
+
+        // we need to have the same length for all line numbers
+        const lineNumberStr =
+          c.lineNumber.toString().length < maxLineNumberLength
+            ? ` ${c.lineNumber.toString()}`
+            : c.lineNumber.toString()
+
+        // an extra line is added to after the highlighted line when we have a column number,
+        // so we can highlight the actual column with a ^
+        let extraLine = ''
+        if (c.highlight && columnNumber != null) {
+          extraLine = `\n${Array(columnNumber - 1)
+            .fill(' ')
+            .join('')}^`
+        }
+
+        return `${prefix}${lineNumberStr} | ${c.content}${extraLine}`
+      })
+      .join('\n') ?? ''
+
+  return printedCode
 }

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -920,7 +920,7 @@ function printScriptLines(scriptLines: Array<ScriptLine>, columnNumber: number |
         // so we can highlight the actual column with a ^
         let extraLine = ''
         if (c.highlight && columnNumber != null) {
-          extraLine = `\n${Array(columnNumber - 1)
+          extraLine = `\n${Array(columnNumber + maxLineNumberLength + 5)
             .fill(' ')
             .join('')}^`
         }


### PR DESCRIPTION
**Problem:**
Make better error message for component descriptor file evaluation errors.

**Fix:**
Evaluation produces `FancyError`s, and we don't have yet a conversion from `FancyError`s to `ErrorMessage`s, so I implemented a simple one.

Before:

<img width="1138" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/849650fa-42fe-47be-aa6b-b0b8681fb48c">

After:

<img width="1324" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/a453e793-587b-4dce-9126-0ed4896a1235">

