### PR TITLE
Update property controls on github change

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -21,7 +21,7 @@ import type {
   JSXControlDescription,
   PreferredChildComponentDescriptor,
 } from '../../components/custom-code/internal-property-controls'
-import { packageJsonFileFromProjectContents } from '../../components/assets'
+import { packageJsonFileFromProjectContents, walkContentsTree } from '../../components/assets'
 import {
   ComponentDescriptorDefaults,
   componentDescriptorFromDescriptorFile,
@@ -67,7 +67,7 @@ import {
 import { setOptionalProp } from '../shared/object-utils'
 import { assertNever } from '../shared/utils'
 import type { ParsedTextFile } from '../shared/project-file-types'
-import { isExportDefault } from '../shared/project-file-types'
+import { isExportDefault, isTextFile } from '../shared/project-file-types'
 import type { UiJsxCanvasContextData } from '../../components/canvas/ui-jsx-canvas'
 import type { EditorState } from '../../components/editor/store/editor-state'
 import type { MutableUtopiaCtxRefData } from '../../components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts'
@@ -971,4 +971,17 @@ function printScriptLines(scriptLines: Array<ScriptLine>, columnNumber: number |
       .join('\n') ?? ''
 
   return printedCode
+}
+
+export function getAllComponentDescriptorFilePaths(
+  projectContents: ProjectContentTreeRoot,
+): Array<string> {
+  let componentDescriptorFiles: Array<string> = []
+
+  walkContentsTree(projectContents, (fullPath, file) => {
+    if (isTextFile(file) && isComponentDescriptorFile(fullPath)) {
+      componentDescriptorFiles.push(fullPath)
+    }
+  })
+  return componentDescriptorFiles
 }

--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -18,6 +18,7 @@ import { notice } from '../../../components/common/notice'
 import type { EditorAction, EditorDispatch } from '../../../components/editor/action-types'
 import {
   deleteFile,
+  extractPropertyControlsFromDescriptorFiles,
   removeFileConflict,
   setGithubState,
   showToast,
@@ -65,6 +66,7 @@ import { set } from '../optics/optic-utilities'
 import { fromField } from '../optics/optic-creators'
 import type { GithubOperationContext } from './operations/github-operation-context'
 import { GithubEndpoints } from './endpoints'
+import { getAllComponentDescriptorFilePaths } from '../../property-controls/property-controls-local'
 
 export function dispatchPromiseActions(
   dispatch: EditorDispatch,
@@ -474,7 +476,9 @@ export async function revertAllGithubFiles(
       workers,
       branchContents,
     )
+    const componentDescriptorFiles = getAllComponentDescriptorFilePaths(parsedBranchContents)
     actions.push(updateProjectContents(parsedBranchContents))
+    actions.push(extractPropertyControlsFromDescriptorFiles(componentDescriptorFiles))
   }
   return actions
 }
@@ -501,7 +505,9 @@ export async function revertGithubFile(
         const previousFile = getProjectFileByFilePath(parsedBranchContents, filename)
         if (previousFile != null) {
           const newTree = addFileToProjectContents(projectContents, filename, previousFile)
+          const componentDescriptorFiles = getAllComponentDescriptorFilePaths(newTree)
           actions.push(updateProjectContents(newTree))
+          actions.push(extractPropertyControlsFromDescriptorFiles(componentDescriptorFiles))
         }
         break
     }

--- a/editor/src/core/shared/github/operations/load-branch.ts
+++ b/editor/src/core/shared/github/operations/load-branch.ts
@@ -153,9 +153,6 @@ export const updateProjectWithBranchContent =
               currentProjectContents,
             )
 
-            const componentDescriptorFiles =
-              getAllComponentDescriptorFilePaths(parsedProjectContents)
-
             // Update the editor with everything so that if anything else fails past this point
             // there's no loss of data from the user's perspective.
             dispatch(
@@ -168,12 +165,14 @@ export const updateProjectWithBranchContent =
                   true,
                 ),
                 updateProjectContents(parsedProjectContents),
-                extractPropertyControlsFromDescriptorFiles(componentDescriptorFiles),
                 updateBranchContents(parsedProjectContents),
                 truncateHistory(),
               ],
               'everyone',
             )
+
+            const componentDescriptorFiles =
+              getAllComponentDescriptorFilePaths(parsedProjectContents)
 
             // If there's a package.json file, then attempt to load the dependencies for it.
             let dependenciesPromise: Promise<void> = Promise.resolve()
@@ -206,6 +205,7 @@ export const updateProjectWithBranchContent =
               .finally(() => {
                 dispatch(
                   [
+                    extractPropertyControlsFromDescriptorFiles(componentDescriptorFiles),
                     showToast(
                       notice(
                         `Github: Updated the project with the content from ${branchName}`,

--- a/editor/src/core/shared/github/operations/load-branch.ts
+++ b/editor/src/core/shared/github/operations/load-branch.ts
@@ -8,6 +8,7 @@ import {
 import { notice } from '../../../../components/common/notice'
 import type { EditorDispatch } from '../../../../components/editor/action-types'
 import {
+  extractPropertyControlsFromDescriptorFiles,
   showToast,
   truncateHistory,
   updateBranchContents,
@@ -35,6 +36,7 @@ import {
 import { updateProjectContentsWithParseResults } from '../../parser-projectcontents-utils'
 import type { GithubOperationContext } from './github-operation-context'
 import { createStoryboardFileIfNecessary } from '../../../../components/editor/actions/actions'
+import { getAllComponentDescriptorFilePaths } from '../../../property-controls/property-controls-local'
 
 export const saveAssetsToProject =
   (operationContext: GithubOperationContext) =>
@@ -151,6 +153,9 @@ export const updateProjectWithBranchContent =
               currentProjectContents,
             )
 
+            const componentDescriptorFiles =
+              getAllComponentDescriptorFilePaths(parsedProjectContents)
+
             // Update the editor with everything so that if anything else fails past this point
             // there's no loss of data from the user's perspective.
             dispatch(
@@ -163,6 +168,7 @@ export const updateProjectWithBranchContent =
                   true,
                 ),
                 updateProjectContents(parsedProjectContents),
+                extractPropertyControlsFromDescriptorFiles(componentDescriptorFiles),
                 updateBranchContents(parsedProjectContents),
                 truncateHistory(),
               ],


### PR DESCRIPTION
**Problem:**
After changes coming from github the component descriptor files are not parsed/evaluated, so the property controls are not updated

**Fix:**
Since github operations replace the whole project contents, I implemented a simple solution: parse/eval all component descriptor files in these cases.
Some of these can be unnecessary, so maybe later we can optimize these so they only happen when the content has been really changed.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #[ticket_number] (<< pls delete this line if it's not relevant)
