### PR TITLE
Italic font style for non-favorite routes

### DIFF
--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -403,6 +403,7 @@ const FavoriteEntry = React.memo(({ favorite, active, addedToFavorites }: Favori
           ? '1px solid transparent'
           : '1px dashed ' + colorTheme.border3.value,
         boxSizing: 'border-box',
+        fontStyle: !addedToFavorites ? 'italic' : 'normal',
         marginLeft: 8,
         marginRight: 8,
         paddingLeft: 19, // to visually align the icons with the route entries underneath the favorites section


### PR DESCRIPTION
For non-favorite routes that can be favorited, show them with italic font style.

![image](https://github.com/concrete-utopia/utopia/assets/1081051/41af9053-47d0-47a6-a041-68a23ab59162)
