### PR TITLE
Collaboration Duplicate UID Mitigation.

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -106,10 +106,12 @@ import {
   setProp_UNSAFE,
   updateFilePath,
   updateFromWorker,
+  updateTopLevelElementsFromCollaborationUpdate,
   workerCodeAndParsedUpdate,
 } from './action-creators'
 import { UPDATE_FNS } from './actions'
 import { CURRENT_PROJECT_VERSION } from './migrations/migrations'
+import { getAllUniqueUids } from '../../../core/model/get-unique-ids'
 
 const chaiExpect = Chai.expect
 
@@ -1181,5 +1183,23 @@ describe('UPDATE_FROM_WORKER', () => {
     expect(updatedAppJSVersionNumberFromState).toBeGreaterThanOrEqual(versionNumberOfAppJS)
     expect(updatedStoryboardFileFromState).toStrictEqual(updatedStoryboardFile)
     expect(updatedAppJSFileFromState).toStrictEqual(updatedAppJSFile)
+  })
+})
+
+describe('UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION', () => {
+  it('fixes up the uids if there are duplicates', () => {
+    // Setup and getting some starting values.
+    const project = complexDefaultProjectPreParsed()
+    const startingEditorState = editorModelFromPersistentModel(project, NO_OP)
+    const appJSFile = unsafeGet(parsedTextFileOptic('/src/app.js'), startingEditorState)
+    // Doubling up the top level elements should definitely create some duplicates.
+    const newTopLevelElements = [...appJSFile.topLevelElements, ...appJSFile.topLevelElements]
+    const action = updateTopLevelElementsFromCollaborationUpdate('/src/app.js', newTopLevelElements)
+    const updatedEditorState = UPDATE_FNS.UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE(
+      action,
+      startingEditorState,
+    )
+    const uniqueUIDsResult = getAllUniqueUids(updatedEditorState.projectContents)
+    expect(uniqueUIDsResult.duplicateIDs).toEqual({})
   })
 })

--- a/editor/src/sample-projects/sample-project-utils.test-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.test-utils.ts
@@ -44,6 +44,7 @@ export function complexDefaultProjectPreParsed(): PersistentModel {
 export function parseProjectContents(
   projectContents: ProjectContentTreeRoot,
 ): ProjectContentTreeRoot {
+  let alreadyExistingUIDs: Set<string> = emptySet()
   return transformContentsTree(projectContents, (tree: ProjectContentsTree) => {
     if (tree.type === 'PROJECT_CONTENT_FILE') {
       const file = tree.content
@@ -52,7 +53,7 @@ export function parseProjectContents(
           tree.fullPath,
           file.fileContents.code,
           null,
-          emptySet(),
+          alreadyExistingUIDs,
           'trim-bounds',
           'do-not-apply-steganography',
         )


### PR DESCRIPTION
**Problem:**
Updates to the top level elements via the collaboration updates can sometimes cause issues with duplicate UIDs being identified as a result of the update.

**Fix:**
As the cause has been difficult to locate due to how hard it is to reproduce reliably, this attempts to mitigate the issue as an alternative.

Now when ingesting the updates to top level elements, we fix the UIDs for the incoming elements to ensure no duplicates at that point. This does mean that UIDs might end up differing between instances of the editor, but those are likely to fall back in line as further changes are made by the editor with control over the project.

**Commit Details:**
- `UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION_UPDATE` now attempts to fix the UIDs of the incoming top level elements against the existing project contents.
- Fixed a small bug in `parseProjectContents` that was creating projects with duplicate UIDs in them.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5918
