### PR TITLE
do not switch tabs on select

### DIFF
--- a/editor/src/components/canvas/commands/update-selected-views-command.ts
+++ b/editor/src/components/canvas/commands/update-selected-views-command.ts
@@ -1,10 +1,7 @@
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import {
-  LeftMenuTab,
-  type EditorState,
-  type EditorStatePatch,
-} from '../../editor/store/editor-state'
+import { nextSelectedTab } from '../../editor/editor-modes'
+import { type EditorState, type EditorStatePatch } from '../../editor/store/editor-state'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface UpdateSelectedViews extends BaseCommand {
@@ -24,7 +21,7 @@ export function updateSelectedViews(
 }
 
 export const runUpdateSelectedViews: CommandFunction<UpdateSelectedViews> = (
-  _: EditorState,
+  editorState: EditorState,
   command: UpdateSelectedViews,
 ) => {
   const editorStatePatch: EditorStatePatch = {
@@ -33,7 +30,7 @@ export const runUpdateSelectedViews: CommandFunction<UpdateSelectedViews> = (
     },
     leftMenu: {
       selectedTab: {
-        $set: LeftMenuTab.Navigator,
+        $set: nextSelectedTab(editorState),
       },
     },
   }

--- a/editor/src/components/canvas/commands/update-selected-views-command.ts
+++ b/editor/src/components/canvas/commands/update-selected-views-command.ts
@@ -1,7 +1,7 @@
 import * as EP from '../../../core/shared/element-path'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import { nextSelectedTab } from '../../editor/editor-modes'
 import { type EditorState, type EditorStatePatch } from '../../editor/store/editor-state'
+import { nextSelectedTab } from '../../navigator/left-pane/left-pane-utils'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 
 export interface UpdateSelectedViews extends BaseCommand {
@@ -30,7 +30,7 @@ export const runUpdateSelectedViews: CommandFunction<UpdateSelectedViews> = (
     },
     leftMenu: {
       selectedTab: {
-        $set: nextSelectedTab(editorState),
+        $set: nextSelectedTab(editorState.leftMenu.selectedTab, command.value),
       },
     },
   }

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -7700,7 +7700,7 @@ export var storyboard = (
       }
 
       {
-        // setLeftMenuTab
+        // clearSelection
         await renderResult.dispatch([setLeftMenuTab(LeftMenuTab.Github)], true)
         expect(renderResult.getEditorState().editor.leftMenu.selectedTab).toEqual(
           LeftMenuTab.Github,
@@ -7710,7 +7710,7 @@ export var storyboard = (
 
         expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([])
         expect(renderResult.getEditorState().editor.leftMenu.selectedTab).toEqual(
-          LeftMenuTab.Navigator,
+          LeftMenuTab.Github,
         )
       }
 

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -7695,7 +7695,7 @@ export var storyboard = (
           'utopia-storyboard-uid/scene-aaa/app-entity:root/child1',
         ])
         expect(renderResult.getEditorState().editor.leftMenu.selectedTab).toEqual(
-          LeftMenuTab.Navigator,
+          LeftMenuTab.Github,
         )
       }
 
@@ -7734,7 +7734,7 @@ export var storyboard = (
           'utopia-storyboard-uid/scene-aaa/app-entity:root',
         ])
         expect(renderResult.getEditorState().editor.leftMenu.selectedTab).toEqual(
-          LeftMenuTab.Navigator,
+          LeftMenuTab.Github,
         )
       }
     })

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -7709,6 +7709,8 @@ export var storyboard = (
             await renderResult.dispatch([setLeftMenuTab(page)], true)
             await deselect()
             expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([])
+
+            // stays on the same page
             expect(renderResult.getEditorState().editor.leftMenu.selectedTab).toEqual(page)
           }
         }
@@ -7726,21 +7728,21 @@ export var storyboard = (
 
         const entryPoints = selectActions(renderResult)
 
-        const pages = [{ fromPage: LeftMenuTab.Pages, toPage: LeftMenuTab.Pages }]
+        for await (const select of entryPoints) {
+          await selectComponentsForTest(renderResult, [
+            EP.appendNewElementPath(TestScenePath, ['root', 'child1']),
+          ])
+          await renderResult.dispatch([setLeftMenuTab(LeftMenuTab.Pages)], true)
+          const pathToSelect = EP.appendNewElementPath(TestScenePath, ['root', 'child2'])
+          await select([pathToSelect])
+          expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
+            EP.toString(pathToSelect),
+          ])
 
