### PR TITLE
Update focused panel when opening Github pane

### DIFF
--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -51,6 +51,7 @@ import { RefreshIcon } from './refresh-icon'
 import { RepositoryListing } from './repository-listing'
 import { GithubOperations } from '../../../../core/shared/github/operations'
 import { useOnClickAuthenticateWithGithub } from '../../../../utils/github-auth-hooks'
+import { setFocus } from '../../../common/actions'
 
 const compactTimeagoFormatter = (value: number, unit: string) => {
   return `${value}${unit.charAt(0)}`
@@ -1101,6 +1102,15 @@ const PullRequestBlock = () => {
 }
 
 export const GithubPane = React.memo(() => {
+  const dispatch = useDispatch()
+
+  const onFocus = React.useCallback(
+    (_: React.FocusEvent<HTMLElement>) => {
+      dispatch([setFocus('githuboptions')])
+    },
+    [dispatch],
+  )
+
   const githubUser = useEditorState(
     Substores.github,
     (store) => store.editor.githubData.githubUserDetails,
@@ -1120,7 +1130,7 @@ export const GithubPane = React.memo(() => {
     }
   }, [githubUser])
   return (
-    <div style={{ height: '100%', overflowY: 'scroll' }}>
+    <div style={{ height: '100%', overflowY: 'scroll' }} onFocus={onFocus}>
       <Section>
         <SectionTitleRow minimised={false} hideButton>
           <FlexRow>

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -6,6 +6,7 @@ import React, { useEffect } from 'react'
 import TimeAgo from 'react-timeago'
 import { forceNotNull } from '../../../../core/shared/optional-utils'
 import { projectDependenciesSelector } from '../../../../core/shared/dependencies'
+import type { GithubBranch } from '../../../../core/shared/github/helpers'
 import {
   dispatchPromiseActions,
   getGithubFileChangesCount,
@@ -259,6 +260,24 @@ const BranchBlock = () => {
     )
   }, [dispatch])
 
+  const selectBranch = React.useCallback(
+    (branch: GithubBranch) => () => {
+      if (isListingBranches) {
+        return
+      }
+      dispatch(
+        [
+          EditorActions.updateGithubSettings({
+            branchName: branch.name,
+            branchLoaded: false,
+          }),
+        ],
+        'everyone',
+      )
+    },
+    [dispatch, isListingBranches],
+  )
+
   const listBranchesUI = React.useMemo(() => {
     return (
       <UIGridRow padded={false} variant='<-------------1fr------------->' style={{ width: '100%' }}>
@@ -291,20 +310,6 @@ const BranchBlock = () => {
           }}
         >
           {filteredBranches.map((branch, index) => {
-            function selectBranch() {
-              if (isListingBranches) {
-                return
-              }
-              dispatch(
-                [
-                  EditorActions.updateGithubSettings({
-                    branchName: branch.name,
-                    branchLoaded: false,
-                  }),
-                ],
-                'everyone',
-              )
-            }
             const loadingThisBranch = isGithubLoadingBranch(
               githubOperations,
               branch.name,
@@ -331,7 +336,7 @@ const BranchBlock = () => {
                   fontWeight: isCurrent ? 'bold' : 'normal',
                   color: branch.new === true ? colorTheme.dynamicBlue.value : 'inherit',
                 }}
-                onClick={selectBranch}
+                onClick={selectBranch(branch)}
               >
                 <Ellipsis>
                   {when(isCurrent, <span>&rarr; </span>)}
@@ -390,7 +395,7 @@ const BranchBlock = () => {
     githubOperations,
     targetRepository,
     repositoryData?.defaultBranch,
-    dispatch,
+    selectBranch,
   ])
 
   const githubAuthenticated = useEditorState(


### PR DESCRIPTION
**Problem:**

When selecting the Github pane the focused panel is not updated, leading to paste issues.

**Fix:**

Update the focused panel when focusing the GithubPane component.

**Note:** I had to update the `selectBranch` implementation (which is unrelated to the fix) in order to escape the linting issues with `react/jsx-no-bind` 😞  (https://github.com/concrete-utopia/utopia/commit/13c0e2a174c559fd12c48c25980006f8200297c5)