### PR TITLE
Use moduleName when looking up registered component

### DIFF
--- a/editor/src/components/custom-code/internal-property-controls.ts
+++ b/editor/src/components/custom-code/internal-property-controls.ts
@@ -217,7 +217,7 @@ export interface Vector4ControlDescription {
 
 export interface PreferredChildComponentDescriptor {
   name: string
-  imports: Imports
+  moduleName: string | null
   variants: Array<ComponentInfo>
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3358,11 +3358,11 @@ const PreferredChildComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<Pr
   combine3EqualityCalls(
     (d) => d.name,
     StringKeepDeepEquality,
-    (d) => d.imports,
-    createCallWithTripleEquals(),
+    (d) => d.moduleName,
+    nullableDeepEquality(StringKeepDeepEquality),
     (d) => d.variants,
     arrayDeepEquality(createCallWithTripleEquals()),
-    (name, imports, variants) => ({ name, imports, variants }),
+    (name, moduleName, variants) => ({ name, moduleName, variants }),
   )
 
 export const DescriptorFileComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<ComponentDescriptorFromDescriptorFile> =

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -10,6 +10,7 @@ import { type Imports } from '../../../core/shared/project-file-types'
 import { elementFromInsertMenuItem } from '../../editor/insert-callbacks'
 import { componentInfo, type ComponentInfo } from '../../custom-code/code-file'
 import { when } from '../../../utils/react-conditionals'
+import { defaultImportsForComponentModule } from '../../../core/property-controls/property-controls-local'
 
 export interface ComponentPickerProps {
   insertionTargetName: string
@@ -348,7 +349,11 @@ interface ComponentPickerOptionProps {
 
 function variantsForComponent(component: PreferredChildComponentDescriptor): ComponentInfo[] {
   return [
-    componentInfo('(empty)', () => jsxElementWithoutUID(component.name, [], []), component.imports),
+    componentInfo(
+      '(empty)',
+      () => jsxElementWithoutUID(component.name, [], []),
+      defaultImportsForComponentModule(component.name, component.moduleName),
+    ),
     ...(component.variants ?? []),
   ]
 }

--- a/editor/src/components/navigator/navigator-item/render-prop-selector-popup.tsx
+++ b/editor/src/components/navigator/navigator-item/render-prop-selector-popup.tsx
@@ -53,7 +53,7 @@ const usePreferredChildrenForTargetProp = (
   const selectedElement = useEditorState(
     Substores.metadata,
     (store) => MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, target),
-    'usePreferredChildrenForSelectedElement selectedElement',
+    'usePreferredChildrenForTargetProp selectedElement',
   )
 
   const preferredChildrenForTargetProp = useEditorState(

--- a/editor/src/components/navigator/navigator-item/render-prop-selector-popup.tsx
+++ b/editor/src/components/navigator/navigator-item/render-prop-selector-popup.tsx
@@ -266,6 +266,14 @@ function iconPropsForIcon(icon: Icon): IcnProps {
   }
 }
 
+export function labelTestIdForComponentIcon(
+  componentName: string,
+  moduleName: string,
+  icon: Icon,
+): string {
+  return `variant-label-${componentName}-${moduleName}-${icon}`
+}
+
 const RenderPropPickerSimple = React.memo<RenderPropPickerProps>(({ key, id, target, prop }) => {
   const { showRenderPropPicker } = useShowRenderPropPicker(`${id}-full`)
 
@@ -300,7 +308,10 @@ const RenderPropPickerSimple = React.memo<RenderPropPickerProps>(({ key, id, tar
       const iconProps = iconPropsForIcon(data.icon)
 
       const submenuLabel = (
-        <FlexRow style={{ gap: 5 }}>
+        <FlexRow
+          style={{ gap: 5 }}
+          data-testId={labelTestIdForComponentIcon(data.name, data.moduleName ?? '', data.icon)}
+        >
           <Icn {...iconProps} width={12} height={12} />
           {data.name}
         </FlexRow>

--- a/editor/src/components/navigator/navigator-item/render-prop-selector-popup.tsx
+++ b/editor/src/components/navigator/navigator-item/render-prop-selector-popup.tsx
@@ -23,30 +23,21 @@ import { type ContextMenuItem } from '../../context-menu-items'
 import { FlexRow, Icn, type IcnProps } from '../../../uuiui'
 import { type EditorDispatch } from '../../editor/action-types'
 import { type ProjectContentTreeRoot } from '../../assets'
-import {
-  type PropertyControlsInfo,
-  type ComponentInfo,
-  type ComponentDescriptor,
-} from '../../custom-code/code-file'
+import { type PropertyControlsInfo, type ComponentInfo } from '../../custom-code/code-file'
 import { type Icon } from 'utopia-api'
+import { getRegisteredComponent } from '../../../core/property-controls/property-controls-utils'
+import { defaultImportsForComponentModule } from '../../../core/property-controls/property-controls-local'
 
-function getRegisteredComponent(
+function getIconForComponent(
   targetName: string,
+  moduleName: string | null,
   propertyControlsInfo: PropertyControlsInfo,
-): ComponentDescriptor | null {
-  for (const componentsFile of Object.values(propertyControlsInfo)) {
-    // FIXME This isn't good enough - we need to know which module the target is coming from,
-    // otherwise we'll be returning the first component with a matching name
-    if (componentsFile[targetName] != null) {
-      return componentsFile[targetName]
-    }
+): Icon {
+  if (moduleName == null) {
+    return 'regular'
   }
 
-  return null
-}
-
-function getIconForComponent(targetName: string, propertyControlsInfo: PropertyControlsInfo): Icon {
-  const registeredComponent = getRegisteredComponent(targetName, propertyControlsInfo)
+  const registeredComponent = getRegisteredComponent(targetName, moduleName, propertyControlsInfo)
 
   return registeredComponent?.icon ?? 'regular'
 }
@@ -59,22 +50,26 @@ const usePreferredChildrenForTargetProp = (
   target: ElementPath,
   prop: string,
 ): Array<PreferredChildComponentDescriptorWithIcon> => {
-  const selectedJSXElement = useEditorState(
+  const selectedElement = useEditorState(
     Substores.metadata,
-    (store) => MetadataUtils.getJSXElementFromMetadata(store.editor.jsxMetadata, target),
-    'usePreferredChildrenForSelectedElement selectedJSXElement',
+    (store) => MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, target),
+    'usePreferredChildrenForSelectedElement selectedElement',
   )
 
   const preferredChildrenForTargetProp = useEditorState(
     Substores.restOfEditor,
     (store) => {
-      if (selectedJSXElement == null) {
+      const selectedJSXElement =
+        MetadataUtils.getJSXElementFromElementInstanceMetadata(selectedElement)
+      const elementImportInfo = selectedElement?.importInfo
+      if (elementImportInfo == null || selectedJSXElement == null) {
         return null
       }
 
       const targetName = getJSXElementNameAsString(selectedJSXElement.name)
       const registeredComponent = getRegisteredComponent(
         targetName,
+        elementImportInfo.filePath,
         store.editor.propertyControlsInfo,
       )
 
@@ -90,7 +85,7 @@ const usePreferredChildrenForTargetProp = (
           ) {
             return registeredPropValue.preferredChildComponents.map((v) => ({
               ...v,
-              icon: getIconForComponent(v.name, store.editor.propertyControlsInfo),
+              icon: getIconForComponent(v.name, v.moduleName, store.editor.propertyControlsInfo),
             }))
           }
         }
@@ -101,11 +96,7 @@ const usePreferredChildrenForTargetProp = (
     'usePreferredChildrenForSelectedElement propertyControlsInfo',
   )
 
-  if (selectedJSXElement == null || preferredChildrenForTargetProp == null) {
-    return []
-  }
-
-  return preferredChildrenForTargetProp
+  return preferredChildrenForTargetProp ?? []
 }
 
 type ShowRenderPropPicker = (
@@ -315,11 +306,21 @@ const RenderPropPickerSimple = React.memo<RenderPropPickerProps>(({ key, id, tar
         </FlexRow>
       )
 
+      const defaultVariantImports = defaultImportsForComponentModule(data.name, data.moduleName)
+
       if (data.variants == null || data.variants.length === 0) {
-        return [defaultVariantItem(data.name, submenuLabel, data.imports, null, onItemClick)]
+        return [
+          defaultVariantItem(data.name, submenuLabel, defaultVariantImports, null, onItemClick),
+        ]
       } else {
         return [
-          defaultVariantItem(data.name, '(empty)', data.imports, submenuLabel, onItemClick),
+          defaultVariantItem(
+            data.name,
+            '(empty)',
+            defaultVariantImports,
+            submenuLabel,
+            onItemClick,
+          ),
           ...data.variants.map((variant) => {
             return variantItem(variant, submenuLabel, onItemClick)
           }),

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -77,6 +77,7 @@ import { memoize } from '../shared/memoize'
 import { filenameFromParts, getFilenameParts } from '../../components/images'
 import globToRegexp from 'glob-to-regexp'
 import { is } from '../shared/equality-utils'
+import { absolutePathFromRelativePath } from '../../utils/path-utils'
 
 export const sceneMetadata = _sceneMetadata // This is a hotfix for a circular dependency AND a leaking of utopia-api into the workers
 
@@ -289,12 +290,14 @@ export function importInfoFromImportDetails(
       (fromWithin) => fromWithin.alias === baseVariable,
     )
 
+    const absolutePath = absolutePathFromRelativePath(filePath, false, pathOrModuleName)
+
     if (importAlias != null) {
-      return createImportedFrom(importAlias.alias, importAlias.name, pathOrModuleName)
+      return createImportedFrom(importAlias.alias, importAlias.name, absolutePath)
     } else if (importDetail.importedAs === baseVariable) {
-      return createImportedFrom(importDetail.importedAs, null, pathOrModuleName)
+      return createImportedFrom(importDetail.importedAs, null, absolutePath)
     } else if (importDetail.importedWithName === baseVariable) {
-      return createImportedFrom(importDetail.importedWithName, null, pathOrModuleName)
+      return createImportedFrom(importDetail.importedWithName, null, absolutePath)
     } else {
       return null
     }

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -1315,7 +1315,7 @@ describe('registered property controls', () => {
           "childrenPropPlaceholder": null,
           "preferredChildComponents": Array [
             Object {
-              "imports": Object {},
+              "moduleName": null,
               "name": "Card",
               "variants": Array [
                 Object {
@@ -1390,7 +1390,7 @@ describe('registered property controls', () => {
           },
           "preferredChildComponents": Array [
             Object {
-              "imports": Object {},
+              "moduleName": null,
               "name": "span",
               "variants": Array [
                 Object {
@@ -1401,7 +1401,7 @@ describe('registered property controls', () => {
               ],
             },
             Object {
-              "imports": Object {},
+              "moduleName": "/src/card2",
               "name": "Card2",
               "variants": Array [
                 Object {
@@ -1591,7 +1591,7 @@ describe('registered property controls', () => {
                 },
                 "preferredChildComponents": Array [
                   Object {
-                    "imports": Object {},
+                    "moduleName": null,
                     "name": "span",
                     "variants": Array [
                       Object {
@@ -1602,7 +1602,7 @@ describe('registered property controls', () => {
                     ],
                   },
                   Object {
-                    "imports": Object {},
+                    "moduleName": "/src/card2",
                     "name": "Card2",
                     "variants": Array [
                       Object {

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -73,7 +73,12 @@ import {
 import { setOptionalProp } from '../shared/object-utils'
 import { assertNever } from '../shared/utils'
 import type { Imports, ParsedTextFile } from '../shared/project-file-types'
-import { isExportDefault, isTextFile } from '../shared/project-file-types'
+import {
+  importAlias,
+  importDetails,
+  isExportDefault,
+  isTextFile,
+} from '../shared/project-file-types'
 import type { UiJsxCanvasContextData } from '../../components/canvas/ui-jsx-canvas'
 import type { EditorState } from '../../components/editor/store/editor-state'
 import type { MutableUtopiaCtxRefData } from '../../components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-contexts'
@@ -814,7 +819,7 @@ async function parsePreferredChildren(
     if (contents === 'text') {
       descriptors.push({
         name: componentName,
-        imports: {},
+        moduleName: null,
         variants: [
           {
             insertMenuLabel: 'text',
@@ -839,13 +844,24 @@ async function parsePreferredChildren(
 
       descriptors.push({
         name: contents.component,
-        imports: {},
+        moduleName: contents.moduleName ?? null,
         variants: parsedVariants.value,
       })
     }
   }
 
   return right(descriptors)
+}
+
+export function defaultImportsForComponentModule(
+  componentName: string,
+  moduleName: string | null,
+): Imports {
+  return moduleName == null
+    ? {}
+    : {
+        [moduleName]: importDetails(null, [importAlias(componentName)], null),
+      }
 }
 
 export async function parsePreferredChildrenExamples(

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -1,4 +1,7 @@
-import type { PropertyControlsInfo } from '../../components/custom-code/code-file'
+import type {
+  ComponentDescriptor,
+  PropertyControlsInfo,
+} from '../../components/custom-code/code-file'
 import type { JSXElementChild } from '../shared/element-template'
 import {
   getJSXElementNameAsString,
@@ -18,6 +21,7 @@ import { importedFromWhere } from '../../components/editor/import-utils'
 import { absolutePathFromRelativePath } from '../../utils/path-utils'
 import { getThirdPartyControlsIntrinsic } from './property-controls-local'
 import type { PropertyControls } from '../../components/custom-code/internal-property-controls'
+import { dropFileExtension } from '../shared/file-utils'
 
 export function propertyControlsForComponentInFile(
   componentName: string,
@@ -125,6 +129,16 @@ export function getPropertyControlsForTarget(
       }
     },
   )
+}
+
+export function getRegisteredComponent(
+  component: string,
+  moduleName: string,
+  propertyControlsInfo: PropertyControlsInfo,
+): ComponentDescriptor | null {
+  const registeredModule =
+    propertyControlsInfo[moduleName] ?? propertyControlsInfo[dropFileExtension(moduleName)]
+  return registeredModule?.[component]
 }
 
 export function hasStyleControls(propertyControls: PropertyControls): boolean {

--- a/editor/src/utils/path-utils.ts
+++ b/editor/src/utils/path-utils.ts
@@ -83,7 +83,7 @@ export function absolutePathFromRelativePath(
   originIsDir: boolean,
   relativePath: string,
 ): string {
-  if (relativePath.startsWith('/') || !relativePath.includes('/')) {
+  if (!relativePath.startsWith('.')) {
     // Not actually relative in this case.
     return relativePath
   } else {


### PR DESCRIPTION
**Problem:**
In the render prop picker we are currently looking up registered components using just the component name, meaning we can return a matching component from different module.

**Fix:**
With the merge of #5268 we can now rely on the `moduleName` to lookup the correct registered component. This change also pulls through that `moduleName` into the internal `PreferredChildComponentDescriptor` (as that had drifted), and then adds a function for creating the default `Imports` for the default empty variant, using that `moduleName`.

To be able to find the correct registered component for the target of the picker (i.e. the component containing the slot that was clicked), I've also very slightly tweaked the way we store `ImportInfo` in the metadata. Currently, the import statement:
```js
import { Card } from '../../src/Card'
```
would result in `ImportInfo.filename` being `'../../src/Card'`, which is useless in that form. This PR will convert that relative filepath to an absolute one at the point of creating the metadata, so that we can now use it to look up the registered component.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5263