-        for await (const { fromPage, toPage } of pages) {
-          for await (const select of entryPoints) {
-            await selectComponentsForTest(renderResult, [
-              EP.appendNewElementPath(TestScenePath, ['root', 'child1']),
-            ])
-            await renderResult.dispatch([setLeftMenuTab(fromPage)], true)
-            const pathToSelect = EP.appendNewElementPath(TestScenePath, ['root', 'child2'])
-            await select([pathToSelect])
-            expect(renderResult.getEditorState().editor.selectedViews.map(EP.toString)).toEqual([
-              EP.toString(pathToSelect),
-            ])
-            expect(renderResult.getEditorState().editor.leftMenu.selectedTab).toEqual(toPage)
-          }
+          // stays on the pages tab
+          expect(renderResult.getEditorState().editor.leftMenu.selectedTab).toEqual(
+            LeftMenuTab.Pages,
+          )
         }
       })
 

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -336,7 +336,7 @@ import type {
 } from '../action-types'
 import { isLoggedIn } from '../action-types'
 import type { Mode } from '../editor-modes'
-import { isCommentMode, isFollowMode, isTextEditMode } from '../editor-modes'
+import { isCommentMode, isFollowMode, isTextEditMode, nextSelectedTab } from '../editor-modes'
 import { EditorModes, isLiveMode, isSelectMode } from '../editor-modes'
 import * as History from '../history'
 import type { StateHistory } from '../history'
