### PR TITLE
Fix auth url in all environments

### DIFF
--- a/utopia-remix/app/routes-test/login.spec.ts
+++ b/utopia-remix/app/routes-test/login.spec.ts
@@ -1,6 +1,7 @@
 import { newTestRequest } from '../test-util'
 import { handleLogin } from '../routes/login'
 import { ServerEnvironment } from '../env.server'
+import { authenticateUrl } from '../util/auth0.server'
 
 describe('handleLogin', () => {
   it('should redirect to auth0 login with the correct redirectTo param', async () => {
@@ -37,7 +38,7 @@ describe('handleLogin', () => {
     const response = await handleLogin(request, {})
     expect(response.status).toBe(302)
     const redirectLocation = response.headers.get('Location')
-    expect(redirectLocation).toContain(`${ServerEnvironment.CORS_ORIGIN}/authenticate`)
+    expect(redirectLocation).toContain(authenticateUrl())
     const redirectToParam = getDecodedParam(redirectLocation, 'redirectTo')
     expect(redirectToParam).toBe('/p/test-project')
     const codeParam = getDecodedParam(redirectLocation, 'code')

--- a/utopia-remix/app/routes-test/login.spec.ts
+++ b/utopia-remix/app/routes-test/login.spec.ts
@@ -38,7 +38,7 @@ describe('handleLogin', () => {
     const response = await handleLogin(request, {})
     expect(response.status).toBe(302)
     const redirectLocation = response.headers.get('Location')
-    expect(redirectLocation).toContain(authenticateUrl())
+    expect(redirectLocation).toContain(authenticateUrl().toString())
     const redirectToParam = getDecodedParam(redirectLocation, 'redirectTo')
     expect(redirectToParam).toBe('/p/test-project')
     const codeParam = getDecodedParam(redirectLocation, 'code')

--- a/utopia-remix/app/routes-test/p._index.spec.ts
+++ b/utopia-remix/app/routes-test/p._index.spec.ts
@@ -79,7 +79,7 @@ describe('handleEditorWithLogin', () => {
       const redirectResponse = err as Response
       expect(redirectResponse.status).toBe(302)
       const redirectLocation = redirectResponse.headers.get('Location')
-      expect(redirectLocation).toContain(authenticateUrl())
+      expect(redirectLocation).toContain(authenticateUrl().toString())
       const redirectToParam = getDecodedParam(redirectLocation, 'redirectTo')
       const expectedRedirectUrl = new URL(request.url)
       expectedRedirectUrl.searchParams.delete('fakeUser')

--- a/utopia-remix/app/routes-test/p._index.spec.ts
+++ b/utopia-remix/app/routes-test/p._index.spec.ts
@@ -3,6 +3,7 @@ import { prisma } from '../db.server'
 import { createTestSession, createTestUser, newTestRequest, truncateTables } from '../test-util'
 import { loader as p_loader } from '../routes/p._index'
 import { ServerEnvironment } from '../env.server'
+import { authenticateUrl } from '../util/auth0.server'
 import * as serverProxy from '../util/proxy.server'
 
 describe('handleEditorWithLogin', () => {
@@ -78,7 +79,7 @@ describe('handleEditorWithLogin', () => {
       const redirectResponse = err as Response
       expect(redirectResponse.status).toBe(302)
       const redirectLocation = redirectResponse.headers.get('Location')
-      expect(redirectLocation).toContain(`${ServerEnvironment.CORS_ORIGIN}/authenticate`)
+      expect(redirectLocation).toContain(authenticateUrl())
       const redirectToParam = getDecodedParam(redirectLocation, 'redirectTo')
       const expectedRedirectUrl = new URL(request.url)
       expectedRedirectUrl.searchParams.delete('fakeUser')

--- a/utopia-remix/app/util/auth0.server.ts
+++ b/utopia-remix/app/util/auth0.server.ts
@@ -8,7 +8,7 @@ export function auth0LoginURL({
   const behaviour: 'auto-close' | 'authd-redirect' = 'authd-redirect'
 
   if (fakeUser != null) {
-    const url = new URL(urlJoin(ServerEnvironment.CORS_ORIGIN, 'authenticate'))
+    const url = authenticateUrl()
     url.searchParams.set('code', fakeUser)
     url.searchParams.set('onto', behaviour)
     if (redirectTo != null) {
@@ -25,7 +25,7 @@ export function auth0LoginURL({
     console.warn(
       'Auth0 is disabled, if you need it be sure to set the AUTH0_ENDPOINT, AUTH0_CLIENT_ID, AUTH0_REDIRECT_URI environment variables',
     )
-    const url = new URL(urlJoin(ServerEnvironment.CORS_ORIGIN, 'authenticate'))
+    const url = authenticateUrl()
     url.searchParams.set('code', 'logmein')
     url.searchParams.set('onto', behaviour)
     if (redirectTo != null) {
@@ -47,4 +47,10 @@ export function auth0LoginURL({
 
   url.searchParams.set('redirect_uri', redirectURL.href)
   return url.href
+}
+
+export function authenticateUrl(): URL {
+  return new URL(
+    ServerEnvironment.AUTH0_ENDPOINT || urlJoin(ServerEnvironment.CORS_ORIGIN, 'authenticate'),
+  )
 }

--- a/utopia-remix/app/util/auth0.server.ts
+++ b/utopia-remix/app/util/auth0.server.ts
@@ -51,6 +51,6 @@ export function auth0LoginURL({
 
 export function authenticateUrl(): URL {
   return new URL(
-    ServerEnvironment.AUTH0_ENDPOINT || urlJoin(ServerEnvironment.CORS_ORIGIN, 'authenticate'),
+    ServerEnvironment.AUTH0_REDIRECT_URI || urlJoin(ServerEnvironment.CORS_ORIGIN, 'authenticate'),
   )
 }

--- a/utopia-remix/app/util/auth0.server.ts
+++ b/utopia-remix/app/util/auth0.server.ts
@@ -9,6 +9,7 @@ export function auth0LoginURL({
 
   if (fakeUser != null) {
     const url = authenticateUrl()
+    console.info('Authenticating with fake user:', fakeUser, url.toString())
     url.searchParams.set('code', fakeUser)
     url.searchParams.set('onto', behaviour)
     if (redirectTo != null) {


### PR DESCRIPTION
**Problem:**
In our servers (`.pizza`, `.app`) the env var `CORS_ORIGIN` is a comma-delimited list, which makes it unusable for generating a URL.
<img width="388" alt="image" src="https://github.com/concrete-utopia/utopia/assets/7003853/3ca806d6-6495-41f8-96d0-dc0a636c944b">

**Fix:**
We can use `AUTH0_REDIRECT_URI` and fallback for `CORS_ORIGIN`