### PR TITLE
Component API - Navigator/Inspector configuration

### DIFF
--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -130,10 +130,20 @@ export interface ComponentDescriptor {
   preferredChildComponents: Array<PreferredChildComponentDescriptor>
   variants: ComponentInfo[]
   source: ComponentDescriptorSource
-  focus?: Focus
-  inspector?: InspectorSpec
-  emphasis?: Emphasis
-  icon?: Icon
+  focus: Focus
+  inspector: InspectorSpec
+  emphasis: Emphasis
+  icon: Icon
+}
+
+export const ComponentDescriptorDefaults: Pick<
+  ComponentDescriptor,
+  'focus' | 'inspector' | 'emphasis' | 'icon'
+> = {
+  focus: 'default',
+  inspector: 'all',
+  emphasis: 'regular',
+  icon: 'regular',
 }
 
 export function componentDescriptor(
@@ -142,10 +152,10 @@ export function componentDescriptor(
   variants: Array<ComponentInfo>,
   preferredChildComponents: Array<PreferredChildComponentDescriptor>,
   source: ComponentDescriptorSource,
-  focus: Focus | undefined,
-  inspector: InspectorSpec | undefined,
-  emphasis: Emphasis | undefined,
-  icon: Icon | undefined,
+  focus: Focus,
+  inspector: InspectorSpec,
+  emphasis: Emphasis,
+  icon: Icon,
 ): ComponentDescriptor {
   return {
     properties: properties,

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -49,6 +49,7 @@ import type {
 import type { ProjectContentTreeRoot } from '../assets'
 import { getProjectFileByFilePath } from '../assets'
 import type { EditorDispatch } from '../editor/action-types'
+import type { Emphasis, Focus, Icon, InspectorSpec } from 'utopia-api'
 
 type ModuleExportTypes = { [name: string]: ExportType }
 
@@ -129,6 +130,10 @@ export interface ComponentDescriptor {
   preferredChildComponents: Array<PreferredChildComponentDescriptor>
   variants: ComponentInfo[]
   source: ComponentDescriptorSource
+  focus?: Focus
+  inspector?: InspectorSpec
+  emphasis?: Emphasis
+  icon?: Icon
 }
 
 export function componentDescriptor(
@@ -137,6 +142,10 @@ export function componentDescriptor(
   variants: Array<ComponentInfo>,
   preferredChildComponents: Array<PreferredChildComponentDescriptor>,
   source: ComponentDescriptorSource,
+  focus: Focus | undefined,
+  inspector: InspectorSpec | undefined,
+  emphasis: Emphasis | undefined,
+  icon: Icon | undefined,
 ): ComponentDescriptor {
   return {
     properties: properties,
@@ -144,6 +153,10 @@ export function componentDescriptor(
     variants: variants,
     preferredChildComponents: preferredChildComponents,
     source: source,
+    focus: focus,
+    inspector: inspector,
+    emphasis: emphasis,
+    icon: icon,
   }
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -78,7 +78,7 @@ import {
   exportType,
   singleFileBuildResult,
 } from '../../../core/workers/common/worker-types'
-import type { Sides, Focus, Styling, Emphasis, Icon } from 'utopia-api/core'
+import type { Sides, Focus, Styling, Emphasis, Icon, InspectorSpec } from 'utopia-api/core'
 import type {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
@@ -3337,6 +3337,18 @@ export function ComponentDescriptorSourceKeepDeepEquality(): KeepDeepEqualityCal
   }
 }
 
+const InspectorSpecKeepDeepEquality: KeepDeepEqualityCall<InspectorSpec> = (oldValue, newValue) => {
+  if (typeof oldValue === 'string' && typeof newValue === 'string') {
+    return StringKeepDeepEquality(oldValue, newValue) as KeepDeepEqualityResult<InspectorSpec>
+  }
+
+  if (Array.isArray(oldValue) && Array.isArray(newValue)) {
+    return arrayDeepEquality(createCallWithTripleEquals<Styling>())(oldValue, newValue)
+  }
+
+  return { value: newValue, areEqual: false }
+}
+
 export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<ComponentDescriptor> =
   combine9EqualityCalls(
     (descriptor) => descriptor.properties,
@@ -3352,7 +3364,7 @@ export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<Component
     (descriptor) => descriptor.focus,
     undefinableDeepEquality(createCallWithTripleEquals<Focus>()),
     (descriptor) => descriptor.inspector,
-    undefinableDeepEquality(arrayDeepEquality(createCallWithTripleEquals<Styling>())),
+    undefinableDeepEquality(InspectorSpecKeepDeepEquality),
     (descriptor) => descriptor.emphasis,
     undefinableDeepEquality(createCallWithTripleEquals<Emphasis>()),
     (descriptor) => descriptor.icon,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3364,13 +3364,13 @@ export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<Component
     (descriptor) => descriptor.source,
     ComponentDescriptorSourceKeepDeepEquality(),
     (descriptor) => descriptor.focus,
-    undefinableDeepEquality(createCallWithTripleEquals<Focus>()),
+    createCallWithTripleEquals<Focus>(),
     (descriptor) => descriptor.inspector,
-    undefinableDeepEquality(InspectorSpecKeepDeepEquality),
+    InspectorSpecKeepDeepEquality,
     (descriptor) => descriptor.emphasis,
-    undefinableDeepEquality(createCallWithTripleEquals<Emphasis>()),
+    createCallWithTripleEquals<Emphasis>(),
     (descriptor) => descriptor.icon,
-    undefinableDeepEquality(createCallWithTripleEquals<Icon>()),
+    createCallWithTripleEquals<Icon>(),
     componentDescriptor,
   )
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -78,7 +78,7 @@ import {
   exportType,
   singleFileBuildResult,
 } from '../../../core/workers/common/worker-types'
-import type { PreferredChildComponent, Sides } from 'utopia-api/core'
+import type { Sides, Focus, Styling, Emphasis, Icon } from 'utopia-api/core'
 import type {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
@@ -3338,7 +3338,7 @@ export function ComponentDescriptorSourceKeepDeepEquality(): KeepDeepEqualityCal
 }
 
 export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<ComponentDescriptor> =
-  combine5EqualityCalls(
+  combine9EqualityCalls(
     (descriptor) => descriptor.properties,
     PropertyControlsKeepDeepEquality,
     (descriptor) => descriptor.supportsChildren,
@@ -3349,6 +3349,14 @@ export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<Component
     arrayDeepEquality(PreferredChildComponentDescriptorKeepDeepEquality),
     (descriptor) => descriptor.source,
     ComponentDescriptorSourceKeepDeepEquality(),
+    (descriptor) => descriptor.focus,
+    undefinableDeepEquality(createCallWithTripleEquals<Focus>()),
+    (descriptor) => descriptor.inspector,
+    undefinableDeepEquality(arrayDeepEquality(createCallWithTripleEquals<Styling>())),
+    (descriptor) => descriptor.emphasis,
+    undefinableDeepEquality(createCallWithTripleEquals<Emphasis>()),
+    (descriptor) => descriptor.icon,
+    undefinableDeepEquality(createCallWithTripleEquals<Icon>()),
     componentDescriptor,
   )
 

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -34,7 +34,10 @@ import {
 } from '../../../core/shared/element-template'
 import type { PropertyControls } from '../../custom-code/internal-property-controls'
 import { emptyProjectServerState } from '../../editor/store/project-server-state'
-import { defaultComponentDescriptor } from '../../custom-code/code-file'
+import {
+  ComponentDescriptorDefaults,
+  defaultComponentDescriptor,
+} from '../../custom-code/code-file'
 
 const TestAppUID2 = 'app-entity-2'
 const TestOtherComponentUID = 'other-component-entity-1'
@@ -195,6 +198,7 @@ function callPropertyControlsHook(
             },
           ],
           source: defaultComponentDescriptor(),
+          ...ComponentDescriptorDefaults,
         },
         OtherComponent: {
           properties: propertyControlsForOtherComponent,
@@ -208,6 +212,7 @@ function callPropertyControlsHook(
             },
           ],
           source: defaultComponentDescriptor(),
+          ...ComponentDescriptorDefaults,
         },
       },
     },

--- a/editor/src/components/shared/project-components.spec.ts
+++ b/editor/src/components/shared/project-components.spec.ts
@@ -5,7 +5,11 @@ import type {
 import { resolvedNpmDependency } from '../../core/shared/npm-dependency-types'
 import { DefaultThirdPartyControlDefinitions } from '../../core/third-party/third-party-controls'
 import { simpleDefaultProjectPreParsed } from '../../sample-projects/sample-project-utils.test-utils'
-import { defaultComponentDescriptor, type PropertyControlsInfo } from '../custom-code/code-file'
+import {
+  ComponentDescriptorDefaults,
+  defaultComponentDescriptor,
+  type PropertyControlsInfo,
+} from '../custom-code/code-file'
 import {
   clearInsertableComponentGroupUniqueIDs,
   getComponentGroups,
@@ -51,6 +55,7 @@ describe('getComponentGroups', () => {
           preferredChildComponents: [],
           variants: [],
           source: defaultComponentDescriptor(),
+          ...ComponentDescriptorDefaults,
         },
       },
     }
@@ -77,6 +82,7 @@ describe('getDependencyStatus', () => {
           preferredChildComponents: [],
           variants: [],
           source: defaultComponentDescriptor(),
+          ...ComponentDescriptorDefaults,
         },
       },
     }

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -42,6 +42,7 @@ import type {
   ComponentInfo,
 } from '../custom-code/code-file'
 import {
+  ComponentDescriptorDefaults,
   clearComponentElementToInsertUniqueIDs,
   defaultComponentDescriptor,
 } from '../custom-code/code-file'
@@ -370,6 +371,7 @@ function makeHTMLDescriptor(
       },
     ],
     source: defaultComponentDescriptor(),
+    ...ComponentDescriptorDefaults,
   }
 }
 
