### PR TITLE
Component api: add `moduleName` prop

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -1289,10 +1289,7 @@ describe('registered property controls', () => {
             component: Card,
             properties: { },
             children: {
-              preferredContents: {
-                component: 'text',
-                variants: 'text'
-              }
+              preferredContents: 'text'
             }
           },
         },
@@ -1351,6 +1348,7 @@ describe('registered property controls', () => {
                 { component: 'span', variants: { name: 'span' } },
                 {
                   component: 'Card2',
+                  moduleName: '/src/card2',
                   variants: [
                     { component: Card2 },
                     {
@@ -1547,6 +1545,7 @@ describe('registered property controls', () => {
                   { component: 'span', variants: { name: 'span' } },
                   {
                     component: 'Card2',
+                    moduleName: '/src/card2',
                     variants: [
                       { component: Card2 },
                       {
@@ -1660,6 +1659,7 @@ describe('registered property controls', () => {
                   },
                   Object {
                     "component": "Card2",
+                    "moduleName": "/src/card2",
                     "variants": Array [
                       Object {
                         "component": [Function],

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -307,9 +307,6 @@ function isComponentRegistrationValid(
     }
   }
 
-  // TODO check whether non-intrinsic element in preferredContents has
-  // `moduleName` specified
-
   return { type: 'valid' }
 }
 

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -30,10 +30,13 @@ export type PlaceholderSpec =
   // inserts a spacer that completely fills the available space
   | 'fill'
 
-export interface PreferredContents {
-  component: string
-  variants: 'text' | ComponentExample | ComponentExample[]
-}
+export type PreferredContents =
+  | 'text'
+  | {
+      component: string
+      moduleName?: string
+      variants: ComponentExample | ComponentExample[]
+    }
 
 export interface ChildrenSpec {
   // specifies what component(s) are preferred.


### PR DESCRIPTION
## Problem
When the component picker looks for the icon of a registered component, without knowing which module it came from, the icon of the first registered component will be returned, which might not be the right one. To fix this, we need to add a `moduleName` prop to `PreferredContents`, which tells the component picker which module that component is coming from.

## Fix
- add a `moduleName` prop to `PreferredContents`
- update the shape of the `PreferredContents` interface so that `'text'` doesn't need a `moduleName` or a `component`

### Details
`moduleName` is optional in `PreferredContents`, because intrinsic element don't have a corresponding module

## Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode