### PR TITLE
Check offline state before some service calls.

### DIFF
--- a/editor/src/components/editor/online-status.tsx
+++ b/editor/src/components/editor/online-status.tsx
@@ -31,36 +31,49 @@ export function useGetOnlineStatus(): boolean {
   return runningFailureCount < FailureLimit
 }
 
+export async function checkOnlineState(): Promise<boolean> {
+  if (IS_TEST_ENVIRONMENT) {
+    return true
+  } else {
+    // Perform a HEAD request against the backend to see if we are able to connect to it.
+    return fetch(UTOPIA_BACKEND_BASE_URL + 'online-status', {
+      method: 'HEAD',
+      credentials: 'include',
+      headers: HEADERS,
+      mode: MODE,
+    })
+      .then((response) => {
+        if (response.ok) {
+          // We're able to connect and we get a good status code
+          // from the server.
+          return true
+        } else {
+          // We received a failure type response code, which
+          // potentially means that our service provider is down or a deploy got mangled.
+          return false
+        }
+      })
+      .catch((error) => {
+        console.error('Error while fetching online status.', error)
+        // There was an error either connecting or while
+        // receiving the response.
+        return false
+      })
+  }
+}
+
 export function startOnlineStatusPolling(dispatch: EditorDispatch): void {
   // Don't run any of this functionality in tests.
   if (!IS_TEST_ENVIRONMENT) {
     // Trigger this just the once and once started never again.
     if (onlineStateIntervalID == null) {
-      const newIntervalID = window.setInterval(() => {
-        // Perform a HEAD request against the backend to see if we are able to react it.
-        fetch(UTOPIA_BACKEND_BASE_URL + 'online-status', {
-          method: 'HEAD',
-          credentials: 'include',
-          headers: HEADERS,
-          mode: MODE,
-        })
-          .then((response) => {
-            if (response.ok) {
-              // Reset the status, as we're able to connect and we get a good status code
-              // from the server.
-              dispatch([resetOnlineState()])
-            } else {
-              // Bump the failure count, as we got a failure type response code, which
-              // potentially means that our service provider is down or a deploy got mangled.
-              dispatch([increaseOnlineStateFailureCount()])
-            }
-          })
-          .catch((error) => {
-            console.error('Error while fetching online status.', error)
-            // Bump the failure count as there was an error either connecting or while
-            // recieving the response.
-            dispatch([increaseOnlineStateFailureCount()])
-          })
+      const newIntervalID = window.setInterval(async () => {
+        const isOnline = await checkOnlineState()
+        if (isOnline) {
+          dispatch([resetOnlineState()])
+        } else {
+          dispatch([increaseOnlineStateFailureCount()])
+        }
       }, OnlineStatusPollingInterval)
 
       // Store the interval ID so that we can ensure to only start the interval once.

--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -607,6 +607,9 @@ getPackageLatestVersionEndpoint javascriptPackageName = getPackageVersionsEndpoi
 getMatchingPackageVersionsEndpoint :: Text -> Text -> ServerMonad Value
 getMatchingPackageVersionsEndpoint javascriptPackageName javascriptPackageVersion = getPackageVersionsEndpoint javascriptPackageName (Just javascriptPackageVersion)
 
+getOnlineStatusEndpoint :: ServerMonad Text
+getOnlineStatusEndpoint = pure "Online"
+
 hashedAssetPathsEndpoint :: ServerMonad Value
 hashedAssetPathsEndpoint = getHashedAssetPaths
 
@@ -780,6 +783,7 @@ unprotected = authenticate
          :<|> getPackageVersionJSONEndpoint
          :<|> getPackageLatestVersionEndpoint
          :<|> getMatchingPackageVersionsEndpoint
+         :<|> getOnlineStatusEndpoint
          :<|> hashedAssetPathsEndpoint
          :<|> editorAssetsEndpoint "./editor"
          :<|> editorAssetsEndpoint "./sockjs-node" Nothing

--- a/server/src/Utopia/Web/Types.hs
+++ b/server/src/Utopia/Web/Types.hs
@@ -174,6 +174,8 @@ type MonitoringAPI = "monitoring" :> "secret" :> "location" :> Get '[JSON] Value
 
 type ClearBranchAPI = "internal" :> "branch" :> QueryParam' '[Required, Strict] "branch_name" Text :> Delete '[JSON] NoContent
 
+type OnlineStatusAPI = "online-status" :> Get '[PlainText] Text
+
 type HashedAssetPathsAPI = "hashed-assets.json" :> Get '[JSON] Value
 
 type EditorAssetsAPI = "editor" :> BranchNameParam :> RawM
@@ -239,6 +241,7 @@ type Unprotected = AuthenticateAPI H.Html
               :<|> GetPackageVersionJSONAPI
               :<|> GetLatestPackageAPI
               :<|> GetPackageVersionsAPI
+              :<|> OnlineStatusAPI
               :<|> HashedAssetPathsAPI
               :<|> EditorAssetsAPI
               :<|> WebpackSockJSAPI

--- a/utopia-remix/app/routes/online-status.tsx
+++ b/utopia-remix/app/routes/online-status.tsx
@@ -1,3 +1,15 @@
-export async function loader() {
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { proxy } from '../util/proxy.server'
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  // Call the old server to check if it's online.
+  const url = new URL(request.url)
+  url.pathname = '/online-status'
+  const onlineStatusRequest = new Request(url, {
+    method: 'GET',
+  })
+  await proxy(onlineStatusRequest, { rawOutput: true })
+
+  // Return a simple response.
   return new Response('Online', { headers: { 'content-type': 'text/plain' } })
 }

--- a/utopia-remix/app/routes/online-status.tsx
+++ b/utopia-remix/app/routes/online-status.tsx
@@ -11,5 +11,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   await proxy(onlineStatusRequest, { rawOutput: true })
 
   // Return a simple response.
-  return new Response('Online', { headers: { 'content-type': 'text/plain' } })
+  return new Response('Online', {
+    headers: { 'content-type': 'text/plain', 'cache-control': 'no-cache' },
+  })
 }


### PR DESCRIPTION
**Problem:**
When the editor goes offline, the inspector switches to an offline state before the offline banner appears, which looks a bit strange.

**Fix:**
Now the checks for login state and project server state are prefixed with a check to see if the server is online, then those calls will only proceed if the server is online. Otherwise the state isn't updated at all and will be left as it is.

**Notes:**
There's an issue with the low priority store which causes the offline bar to show up later than it should, this will be fixed in a separate PR.

**Commit Details:**
- Extract out the online state checking into `checkOnlineState` from `startOnlineStatusPolling`.
- `getProjectServerState` checks the result of `checkOnlineState` initially and if that indicates the server is offline it doesn't check the project state.
- `startPollingLoginState` checks the result of `checkOnlineState` initially and if that indicates the server is offline it doesn't check the login state.
- Added `/online-status` endpoint to the Haskell server.
- Remix `/online-status` endpoint checks the same URL on the Haskell server.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5230
