### PR TITLE
Moved store updates outside of dom walker conditional.

### DIFF
--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -29,6 +29,7 @@ import { InitialOnlineState } from '../online-status'
 import type { Optic } from '../../../core/shared/optics/optics'
 import { fromField } from '../../../core/shared/optics/optic-creators'
 import { modify } from '../../../core/shared/optics/optic-utilities'
+import { ProjectServerStateKeepDeepEquality } from './store-deep-equality-instances'
 
 export function runLocalEditorAction(
   state: EditorState,
@@ -549,12 +550,20 @@ export function runUpdateProjectServerState(
   working: EditorStoreUnpatched,
   action: UpdateProjectServerState,
 ): EditorStoreUnpatched {
-  return {
-    ...working,
-    projectServerState: {
+  const projectServerStateKeepDeepResult = ProjectServerStateKeepDeepEquality(
+    working.projectServerState,
+    {
       ...working.projectServerState,
       ...action.serverState,
     },
+  )
+  if (projectServerStateKeepDeepResult.areEqual) {
+    return working
+  } else {
+    return {
+      ...working,
+      projectServerState: projectServerStateKeepDeepResult.value,
+    }
   }
 }
 


### PR DESCRIPTION
**Problem:**
It was observed that updates reliant on the low priority store seemed to be triggered later than would be expected.

**Cause:**
The updates to the low and regular stores were inside a conditional for running the DOM walker, which meant that updates not related to the canvas would only affect the editor when an update to the canvas was triggered.

**Fix:**
Now updates to the stores are done outside of the conditional which specifies if the DOM walker should be triggered.

A smaller fix was done in the process of testing this as updates to the project server state were triggering updates when they shouldn't have done, as no change actually occurred.

**Commit Details:**
- Tweaked `runUpdateProjectServerState` to not always cause updates.
- In `boundDispatch`, the updates to the regular and low priority stores are now triggered outside of a conditional for running the DOM walker.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5274
