### PR TITLE
Don't deselect from vscode

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1443,23 +1443,28 @@ function updateSelectedComponentsFromEditorPosition(
   if (Object.keys(editor.jsxMetadata).length === 0) {
     // Looks like the canvas has errored out, so leave it alone for now.
     return editor
-  } else {
-    const highlightBoundsForUids = getHighlightBoundsForFile(editor, filePath)
-    const allElementPathsOptic = traverseArray<NavigatorEntry>().compose(fromField('elementPath'))
-    const newlySelectedElements = getElementPathsInBounds(
-      line,
-      highlightBoundsForUids,
-      toArrayOf(
-        allElementPathsOptic,
-        derived.navigatorTargets.filter((t) => !isConditionalClauseNavigatorEntry(t)),
-      ),
-    )
-    return UPDATE_FNS.SELECT_COMPONENTS(
-      selectComponents(newlySelectedElements, false),
-      editor,
-      dispatch,
-    )
   }
+
+  const highlightBoundsForUids = getHighlightBoundsForFile(editor, filePath)
+  const allElementPathsOptic = traverseArray<NavigatorEntry>().compose(fromField('elementPath'))
+  const newlySelectedElements = getElementPathsInBounds(
+    line,
+    highlightBoundsForUids,
+    toArrayOf(
+      allElementPathsOptic,
+      derived.navigatorTargets.filter((t) => !isConditionalClauseNavigatorEntry(t)),
+    ),
+  )
+
+  if (newlySelectedElements.length === 0) {
+    return editor
+  }
+
+  return UPDATE_FNS.SELECT_COMPONENTS(
+    selectComponents(newlySelectedElements, false),
+    editor,
+    dispatch,
+  )
 }
 
 function normalizeGithubData(editor: EditorModel): EditorModel {


### PR DESCRIPTION
**Problem:**
Moving in the code editor should never lead to selection loss. 

**Fix:**
If we can not select a different element (or elements), just leave selection as it is. Extra check added to `Checked it in `updateSelectedComponentsFromEditorPosition`.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5272
