### PR TITLE
Turn down connection amount for Haskell server.

### DIFF
--- a/server/src/Utopia/Web/Database.hs
+++ b/server/src/Utopia/Web/Database.hs
@@ -109,7 +109,9 @@ getDatabaseConnectionString = lookupEnv "DATABASE_URL"
 createDatabasePoolFromConnection :: IO Connection -> IO DBPool
 createDatabasePoolFromConnection createConnection = do
   let keepResourceOpenFor = 10
-  createPool createConnection close 2 keepResourceOpenFor 1
+  let poolStripes = 2
+  let connectionsPerStripe = 1
+  createPool createConnection close poolStripes keepResourceOpenFor connectionsPerStripe
 
 createLocalDatabasePool :: IO DBPool
 createLocalDatabasePool = do

--- a/server/src/Utopia/Web/Database.hs
+++ b/server/src/Utopia/Web/Database.hs
@@ -109,7 +109,7 @@ getDatabaseConnectionString = lookupEnv "DATABASE_URL"
 createDatabasePoolFromConnection :: IO Connection -> IO DBPool
 createDatabasePoolFromConnection createConnection = do
   let keepResourceOpenFor = 10
-  createPool createConnection close 3 keepResourceOpenFor 3
+  createPool createConnection close 2 keepResourceOpenFor 1
 
 createLocalDatabasePool :: IO DBPool
 createLocalDatabasePool = do


### PR DESCRIPTION
**Problem:**
Collectively we're consuming too many of the PostgreSQL connection pool connections.

**Fix:**
Turn down the number of connections the Haskell server opens.

**Commit Details:**
- In `createDatabasePoolFromConnection` turn the connections down to 2 stripes of 1 connection each for an absolute maximum of 2.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

