### PR TITLE
Remix support: renaming (home) to /

### DIFF
--- a/editor/src/components/canvas/remix/remix-utils.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.tsx
@@ -455,7 +455,7 @@ export function getRouteComponentNameForOutlet(
   return defaultExport.name
 }
 
-export const RemixIndexPathLabel = '(home)'
+export const RemixIndexPathLabel = '/'
 
 export function getRemixLocationLabel(location: string | undefined): string | null {
   if (location == null) {

--- a/editor/src/components/editor/remix-navigation-bar.tsx
+++ b/editor/src/components/editor/remix-navigation-bar.tsx
@@ -114,6 +114,7 @@ export const RemixNavigationBar = React.memo(() => {
           borderRadius: 20,
           padding: '2px 10px',
           fontSize: 11,
+          minWidth: 150,
         }}
       >
         {label}

--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -5,10 +5,17 @@ import { jsx } from '@emotion/react'
 
 import { useAtom } from 'jotai'
 import React from 'react'
+import ReactDOM from 'react-dom'
 import { matchRoutes } from 'react-router'
 import { safeIndex, uniqBy } from '../../../core/shared/array-utils'
+import { defaultEither } from '../../../core/shared/either'
 import * as EP from '../../../core/shared/element-path'
 import { NO_OP, PortalTargetID } from '../../../core/shared/utils'
+import {
+  getFeaturedRoutesFromPackageJSON,
+  getPageTemplatesFromPackageJSON,
+} from '../../../printer-parsers/html/external-resources-parser'
+import { when } from '../../../utils/react-conditionals'
 import {
   FlexColumn,
   FlexRow,
@@ -27,25 +34,18 @@ import {
   ActiveRemixSceneAtom,
   RemixNavigationAtom,
 } from '../../canvas/remix/utopia-remix-root-component'
-import { Substores, useEditorState } from '../../editor/store/store-hook'
-import { ExpandableIndicator } from '../navigator-item/expandable-indicator'
-import {
-  getFeaturedRoutesFromPackageJSON,
-  getPageTemplatesFromPackageJSON,
-} from '../../../printer-parsers/html/external-resources-parser'
-import { defaultEither } from '../../../core/shared/either'
-import { when } from '../../../utils/react-conditionals'
 import { MomentumContextMenu } from '../../context-menu-wrapper'
-import { useDispatch } from '../../editor/store/dispatch-context'
 import {
   addNewFeaturedRoute,
   addNewPage,
   removeFeaturedRoute,
   showContextMenu,
 } from '../../editor/actions/action-creators'
-import type { ElementContextMenuInstance } from '../../element-context-menu'
-import ReactDOM from 'react-dom'
+import { useDispatch } from '../../editor/store/dispatch-context'
 import { createNewPageName } from '../../editor/store/editor-state'
+import { Substores, useEditorState } from '../../editor/store/store-hook'
+import type { ElementContextMenuInstance } from '../../element-context-menu'
+import { ExpandableIndicator } from '../navigator-item/expandable-indicator'
 
 type RouteMatch = {
   path: string

--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -5,17 +5,10 @@ import { jsx } from '@emotion/react'
 
 import { useAtom } from 'jotai'
 import React from 'react'
-import ReactDOM from 'react-dom'
 import { matchRoutes } from 'react-router'
 import { safeIndex, uniqBy } from '../../../core/shared/array-utils'
-import { defaultEither } from '../../../core/shared/either'
 import * as EP from '../../../core/shared/element-path'
 import { NO_OP, PortalTargetID } from '../../../core/shared/utils'
-import {
-  getFeaturedRoutesFromPackageJSON,
-  getPageTemplatesFromPackageJSON,
-} from '../../../printer-parsers/html/external-resources-parser'
-import { when } from '../../../utils/react-conditionals'
 import {
   FlexColumn,
   FlexRow,
@@ -34,18 +27,25 @@ import {
   ActiveRemixSceneAtom,
   RemixNavigationAtom,
 } from '../../canvas/remix/utopia-remix-root-component'
+import { Substores, useEditorState } from '../../editor/store/store-hook'
+import { ExpandableIndicator } from '../navigator-item/expandable-indicator'
+import {
+  getFeaturedRoutesFromPackageJSON,
+  getPageTemplatesFromPackageJSON,
+} from '../../../printer-parsers/html/external-resources-parser'
+import { defaultEither } from '../../../core/shared/either'
+import { when } from '../../../utils/react-conditionals'
 import { MomentumContextMenu } from '../../context-menu-wrapper'
+import { useDispatch } from '../../editor/store/dispatch-context'
 import {
   addNewFeaturedRoute,
   addNewPage,
   removeFeaturedRoute,
   showContextMenu,
 } from '../../editor/actions/action-creators'
-import { useDispatch } from '../../editor/store/dispatch-context'
-import { createNewPageName } from '../../editor/store/editor-state'
-import { Substores, useEditorState } from '../../editor/store/store-hook'
 import type { ElementContextMenuInstance } from '../../element-context-menu'
-import { ExpandableIndicator } from '../navigator-item/expandable-indicator'
+import ReactDOM from 'react-dom'
+import { createNewPageName } from '../../editor/store/editor-state'
 
 type RouteMatch = {
   path: string


### PR DESCRIPTION
**Problem**
On master, we display the root route as `(home)` in the canvas topmenu's navigation bar, and in the Routes section of the Pages tab.

This is non-standard, and once we want to allow free text input in the navigation bar, this will become weird. In the Routes section it's also sticking out from the rest of the routes which are displayed in standard format.

**Fix**
<img width="1039" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/3ae7456d-015f-456f-bf3e-7ece2058a610">

Show the root route as `/` everywhere