### PR TITLE
skip parsing package-lock.json

### DIFF
--- a/editor/src/core/workers/parser-printer/parser-printer.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.ts
@@ -87,6 +87,7 @@ import {
   exportDefaultIdentifier,
   isImportSideEffects,
   isParseSuccess,
+  unparsed,
 } from '../../shared/project-file-types'
 import * as PP from '../../shared/property-path'
 import { assertNever, fastForEach } from '../../shared/utils'
@@ -1334,6 +1335,9 @@ export function parseCode(
   alreadyExistingUIDs_MUTABLE: Set<string>,
   applySteganography: SteganographyMode,
 ): ParsedTextFile {
+  if (filePath.endsWith('package-lock.json')) {
+    return unparsed
+  }
   const originalAlreadyExistingUIDs_MUTABLE: Set<string> = new Set(alreadyExistingUIDs_MUTABLE)
   const sourceFile = TS.createSourceFile(filePath, sourceText, TS.ScriptTarget.ES3)
 


### PR DESCRIPTION
## Problem
Parsing package-lock.json takes a long time when a project is loaded.
https://github.com/concrete-utopia/utopia/issues/5245

## Fix
In `parseCode` (the entrypoint to the parsing code afaik), check whether the file to be parsed is `package-lock.json`, and it it is, return `unparsed`

## Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