@@ -2033,7 +2033,7 @@ export const UPDATE_FNS = {
     const updatedEditor: EditorModel = {
       ...editor,
       selectedViews: newlySelectedPaths,
-      leftMenu: { visible: editor.leftMenu.visible, selectedTab: LeftMenuTab.Navigator },
+      leftMenu: { visible: editor.leftMenu.visible, selectedTab: nextSelectedTab(editor) },
       navigator:
         newlySelectedPaths === editor.selectedViews
           ? editor.navigator
@@ -2050,7 +2050,7 @@ export const UPDATE_FNS = {
 
     return {
       ...editor,
-      leftMenu: { visible: editor.leftMenu.visible, selectedTab: LeftMenuTab.Navigator },
+      leftMenu: { visible: editor.leftMenu.visible, selectedTab: nextSelectedTab(editor) },
       selectedViews: [],
       navigator: updateNavigatorCollapsedState([], editor.navigator),
       pasteTargetsToIgnore: [],
@@ -2081,7 +2081,7 @@ export const UPDATE_FNS = {
 
     return {
       ...editor,
-      leftMenu: { visible: editor.leftMenu.visible, selectedTab: LeftMenuTab.Navigator },
+      leftMenu: { visible: editor.leftMenu.visible, selectedTab: nextSelectedTab(editor) },
       selectedViews: [...editor.selectedViews, ...additionalTargets],
       pasteTargetsToIgnore: [],
     }

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -336,7 +336,7 @@ import type {
 } from '../action-types'
 import { isLoggedIn } from '../action-types'
 import type { Mode } from '../editor-modes'
-import { isCommentMode, isFollowMode, isTextEditMode, nextSelectedTab } from '../editor-modes'
+import { isCommentMode, isFollowMode, isTextEditMode } from '../editor-modes'
 import { EditorModes, isLiveMode, isSelectMode } from '../editor-modes'
 import * as History from '../history'
 import type { StateHistory } from '../history'
@@ -581,6 +581,7 @@ import {
 } from '../../canvas/remix/remix-utils'
 import type { FixUIDsState } from '../../../core/workers/parser-printer/uid-fix'
 import { fixTopLevelElementsUIDs } from '../../../core/workers/parser-printer/uid-fix'
+import { nextSelectedTab } from '../../navigator/left-pane/left-pane-utils'
 
 export const MIN_CODE_PANE_REOPEN_WIDTH = 100
 
@@ -2033,7 +2034,10 @@ export const UPDATE_FNS = {
     const updatedEditor: EditorModel = {
       ...editor,
       selectedViews: newlySelectedPaths,
-      leftMenu: { visible: editor.leftMenu.visible, selectedTab: nextSelectedTab(editor) },
+      leftMenu: {
+        visible: editor.leftMenu.visible,
+        selectedTab: nextSelectedTab(editor.leftMenu.selectedTab, newlySelectedPaths),
+      },
       navigator:
         newlySelectedPaths === editor.selectedViews
           ? editor.navigator
@@ -2048,12 +2052,17 @@ export const UPDATE_FNS = {
       return UPDATE_FNS.SET_FOCUSED_ELEMENT(setFocusedElement(null), editor, derived)
     }
 
+    const newlySelectedPaths: Array<ElementPath> = []
+
     return {
       ...editor,
-      leftMenu: { visible: editor.leftMenu.visible, selectedTab: nextSelectedTab(editor) },
+      leftMenu: {
+        visible: editor.leftMenu.visible,
+        selectedTab: nextSelectedTab(editor.leftMenu.selectedTab, newlySelectedPaths),
+      },
       selectedViews: [],
       navigator: updateNavigatorCollapsedState([], editor.navigator),
-      pasteTargetsToIgnore: [],
+      pasteTargetsToIgnore: newlySelectedPaths,
     }
   },
   SELECT_ALL_SIBLINGS: (
@@ -2079,10 +2088,15 @@ export const UPDATE_FNS = {
         })
     }, uniqueParents)
 
+    const nextSelectedViews = [...editor.selectedViews, ...additionalTargets]
+
     return {
       ...editor,
-      leftMenu: { visible: editor.leftMenu.visible, selectedTab: nextSelectedTab(editor) },
-      selectedViews: [...editor.selectedViews, ...additionalTargets],
+      leftMenu: {
+        visible: editor.leftMenu.visible,
+        selectedTab: nextSelectedTab(editor.leftMenu.selectedTab, nextSelectedViews),
+      },
+      selectedViews: nextSelectedViews,
       pasteTargetsToIgnore: [],
     }
   },

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../core/shared/project-file-types'
 import type { JSXElement } from '../../core/shared/element-template'
 import type { CanvasPoint, LocalPoint, Size } from '../../core/shared/math-utils'
+import type { EditorState, LeftMenuTab } from './store/editor-state'
 
 export const DefaultInsertSize: Size = { width: 100, height: 100 }
 
@@ -297,4 +298,8 @@ export function convertModeToSavedMode(mode: Mode): PersistedMode {
     case 'follow':
       return EditorModes.selectMode(null, false, 'none')
   }
+}
+
+export function nextSelectedTab(editor: EditorState): LeftMenuTab {
+  return editor.leftMenu.selectedTab // keep it the same
 }

--- a/editor/src/components/editor/editor-modes.ts
+++ b/editor/src/components/editor/editor-modes.ts
@@ -6,7 +6,6 @@ import type {
 } from '../../core/shared/project-file-types'
 import type { JSXElement } from '../../core/shared/element-template'
 import type { CanvasPoint, LocalPoint, Size } from '../../core/shared/math-utils'
-import type { EditorState, LeftMenuTab } from './store/editor-state'
 
 export const DefaultInsertSize: Size = { width: 100, height: 100 }
 
@@ -298,8 +297,4 @@ export function convertModeToSavedMode(mode: Mode): PersistedMode {
     case 'follow':
       return EditorModes.selectMode(null, false, 'none')
   }
-}
-
-export function nextSelectedTab(editor: EditorState): LeftMenuTab {
-  return editor.leftMenu.selectedTab // keep it the same
 }

--- a/editor/src/components/navigator/left-pane/left-pane-utils.ts
+++ b/editor/src/components/navigator/left-pane/left-pane-utils.ts
@@ -1,0 +1,17 @@
+import type { ElementPath } from '../../../core/shared/project-file-types'
+import { LeftMenuTab } from '../../editor/store/editor-state'
+
+export function nextSelectedTab(
+  currentLeftMenuTab: LeftMenuTab,
+  newSelectedPaths: ElementPath[],
+): LeftMenuTab {
+  if (newSelectedPaths.length === 0) {
+    return currentLeftMenuTab
+  }
+
+  if (currentLeftMenuTab === LeftMenuTab.Pages) {
+    return LeftMenuTab.Pages // same as LeftMenuTab.Pages
+  }
+
+  return LeftMenuTab.Navigator
+}

--- a/editor/src/components/navigator/left-pane/left-pane-utils.ts
+++ b/editor/src/components/navigator/left-pane/left-pane-utils.ts
@@ -10,7 +10,7 @@ export function nextSelectedTab(
   }
 
   if (currentLeftMenuTab === LeftMenuTab.Pages) {
-    return LeftMenuTab.Pages // same as LeftMenuTab.Pages
+    return LeftMenuTab.Pages
   }
 
   return LeftMenuTab.Navigator


### PR DESCRIPTION
Prior art: https://github.com/concrete-utopia/utopia/pull/4381 (noting it for posterity)

## Problem
We don't always want to switch to the navigator tab when selection changes.

The new ruleset is the following: 
- if all elements are deselected (selected views are []): do not switch to the navigator
- if something is selected and the pages tab is active: do not switch to the navigator
- otherwise: switch to the navigator

## Fix
Tweak the `UpdateSelectedViews` command, the `SELECT_COMPONENTS` action, the `SELECT_ALL_SIBLINGS` action and the `CLEAR_SELECTION` action so that they don't change the left panel.

### Details
- The PR adds a function called `nextSelectedTab`, which implements the rules on when to switch tabs
- the following actions still switch back to the Navigator tab: `INSERT_JSX_ELEMENT`, `WRAP_IN_ELEMENT`, `UNWRAP_ELEMENTS`, `INSERT_INSERTABLE`

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
