### PR TITLE
Fix Github error messages

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -7,7 +7,7 @@ import React from 'react'
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import { IS_TEST_ENVIRONMENT } from '../../common/env-vars'
-import { projectURLForProject } from '../../core/shared/utils'
+import { assertNever, projectURLForProject } from '../../core/shared/utils'
 import Keyboard from '../../utils/keyboard'
 import { Modifier } from '../../utils/modifiers'
 import {
@@ -40,12 +40,8 @@ import { FatalIndexedDBErrorComponent } from './fatal-indexeddb-error-component'
 import { editorIsTarget, handleKeyDown, handleKeyUp } from './global-shortcuts'
 import { BrowserInfoBar, LoginStatusBar } from './notification-bar'
 import { applyShortcutConfigurationToDefaults } from './shortcut-definitions'
-import {
-  githubOperationLocksEditor,
-  githubOperationPrettyName,
-  LeftMenuTab,
-  RightMenuTab,
-} from './store/editor-state'
+import type { GithubOperation } from './store/editor-state'
+import { githubOperationLocksEditor, LeftMenuTab, RightMenuTab } from './store/editor-state'
 import {
   Substores,
   useEditorState,
@@ -101,6 +97,27 @@ function pushProjectURLToBrowserHistory(
   const title = `Utopia ${projectName}`
 
   window.top?.history.replaceState({}, title, `${projectURL}${queryParamsStr}`)
+}
+
+function githubOperationPrettyNameForOverlay(op: GithubOperation): string {
+  switch (op.name) {
+    case 'commitAndPush':
+      return 'Saving to GitHub'
+    case 'listBranches':
+      return 'Listing branches from GitHub'
+    case 'loadBranch':
+      return 'Loading branch from GitHub'
+    case 'loadRepositories':
+      return 'Loading Repositories'
+    case 'updateAgainstBranch':
+      return 'Updating against branch from GitHub'
+    case 'listPullRequestsForBranch':
+      return 'Listing GitHub pull requests'
+    case 'saveAsset':
+      return 'Saving asset to GitHub'
+    default:
+      assertNever(op)
+  }
 }
 
 export interface EditorProps {}
@@ -686,7 +703,7 @@ const LockedOverlay = React.memo(() => {
       return 'Refreshing dependencies…'
     }
     if (githubOperations.length > 0) {
-      return `${githubOperationPrettyName(githubOperations[0])}…`
+      return `${githubOperationPrettyNameForOverlay(githubOperations[0])}…`
     }
     if (forking) {
       return 'Forking project…'

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -342,22 +342,23 @@ export type GithubOperation =
   | GithubListPullRequestsForBranch
   | GithubSaveAsset
 
+// context: "Couldn't ${opName}"
 export function githubOperationPrettyName(op: GithubOperation): string {
   switch (op.name) {
     case 'commitAndPush':
-      return 'Saving to GitHub'
+      return 'save to Github'
     case 'listBranches':
-      return 'Listing branches from GitHub'
+      return 'list branches from GitHub'
     case 'loadBranch':
-      return 'Loading branch from GitHub'
+      return 'load branch from GitHub'
     case 'loadRepositories':
-      return 'Loading Repositories'
+      return 'load repositories'
     case 'updateAgainstBranch':
-      return 'Updating against branch from GitHub'
+      return 'update against branch from GitHub'
     case 'listPullRequestsForBranch':
-      return 'Listing GitHub pull requests'
+      return 'list GitHub pull requests'
     case 'saveAsset':
-      return 'Saving asset to GitHub'
+      return 'save asset to GitHub'
     default:
       assertNever(op)
   }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -342,28 +342,6 @@ export type GithubOperation =
   | GithubListPullRequestsForBranch
   | GithubSaveAsset
 
-// context: "Couldn't ${opName}"
-export function githubOperationPrettyName(op: GithubOperation): string {
-  switch (op.name) {
-    case 'commitAndPush':
-      return 'save to Github'
-    case 'listBranches':
-      return 'list branches from GitHub'
-    case 'loadBranch':
-      return 'load branch from GitHub'
-    case 'loadRepositories':
-      return 'load repositories'
-    case 'updateAgainstBranch':
-      return 'update against branch from GitHub'
-    case 'listPullRequestsForBranch':
-      return 'list GitHub pull requests'
-    case 'saveAsset':
-      return 'save asset to GitHub'
-    default:
-      assertNever(op)
-  }
-}
-
 export function githubOperationLocksEditor(op: GithubOperation): boolean {
   switch (op.name) {
     case 'listBranches':

--- a/editor/src/components/github/github-repository-clone-flow.tsx
+++ b/editor/src/components/github/github-repository-clone-flow.tsx
@@ -110,9 +110,6 @@ async function cloneGithubRepo(
     [],
     storeRef.current.builtInDependencies,
     {}, // Assuming a totally empty project (that is being saved probably parallel to this operation, hopefully not causing any race conditions)
-
-    // this is technically user initiated, but since the github clone is
-    // triggered by loading a URL this should be a different category
     'user-initiated',
   )
 

--- a/editor/src/components/github/github-repository-clone-flow.tsx
+++ b/editor/src/components/github/github-repository-clone-flow.tsx
@@ -110,6 +110,10 @@ async function cloneGithubRepo(
     [],
     storeRef.current.builtInDependencies,
     {}, // Assuming a totally empty project (that is being saved probably parallel to this operation, hopefully not causing any race conditions)
+
+    // this is technically user initiated, but since the github clone is
+    // triggered by loading a URL this should be a different category
+    'user-initiated',
   )
 
   // at this point we can assume the repo is loaded and we can finally hide the overlay

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -178,18 +178,27 @@ const BranchBlock = () => {
     [githubOperations],
   )
 
-  const refreshBranches = React.useCallback(() => {
+  const refreshBranchesOnMouseUp = React.useCallback(() => {
     if (targetRepository != null) {
       void dispatchPromiseActions(
         dispatch,
-        GithubOperations.getBranchesForGithubRepository(dispatch, targetRepository),
+        GithubOperations.getBranchesForGithubRepository(
+          dispatch,
+          targetRepository,
+          'user-initiated',
+        ),
       )
     }
   }, [dispatch, targetRepository])
 
   React.useEffect(() => {
-    refreshBranches()
-  }, [refreshBranches])
+    if (targetRepository != null) {
+      void dispatchPromiseActions(
+        dispatch,
+        GithubOperations.getBranchesForGithubRepository(dispatch, targetRepository, 'polling'),
+      )
+    }
+  }, [dispatch, targetRepository])
 
   const [expandedFlag, setExpandedFlag] = React.useState(false)
 
@@ -358,7 +367,7 @@ const BranchBlock = () => {
             spotlight
             highlight
             style={{ padding: '0 6px', marginTop: 6 }}
-            onMouseUp={refreshBranches}
+            onMouseUp={refreshBranchesOnMouseUp}
             disabled={isListingBranches}
           >
             {isListingBranches ? (
@@ -389,7 +398,7 @@ const BranchBlock = () => {
     branchFilter,
     updateBranchFilter,
     filteredBranches,
-    refreshBranches,
+    refreshBranchesOnMouseUp,
     isListingBranches,
     currentBranch,
     clearBranch,
@@ -502,6 +511,7 @@ const RemoteChangesBlock = () => {
         commit,
         forceNotNull('Should have a project ID by now.', projectIDRef.current),
         currentContentsRef.current,
+        'user-initiated',
       )
     }
   }, [workersRef, dispatch, repo, branch, commit, projectIDRef, currentContentsRef])
@@ -676,6 +686,7 @@ const LocalChangesBlock = () => {
             ? {}
             : fileChecksumsWithFileToFileChecksums(branchOriginContentsChecksums),
       },
+      'user-initiated',
     )
   }, [
     dispatch,
@@ -882,6 +893,7 @@ const BranchNotLoadedBlock = () => {
         currentDependencies,
         builtInDependencies,
         projectContentsRef.current,
+        'user-initiated',
       )
     }
   }, [
@@ -942,6 +954,7 @@ const BranchNotLoadedBlock = () => {
         branchName: branchName,
         commitMessage: commitMessage ?? 'Committed automatically',
       },
+      'user-initiated',
     )
   }, [
     dispatch,

--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -20,7 +20,6 @@ import {
 import { UIGridRow } from '../../../../components/inspector/widgets/ui-grid-row'
 import type { RepositoryEntry } from '../../../../core/shared/github/helpers'
 import { connectRepo, parseGithubProjectString } from '../../../../core/shared/github/helpers'
-import { getUsersPublicGithubRepositories } from '../../../../core/shared/github/operations/load-repositories'
 import { when } from '../../../../utils/react-conditionals'
 import { Button, colorTheme, FlexColumn, FlexRow, StringInput } from '../../../../uuiui'
 import { useDispatch } from '../../../editor/store/dispatch-context'
@@ -240,9 +239,19 @@ export const RepositoryListing = React.memo(
     const dispatch = useDispatch()
 
     const refreshRepos = React.useCallback(() => {
-      void GithubOperations.getUsersPublicGithubRepositories(dispatch).then((actions) => {
-        dispatch(actions, 'everyone')
-      })
+      void GithubOperations.getUsersPublicGithubRepositories(dispatch, 'polling').then(
+        (actions) => {
+          dispatch(actions, 'everyone')
+        },
+      )
+    }, [dispatch])
+
+    const refreshReposOnClick = React.useCallback(() => {
+      void GithubOperations.getUsersPublicGithubRepositories(dispatch, 'user-initiated').then(
+        (actions) => {
+          dispatch(actions, 'everyone')
+        },
+      )
     }, [dispatch])
 
     React.useEffect(() => {
@@ -299,7 +308,7 @@ export const RepositoryListing = React.memo(
           highlight
           style={{ padding: '0 6px' }}
           disabled={isLoadingRepositories}
-          onMouseDown={refreshRepos}
+          onMouseDown={refreshReposOnClick}
         >
           {isLoadingRepositories ? (
             <GithubSpinner />

--- a/editor/src/core/shared/github-ui.tsx
+++ b/editor/src/core/shared/github-ui.tsx
@@ -2,7 +2,6 @@ import type { ContextMenuItem } from '../../components/context-menu-items'
 import type { EditorDispatch } from '../../components/editor/action-types'
 import type { GithubRepo } from '../../components/editor/store/editor-state'
 import type { Conflict } from './github/helpers'
-import { resolveConflict } from './github/helpers'
 import { GithubOperations } from './github/operations'
 
 export function getConflictMenuItems(
@@ -21,6 +20,7 @@ export function getConflictMenuItems(
       conflict,
       whichChange,
       dispatch,
+      'user-initiated',
     )
   }
   switch (conflict.type) {

--- a/editor/src/core/shared/github/github.spec.ts
+++ b/editor/src/core/shared/github/github.spec.ts
@@ -86,6 +86,7 @@ describe('github helpers', () => {
         null,
         null,
         makeMockContext(),
+        'user-initiated',
       )
       expect(got.length).toBe(1)
       const promises = await got[0]
@@ -108,6 +109,7 @@ describe('github helpers', () => {
         null,
         null,
         makeMockContext(),
+        'user-initiated',
       )
       expect(got.length).toBe(1)
       const promises = await got[0]
@@ -136,6 +138,7 @@ describe('github helpers', () => {
         null,
         null,
         makeMockContext(),
+        'user-initiated',
       )
       expect(got.length).toBe(1)
       const promises = await got[0]
@@ -167,6 +170,7 @@ describe('github helpers', () => {
         null,
         null,
         makeMockContext(mockFetch.getMockImplementation()),
+        'user-initiated',
       )
       expect(got.length).toBe(2)
 

--- a/editor/src/core/shared/github/github.spec.ts
+++ b/editor/src/core/shared/github/github.spec.ts
@@ -3,7 +3,7 @@ import type { EditorDispatch } from '../../../components/editor/action-types'
 import { emptyGithubData } from '../../../components/editor/store/editor-state'
 import {
   getRefreshGithubActions,
-  getUserDetailsFromServer,
+  GithubHelpers,
   updateUserDetailsWhenAuthenticated,
 } from './helpers'
 import type { GithubOperationContext } from './operations/github-operation-context'
@@ -23,13 +23,13 @@ describe('github helpers', () => {
   describe('getUserDetailsFromServer', () => {
     it('returns null if the response is not ok', async () => {
       mockFetch.mockResolvedValue(new Response(null, { status: 418 }))
-      const got = await getUserDetailsFromServer()
+      const got = await GithubHelpers.getUserDetailsFromServer()
       expect(got).toBe(null)
     })
 
     it('returns null if the request returns a failure', async () => {
       mockFetch.mockResolvedValue(new Response(JSON.stringify({ type: 'FAILURE' })))
-      const got = await getUserDetailsFromServer()
+      const got = await GithubHelpers.getUserDetailsFromServer()
       expect(got).toBe(null)
     })
 
@@ -37,7 +37,7 @@ describe('github helpers', () => {
       mockFetch.mockResolvedValue(
         new Response(JSON.stringify({ type: 'SUCCESS', user: { id: 'that-guy' } })),
       )
-      const got = await getUserDetailsFromServer()
+      const got = await GithubHelpers.getUserDetailsFromServer()
       expect(got).toEqual({ id: 'that-guy' })
     })
   })

--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -192,13 +192,11 @@ export async function runGithubOperation(
     if (userDetails == null) {
       actions.push(...resetGithubStateAndDataActions())
     } else {
-      actions.push(
-        showToast(notice(`${opName} failed. See the console for more information.`, 'ERROR')),
-      )
+      actions.push(showToast(notice(`Couldn't ${opName} (see console)`, 'ERROR')))
     }
 
     dispatch(actions, 'everyone')
-    console.error(`[GitHub] operation "${opName}" failed:`, error)
+    console.error(`Couldn't ${opName}`, error)
     throw error
   } finally {
     dispatch([updateGithubOperations(operation, 'remove')], 'everyone')

--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -192,7 +192,7 @@ export async function runGithubOperation(
     if (userDetails == null) {
       actions.push(...resetGithubStateAndDataActions())
     } else {
-      actions.push(showToast(notice(`Couldn't ${opName} (see console)`, 'ERROR')))
+      actions.push(showToast(notice(`Couldn't ${opName} (see console)`, 'PRIMARY')))
     }
 
     dispatch(actions, 'everyone')

--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -40,7 +40,6 @@ import type {
 import {
   emptyGithubData,
   emptyGithubSettings,
-  githubOperationPrettyName,
   projectGithubSettings,
 } from '../../../components/editor/store/editor-state'
 import type { UtopiaStoreAPI } from '../../../components/editor/store/store-hook'
@@ -57,7 +56,7 @@ import {
 } from '../project-file-types'
 import { emptySet } from '../set-utils'
 import { trimUpToAndIncluding } from '../string-utils'
-import { arrayEqualsByReference } from '../utils'
+import { arrayEqualsByReference, assertNever } from '../utils'
 import { getBranchChecksums } from './operations/get-branch-checksums'
 import { getBranchesForGithubRepository } from './operations/list-branches'
 import { updatePullRequestsForBranch } from './operations/list-pull-requests-for-branch'
@@ -165,6 +164,27 @@ export function repositoryEntry(
   }
 }
 
+function githubOperationPrettyNameForToast(op: GithubOperation): string {
+  switch (op.name) {
+    case 'commitAndPush':
+      return 'save to Github'
+    case 'listBranches':
+      return 'list branches from GitHub'
+    case 'loadBranch':
+      return 'load branch from GitHub'
+    case 'loadRepositories':
+      return 'load repositories'
+    case 'updateAgainstBranch':
+      return 'update against branch from GitHub'
+    case 'listPullRequestsForBranch':
+      return 'list GitHub pull requests'
+    case 'saveAsset':
+      return 'save asset to GitHub'
+    default:
+      assertNever(op)
+  }
+}
+
 export interface GetGithubUserSuccess {
   type: 'SUCCESS'
   user: GithubUser
@@ -189,7 +209,7 @@ export async function runGithubOperation(
     return result
   }
 
-  const opName = githubOperationPrettyName(operation)
+  const opName = githubOperationPrettyNameForToast(operation)
   try {
     dispatch([updateGithubOperations(operation, 'add')], 'everyone')
     result = await logic(operation)

--- a/editor/src/core/shared/github/operations/commit-and-push.ts
+++ b/editor/src/core/shared/github/operations/commit-and-push.ts
@@ -13,7 +13,7 @@ import type {
   PersistentModel,
 } from '../../../../components/editor/store/editor-state'
 import { projectGithubSettings } from '../../../../components/editor/store/editor-state'
-import type { GetBranchContentResponse, GithubFailure } from '../helpers'
+import type { GetBranchContentResponse, GithubFailure, GithubOperationSource } from '../helpers'
 import {
   dispatchPromiseActions,
   getBranchContentFromServer,
@@ -48,10 +48,12 @@ export const saveProjectToGithub =
     persistentModel: PersistentModel,
     dispatch: EditorDispatch,
     options: SaveProjectToGithubOptions,
+    initiator: GithubOperationSource,
   ): Promise<void> => {
     await runGithubOperation(
       { name: 'commitAndPush' },
       dispatch,
+      initiator,
       async (operation: GithubOperation) => {
         const { branchName, commitMessage } = options
 
@@ -136,7 +138,11 @@ export const saveProjectToGithub =
             // refresh the branches after the content was saved
             await dispatchPromiseActions(
               dispatch,
-              getBranchesForGithubRepository(operationContext)(dispatch, targetRepository),
+              getBranchesForGithubRepository(operationContext)(
+                dispatch,
+                targetRepository,
+                initiator,
+              ),
             )
             break
           default:

--- a/editor/src/core/shared/github/operations/github-operations.test-utils.ts
+++ b/editor/src/core/shared/github/operations/github-operations.test-utils.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../../components/editor/actions/action-creators'
 import { getUsersPublicGithubRepositories } from './load-repositories'
 import { updateProjectAgainstGithub } from './update-against-branch'
-import { resolveConflict, startGithubPolling } from '../helpers'
+import { GithubHelpers, resolveConflict, startGithubPolling } from '../helpers'
 import type { AsyncEditorDispatch } from '../../../../components/canvas/ui-jsx.test-utils'
 
 export async function loginUserToGithubForTests(dispatch: AsyncEditorDispatch) {
@@ -79,6 +79,17 @@ export class MockGithubOperations {
   mock(options: MockOperationContextOptions): MockGithubOperations {
     beforeEach(() => {
       this.sandbox = Sinon.createSandbox()
+
+      const getUserDetailsFromServerStub = this.sandbox.stub(
+        GithubHelpers,
+        'getUserDetailsFromServer',
+      )
+      getUserDetailsFromServerStub.callsFake(async () => ({
+        login: 'stub',
+        avatarURL: 'stub',
+        htmlURL: 'stub',
+        name: null,
+      }))
 
       const startGithubAuthenticationStub = this.sandbox.stub(
         GithubAuth,

--- a/editor/src/core/shared/github/operations/list-branches.ts
+++ b/editor/src/core/shared/github/operations/list-branches.ts
@@ -3,7 +3,7 @@ import type { EditorAction, EditorDispatch } from '../../../../components/editor
 import { updateGithubData } from '../../../../components/editor/actions/action-creators'
 import type { GithubOperation, GithubRepo } from '../../../../components/editor/store/editor-state'
 import { GithubEndpoints } from '../endpoints'
-import type { GithubBranch, GithubFailure } from '../helpers'
+import type { GithubBranch, GithubFailure, GithubOperationSource } from '../helpers'
 import { githubAPIError, githubAPIErrorFromResponse, runGithubOperation } from '../helpers'
 import type { GithubOperationContext } from './github-operation-context'
 
@@ -18,10 +18,15 @@ export type GetBranchesResponse = GetBranchesSuccess | GithubFailure
 
 export const getBranchesForGithubRepository =
   (operationContext: GithubOperationContext) =>
-  async (dispatch: EditorDispatch, githubRepo: GithubRepo): Promise<Array<EditorAction>> => {
+  async (
+    dispatch: EditorDispatch,
+    githubRepo: GithubRepo,
+    initiator: GithubOperationSource,
+  ): Promise<Array<EditorAction>> => {
     return runGithubOperation(
       { name: 'listBranches' },
       dispatch,
+      initiator,
       async (operation: GithubOperation) => {
         const url = GithubEndpoints.getBranches(githubRepo)
 

--- a/editor/src/core/shared/github/operations/list-pull-requests-for-branch.ts
+++ b/editor/src/core/shared/github/operations/list-pull-requests-for-branch.ts
@@ -7,7 +7,7 @@ import type {
   PullRequest,
 } from '../../../../components/editor/store/editor-state'
 import { GithubEndpoints } from '../endpoints'
-import type { GithubFailure } from '../helpers'
+import type { GithubFailure, GithubOperationSource } from '../helpers'
 import { githubAPIError, githubAPIErrorFromResponse, runGithubOperation } from '../helpers'
 import type { GithubOperationContext } from './github-operation-context'
 
@@ -34,6 +34,7 @@ export const updatePullRequestsForBranch =
     dispatch: EditorDispatch,
     githubRepo: GithubRepo,
     branchName: string,
+    initiator: GithubOperationSource,
   ): Promise<Array<EditorAction>> => {
     return runGithubOperation(
       {
@@ -42,6 +43,7 @@ export const updatePullRequestsForBranch =
         branchName: branchName,
       },
       dispatch,
+      initiator,
       async (operation: GithubOperation) => {
         const url = GithubEndpoints.updatePullRequests(githubRepo, branchName)
 

--- a/editor/src/core/shared/github/operations/load-branch.ts
+++ b/editor/src/core/shared/github/operations/load-branch.ts
@@ -24,7 +24,7 @@ import { refreshDependencies } from '../../dependencies'
 import type { RequestedNpmDependency } from '../../npm-dependency-types'
 import { forceNotNull } from '../../optional-utils'
 import { isTextFile } from '../../project-file-types'
-import type { BranchContent, GetBranchContentResponse } from '../helpers'
+import type { BranchContent, GetBranchContentResponse, GithubOperationSource } from '../helpers'
 import {
   connectRepo,
   getBranchContentFromServer,
@@ -46,6 +46,7 @@ export const saveAssetsToProject =
     branchContent: BranchContent,
     dispatch: EditorDispatch,
     currentProjectContents: ProjectContentTreeRoot,
+    initiator: GithubOperationSource,
   ): Promise<void> => {
     await walkContentsTreeAsync(branchContent.content, async (fullPath, projectFile) => {
       const alreadyExistingFile = getProjectFileByFilePath(currentProjectContents, fullPath)
@@ -70,6 +71,7 @@ export const saveAssetsToProject =
                 fullPath,
                 dispatch,
                 operationContext,
+                initiator,
               )
               break
             case 'ASSET_FILE':
@@ -80,6 +82,7 @@ export const saveAssetsToProject =
                 fullPath,
                 dispatch,
                 operationContext,
+                initiator,
               )
               break
             default:
@@ -102,6 +105,7 @@ export const updateProjectWithBranchContent =
     currentDeps: Array<RequestedNpmDependency>,
     builtInDependencies: BuiltInDependencies,
     currentProjectContents: ProjectContentTreeRoot,
+    initiator: GithubOperationSource,
   ): Promise<void> => {
     await runGithubOperation(
       {
@@ -110,6 +114,7 @@ export const updateProjectWithBranchContent =
         githubRepo: githubRepo,
       },
       dispatch,
+      initiator,
       async (operation: GithubOperation) => {
         const response = await getBranchContentFromServer(
           githubRepo,
@@ -151,6 +156,7 @@ export const updateProjectWithBranchContent =
               responseBody.branch,
               dispatch,
               currentProjectContents,
+              initiator,
             )
 
             // Update the editor with everything so that if anything else fails past this point

--- a/editor/src/core/shared/github/operations/load-repositories.ts
+++ b/editor/src/core/shared/github/operations/load-repositories.ts
@@ -8,7 +8,7 @@ import {
 import type { GithubOperation } from '../../../../components/editor/store/editor-state'
 import { emptyGithubSettings } from '../../../../components/editor/store/editor-state'
 import { GithubEndpoints } from '../endpoints'
-import type { GithubFailure, RepositoryEntry } from '../helpers'
+import type { GithubFailure, GithubOperationSource, RepositoryEntry } from '../helpers'
 import { githubAPIError, githubAPIErrorFromResponse, runGithubOperation } from '../helpers'
 import type { GithubOperationContext } from './github-operation-context'
 
@@ -21,10 +21,14 @@ export type GetUsersPublicRepositoriesResponse = GetUsersPublicRepositoriesSucce
 
 export const getUsersPublicGithubRepositories =
   (operationContext: GithubOperationContext) =>
-  async (dispatch: EditorDispatch): Promise<Array<EditorAction>> => {
+  async (
+    dispatch: EditorDispatch,
+    initiator: GithubOperationSource,
+  ): Promise<Array<EditorAction>> => {
     return runGithubOperation(
       { name: 'loadRepositories' },
       dispatch,
+      initiator,
       async (operation: GithubOperation) => {
         const url = GithubEndpoints.repositories()
 

--- a/editor/src/core/shared/github/operations/update-against-branch.ts
+++ b/editor/src/core/shared/github/operations/update-against-branch.ts
@@ -7,11 +7,10 @@ import {
   updateAgainstGithub,
   updateBranchContents,
   updateGithubData,
-  updateProjectContents,
 } from '../../../../components/editor/actions/action-creators'
 import type { GithubOperation, GithubRepo } from '../../../../components/editor/store/editor-state'
 import { updateProjectContentsWithParseResults } from '../../parser-projectcontents-utils'
-import type { GetBranchContentResponse } from '../helpers'
+import type { GetBranchContentResponse, GithubOperationSource } from '../helpers'
 import {
   getBranchContentFromServer,
   githubAPIError,
@@ -31,10 +30,12 @@ export const updateProjectAgainstGithub =
     commitSha: string,
     projectID: string,
     currentProjectContents: ProjectContentTreeRoot,
+    initiator: GithubOperationSource,
   ): Promise<void> => {
     await runGithubOperation(
       { name: 'updateAgainstBranch' },
       dispatch,
+      initiator,
       async (operation: GithubOperation) => {
         const branchLatestRequest = getBranchContentFromServer(
           githubRepo,
@@ -95,6 +96,7 @@ export const updateProjectAgainstGithub =
           branchLatestContent.branch,
           dispatch,
           currentProjectContents,
+          initiator,
         )
 
         dispatch(


### PR DESCRIPTION
## Problem
fixes https://github.com/concrete-utopia/utopia/issues/5275

## Fix with details
(based on the issue)
- We change the copy: "Couldn't xxxx (see console)" - ie "Couldn't list Github pull requests (see console)" - to read friendlier and not line-wrap: implemented as described
- We bump down the level from error to primary (to avoid the "IT'S RED EVERYTHING IS BROKEN"): implemented as described
- We never try to connect to Github if the user isn't authenticated: implemented by calling `GithubHelpers.getUserDetailsFromServer` at the beginning of `runGithubOperation`, and early returning if the result is `null`. `GithubHelpers.getUserDetailsFromServer` fires off a request internally
- We only show the toasts for user-initiated actions (those from buttons, in the UI); we don't fire error messages for system-initiated polling-type failures: this is implemented by passing down a flag to `runGithubOperation` (`'polling' | 'user-initiated'`), and the toast is only shown if the flag is `user-initiated`. 

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
