### PR TITLE
Change redirect URL to relative

### DIFF
--- a/utopia-remix/app/routes-test/p._index.spec.ts
+++ b/utopia-remix/app/routes-test/p._index.spec.ts
@@ -49,7 +49,7 @@ describe('handleEditorWithLogin', () => {
       expect(redirectResponse.status).toBe(302)
       const redirectLocation = redirectResponse.headers.get('Location')
       const redirectToParam = getParamFromLoginURL(redirectLocation ?? '', 'redirectTo')
-      expect(redirectToParam).toBe(request.url)
+      expect(redirectToParam).toBe(toRelative(request.url))
     }
     expect(response).toBeUndefined()
   })
@@ -82,7 +82,7 @@ describe('handleEditorWithLogin', () => {
       const redirectToParam = getDecodedParam(redirectLocation, 'redirectTo')
       const expectedRedirectUrl = new URL(request.url)
       expectedRedirectUrl.searchParams.delete('fakeUser')
-      expect(redirectToParam).toBe(expectedRedirectUrl.toString())
+      expect(redirectToParam).toBe(toRelative(expectedRedirectUrl.toString()))
       const codeParam = getDecodedParam(redirectLocation, 'code')
       expect(codeParam).toBe('alice')
     }
@@ -100,4 +100,9 @@ function getParamFromLoginURL(url: string, param: string): string | null {
 function getDecodedParam(url: string | null, param: string): string | null {
   const value = new URL(url ?? '').searchParams.get(param)
   return value ? decodeURIComponent(value) : null
+}
+
+function toRelative(url: string): string {
+  const urlObj = new URL(url)
+  return urlObj.href.replace(urlObj.origin, '')
 }

--- a/utopia-remix/app/routes-test/p._index.spec.ts
+++ b/utopia-remix/app/routes-test/p._index.spec.ts
@@ -4,6 +4,7 @@ import { createTestSession, createTestUser, newTestRequest, truncateTables } fro
 import { loader as p_loader } from '../routes/p._index'
 import { ServerEnvironment } from '../env.server'
 import * as serverProxy from '../util/proxy.server'
+import { urlToRelative } from '../util/common'
 
 describe('handleEditorWithLogin', () => {
   let pageProxy: jest.SpyInstance
@@ -49,7 +50,7 @@ describe('handleEditorWithLogin', () => {
       expect(redirectResponse.status).toBe(302)
       const redirectLocation = redirectResponse.headers.get('Location')
       const redirectToParam = getParamFromLoginURL(redirectLocation ?? '', 'redirectTo')
-      expect(redirectToParam).toBe(toRelative(request.url))
+      expect(redirectToParam).toBe(urlToRelative(request.url))
     }
     expect(response).toBeUndefined()
   })
@@ -82,7 +83,7 @@ describe('handleEditorWithLogin', () => {
       const redirectToParam = getDecodedParam(redirectLocation, 'redirectTo')
       const expectedRedirectUrl = new URL(request.url)
       expectedRedirectUrl.searchParams.delete('fakeUser')
-      expect(redirectToParam).toBe(toRelative(expectedRedirectUrl.toString()))
+      expect(redirectToParam).toBe(urlToRelative(expectedRedirectUrl.toString()))
       const codeParam = getDecodedParam(redirectLocation, 'code')
       expect(codeParam).toBe('alice')
     }
@@ -100,9 +101,4 @@ function getParamFromLoginURL(url: string, param: string): string | null {
 function getDecodedParam(url: string | null, param: string): string | null {
   const value = new URL(url ?? '').searchParams.get(param)
   return value ? decodeURIComponent(value) : null
-}
-
-function toRelative(url: string): string {
-  const urlObj = new URL(url)
-  return urlObj.href.replace(urlObj.origin, '')
 }

--- a/utopia-remix/app/util/api.server.ts
+++ b/utopia-remix/app/util/api.server.ts
@@ -12,6 +12,7 @@ import { Status } from './statusCodes'
 import { ServerEnvironment } from '../env.server'
 import { maybeGetUserFromSession } from '../models/session.server'
 import { auth0LoginURL } from './auth0.server'
+import { urlToRelative } from './common'
 
 interface ErrorResponse {
   error: string
@@ -214,7 +215,7 @@ export async function requireUserOrRedirectToLogin(request: Request): Promise<Us
   return await requireUser(request, {
     redirect: auth0LoginURL({
       // send relative urls as our servers sometime redirect internally to different domains
-      redirectTo: url.href.replace(url.origin, ''),
+      redirectTo: urlToRelative(url.toString()),
       fakeUser: fakeUser,
     }),
   })

--- a/utopia-remix/app/util/api.server.ts
+++ b/utopia-remix/app/util/api.server.ts
@@ -213,7 +213,8 @@ export async function requireUserOrRedirectToLogin(request: Request): Promise<Us
 
   return await requireUser(request, {
     redirect: auth0LoginURL({
-      redirectTo: url.toString(),
+      // send relative urls as our servers sometime redirect internally to different domains
+      redirectTo: url.href.replace(url.origin, ''),
       fakeUser: fakeUser,
     }),
   })

--- a/utopia-remix/app/util/common.spec.ts
+++ b/utopia-remix/app/util/common.spec.ts
@@ -1,0 +1,8 @@
+import { urlToRelative } from './common'
+
+describe('urlToRelative', () => {
+  it('should return the relative path of a URL', () => {
+    const url = 'https://example.com:8080/some/path#hash?query=string'
+    expect(urlToRelative(url)).toBe('/some/path#hash?query=string')
+  })
+})

--- a/utopia-remix/app/util/common.ts
+++ b/utopia-remix/app/util/common.ts
@@ -24,3 +24,8 @@ export function mapArrayToDictionary<From, Values, Keys extends string | number>
     },
   )
 }
+
+export function urlToRelative(url: string): string {
+  const parsed = new URL(url)
+  return parsed.href.replace(parsed.origin, '')
+}


### PR DESCRIPTION
**Problem:**
`utopia.pizza` is actually redirected internally to `staging-utopia-remix-c1c8fa15569f.herokuapp.com`.
so what happens is:
- A test calls `utopia.pizza/p?fakeUser=alice`
- The handler logs in as "alice" on `utopia.pizza` , as it should
- However our route handler actually gets the `staging-utopia-...` as the url that was called, so after the log in it redirects to `staging-utopia-.../p`.
- On `staging-utopia....` no user is logged in, so the login screen pops again

**Fix:**
On these cases, all login redirects that use `request.url` will now strip the origin, so the redirect will always be relative