### PR TITLE
Pages tab: show all routes

### DIFF
--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -100,10 +100,12 @@ export const PagesPane = React.memo((props) => {
             (favorite) => matchPath(path, favorite)?.pathname ?? null,
           )
 
-          result[path] = {
-            path: path,
-            resolvedPath: firstMatchingFavorite,
-            matchesRealRoute: true,
+          if (path !== '') {
+            result[path] = {
+              path: path,
+              resolvedPath: firstMatchingFavorite,
+              matchesRealRoute: true,
+            }
           }
           if (route.children != null) {
             result = { ...result, ...processRoutes(route.children, path) }
@@ -354,7 +356,7 @@ const PageRouteEntry = React.memo<PageRouteEntryProps>((props) => {
               flexGrow: 1,
             }}
           >
-            {lastTemplateSegment === '' ? RemixIndexPathLabel : '/' + lastTemplateSegment}
+            {props.routePath}
           </span>
           <span
             style={{

--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -257,14 +257,23 @@ const PageRouteEntry = React.memo<PageRouteEntryProps>((props) => {
   const [navigationControls] = useAtom(RemixNavigationAtom)
   const [activeRemixScene] = useAtom(ActiveRemixSceneAtom)
 
+  const pathCanBeClickedToNavigate =
+    props.matchesRealRoute && !(props.resolvedPath == null && props.routePath.includes(':'))
+
   const onClick = React.useCallback(() => {
-    if (props.resolvedPath == null && props.routePath.includes(':')) {
+    if (!pathCanBeClickedToNavigate) {
       return
     }
     void navigationControls[EP.toString(activeRemixScene)]?.navigate(
       props.resolvedPath ?? props.routePath,
     )
-  }, [navigationControls, activeRemixScene, props.resolvedPath, props.routePath])
+  }, [
+    navigationControls,
+    activeRemixScene,
+    pathCanBeClickedToNavigate,
+    props.resolvedPath,
+    props.routePath,
+  ])
 
   const resolvedPathWithoutQueryOrHash = props.resolvedPath?.split('?')[0].split('#')[0]
 
@@ -298,6 +307,7 @@ const PageRouteEntry = React.memo<PageRouteEntryProps>((props) => {
         alignItems: 'center',
         borderRadius: 2,
         position: 'relative',
+        cursor: pathCanBeClickedToNavigate ? 'pointer' : 'auto',
       }}
       onClick={props.matchesRealRoute ? onClick : NO_OP}
     >

--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -95,7 +95,6 @@ export const PagesPane = React.memo((props) => {
     'PagesPane featuredRoutes',
   )
 
-  // all remix routes in the project, ordered alphabetically
   const remixRoutesObject: RouteMatches = useEditorState(
     Substores.derived,
     (store) => {
@@ -127,6 +126,7 @@ export const PagesPane = React.memo((props) => {
     'PagesPane remixRoutes',
   )
 
+  // all remix routes in the project, ordered alphabetically
   const remixRoutes = fillInGapsInRoutes(remixRoutesObject)
 
   const pageTemplates = useEditorState(

--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -257,7 +257,6 @@ interface PageRouteEntryProps {
 }
 const PageRouteEntry = React.memo<PageRouteEntryProps>((props) => {
   const ref = React.useRef<HTMLDivElement | null>(null)
-  useScrollToNavigateToRoute(ref, props.resolvedPath, props.navigateTo)
 
   const [navigationControls] = useAtom(RemixNavigationAtom)
   const [activeRemixScene] = useAtom(ActiveRemixSceneAtom)
@@ -605,18 +604,6 @@ export const AddPageContextMenu = React.memo(
     )
   },
 )
-
-function useScrollToNavigateToRoute(
-  ref: React.MutableRefObject<HTMLDivElement | null>,
-  path: string | null,
-  navigateTo: NavigateTo | null,
-) {
-  React.useEffect(() => {
-    if (navigateTo?.resolvedPath === path) {
-      ref.current?.scrollIntoView()
-    }
-  }, [navigateTo, ref, path])
-}
 
 function useNavigateToRouteWhenAvailable(
   remixRoutes: RouteMatch[],

--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -633,9 +633,8 @@ function useNavigateToRouteWhenAvailable(
     }
 
     // if the target is a specific route, go to it
-    const navigateToMatchesRealRoute = remixRoutes.find((r) => {
-      return r.resolvedPath === navigateTo.resolvedPath
-    })?.matchesRealRoute
+    const navigateToMatchesRealRoute =
+      matchRoutes(remixRoutes, navigateTo.resolvedPath)?.[0].route.matchesRealRoute ?? false
 
     // otherwise if the target is not a specific route, go to the first valid match for its prefix
     const navigationTarget = navigateToMatchesRealRoute

--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -224,23 +224,6 @@ export const PagesPane = React.memo((props) => {
         )}
       </InspectorSectionHeader>
 
-      {when(
-        remixRoutes.length === 0,
-        <FlexColumn
-          style={{
-            height: '100%',
-            overflowY: 'scroll',
-            whiteSpace: 'normal',
-            padding: 16,
-            paddingTop: 32,
-          }}
-        >
-          <Subdued>
-            No featured routes were found in the project. Please add a favorite route using the
-            Favorites section.
-          </Subdued>
-        </FlexColumn>,
-      )}
       {remixRoutes.map((route: RouteMatch, index) => {
         const { path, resolvedPath } = route
         const pathMatchesActivePath = matchResult?.[0].route.path === path

--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -98,10 +98,10 @@ export const PagesPane = React.memo((props) => {
   const remixRoutesObject: RouteMatches = useEditorState(
     Substores.derived,
     (store) => {
-      function processRoutes(routes: Array<any>, prefix: string | null): RouteMatches {
+      function processRoutes(routes: Array<any>, prefix: string): RouteMatches {
         let result: RouteMatches = {}
         for (const route of routes) {
-          const path = prefix == null ? route.path : prefix + '/' + (route.path ?? '')
+          const path = urljoin(prefix, '/', route.path ?? '')
           const firstMatchingFavorite = mapFirstApplicable(
             [...featuredRoutes, activeRoute],
             (favorite) => matchPath(path, favorite)?.pathname ?? null,
@@ -120,7 +120,7 @@ export const PagesPane = React.memo((props) => {
         }
         return result
       }
-      const routes = processRoutes(store.derived.remixData?.routes ?? [], null)
+      const routes = processRoutes(store.derived.remixData?.routes ?? [], '')
       return routes
     },
     'PagesPane remixRoutes',

--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -686,7 +686,8 @@ function useRenaming(props: PageRouteEntryProps) {
   const onDoneRenaming = React.useCallback(
     (newPath: string | null) => {
       setIsRenaming(false)
-      if (props.resolvedPath == null && props.routePath.includes(':')) {
+      const pathIsDynamicUnresolved = props.resolvedPath == null && props.routePath.includes(':')
+      if (pathIsDynamicUnresolved) {
         return
       }
       const newResolvedPath = runRenameRemixRoute(

--- a/editor/src/core/shared/array-utils.ts
+++ b/editor/src/core/shared/array-utils.ts
@@ -63,6 +63,19 @@ export function mapAndFilter<T, U>(
   }, a)
 }
 
+export function mapFirstApplicable<T, U>(
+  array: ReadonlyArray<T>,
+  mapFn: (t: T, i: number) => U | null,
+): U | null {
+  for (const value of array) {
+    const mapped = mapFn(value, 0)
+    if (mapped != null) {
+      return mapped
+    }
+  }
+  return null
+}
+
 // Dumb version of:
 // traverse :: (Traversable t, Applicative f) => (a -> f b) -> t a -> f (t b)
 export function traverseArray<T, U>(


### PR DESCRIPTION
**Problem:**
Now that we have the Favorites section and the separate Routes section, we want the Routes section to show all routes.

**Fix:**
<img width="270" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/b9da5e08-35c0-499c-846d-d07ad42ced4d">

**Commit Details:**
- Moved a bunch of code around in `PagesPane`
- New selector that creates a remixRoutesObject
- Modified the gap filler to work with the routes object
- Route rows can only be clicked if they have dynamic parameters filled in
- Fixed some bugs I caused in the rename auto-navigate feature

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #[ticket_number] (<< pls delete this line if it's not relevant)
