### PR TITLE
Force vscode navigation on second click in the navigator

### DIFF
--- a/editor/src/components/editor/store/vscode-changes.ts
+++ b/editor/src/components/editor/store/vscode-changes.ts
@@ -326,7 +326,7 @@ export function getProjectChanges(
       : null,
     selectedChanged:
       !updatedFromVSCode && shouldIncludeSelectedElementChanges(oldEditorState, newEditorState)
-        ? getSelectedElementChangedMessage(newEditorState)
+        ? getSelectedElementChangedMessage(newEditorState, 'do-not-force-navigation')
         : null,
   }
 }

--- a/utopia-vscode-common/src/messages.ts
+++ b/utopia-vscode-common/src/messages.ts
@@ -77,15 +77,22 @@ export function updateDecorationsMessage(
   }
 }
 
+export type ForceNavigation = 'do-not-force-navigation' | 'force-navigation'
+
 export interface SelectedElementChanged {
   type: 'SELECTED_ELEMENT_CHANGED'
   boundsInFile: BoundsInFile
+  forceNavigation: ForceNavigation
 }
 
-export function selectedElementChanged(bounds: BoundsInFile): SelectedElementChanged {
+export function selectedElementChanged(
+  bounds: BoundsInFile,
+  forceNavigation: ForceNavigation,
+): SelectedElementChanged {
   return {
     type: 'SELECTED_ELEMENT_CHANGED',
     boundsInFile: bounds,
+    forceNavigation: forceNavigation,
   }
 }
 

--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -347,7 +347,8 @@ function initMessaging(context: vscode.ExtensionContext, workspaceRootUri: vscod
       case 'SELECTED_ELEMENT_CHANGED':
         const followSelectionEnabled = getFollowSelectionEnabledConfig()
         const shouldFollowSelection =
-          followSelectionEnabled && shouldFollowSelectionWithActiveFile()
+          followSelectionEnabled &&
+          (shouldFollowSelectionWithActiveFile() || message.forceNavigation === 'force-navigation')
         if (shouldFollowSelection) {
           currentSelection = message.boundsInFile
           revealRangeIfPossible(workspaceRootUri, message.boundsInFile)


### PR DESCRIPTION
**Problem:**
After https://github.com/concrete-utopia/utopia/pull/5259 it is impossible to leave a component descriptor file using the navigator. 

**Fix:**
We still don't navigate away on selection, but we allow navigation if the user clicks on the selected element again (in the navigator)

**Commit Details:** (< vv pls delete this section if's not relevant)

Introduced a new property in the `SelectionChangedMessage` called `forceNavigation`

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5269
