### PR TITLE
Hide pages tab when not Remix

### DIFF
--- a/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
@@ -9,7 +9,7 @@ import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import {
   DefaultFutureConfig,
   createRouteManifestFromProjectContents,
-  getRootFile,
+  getRemixRootFile,
   getRoutesAndModulesFromManifest,
 } from './remix-utils'
 import { RouteExportsForRouteObject } from './utopia-remix-root-component'
@@ -122,7 +122,7 @@ describe('Route manifest', () => {
 
     const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
     const rootFilePath =
-      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
+      getRemixRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(
       { rootDir, rootFilePath },
       renderResult.getEditorState().editor.projectContents,
@@ -181,7 +181,7 @@ describe('Route manifest', () => {
 
     const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
     const rootFilePath =
-      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
+      getRemixRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(
       { rootDir, rootFilePath },
       renderResult.getEditorState().editor.projectContents,
@@ -206,7 +206,7 @@ describe('Route manifest', () => {
 
     const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
     const rootFilePath =
-      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
+      getRemixRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(
       { rootDir, rootFilePath },
       renderResult.getEditorState().editor.projectContents,
@@ -320,7 +320,7 @@ describe('Routes', () => {
 
     const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
     const rootFilePath =
-      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
+      getRemixRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(
       { rootDir, rootFilePath },
       renderResult.getEditorState().editor.projectContents,
@@ -329,7 +329,7 @@ describe('Routes', () => {
 
     let routeModuleCache = { current: {} }
     const remixRoutes = getRoutesAndModulesFromManifest(
-      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)!.file,
+      getRemixRootFile(rootDir, renderResult.getEditorState().editor.projectContents)!.file,
       remixManifest!,
       DefaultFutureConfig,
       renderResult.getEditorState().editor.codeResultCache.curriedRequireFn,
@@ -442,7 +442,7 @@ describe('Routes', () => {
 
     const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
     const rootFilePath =
-      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
+      getRemixRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(
       { rootDir, rootFilePath },
       renderResult.getEditorState().editor.projectContents,
@@ -451,7 +451,7 @@ describe('Routes', () => {
     let routeModuleCache = { current: {} }
     expect(remixManifest).not.toBeNull()
     const remixRoutes = getRoutesAndModulesFromManifest(
-      getRootFile(rootDir, renderResult.getEditorState().editor.projectContents)!.file,
+      getRemixRootFile(rootDir, renderResult.getEditorState().editor.projectContents)!.file,
       remixManifest!,
       DefaultFutureConfig,
       renderResult.getEditorState().editor.codeResultCache.curriedRequireFn,

--- a/editor/src/components/canvas/remix/remix-utils.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.tsx
@@ -344,7 +344,7 @@ function safeGetClientRoutes(
   }
 }
 
-export function getRootFile(
+export function getRemixRootFile(
   rootDir: string,
   projectContents: ProjectContentTreeRoot,
 ): { file: TextFile; path: string } | null {

--- a/editor/src/components/editor/store/remix-derived-data.tsx
+++ b/editor/src/components/editor/store/remix-derived-data.tsx
@@ -21,7 +21,7 @@ import {
   DefaultFutureConfig,
   createAssetsManifest,
   createRouteManifestFromProjectContents,
-  getRootFile,
+  getRemixRootFile,
   getRoutesAndModulesFromManifest,
 } from '../../canvas/remix/remix-utils'
 import type { CurriedUtopiaRequireFn, CurriedResolveFn } from '../../custom-code/code-file'
@@ -83,7 +83,7 @@ export function createRemixDerivedData(
   curriedResolveFn: CurriedResolveFn,
 ): RemixDerivedData | null {
   const rootDir = getRemixRootDir(projectContents)
-  const rootJsFile = getRootFile(rootDir, projectContents)
+  const rootJsFile = getRemixRootFile(rootDir, projectContents)
   if (rootJsFile == null) {
     return null
   }

--- a/editor/src/components/navigator/left-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/index.tsx
@@ -20,6 +20,8 @@ import type { StoredPanel } from '../../canvas/stored-layout'
 import { useIsMyProject } from '../../editor/store/collaborative-editing'
 import { when } from '../../../utils/react-conditionals'
 import { PagesPane } from './pages-pane'
+import { getRemixRootFile } from '../../canvas/remix/remix-utils'
+import { getRemixRootDir } from '../../editor/store/remix-derived-data'
 
 export interface LeftPaneProps {
   editorState: EditorState
@@ -72,6 +74,15 @@ export const LeftPaneComponent = React.memo<LeftPaneComponentProps>((props) => {
 
   const isMyProject = useIsMyProject()
 
+  const isRemixProject = useEditorState(
+    Substores.projectContents,
+    (store) =>
+      getRemixRootFile(
+        getRemixRootDir(store.editor.projectContents),
+        store.editor.projectContents,
+      ) != null,
+    'LeftPaneComponent isRemixProject',
+  )
   return (
     <LowPriorityStoreProvider>
       <FlexColumn
@@ -100,11 +111,14 @@ export const LeftPaneComponent = React.memo<LeftPaneComponentProps>((props) => {
           {when(
             isMyProject,
             <FlexRow style={{ marginBottom: 10, gap: 10 }} css={undefined}>
-              <MenuTab
-                label={'Pages'}
-                selected={selectedTab === LeftMenuTab.Pages}
-                onClick={onClickPagesTab}
-              />
+              {when(
+                isRemixProject,
+                <MenuTab
+                  label={'Pages'}
+                  selected={selectedTab === LeftMenuTab.Pages}
+                  onClick={onClickPagesTab}
+                />,
+              )}
               <MenuTab
                 label={'Navigator'}
                 selected={selectedTab === LeftMenuTab.Navigator}
@@ -122,7 +136,7 @@ export const LeftPaneComponent = React.memo<LeftPaneComponentProps>((props) => {
               />
             </FlexRow>,
           )}
-          {when(isMyProject && selectedTab === LeftMenuTab.Pages, <PagesPane />)}
+          {when(isMyProject && isRemixProject && selectedTab === LeftMenuTab.Pages, <PagesPane />)}
           {when(selectedTab === LeftMenuTab.Navigator, <NavigatorComponent />)}
           {when(isMyProject && selectedTab === LeftMenuTab.Project, <ContentsPane />)}
           {when(isMyProject && selectedTab === LeftMenuTab.Github, <GithubPane />)}


### PR DESCRIPTION
**Problem:**

The pages pane should only be shown when in a Remix project.

**Fix:**

Hide the pages tab if the remix root file is not found.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5294 