### PR TITLE
Better Offline Flagging.

### DIFF
--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -153,6 +153,7 @@ import {
   getUpdateProjectServerStateInStoreRunCount,
 } from '../editor/store/project-server-state'
 import { uniqBy } from '../../core/shared/array-utils'
+import { InitialOnlineState } from '../editor/online-status'
 
 // eslint-disable-next-line no-unused-expressions
 typeof process !== 'undefined' &&
@@ -578,6 +579,7 @@ export async function renderTestEditorWithModel(
       isMyProject: 'yes',
     },
     collaborativeEditingSupport: emptyCollaborativeEditingSupport(),
+    onlineState: InitialOnlineState,
   }
 
   const canvasStoreHook: UtopiaStoreAPI = createStoresAndState(

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -1117,6 +1117,14 @@ export interface SetSharingDialogOpen {
   open: boolean
 }
 
+export interface ResetOnlineState {
+  action: 'RESET_ONLINE_STATE'
+}
+
+export interface IncreaseOnlineStateFailureCount {
+  action: 'INCREASE_ONLINE_STATE_FAILURE_COUNT'
+}
+
 export type EditorAction =
   | ClearSelection
   | InsertJSXElement
@@ -1298,6 +1306,8 @@ export type EditorAction =
   | SetCollaborators
   | ExtractPropertyControlsFromDescriptorFiles
   | SetSharingDialogOpen
+  | ResetOnlineState
+  | IncreaseOnlineStateFailureCount
 
 export type DispatchPriority =
   | 'everyone'

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -224,6 +224,8 @@ import type {
   SetSharingDialogOpen,
   SetCodeEditorComponentDescriptorErrors,
   AddNewPage,
+  ResetOnlineState,
+  IncreaseOnlineStateFailureCount,
 } from '../action-types'
 import type { InsertionSubjectWrapper, Mode } from '../editor-modes'
 import { EditorModes, insertionSubject } from '../editor-modes'
@@ -1772,5 +1774,17 @@ export function setSharingDialogOpen(open: boolean): SetSharingDialogOpen {
   return {
     action: 'SET_SHARING_DIALOG_OPEN',
     open: open,
+  }
+}
+
+export function resetOnlineState(): ResetOnlineState {
+  return {
+    action: 'RESET_ONLINE_STATE',
+  }
+}
+
+export function increaseOnlineStateFailureCount(): IncreaseOnlineStateFailureCount {
+  return {
+    action: 'INCREASE_ONLINE_STATE_FAILURE_COUNT',
   }
 }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -136,6 +136,8 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'SET_COLLABORATORS':
     case 'EXTRACT_PROPERTY_CONTROLS_FROM_DESCRIPTOR_FILES':
     case 'SET_SHARING_DIALOG_OPEN':
+    case 'RESET_ONLINE_STATE':
+    case 'INCREASE_ONLINE_STATE_FAILURE_COUNT':
       return true
 
     case 'TRUE_UP_ELEMENTS':

--- a/editor/src/components/editor/notification-bar.tsx
+++ b/editor/src/components/editor/notification-bar.tsx
@@ -3,6 +3,7 @@ import { auth0Url } from '../../common/env-vars'
 import { Substores, useEditorState } from './store/store-hook'
 
 import { NotificationBar } from '../common/notices'
+import { useGetOnlineStatus } from './online-status'
 
 export const BrowserInfoBar = React.memo(() => {
   return (
@@ -25,17 +26,14 @@ export const LoginStatusBar = React.memo(() => {
     (store) => store.userState.loginState,
     'LoginStatusBar',
   )
-  const saveError = useEditorState(
-    Substores.restOfEditor,
-    (store) => store.editor.saveError,
-    'EditorComponentInner saveError',
-  )
+
+  const isOnline = useGetOnlineStatus()
 
   const onClickLoginNewTab = React.useCallback(() => {
     window.open(auth0Url('auto-close'), '_blank')
   }, [])
 
-  if (saveError) {
+  if (!isOnline) {
     return <EditorOfflineBar />
   }
 
@@ -45,7 +43,7 @@ export const LoginStatusBar = React.memo(() => {
     case 'LOGGED_IN':
       return null
     case 'OFFLINE_STATE':
-      return <EditorOfflineBar />
+      return null
     case 'NOT_LOGGED_IN':
       return null
     case 'LOGIN_LOST':

--- a/editor/src/components/editor/online-status.spec.browser2.tsx
+++ b/editor/src/components/editor/online-status.spec.browser2.tsx
@@ -1,0 +1,37 @@
+import {
+  makeTestProjectCodeWithSnippet,
+  renderTestEditorWithCode,
+} from '../canvas/ui-jsx.test-utils'
+import { increaseOnlineStateFailureCount, resetOnlineState } from './actions/action-creators'
+
+describe('Editor is offline banner', () => {
+  it('renders when the editor is offline', async () => {
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`<span>Editor Offline Text</span>`),
+      'await-first-dom-report',
+    )
+    await editor.dispatch(
+      [
+        increaseOnlineStateFailureCount(),
+        increaseOnlineStateFailureCount(),
+        increaseOnlineStateFailureCount(),
+      ],
+      true,
+    )
+    const offlineBanners = editor.renderedDOM.queryAllByText(
+      `Utopia is offline, and will reconnect automatically.`,
+    )
+    expect(offlineBanners).toHaveLength(1)
+  })
+  it('does not render when the editor is online', async () => {
+    const editor = await renderTestEditorWithCode(
+      makeTestProjectCodeWithSnippet(`<span>Editor Offline Text</span>`),
+      'await-first-dom-report',
+    )
+    await editor.dispatch([resetOnlineState()], true)
+    const offlineBanners = editor.renderedDOM.queryAllByText(
+      `Utopia is offline, and will reconnect automatically.`,
+    )
+    expect(offlineBanners).toHaveLength(0)
+  })
+})

--- a/editor/src/components/editor/online-status.tsx
+++ b/editor/src/components/editor/online-status.tsx
@@ -1,0 +1,70 @@
+import { IS_TEST_ENVIRONMENT, UTOPIA_BACKEND_BASE_URL } from '../../common/env-vars'
+import { HEADERS, MODE } from '../../common/server'
+import type { EditorDispatch } from './action-types'
+import { increaseOnlineStateFailureCount, resetOnlineState } from './actions/action-creators'
+import { Substores, useEditorState } from './store/store-hook'
+
+export interface OnlineState {
+  runningFailureCount: number
+}
+
+export function onlineState(runningFailureCount: number): OnlineState {
+  return {
+    runningFailureCount: runningFailureCount,
+  }
+}
+
+export const InitialOnlineState: OnlineState = { runningFailureCount: 0 }
+
+let onlineStateIntervalID: number | null = null
+
+export const FailureLimit = 3
+
+export const OnlineStatusPollingInterval = 5_000
+
+export function useGetOnlineStatus(): boolean {
+  const runningFailureCount = useEditorState(
+    Substores.onlineState,
+    (store) => store.onlineState.runningFailureCount,
+    'useGetOnlineStatus runningFailureCount',
+  )
+  return runningFailureCount < FailureLimit
+}
+
+export function startOnlineStatusPolling(dispatch: EditorDispatch): void {
+  // Don't run any of this functionality in tests.
+  if (!IS_TEST_ENVIRONMENT) {
+    // Trigger this just the once and once started never again.
+    if (onlineStateIntervalID == null) {
+      const newIntervalID = window.setInterval(() => {
+        // Perform a HEAD request against the backend to see if we are able to react it.
+        fetch(UTOPIA_BACKEND_BASE_URL + 'online-status', {
+          method: 'HEAD',
+          credentials: 'include',
+          headers: HEADERS,
+          mode: MODE,
+        })
+          .then((response) => {
+            if (response.ok) {
+              // Reset the status, as we're able to connect and we get a good status code
+              // from the server.
+              dispatch([resetOnlineState()])
+            } else {
+              // Bump the failure count, as we got a failure type response code, which
+              // potentially means that our service provider is down or a deploy got mangled.
+              dispatch([increaseOnlineStateFailureCount()])
+            }
+          })
+          .catch((error) => {
+            console.error('Error while fetching online status.', error)
+            // Bump the failure count as there was an error either connecting or while
+            // recieving the response.
+            dispatch([increaseOnlineStateFailureCount()])
+          })
+      }, OnlineStatusPollingInterval)
+
+      // Store the interval ID so that we can ensure to only start the interval once.
+      onlineStateIntervalID = newIntervalID
+    }
+  }
+}

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -48,6 +48,7 @@ import { toggleBackgroundLayers, toggleStylePropPaths } from '../../inspector/co
 import { EditorDispatch, notLoggedIn } from '../action-types'
 import { saveDOMReport, selectComponents, toggleProperty } from '../actions/action-creators'
 import * as History from '../history'
+import { InitialOnlineState } from '../online-status'
 import { DummyPersistenceMachine } from '../persistence/persistence.test-utils'
 import type { DispatchResult } from './dispatch'
 import {
@@ -114,6 +115,7 @@ function createEditorStore(
     postActionInteractionSession: null,
     projectServerState: emptyProjectServerState(),
     collaborativeEditingSupport: emptyCollaborativeEditingSupport(),
+    onlineState: InitialOnlineState,
   }
 
   return initialEditorStore

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -38,7 +38,9 @@ import {
   runClearPostActionSession,
   runExecuteStartPostActionMenuAction,
   runExecuteWithPostActionMenuAction,
+  runIncreaseOnlineStateFailureCount,
   runLocalEditorAction,
+  runResetOnlineState,
   runUpdateProjectServerState,
 } from './editor-update'
 import { isBrowserEnvironment } from '../../../core/shared/utils'
@@ -200,6 +202,14 @@ function processAction(
         working = runUpdateProjectServerState(working, action)
       }
 
+      if (action.action === 'RESET_ONLINE_STATE') {
+        working = runResetOnlineState(working, action)
+      }
+
+      if (action.action === 'INCREASE_ONLINE_STATE_FAILURE_COUNT') {
+        working = runIncreaseOnlineStateFailureCount(working, action)
+      }
+
       // Process action on the JS side.
       const editorAfterUpdateFunction = runLocalEditorAction(
         working.unpatchedEditor,
@@ -277,6 +287,7 @@ function processAction(
         builtInDependencies: working.builtInDependencies,
         projectServerState: working.projectServerState,
         collaborativeEditingSupport: working.collaborativeEditingSupport,
+        onlineState: working.onlineState,
       }
     },
   )
@@ -648,6 +659,7 @@ export function editorDispatchClosingOut(
     builtInDependencies: storedState.builtInDependencies,
     projectServerState: result.projectServerState,
     collaborativeEditingSupport: storedState.collaborativeEditingSupport,
+    onlineState: result.onlineState,
   }
 
   reduxDevtoolsSendActions(actionGroupsToProcess, finalStore, allTransient)
@@ -1019,6 +1031,7 @@ function editorDispatchInner(
       builtInDependencies: storedState.builtInDependencies,
       projectServerState: result.projectServerState,
       collaborativeEditingSupport: result.collaborativeEditingSupport,
+      onlineState: result.onlineState,
     }
   } else {
     //empty return

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -187,6 +187,7 @@ import { removeUnusedImportsForRemovedElement } from '../import-utils'
 import { emptyImports } from '../../../core/workers/common/project-file-utils'
 import type { CommentFilterMode } from '../../inspector/sections/comment-section'
 import type { Collaborator } from '../../../core/shared/multiplayer'
+import type { OnlineState } from '../online-status'
 
 const ObjectPathImmutable: any = OPI
 
@@ -485,6 +486,7 @@ export type EditorStoreShared = {
   saveCountThisSession: number
   projectServerState: ProjectServerState
   collaborativeEditingSupport: CollaborativeEditingSupport
+  onlineState: OnlineState
 }
 
 export type EditorStoreFull = EditorStoreShared & {

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -9,7 +9,9 @@ import type {
   EditorAction,
   EditorDispatch,
   ExecutePostActionMenuChoice,
+  IncreaseOnlineStateFailureCount,
   LoginState,
+  ResetOnlineState,
   StartPostActionSession,
   UpdateProjectServerState,
 } from '../action-types'
@@ -23,6 +25,10 @@ import { foldAndApplyCommandsSimple } from '../../canvas/commands/commands'
 import type { ProjectServerState } from './project-server-state'
 import { isTransientAction } from '../actions/action-utils'
 import { allowedToEditProject } from './collaborative-editing'
+import { InitialOnlineState } from '../online-status'
+import type { Optic } from '../../../core/shared/optics/optics'
+import { fromField } from '../../../core/shared/optics/optic-creators'
+import { modify } from '../../../core/shared/optics/optic-utilities'
 
 export function runLocalEditorAction(
   state: EditorState,
@@ -546,4 +552,26 @@ export function runUpdateProjectServerState(
       ...action.serverState,
     },
   }
+}
+
+export function runResetOnlineState(
+  working: EditorStoreUnpatched,
+  _action: ResetOnlineState,
+): EditorStoreUnpatched {
+  return {
+    ...working,
+    onlineState: InitialOnlineState,
+  }
+}
+
+export const editorStateRunningFailureCountOptic: Optic<EditorStoreUnpatched, number> = fromField<
+  EditorStoreUnpatched,
+  'onlineState'
+>('onlineState').compose(fromField('runningFailureCount'))
+
+export function runIncreaseOnlineStateFailureCount(
+  working: EditorStoreUnpatched,
+  _action: IncreaseOnlineStateFailureCount,
+): EditorStoreUnpatched {
+  return modify(editorStateRunningFailureCountOptic, (count) => count + 1, working)
 }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -594,6 +594,8 @@ import type {
   PreferredChildComponentDescriptor,
   PropertyControls,
 } from '../../custom-code/internal-property-controls'
+import type { OnlineState } from '../online-status'
+import { onlineState } from '../online-status'
 
 export const ProjectMetadataFromServerKeepDeepEquality: KeepDeepEqualityCall<ProjectMetadataFromServer> =
   combine4EqualityCalls(
@@ -634,12 +636,18 @@ export const CollaboratorKeepDeepEquality: KeepDeepEqualityCall<Collaborator> =
     (id, name, avatar) => ({ id, name, avatar }),
   )
 
-export const MutiplayerSubstateKeepDeepEquality: KeepDeepEqualityCall<MultiplayerSubstate> =
+export const MultiplayerSubstateKeepDeepEquality: KeepDeepEqualityCall<MultiplayerSubstate> =
   combine1EqualityCall(
     (entry) => entry.editor.collaborators,
     arrayDeepEquality(CollaboratorKeepDeepEquality),
     (collaborators) => ({ editor: { collaborators: collaborators } }),
   )
+
+export const OnlineStateKeepDeepEquality: KeepDeepEqualityCall<OnlineState> = combine1EqualityCall(
+  (status) => status.runningFailureCount,
+  createCallWithTripleEquals<number>(),
+  onlineState,
+)
 
 export function TransientCanvasStateFilesStateKeepDeepEquality(
   oldValue: TransientFilesState,

--- a/editor/src/components/editor/store/store-hook-substore-types.ts
+++ b/editor/src/components/editor/store/store-hook-substore-types.ts
@@ -194,6 +194,10 @@ export interface ProjectServerStateSubstate {
   projectServerState: EditorStoreShared['projectServerState']
 }
 
+export interface OnlineStateSubstate {
+  onlineState: EditorStoreShared['onlineState']
+}
+
 export const restOfStoreKeys: ReadonlyArray<keyof Omit<EditorStorePatched, 'editor' | 'derived'>> =
   [
     'storeName',
@@ -205,4 +209,5 @@ export const restOfStoreKeys: ReadonlyArray<keyof Omit<EditorStorePatched, 'edit
     'builtInDependencies',
     'saveCountThisSession',
     'projectServerState',
+    'onlineState',
   ]

--- a/editor/src/components/editor/store/store-hook.spec.tsx
+++ b/editor/src/components/editor/store/store-hook.spec.tsx
@@ -17,6 +17,7 @@ import { shallowEqual } from '../../../core/shared/equality-utils'
 import { createBuiltInDependenciesList } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { notLoggedIn } from '../action-types'
 import { emptyProjectServerState } from './project-server-state'
+import { InitialOnlineState } from '../online-status'
 
 const initialEditorStore: EditorStorePatched = {
   editor: createEditorState(NO_OP),
@@ -40,6 +41,7 @@ const initialEditorStore: EditorStorePatched = {
   storeName: 'editor-store',
   projectServerState: emptyProjectServerState(),
   collaborativeEditingSupport: emptyCollaborativeEditingSupport(),
+  onlineState: InitialOnlineState,
 }
 
 function createEmptyEditorStoreHook() {

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -5,8 +5,9 @@ import { subscribeWithSelector } from 'zustand/middleware'
 import { shallowEqual } from '../../../core/shared/equality-utils'
 import { objectMap } from '../../../core/shared/object-utils'
 import {
-  MutiplayerSubstateKeepDeepEquality,
+  MultiplayerSubstateKeepDeepEquality,
   NavigatorStateKeepDeepEquality,
+  OnlineStateKeepDeepEquality,
   ProjectServerStateKeepDeepEquality,
 } from './store-deep-equality-instances'
 import type { DerivedState, EditorStorePatched } from './editor-state'
@@ -27,6 +28,7 @@ import type {
   MetadataSubstate,
   MultiplayerSubstate,
   NavigatorSubstate,
+  OnlineStateSubstate,
   PostActionInteractionSessionSubstate,
   ProjectContentAndMetadataSubstate,
   ProjectContentSubstate,
@@ -313,7 +315,10 @@ export const Substores = {
     return keysEquality(variablesInScopeSubstateKeys, a.editor, b.editor)
   },
   multiplayer: (a: MultiplayerSubstate, b: MultiplayerSubstate) => {
-    return MutiplayerSubstateKeepDeepEquality(a, b).areEqual
+    return MultiplayerSubstateKeepDeepEquality(a, b).areEqual
+  },
+  onlineState: (a: OnlineStateSubstate, b: OnlineStateSubstate): boolean => {
+    return OnlineStateKeepDeepEquality(a.onlineState, b.onlineState).areEqual
   },
 } as const
 

--- a/editor/src/components/inspector/common/inspector.test-utils.tsx
+++ b/editor/src/components/inspector/common/inspector.test-utils.tsx
@@ -48,6 +48,7 @@ import { styleStringInArray } from '../../../utils/common-constants'
 import { fireEvent } from '@testing-library/react'
 import type { EditorRenderResult } from '../../canvas/ui-jsx.test-utils'
 import { emptyProjectServerState } from '../../editor/store/project-server-state'
+import { InitialOnlineState } from '../../editor/online-status'
 
 type UpdateFunctionHelpers = {
   updateStoreWithImmer: (fn: (store: EditorStorePatched) => void) => void
@@ -76,6 +77,7 @@ export function getStoreHook(): UtopiaStoreAPI & UpdateFunctionHelpers {
     builtInDependencies: createBuiltInDependenciesList(null),
     projectServerState: emptyProjectServerState(),
     collaborativeEditingSupport: emptyCollaborativeEditingSupport(),
+    onlineState: InitialOnlineState,
   }
 
   const storeHook: UtopiaStoreAPI = createStoresAndState(defaultState)

--- a/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/longhand-shorthand-hooks.spec.tsx
@@ -28,6 +28,7 @@ import { setProp_UNSAFE, unsetProperty } from '../../editor/actions/action-creat
 import { DispatchContext } from '../../editor/store/dispatch-context'
 import { styleStringInArray } from '../../../utils/common-constants'
 import { emptyProjectServerState } from '../../editor/store/project-server-state'
+import { InitialOnlineState } from '../../editor/online-status'
 
 const TestSelectedComponent = EP.elementPath([['scene1'], ['aaa', 'bbb']])
 
@@ -70,6 +71,7 @@ function getPaddingHookResult<P extends ParsedPropertiesKeys, S extends ParsedPr
       storeName: 'editor-store',
       projectServerState: emptyProjectServerState(),
       collaborativeEditingSupport: emptyCollaborativeEditingSupport(),
+      onlineState: InitialOnlineState,
     }
 
     const storeHook: UtopiaStoreAPI = createStoresAndState(initialEditorStore)

--- a/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
+++ b/editor/src/components/inspector/common/property-controls-hooks.spec.tsx
@@ -38,6 +38,7 @@ import {
   ComponentDescriptorDefaults,
   defaultComponentDescriptor,
 } from '../../custom-code/code-file'
+import { InitialOnlineState } from '../../editor/online-status'
 
 const TestAppUID2 = 'app-entity-2'
 const TestOtherComponentUID = 'other-component-entity-1'
@@ -234,6 +235,7 @@ function callPropertyControlsHook(
     storeName: 'editor-store',
     projectServerState: emptyProjectServerState(),
     collaborativeEditingSupport: emptyCollaborativeEditingSupport(),
+    onlineState: InitialOnlineState,
   }
 
   const storeHook = createStoresAndState(initialEditorStore)

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -124,6 +124,7 @@ import {
   LoadActionsDispatched,
 } from '../components/github/github-repository-clone-flow'
 import { hasReactRouterErrorBeenLogged } from '../core/shared/runtime-report-logs'
+import { InitialOnlineState, startOnlineStatusPolling } from '../components/editor/online-status'
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()
@@ -266,6 +267,7 @@ export class Editor {
       saveCountThisSession: 0,
       projectServerState: emptyProjectServerState(),
       collaborativeEditingSupport: emptyCollaborativeEditingSupport(),
+      onlineState: InitialOnlineState,
     }
 
     const store = createStoresAndState(patchedStoreFromFullStore(this.storedState, 'editor-store'))
@@ -292,6 +294,7 @@ export class Editor {
     void renderRootEditor()
 
     void GithubOperations.startGithubPolling(this.utopiaStoreHook, this.boundDispatch)
+    startOnlineStatusPolling(this.boundDispatch)
 
     reduxDevtoolsSendInitialState(this.storedState)
 

--- a/utopia-remix/app/routes/online-status.tsx
+++ b/utopia-remix/app/routes/online-status.tsx
@@ -1,0 +1,3 @@
+export async function loader() {
+  return new Response('Online', { headers: { 'content-type': 'text/plain' } })
+}


### PR DESCRIPTION
**Problem:**
Currently the "Utopia is offline" banner appears to be a little sensitive and is also governed by saving and retrieving the user's login state, which aren't necessarily good for checking if a users is online. As well as the former being something that is irregularly called.

**Fix:**
The two existing checks to show the offline bar have been removed and replaced with a check that performs a HEAD request against a minimal endpoint in the BFF server. Should that request fail 3 times in a row then the offline bar will be displayed until another successful request is made.

**Observations:**
With this work the inspector still switches into an offline state quite rapidly because it appears to be checking the login state. This should probably be changed in subsequent work as it looks a bit weird.

**Commit Details:**
- Added `OnlineState` type along with constructing function.
- Added `useGetOnlineStatus` hook which encapsulates the logic for checking if the editor actually really is online/offline.
- Added `startOnlineStatusPolling` which triggers the polling only the one time.
- Hooked `startOnlineStatusPolling` into the initialisation of the `Editor` component.
- Modified `BrowserInfoBar` to only show `EditorOfflineBar` when `useGetOnlineStatus` returns false.
- Added `onlineState` field to `EditorStoreShared`.
- Added additional sub store case for `onlineState`.
- Added additional route to the Remix server which has a minimal plain text response.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5230.
