### PR TITLE
Only navigate to selection in vscode when js file is open

### DIFF
--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -346,7 +346,9 @@ function initMessaging(context: vscode.ExtensionContext, workspaceRootUri: vscod
         break
       case 'SELECTED_ELEMENT_CHANGED':
         const followSelectionEnabled = getFollowSelectionEnabledConfig()
-        if (followSelectionEnabled) {
+        const shouldFollowSelection =
+          followSelectionEnabled && shouldFollowSelectionWithActiveFile()
+        if (shouldFollowSelection) {
           currentSelection = message.boundsInFile
           revealRangeIfPossible(workspaceRootUri, message.boundsInFile)
         }
@@ -603,4 +605,20 @@ function toFileSystemProviderError(projectID: string, error: FSError): vscode.Fi
       const _exhaustiveCheck: never = code
       throw new Error(`Unhandled FS Error ${JSON.stringify(error)}`)
   }
+}
+
+function shouldFollowSelectionWithActiveFile() {
+  const { activeTextEditor } = vscode.window
+  if (activeTextEditor == null) {
+    return true
+  }
+
+  const filePath = activeTextEditor.document.uri.path
+  const isJs =
+    filePath.endsWith('.js') ||
+    filePath.endsWith('.jsx') ||
+    filePath.endsWith('.cjs') ||
+    filePath.endsWith('.mjs')
+  const isComponentDescriptor = filePath.startsWith('/utopia/') && filePath.endsWith('.utopia.js')
+  return isJs && !isComponentDescriptor
 }


### PR DESCRIPTION
**Problem:**
When editing a component descriptor file, a css file, etc, and you click on the canvas to select an object, it can be really annoying that the code editor navigates away to the source of the element.

**Fix:**
Only navigate when the active file is a javascript file, but not a component descriptor file.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5249
