### PR TITLE
Add error path to invalid schema error messages

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -370,6 +370,60 @@ describe('registered property controls', () => {
 
     expect(srcCardKey).toBeUndefined()
   })
+  it('control registration fails when there is an invalid schema error', async () => {
+    const renderResult = await renderTestEditorWithModel(
+      project({
+        ['/utopia/components.utopia.js']: `import { Card } from '../src/card'
+        
+        const Components = {
+      '/src/card': {
+        Card: {
+          component: Card,
+          supportsChildren: false,
+          properties: {
+            label: 'foo',
+          },
+          variants: [ ],
+        },
+      },
+    }
+    
+    export default Components
+  `,
+      }),
+      'await-first-dom-report',
+    )
+    const editorState = renderResult.getEditorState().editor
+
+    expect(editorState.codeEditorErrors).toEqual({
+      buildErrors: {},
+      lintErrors: {},
+      componentDescriptorErrors: {
+        '/utopia/components.utopia.js': [
+          {
+            codeSnippet: '',
+            endColumn: null,
+            endLine: null,
+            errorCode: '',
+            fileName: '/utopia/components.utopia.js',
+            message: 'Malformed component registration: Card.properties.label: Not an object.',
+            passTime: null,
+            severity: 'fatal',
+            source: 'component-descriptor',
+            startColumn: null,
+            startLine: null,
+            type: '',
+          },
+        ],
+      },
+    })
+
+    const srcCardKey = Object.keys(renderResult.getEditorState().editor.propertyControlsInfo).find(
+      (key) => key === '/src/card',
+    )
+
+    expect(srcCardKey).toBeUndefined()
+  })
   it('control registration fails when the imported internal component does not match the name of registration key', async () => {
     const renderResult = await renderTestEditorWithModel(
       project({

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -458,12 +458,11 @@ function errorsFromComponentRegistration(
       case 'no-exported-component-descriptors':
         return [simpleErrorMessage(fileName, `Cannot extract default export from file`)]
       case 'invalid-schema':
+        const errorDetails = getParseErrorDetails(error.invalidSchemaError)
         return [
           simpleErrorMessage(
             fileName,
-            `Malformed component registration: ${
-              getParseErrorDetails(error.invalidSchemaError).description
-            }`,
+            `Malformed component registration: ${errorDetails.path}: ${errorDetails.description}`,
           ),
         ]
       case 'cannot-extract-component':


### PR DESCRIPTION
**Problem:**
Component descriptor object schema is validated by our value parser, and the error message only shows the error description, but not the affected path.

E.g.
<img width="947" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/75dce1d8-1236-45d4-9b44-91a030af5e18">

**Fix:**
Add the property path to the error message:

<img width="1271" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/11551beb-8335-4d2b-8130-0e6661b8201a">
