### PR TITLE
Better component descriptor error messages

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -353,8 +353,7 @@ describe('registered property controls', () => {
             endLine: null,
             errorCode: '',
             fileName: '/utopia/components.utopia.js',
-            message:
-              "Components file evaluation error: TypeError: Cannot read properties of undefined (reading 'foo')",
+            message: "TypeError: Cannot read properties of undefined (reading 'foo')",
             passTime: null,
             severity: 'fatal',
             source: 'component-descriptor',

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -431,12 +431,16 @@ function errorsFromComponentRegistration(
             return errorMsgFromFancyError
           }
         }
-        return [
-          simpleErrorMessage(
-            fileName,
-            `Components file evaluation error: ${JSON.stringify(error.evaluationError)}`,
-          ),
-        ]
+        if (error.evaluationError instanceof Error) {
+          return [
+            simpleErrorMessage(
+              fileName,
+              `${error.evaluationError.name}: ${error.evaluationError.message}`,
+            ),
+          ]
+        }
+        // Note: this is very ugly and should not happen at all, but I keep it here so we see if it happens
+        return [simpleErrorMessage(fileName, JSON.stringify(error))]
       case 'no-export-default':
         return [simpleErrorMessage(fileName, `Components file has no default export`)]
       case 'no-exported-component-descriptors':
@@ -1165,7 +1169,7 @@ function fancyErrorToErrorMessage(error: FancyError): ErrorMessage | null {
       code,
       'fatal',
       '',
-      `Components file evaluation error: ${error}`,
+      `${error.name}: ${error.message}`,
       '',
       'component-descriptor',
       null,


### PR DESCRIPTION
**Problem:**
1. When we evaluate the component descriptor files, we may receive simple javascript Error exceptions, and not FancyErrors. These are not properly converted into our own `ErrorMessage` type.
2. When we actually have a FancyError instance, we accidentally dumped the whole object into the `ErrorMessage.message`, which resulted in lot of noise with the fake stacktrace coming from our evaluation.

**Fix:**
- Add the missing case to handle Error objects.
- Serialize only error.name and error.message into ErrorMessage.message from FancyErrors
- Removed `Components file evaluation error: ` prefix, it just made the usual js error less recognizable

BEFORE:

<img width="911" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/c020e1e4-1f96-48af-8619-74e71ead67e4">

and

<img width="2009" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/f7043a71-08e0-48b9-91ab-877b1792c5fa">

AFTER:

<img width="816" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/9a374056-3401-4d32-ad96-d9ff318e701a">

## Potential improvement:
[ ] Use source maps to create a stack trace

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #[ticket_number] (<< pls delete this line if it's not relevant)
