### PR TITLE
Traverse routes to get their ids

### DIFF
--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -301,10 +301,7 @@ export const UtopiaRemixRootComponent = (props: UtopiaRemixRootComponentProps) =
 
   const [navigationData, setNavigationData] = useAtom(RemixNavigationAtom)
 
-  const currentEntries = React.useMemo(
-    () => navigationData[EP.toString(basePath)]?.entries,
-    [navigationData, basePath],
-  )
+  const currentEntries = navigationData[EP.toString(basePath)]?.entries
   const currentEntriesRef = React.useRef(currentEntries)
   currentEntriesRef.current = currentEntries
 

--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -280,7 +280,7 @@ function traverseRoutesAndGetIDs(routes: RouteLike[]): Set<string> {
   }
 
   const routeIds = new Set<string>()
-  routes.forEach((node) => traverse(node, routeIds))
+  routes.forEach((route) => traverse(route, routeIds))
 
   return routeIds
 }

--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -272,15 +272,15 @@ interface RouteLike {
 }
 
 function traverseRoutesAndGetIDs(routes: RouteLike[]): Set<string> {
-  function traverse(route: RouteLike, ids: Set<string>) {
+  const ids = new Set<string>()
+
+  function traverse(route: RouteLike) {
     ids.add(route.id ?? '0')
-    route.children?.forEach((c) => traverse(c, ids))
+    route.children?.forEach(traverse)
   }
+  routes.forEach((route) => traverse(route))
 
-  const routeIds = new Set<string>()
-  routes.forEach((route) => traverse(route, routeIds))
-
-  return routeIds
+  return ids
 }
 
 export interface UtopiaRemixRootComponentProps {

--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -271,7 +271,7 @@ interface RouteLike {
   children?: RouteLike[]
 }
 
-function traverseRoutesAndGetIDs(routes: RouteLike[]) {
+function traverseRoutesAndGetIDs(routes: RouteLike[]): Set<string> {
   function traverse(route: RouteLike, ids: Set<string>) {
     ids.add(route.id ?? '0')
     if (route.children != null && route.children.length > 0) {

--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -274,9 +274,7 @@ interface RouteLike {
 function traverseRoutesAndGetIDs(routes: RouteLike[]): Set<string> {
   function traverse(route: RouteLike, ids: Set<string>) {
     ids.add(route.id ?? '0')
-    if (route.children != null && route.children.length > 0) {
-      route.children.forEach((c) => traverse(c, ids))
-    }
+    route.children?.forEach((c) => traverse(c, ids))
   }
 
   const routeIds = new Set<string>()


### PR DESCRIPTION
**Problem:**

The routes equality hook does not correctly derive the route ids.

**Fix:**

Since the routes are structured as a tree, the ids should be derived by traversing the tree from the root to the leaves, while currently only the first level is checked.

Additionally, the `same` check should validate that the size of the previous and next id sets are equal as well.