@@ -462,6 +464,7 @@ const conditionalElementsDescriptors: ComponentDescriptorsForFile = {
       },
     ],
     source: defaultComponentDescriptor(),
+    ...ComponentDescriptorDefaults,
   },
 }
 
@@ -478,6 +481,7 @@ const groupElementsDescriptors: ComponentDescriptorsForFile = {
       },
     ],
     source: defaultComponentDescriptor(),
+    ...ComponentDescriptorDefaults,
   },
 }
 
@@ -500,6 +504,7 @@ const fragmentElementsDescriptors: ComponentDescriptorsForFile = {
     variants: [fragmentComponentInfo],
     preferredChildComponents: [],
     source: defaultComponentDescriptor(),
+    ...ComponentDescriptorDefaults,
   },
 }
 
@@ -516,6 +521,7 @@ const samplesDescriptors: ComponentDescriptorsForFile = {
       },
     ],
     source: defaultComponentDescriptor(),
+    ...ComponentDescriptorDefaults,
   },
 }
 

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -218,9 +218,9 @@ describe('registered property controls', () => {
     expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`
       Object {
         "Card": Object {
-          "emphasis": undefined,
-          "focus": undefined,
-          "icon": undefined,
+          "emphasis": "regular",
+          "focus": "default",
+          "icon": "regular",
           "inspector": "all",
           "preferredChildComponents": Array [],
           "properties": Object {
@@ -735,10 +735,10 @@ describe('registered property controls', () => {
     expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`
       Object {
         "Card": Object {
-          "emphasis": undefined,
-          "focus": undefined,
-          "icon": undefined,
-          "inspector": undefined,
+          "emphasis": "regular",
+          "focus": "default",
+          "icon": "regular",
+          "inspector": "all",
           "preferredChildComponents": Array [],
           "properties": Object {
             "background": Object {

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -202,6 +202,7 @@ describe('registered property controls', () => {
                 }),
               },
               variants: [],
+              inspector: 'all',
             },
           },
         }
@@ -220,7 +221,7 @@ describe('registered property controls', () => {
           "emphasis": undefined,
           "focus": undefined,
           "icon": undefined,
-          "inspector": undefined,
+          "inspector": "all",
           "preferredChildComponents": Array [],
           "properties": Object {
             "label": Object {

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -81,6 +81,10 @@ describe('registered property controls', () => {
               defaultValue: true,
             },
           },
+          focus: 'default',
+          inspector: ['visual', 'typography'],
+          emphasis: 'regular',
+          icon: 'regular',
           variants: [
             {
               code: '<Card />',
@@ -107,6 +111,13 @@ describe('registered property controls', () => {
     expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`
       Object {
         "Card": Object {
+          "emphasis": "regular",
+          "focus": "default",
+          "icon": "regular",
+          "inspector": Array [
+            "visual",
+            "typography",
+          ],
           "preferredChildComponents": Array [],
           "properties": Object {
             "background": Object {
@@ -206,6 +217,10 @@ describe('registered property controls', () => {
     expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`
       Object {
         "Card": Object {
+          "emphasis": undefined,
+          "focus": undefined,
+          "icon": undefined,
+          "inspector": undefined,
           "preferredChildComponents": Array [],
           "properties": Object {
             "label": Object {
@@ -719,6 +734,10 @@ describe('registered property controls', () => {
     expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`
       Object {
         "Card": Object {
+          "emphasis": undefined,
+          "focus": undefined,
+          "icon": undefined,
+          "inspector": undefined,
           "preferredChildComponents": Array [],
           "properties": Object {
             "background": Object {

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -5,6 +5,7 @@ import type {
   ComponentToRegister,
   ComponentInsertOption,
   PreferredChildComponent,
+  Styling,
 } from 'utopia-api/core'
 import {
   EmphasisOptions,
@@ -38,9 +39,11 @@ import {
   getParseErrorDetails,
   objectKeyParser,
   optionalObjectKeyParser,
+  parseAlternative,
   parseAny,
   parseArray,
   parseBoolean,
+  parseConstant,
   parseEnum,
   parseObject,
   parseString,
@@ -87,6 +90,7 @@ import { errorMessage } from '../shared/error-messages'
 import { dropFileExtension } from '../shared/file-utils'
 import type { FancyError } from '../shared/code-exec-utils'
 import type { ScriptLine } from '../../third-party/react-error-overlay/utils/stack-frame'
+import { parseEnumValue } from './property-control-values'
 
 async function parseInsertOption(
   insertOption: ComponentInsertOption,
@@ -882,7 +886,13 @@ function parseComponentToRegister(value: unknown): ParseResult<ComponentToRegist
     objectKeyParser(parseArray(parseComponentInsertOption), 'variants')(value),
     optionalObjectKeyParser(parseArray(parsePreferredChild), 'preferredChildComponents')(value),
     optionalObjectKeyParser(parseEnum(FocusOptions), 'focus')(value),
-    optionalObjectKeyParser(parseArray(parseEnum(StylingOptions)), 'inspector')(value),
+    optionalObjectKeyParser(
+      parseAlternative<'all' | Styling[]>(
+        [parseConstant('all'), parseArray(parseEnum(StylingOptions))],
+        'inspector value invalid',
+      ),
+      'inspector',
+    )(value),
     optionalObjectKeyParser(parseEnum(EmphasisOptions), 'emphasis')(value),
     optionalObjectKeyParser(parseEnum(IconOptions), 'icon')(value),
   )

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -23,6 +23,7 @@ import type {
 } from '../../components/custom-code/internal-property-controls'
 import { packageJsonFileFromProjectContents } from '../../components/assets'
 import {
+  ComponentDescriptorDefaults,
   componentDescriptorFromDescriptorFile,
   isDefaultComponentDescriptor,
 } from '../../components/custom-code/code-file'
@@ -816,10 +817,10 @@ export async function componentDescriptorForComponentToRegister(
       variants: variants,
       moduleName: moduleName,
       source: source,
-      focus: componentToRegister.focus,
-      inspector: componentToRegister.inspector,
-      emphasis: componentToRegister.emphasis,
-      icon: componentToRegister.icon,
+      focus: componentToRegister.focus ?? ComponentDescriptorDefaults.focus,
+      inspector: componentToRegister.inspector ?? ComponentDescriptorDefaults.inspector,
+      emphasis: componentToRegister.emphasis ?? ComponentDescriptorDefaults.emphasis,
+      icon: componentToRegister.icon ?? ComponentDescriptorDefaults.icon,
     }
   }, parsedVariants)
 }

--- a/editor/src/core/property-controls/property-controls-parser.ts
+++ b/editor/src/core/property-controls/property-controls-parser.ts
@@ -48,7 +48,6 @@ import {
   parseArray,
   parseBoolean,
   parseConstant,
-  parseEnum,
   parseFunction,
   parseNull,
   parseNullable,

--- a/editor/src/core/third-party/antd-components.ts
+++ b/editor/src/core/third-party/antd-components.ts
@@ -4,6 +4,7 @@ import {
   defaultComponentDescriptor,
   type ComponentDescriptor,
   type ComponentDescriptorsForFile,
+  ComponentDescriptorDefaults,
 } from '../../components/custom-code/code-file'
 import type { JSXAttributes } from '../shared/element-template'
 import { jsxElementName, jsxElementWithoutUID, simpleAttribute } from '../shared/element-template'
@@ -54,6 +55,7 @@ function createBasicComponent(
       },
     ],
     source: defaultComponentDescriptor(),
+    ...ComponentDescriptorDefaults,
   }
 }
 

--- a/editor/src/core/third-party/react-three-fiber-components.ts
+++ b/editor/src/core/third-party/react-three-fiber-components.ts
@@ -4,6 +4,7 @@ import {
   defaultComponentDescriptor,
   type ComponentDescriptor,
   type ComponentDescriptorsForFile,
+  ComponentDescriptorDefaults,
 } from '../../components/custom-code/code-file'
 import type { JSXAttributes, JSXAttributesEntry } from '../shared/element-template'
 import {
@@ -53,6 +54,7 @@ function createBasicComponent(
       },
     ],
     source: defaultComponentDescriptor(),
+    ...ComponentDescriptorDefaults,
   }
 }
 

--- a/editor/src/core/third-party/remix-controls.ts
+++ b/editor/src/core/third-party/remix-controls.ts
@@ -1,6 +1,7 @@
 import {
   defaultComponentDescriptor,
   type ComponentDescriptorsForFile,
+  ComponentDescriptorDefaults,
 } from '../../components/custom-code/code-file'
 import {
   emptyComments,
@@ -41,6 +42,7 @@ export const RemixRunReactComponents: ComponentDescriptorsForFile = {
       },
     ],
     source: defaultComponentDescriptor(),
+    ...ComponentDescriptorDefaults,
   },
   Outlet: {
     properties: {},
@@ -65,5 +67,6 @@ export const RemixRunReactComponents: ComponentDescriptorsForFile = {
       },
     ],
     source: defaultComponentDescriptor(),
+    ...ComponentDescriptorDefaults,
   },
 }

--- a/editor/src/core/third-party/utopia-api-components.ts
+++ b/editor/src/core/third-party/utopia-api-components.ts
@@ -2,6 +2,7 @@ import {
   defaultComponentDescriptor,
   type ComponentDescriptor,
   type ComponentDescriptorsForFile,
+  ComponentDescriptorDefaults,
 } from '../../components/custom-code/code-file'
 import {
   defaultFlexRowOrColStyle,
@@ -50,6 +51,7 @@ const BasicUtopiaComponentDescriptor = (
       },
     ],
     source: defaultComponentDescriptor(),
+    ...ComponentDescriptorDefaults,
   }
 }
 
@@ -97,6 +99,7 @@ const BasicUtopiaSceneDescriptor = (
       },
     ],
     source: defaultComponentDescriptor(),
+    ...ComponentDescriptorDefaults,
   }
 }
 

--- a/editor/src/utils/value-parser-utils.ts
+++ b/editor/src/utils/value-parser-utils.ts
@@ -411,7 +411,7 @@ export function parseJsx(_: unknown, value: unknown): ParseResult<JSXParsedValue
   })
 }
 
-export function parseEnum<E extends string | number>(possibleValues: Array<E>): Parser<E> {
+export function parseEnum<E extends string | number>(possibleValues: ReadonlyArray<E>): Parser<E> {
   return (value: unknown) => {
     for (const possibleValue of possibleValues) {
       if (possibleValue === value) {

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -13,11 +13,29 @@ export interface PreferredChildComponent {
   variants?: Array<ComponentInsertOption>
 }
 
+export const FocusOptions = ['default', 'always', 'never'] as const
+export type Focus = (typeof FocusOptions)[number]
+
+export const StylingOptions = ['all', 'layout', 'layout-system', 'visual', 'typography'] as const
+export type Styling = (typeof StylingOptions)[number]
+
+export type InspectorSpec = Styling[]
+
+export const EmphasisOptions = ['subdued', 'regular', 'emphasized'] as const
+export type Emphasis = (typeof EmphasisOptions)[number]
+
+export const IconOptions = ['column', 'row', 'regular'] as const // and others
+export type Icon = (typeof IconOptions)[number]
+
 export interface ComponentToRegister {
   component: any
   properties: PropertyControls
   supportsChildren: boolean
   preferredChildComponents?: Array<PreferredChildComponent>
+  focus?: Focus
+  inspector?: InspectorSpec
+  emphasis?: Emphasis
+  icon?: Icon
   variants: Array<ComponentInsertOption>
 }
 

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -16,10 +16,10 @@ export interface PreferredChildComponent {
 export const FocusOptions = ['default', 'always', 'never'] as const
 export type Focus = (typeof FocusOptions)[number]
 
-export const StylingOptions = ['all', 'layout', 'layout-system', 'visual', 'typography'] as const
+export const StylingOptions = ['layout', 'layout-system', 'visual', 'typography'] as const
 export type Styling = (typeof StylingOptions)[number]
 
-export type InspectorSpec = Styling[]
+export type InspectorSpec = 'all' | Styling[]
 
 export const EmphasisOptions = ['subdued', 'regular', 'emphasized'] as const
 export type Emphasis = (typeof EmphasisOptions)[number]


### PR DESCRIPTION
## Description

This PR adds new props to `ComponentToRegister`, which can be used by the inspector or the navigator to provide better UX for the registered components. The API change is in `utopia-api/src/helpers/helper-functions.ts`.

### Details
- I went with the following pattern for defining union types:
```typescript
export const FocusOptions = ['default', 'always', 'never'] as const
export type Focus = (typeof FocusOptions)[number]
```
This way, the values can be validated by the `as const` array, and the union type can be created through the `typeof` + `[number]` pattern
- In the constructor function of `ComponentDescriptor` (`componentDescriptor`) I'm passing the optional params as `T | undefined` instead of `param?: T` so that we get type errors wherever these params aren't passed (for example, in the equality instance definitions)