### PR TITLE
Refresh the editor's share dialog data

### DIFF
--- a/utopia-remix/app/components/sharingDialog.tsx
+++ b/utopia-remix/app/components/sharingDialog.tsx
@@ -280,6 +280,11 @@ function AccessRequests(props: {
   // the last successfully-obtained access requests that can be used to roll-back in case of issues when updating requests
   const [previousAccessRequests, setPreviousAccessRequests] = React.useState(props.accessRequests)
 
+  React.useEffect(() => {
+    setAccessRequests(props.accessRequests)
+    setPreviousAccessRequests(props.accessRequests)
+  }, [props.accessRequests])
+
   const updateAccessRequestFetcher = useFetcherWithOperation(projectId, 'updateAccessRequest')
   const onUpdateAccessRequest = React.useCallback(
     (token: string, action: UpdateAccessRequestAction) => () => {

--- a/utopia-remix/app/routes/internal.editor.projects.$id.sharing.tsx
+++ b/utopia-remix/app/routes/internal.editor.projects.$id.sharing.tsx
@@ -99,6 +99,7 @@ const EditorProjectSharingPageInner = React.memo(() => {
 })
 EditorProjectSharingPage.displayName = 'EditorProjectSharingPage'
 
+// Revalidate the loader at fixed intervals of the given timeout milliseconds.
 function useRevalidateWithInterval(timeout: number) {
   const revalidator = useRevalidator()
 
@@ -115,6 +116,7 @@ function getAccessRequestsKey(reqs: ProjectAccessRequestWithUserDetails[]): stri
   return reqs.map((r) => `${r.id}:${r.status}`).join(',')
 }
 
+// Update the store's sharing requests data if they changed after a refresh.
 function useUpdateSharingRequests(initialRequests: ProjectAccessRequestWithUserDetails[]) {
   const [lastRequestsKey, setLastRequestsKey] = React.useState<string | null>(null)
 

--- a/utopia-remix/app/routes/internal.editor.projects.$id.sharing.tsx
+++ b/utopia-remix/app/routes/internal.editor.projects.$id.sharing.tsx
@@ -1,14 +1,16 @@
 import type { LoaderFunctionArgs } from '@remix-run/node'
-import { json, useFetcher, useLoaderData } from '@remix-run/react'
-import type { UserDetails } from 'prisma-client'
+import { json, useFetcher, useLoaderData, useRevalidator } from '@remix-run/react'
 import React from 'react'
 import { SharingDialogContent } from '../components/sharingDialog'
 import { getProjectSharingDetails } from '../models/project.server'
-import type { SharingProjectAccessRequests } from '../stores/projectsStore'
-import { ProjectsContext, createProjectsStore } from '../stores/projectsStore'
-import { AccessLevel, asAccessLevel, type ProjectSharingDetails } from '../types'
+import { ProjectsContext, createProjectsStore, useProjectsStore } from '../stores/projectsStore'
+import type { ProjectAccessRequestWithUserDetails, ProjectSharingDetails } from '../types'
+import { AccessLevel, asAccessLevel } from '../types'
 import { ensure, requireUser } from '../util/api.server'
 import { Status } from '../util/statusCodes'
+import type { UserDetails } from 'prisma-client'
+
+const RevalidateInterval = 10_000 //ms
 
 export async function loader(args: LoaderFunctionArgs) {
   const projectId = args.params.id
@@ -34,23 +36,36 @@ export async function loader(args: LoaderFunctionArgs) {
   )
 }
 
-const EditorProjectSharingPage = React.memo(() => {
-  const data = useLoaderData<typeof loader>() as unknown as {
-    user: UserDetails
-    project: ProjectSharingDetails
-  }
+type LoaderData = {
+  user: UserDetails
+  project: ProjectSharingDetails
+}
 
-  const accessRequests: SharingProjectAccessRequests = React.useMemo(() => {
-    return { state: 'ready', requests: data.project.ProjectAccessRequest }
-  }, [data.project.ProjectAccessRequest])
+const EditorProjectSharingPage = React.memo(() => {
+  const data = useLoaderData<typeof loader>() as unknown as LoaderData
 
   const store = React.useRef(
     createProjectsStore({
       myUser: data.user,
       sharingProjectId: data.project.proj_id,
-      sharingProjectAccessRequests: accessRequests,
     }),
   ).current
+
+  return (
+    <ProjectsContext.Provider value={store}>
+      <EditorProjectSharingPageInner />
+    </ProjectsContext.Provider>
+  )
+})
+EditorProjectSharingPage.displayName = 'EditorProjectSharingPage'
+
+export default EditorProjectSharingPage
+
+const EditorProjectSharingPageInner = React.memo(() => {
+  const data = useLoaderData<typeof loader>() as unknown as LoaderData
+
+  useRevalidateWithInterval(RevalidateInterval)
+  useUpdateSharingRequests(data.project.ProjectAccessRequest)
 
   const [accessLevel, setAccessLevel] = React.useState(
     asAccessLevel(data.project.ProjectAccess?.access_level) ?? AccessLevel.PRIVATE,
@@ -73,17 +88,48 @@ const EditorProjectSharingPage = React.memo(() => {
   )
 
   return (
-    <ProjectsContext.Provider value={store}>
-      <SharingDialogContent
-        project={data.project}
-        accessRequestsState={accessRequests.state}
-        accessLevel={accessLevel}
-        changeProjectAccessLevel={changeProjectAccessLevel}
-        asDialog={false}
-      />
-    </ProjectsContext.Provider>
+    <SharingDialogContent
+      project={data.project}
+      accessRequestsState='ready'
+      accessLevel={accessLevel}
+      changeProjectAccessLevel={changeProjectAccessLevel}
+      asDialog={false}
+    />
   )
 })
 EditorProjectSharingPage.displayName = 'EditorProjectSharingPage'
 
-export default EditorProjectSharingPage
+function useRevalidateWithInterval(timeout: number) {
+  const revalidator = useRevalidator()
+
+  React.useEffect(() => {
+    const interval = window.setInterval(revalidator.revalidate, timeout)
+
+    return function () {
+      window.clearInterval(interval)
+    }
+  }, [revalidator, timeout])
+}
+
+function getAccessRequestsKey(reqs: ProjectAccessRequestWithUserDetails[]): string {
+  return reqs.map((r) => `${r.id}:${r.status}`).join(',')
+}
+
+function useUpdateSharingRequests(initialRequests: ProjectAccessRequestWithUserDetails[]) {
+  const [lastRequestsKey, setLastRequestsKey] = React.useState<string | null>(null)
+
+  const setSharingProjectAccessRequests = useProjectsStore(
+    (store) => store.setSharingProjectAccessRequests,
+  )
+
+  React.useEffect(() => {
+    const newKey = getAccessRequestsKey(initialRequests)
+    if (lastRequestsKey !== newKey) {
+      setLastRequestsKey(newKey)
+      setSharingProjectAccessRequests({
+        state: 'ready',
+        requests: initialRequests,
+      })
+    }
+  }, [initialRequests, setSharingProjectAccessRequests, lastRequestsKey])
+}


### PR DESCRIPTION
This PR adds a 15s refresh on the iframe data used by the editor's share dialog, so it updates automatically with fresh requests without having to re-open it.