### PR TITLE
Visuals scene titles

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
@@ -175,12 +175,12 @@ const RemixSceneLabel = React.memo<RemixSceneLabelProps>((props) => {
   )
   const baseFontSize = 10
   const scaledFontSize = baseFontSize / scale
-  const scaledLineHeight = 17 / scale
+  const scaledLineHeight = 23 / scale
   const paddingY = scaledFontSize / 4
   const paddingX = paddingY * 2
   const offsetY = scaledFontSize / 1.5
   const offsetX = scaledFontSize / 2
-  const borderRadius = 3 / scale
+  const borderRadius = 5 / scale
 
   const editorModeRef = useRefEditorState((store) => {
     return {
@@ -268,8 +268,6 @@ const RemixSceneLabel = React.memo<RemixSceneLabelProps>((props) => {
     }
   }, [onMouseUp])
 
-  const backgroundColor = isSelected ? colorTheme.aqua05solid.value : 'transparent'
-
   if (frame == null || isInfinityRectangle(frame)) {
     return null
   }
@@ -288,7 +286,8 @@ const RemixSceneLabel = React.memo<RemixSceneLabelProps>((props) => {
         className='roleComponentName'
         style={{
           pointerEvents: labelSelectable ? 'initial' : 'none',
-          color: colorTheme.aqua.value,
+          color: colorTheme.primary.value,
+          backgroundColor: colorTheme.bg1subdued.value,
           position: 'absolute',
           left: frame.x,
           bottom: -frame.y + offsetY,
@@ -301,18 +300,13 @@ const RemixSceneLabel = React.memo<RemixSceneLabelProps>((props) => {
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           borderRadius: borderRadius,
-          backgroundColor: backgroundColor,
           justifyContent: 'space-between',
         }}
       >
         <FlexRow style={{ gap: paddingX }}>
-          <div
-            data-testid={RemixSceneLabelTestId(props.target)}
-            style={{
-              fontWeight: 600,
-            }}
-          >
-            {scenelabel}
+          <div data-testid={RemixSceneLabelTestId(props.target)} style={{ gap: 20 }}>
+            <span style={{ fontWeight: 600 }}>{scenelabel}</span>
+            <span style={{ fontWeight: 400 }}>1200 TODO FIXME</span>
           </div>
           <div
             data-testid={RemixSceneLabelPathTestId(props.target)}

--- a/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
-import { isInfinityRectangle, windowPoint } from '../../../../core/shared/math-utils'
+import {
+  isInfinityRectangle,
+  isNotNullFiniteRectangle,
+  windowPoint,
+} from '../../../../core/shared/math-utils'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import { NO_OP } from '../../../../core/shared/utils'
 import { Modifier } from '../../../../utils/modifiers'
@@ -134,6 +138,18 @@ const RemixSceneLabel = React.memo<RemixSceneLabelProps>((props) => {
         store.editor.jsxMetadata,
       ),
     'SceneLabel label',
+  )
+
+  const sceneSize = useEditorState(
+    Substores.metadata,
+    (store) => {
+      const element = store.editor.jsxMetadata[EP.toString(props.target)]
+      if (element == null || !isNotNullFiniteRectangle(element.globalFrame)) {
+        return ''
+      }
+      return `${element.globalFrame.width} × ${element.globalFrame.height}`
+    },
+    'SceneLabel sceneSize',
   )
 
   const currentLocationMatchesRoutes = useCurrentLocationMatchesRoutes(props.target)
@@ -305,8 +321,8 @@ const RemixSceneLabel = React.memo<RemixSceneLabelProps>((props) => {
       >
         <FlexRow style={{ gap: paddingX }}>
           <div data-testid={RemixSceneLabelTestId(props.target)} style={{ gap: 20 }}>
-            <span style={{ fontWeight: 600 }}>{scenelabel}</span>
-            <span style={{ fontWeight: 400 }}>1200 TODO FIXME</span>
+            <span style={{ fontWeight: 600 }}>{scenelabel}</span>{' '}
+            <span style={{ fontWeight: 400 }}>{sceneSize}</span>
           </div>
           <div
             data-testid={RemixSceneLabelPathTestId(props.target)}

--- a/editor/src/components/canvas/controls/select-mode/scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/scene-label.tsx
@@ -101,12 +101,12 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
   )
   const baseFontSize = 10
   const scaledFontSize = baseFontSize / scale
-  const scaledLineHeight = 17 / scale
+  const scaledLineHeight = 23 / scale
   const paddingY = scaledFontSize / 4
   const paddingX = paddingY * 2
   const offsetY = scaledFontSize / 1.5
   const offsetX = scaledFontSize / 2
-  const borderRadius = 3 / scale
+  const borderRadius = 5 / scale
 
   const storeRef = useRefEditorState((store) => {
     return {
@@ -194,11 +194,6 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
     }
   }, [onMouseUp])
 
-  const selectedBackgroundColor = sceneHasSingleChild
-    ? colorTheme.componentPurple05solid.value
-    : colorTheme.bg510solid.value
-  const backgroundColor = isSelected ? selectedBackgroundColor : 'transparent'
-
   if (frame != null && isFiniteRectangle(frame)) {
     return (
       <CanvasOffsetWrapper>
@@ -211,7 +206,8 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
           className='roleComponentName'
           style={{
             pointerEvents: labelSelectable ? 'initial' : 'none',
-            color: sceneHasSingleChild ? colorTheme.componentPurple.value : colorTheme.fg2.value,
+            color: sceneHasSingleChild ? colorTheme.primary.value : colorTheme.fg6.value,
+            backgroundColor: colorTheme.bg1subdued.value,
             position: 'absolute',
             fontWeight: 600,
             left: frame.x,
@@ -223,9 +219,9 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
             lineHeight: `${scaledLineHeight}px`,
             whiteSpace: 'nowrap',
             overflow: 'hidden',
-            textOverflow: 'ellipsis',
             borderRadius: borderRadius,
-            backgroundColor: backgroundColor,
+            textOverflow: 'ellipsis',
+            gap: 20,
           }}
         >
           <div
@@ -234,6 +230,13 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
             }}
           >
             {label}
+          </div>
+          <div
+            style={{
+              fontWeight: 400,
+            }}
+          >
+            1000px TODO FIX ME
           </div>
         </FlexRow>
       </CanvasOffsetWrapper>

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -3,6 +3,7 @@ import type { light } from './light'
 
 const darkBase = {
   primary: createUtopiColor('oklch(59% 0.25 254)'),
+  primary10solid: createUtopiColor('oklch(0.98 0.01 253.75)'),
   primary10: createUtopiColor('oklch(59% 0.25 254 / 10%)'),
   primary25: createUtopiColor('oklch(59% 0.25 254 / 25%)'),
   primary30: createUtopiColor('oklch(59% 0.25 254 / 30%)'),

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -3,6 +3,7 @@ import type { dark } from './dark'
 
 const lightBase = {
   primary: createUtopiColor('oklch(59% 0.25 254)'),
+  primary10solid: createUtopiColor('oklch(0.98 0.01 253.75)'),
   primary10: createUtopiColor('oklch(59% 0.25 254 / 10%)'),
   primary25: createUtopiColor('oklch(59% 0.25 254 / 25%)'),
   primary30: createUtopiColor('oklch(59% 0.25 254 / 30%)'),


### PR DESCRIPTION
<img width="760" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/bb50a876-4e91-4de6-b9c1-af6e3220c90c">

Some visual changes to the scene label:
- always visible
- shows the size
- primary10