### PR TITLE
(fix) add no cache to login redirects

### DIFF
--- a/utopia-remix/app/util/api.server.ts
+++ b/utopia-remix/app/util/api.server.ts
@@ -200,7 +200,9 @@ export async function requireUser(
   } catch (error) {
     if (error instanceof ApiError && error.status === Status.UNAUTHORIZED) {
       if (options?.redirect != null) {
-        throw redirect(options.redirect)
+        throw redirect(options.redirect, {
+          headers: { 'cache-control': 'no-cache' },
+        })
       }
     }
     throw error


### PR DESCRIPTION
**Problem:**
login redirects get caught in cloudfront cache

**Fix:**
add  `'cache-control': 'no-cache'` header
