### PR TITLE
Inserting a render prop causes UID error

### DIFF
--- a/editor/src/components/navigator/navigator-item/render-prop-selector-popup.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/render-prop-selector-popup.spec.browser2.tsx
@@ -5,7 +5,7 @@ import {
   getPrintedUiJsCodeWithoutUIDs,
   renderTestEditorWithModel,
 } from '../../canvas/ui-jsx.test-utils'
-import { StoryboardFilePath } from '../../editor/store/editor-state'
+import { StoryboardFilePath, navigatorEntryToKey } from '../../editor/store/editor-state'
 import * as EP from '../../../core/shared/element-path'
 import {
   mouseClickAtPoint,
@@ -489,7 +489,7 @@ describe('The navigator render prop picker', () => {
     )
   })
 
-  it('deduplicated prop UIDs', async () => {
+  it('deduplicates render prop UIDs', async () => {
     const editor = await renderTestEditorWithModel(
       createModifiedProject({
         [StoryboardFilePath]: `
@@ -516,7 +516,7 @@ describe('The navigator render prop picker', () => {
               <Card
                 data-uid='card'
               >
-                <p data-uid='88b'>Card contents</p>
+                <p data-uid='contents'>Card contents</p>
               </Card>
             </div>
           )
@@ -601,6 +601,27 @@ describe('The navigator render prop picker', () => {
     const menuButton = await waitFor(() => editor.renderedDOM.getByText('Flex Hello'))
     await mouseClickAtPoint(menuButton, { x: 3, y: 3 })
 
-    expect(1).toEqual(1)
+    expect(editor.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey)).toEqual([
+      'regular-sb/scene',
+      'regular-sb/scene/pg',
+      'regular-sb/scene/pg:pg-root',
+      'regular-sb/scene/pg:pg-root/card',
+      'render-prop-sb/scene/pg:pg-root/card/prop-label-title-title',
+      'synthetic-sb/scene/pg:pg-root/card/aab-element-aab',
+      'render-prop-sb/scene/pg:pg-root/card/prop-label-children-children',
+      'regular-sb/scene/pg:pg-root/card/contents',
+    ])
+    expect(
+      editor.getEditorState().derived.visibleNavigatorTargets.map(navigatorEntryToKey),
+    ).toEqual([
+      'regular-sb/scene',
+      'regular-sb/scene/pg',
+      'regular-sb/scene/pg:pg-root',
+      'regular-sb/scene/pg:pg-root/card',
+      'render-prop-sb/scene/pg:pg-root/card/prop-label-title-title',
+      'synthetic-sb/scene/pg:pg-root/card/aab-element-aab',
+      'render-prop-sb/scene/pg:pg-root/card/prop-label-children-children',
+      'regular-sb/scene/pg:pg-root/card/contents',
+    ])
   })
 })

--- a/editor/src/components/navigator/navigator-item/render-prop-selector-popup.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/render-prop-selector-popup.spec.browser2.tsx
@@ -1,5 +1,5 @@
 import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
-import { selectComponentsForTest, wait } from '../../../utils/utils.test-utils'
+import { selectComponentsForTest } from '../../../utils/utils.test-utils'
 import {
   formatTestProjectCode,
   getPrintedUiJsCodeWithoutUIDs,
@@ -607,7 +607,7 @@ describe('The navigator render prop picker', () => {
       'regular-sb/scene/pg:pg-root',
       'regular-sb/scene/pg:pg-root/card',
       'render-prop-sb/scene/pg:pg-root/card/prop-label-title-title',
-      'synthetic-sb/scene/pg:pg-root/card/aab-element-aab',
+      'synthetic-sb/scene/pg:pg-root/card/pro-element-pro',
       'render-prop-sb/scene/pg:pg-root/card/prop-label-children-children',
       'regular-sb/scene/pg:pg-root/card/contents',
     ])
@@ -619,7 +619,7 @@ describe('The navigator render prop picker', () => {
       'regular-sb/scene/pg:pg-root',
       'regular-sb/scene/pg:pg-root/card',
       'render-prop-sb/scene/pg:pg-root/card/prop-label-title-title',
-      'synthetic-sb/scene/pg:pg-root/card/aab-element-aab',
+      'synthetic-sb/scene/pg:pg-root/card/pro-element-pro',
       'render-prop-sb/scene/pg:pg-root/card/prop-label-children-children',
       'regular-sb/scene/pg:pg-root/card/contents',
     ])

--- a/editor/src/components/navigator/navigator-item/render-prop-selector-popup.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/render-prop-selector-popup.spec.browser2.tsx
@@ -498,7 +498,7 @@ describe('The navigator render prop picker', () => {
         import { Storyboard, Scene } from 'utopia-api'
 
         export function Flex({ hello }) {
-          return <div>{hello.gr}</div>
+          return <div>{hello.greeting}</div>
         }
         
         export function Card({ header, children }) {

--- a/editor/src/components/navigator/navigator-item/render-prop-selector-popup.tsx
+++ b/editor/src/components/navigator/navigator-item/render-prop-selector-popup.tsx
@@ -14,7 +14,7 @@ import * as EP from '../../../core/shared/element-path'
 import * as PP from '../../../core/shared/property-path'
 import { ComponentPicker, type ElementToInsert } from './component-picker'
 import type { PreferredChildComponentDescriptor } from '../../custom-code/internal-property-controls'
-import { generateConsistentUID } from '../../../core/shared/uid-utils'
+import { fixUtopiaElement, generateConsistentUID } from '../../../core/shared/uid-utils'
 import { getAllUniqueUids } from '../../../core/model/get-unique-ids'
 import { elementFromInsertMenuItem } from '../../editor/insert-callbacks'
 import { MomentumContextMenu } from '../../context-menu-wrapper'
@@ -189,9 +189,13 @@ function insertPreferredChild(
   projectContents: ProjectContentTreeRoot,
   dispatch: EditorDispatch,
 ) {
+  const uniqueIds = new Set(getAllUniqueUids(projectContents).uniqueIDs)
   const uid = generateConsistentUID('prop', new Set(getAllUniqueUids(projectContents).uniqueIDs))
+  let element = preferredChildToInsert.elementToInsert(uid)
+  uniqueIds.add(uid)
 
-  const element = preferredChildToInsert.elementToInsert(uid)
+  element = fixUtopiaElement(preferredChildToInsert.elementToInsert(uid), uniqueIds).value
+
   if (element.type !== 'JSX_ELEMENT') {
     throw new Error('only JSX elements are supported as preferred components')
   }

--- a/editor/src/components/navigator/navigator-item/render-prop-selector-popup.tsx
+++ b/editor/src/components/navigator/navigator-item/render-prop-selector-popup.tsx
@@ -194,7 +194,7 @@ function insertPreferredChild(
   let element = preferredChildToInsert.elementToInsert(uid)
   uniqueIds.add(uid)
 
-  element = fixUtopiaElement(preferredChildToInsert.elementToInsert(uid), uniqueIds).value
+  element = fixUtopiaElement(element, uniqueIds).value
 
   if (element.type !== 'JSX_ELEMENT') {
     throw new Error('only JSX elements are supported as preferred components')

--- a/editor/src/components/navigator/navigator-item/render-prop-selector-popup.tsx
+++ b/editor/src/components/navigator/navigator-item/render-prop-selector-popup.tsx
@@ -190,9 +190,8 @@ function insertPreferredChild(
   dispatch: EditorDispatch,
 ) {
   const uniqueIds = new Set(getAllUniqueUids(projectContents).uniqueIDs)
-  const uid = generateConsistentUID('prop', new Set(getAllUniqueUids(projectContents).uniqueIDs))
+  const uid = generateConsistentUID('prop', uniqueIds)
   let element = preferredChildToInsert.elementToInsert(uid)
-  uniqueIds.add(uid)
 
   element = fixUtopiaElement(element, uniqueIds).value
 

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -5049,7 +5049,7 @@ describe('Navigator', () => {
         'regular-sb/scene/pg:dbc',
         'regular-sb/scene/pg:dbc/78c',
         'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
-        'regular-sb/scene/pg:dbc/78c/pro', // <- the inserted render prop
+        'regular-sb/scene/pg:dbc/78c/aaa', // <- the inserted render prop
         'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
         'regular-sb/scene/pg:dbc/78c/88b',
       ])
@@ -5061,7 +5061,7 @@ describe('Navigator', () => {
         'regular-sb/scene/pg:dbc',
         'regular-sb/scene/pg:dbc/78c',
         'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
-        'regular-sb/scene/pg:dbc/78c/pro', // <- the inserted render prop
+        'regular-sb/scene/pg:dbc/78c/aaa', // <- the inserted render prop
         'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
         'regular-sb/scene/pg:dbc/78c/88b',
       ])
@@ -5094,7 +5094,7 @@ describe('Navigator', () => {
         'regular-sb/scene/pg:dbc',
         'regular-sb/scene/pg:dbc/78c',
         'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
-        'regular-sb/scene/pg:dbc/78c/pro', // <- the inserted render prop
+        'regular-sb/scene/pg:dbc/78c/aaa', // <- the inserted render prop
         'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
         'regular-sb/scene/pg:dbc/78c/88b',
       ])
@@ -5106,7 +5106,7 @@ describe('Navigator', () => {
         'regular-sb/scene/pg:dbc',
         'regular-sb/scene/pg:dbc/78c',
         'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
-        'regular-sb/scene/pg:dbc/78c/pro', // <- the inserted render prop
+        'regular-sb/scene/pg:dbc/78c/aaa', // <- the inserted render prop
         'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
         'regular-sb/scene/pg:dbc/78c/88b',
       ])
@@ -5139,7 +5139,7 @@ describe('Navigator', () => {
         'regular-sb/scene/pg:dbc',
         'regular-sb/scene/pg:dbc/78c',
         'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
-        'regular-sb/scene/pg:dbc/78c/pro', // <- the inserted render prop
+        'regular-sb/scene/pg:dbc/78c/aaa', // <- the inserted render prop
         'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
         'regular-sb/scene/pg:dbc/78c/88b',
       ])
@@ -5151,7 +5151,7 @@ describe('Navigator', () => {
         'regular-sb/scene/pg:dbc',
         'regular-sb/scene/pg:dbc/78c',
         'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
-        'regular-sb/scene/pg:dbc/78c/pro', // <- the inserted render prop
+        'regular-sb/scene/pg:dbc/78c/aaa', // <- the inserted render prop
         'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
         'regular-sb/scene/pg:dbc/78c/88b',
       ])

--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -5049,7 +5049,7 @@ describe('Navigator', () => {
         'regular-sb/scene/pg:dbc',
         'regular-sb/scene/pg:dbc/78c',
         'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
-        'regular-sb/scene/pg:dbc/78c/aaa', // <- the inserted render prop
+        'regular-sb/scene/pg:dbc/78c/pro', // <- the inserted render prop
         'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
         'regular-sb/scene/pg:dbc/78c/88b',
       ])
@@ -5061,7 +5061,7 @@ describe('Navigator', () => {
         'regular-sb/scene/pg:dbc',
         'regular-sb/scene/pg:dbc/78c',
         'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
-        'regular-sb/scene/pg:dbc/78c/aaa', // <- the inserted render prop
+        'regular-sb/scene/pg:dbc/78c/pro', // <- the inserted render prop
         'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
         'regular-sb/scene/pg:dbc/78c/88b',
       ])
@@ -5094,7 +5094,7 @@ describe('Navigator', () => {
         'regular-sb/scene/pg:dbc',
         'regular-sb/scene/pg:dbc/78c',
         'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
-        'regular-sb/scene/pg:dbc/78c/aaa', // <- the inserted render prop
+        'regular-sb/scene/pg:dbc/78c/pro', // <- the inserted render prop
         'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
         'regular-sb/scene/pg:dbc/78c/88b',
       ])
@@ -5106,7 +5106,7 @@ describe('Navigator', () => {
         'regular-sb/scene/pg:dbc',
         'regular-sb/scene/pg:dbc/78c',
         'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
-        'regular-sb/scene/pg:dbc/78c/aaa', // <- the inserted render prop
+        'regular-sb/scene/pg:dbc/78c/pro', // <- the inserted render prop
         'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
         'regular-sb/scene/pg:dbc/78c/88b',
       ])
@@ -5139,7 +5139,7 @@ describe('Navigator', () => {
         'regular-sb/scene/pg:dbc',
         'regular-sb/scene/pg:dbc/78c',
         'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
-        'regular-sb/scene/pg:dbc/78c/aaa', // <- the inserted render prop
+        'regular-sb/scene/pg:dbc/78c/pro', // <- the inserted render prop
         'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
         'regular-sb/scene/pg:dbc/78c/88b',
       ])
@@ -5151,7 +5151,7 @@ describe('Navigator', () => {
         'regular-sb/scene/pg:dbc',
         'regular-sb/scene/pg:dbc/78c',
         'render-prop-sb/scene/pg:dbc/78c/prop-label-header-header',
-        'regular-sb/scene/pg:dbc/78c/aaa', // <- the inserted render prop
+        'regular-sb/scene/pg:dbc/78c/pro', // <- the inserted render prop
         'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
         'regular-sb/scene/pg:dbc/78c/88b',
       ])


### PR DESCRIPTION
## Problem

https://github.com/concrete-utopia/utopia/issues/5243

## Cause
The uids within the props of the inserted element weren't fixed, which led to duplicate uids creeping into the project.

## Fix
Fix the inserted element with `fixUtopiaElement` before inserting it, which "fixes" the render prop uids too.

## Manual Tests:
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

