### PR TITLE
Preload package dependencies.

### DIFF
--- a/server/package.yaml
+++ b/server/package.yaml
@@ -27,6 +27,7 @@ flags:
 dependencies:
   - aeson ==2.0.3.0
   - aeson-pretty
+  - async
   - aws
   - base >= 4.7 && < 5
   - base16-bytestring

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -516,6 +516,7 @@ startup :: DevServerResources -> IO Stop
 startup DevServerResources{..} = do
   migrateDatabase (not _silentMigration) True _projectPool
   DB.cleanupCollaborationControl _databaseMetrics _projectPool getCurrentTime
+  preloadNPMDependencies _logger _npmMetrics _nodeSemaphore _locksRef
   hashedFilenamesThread <- forkIO $ watchFilenamesWithHashes (_hashCache _assetsCaches) (_assetResultCache _assetsCaches) assetPathsAndBuilders
   return $ do
         killThread hashedFilenamesThread

--- a/server/src/Utopia/Web/Executors/Production.hs
+++ b/server/src/Utopia/Web/Executors/Production.hs
@@ -462,6 +462,7 @@ startup :: ProductionServerResources -> IO Stop
 startup ProductionServerResources{..} = do
   migrateDatabase True False _projectPool
   DB.cleanupCollaborationControl _databaseMetrics _projectPool getCurrentTime
+  preloadNPMDependencies _logger _npmMetrics _nodeSemaphore _locksRef
   hashedFilenamesThread <- forkIO $ watchFilenamesWithHashes (_hashCache _assetsCaches) (_assetResultCache _assetsCaches) assetPathsAndBuilders
   return $ do
         killThread hashedFilenamesThread

--- a/server/src/Utopia/Web/Logging.hs
+++ b/server/src/Utopia/Web/Logging.hs
@@ -5,8 +5,12 @@
 
 module Utopia.Web.Logging where
 
+import           Data.Text
 import           Protolude
 import           System.Log.FastLogger
 
 loggerLn :: FastLogger -> LogStr -> IO ()
 loggerLn logger mainStr = logger (mainStr <> "\n")
+
+logException :: FastLogger -> SomeException -> IO ()
+logException logger e = loggerLn logger (toLogStr ("Exception: " <> show e :: Text))

--- a/server/src/Utopia/Web/Packager/Locking.hs
+++ b/server/src/Utopia/Web/Packager/Locking.hs
@@ -37,3 +37,7 @@ getPackageVersionLock locksRef versionedPackageName = do
   possibleRef <- getLockFromRef locksRef versionedPackageName
   maybe (getOrUpdateLockFromRef locksRef versionedPackageName) pure possibleRef
 
+cleanupWriteLock :: RWLock -> Bool -> IO ()
+cleanupWriteLock lock True = releaseWrite lock
+cleanupWriteLock _ False   = pure ()
+

--- a/server/src/Utopia/Web/Packager/NPM.hs
+++ b/server/src/Utopia/Web/Packager/NPM.hs
@@ -9,31 +9,46 @@
 module Utopia.Web.Packager.NPM where
 
 import           Conduit
-import           Control.Lens              hiding ((.=))
+import           Control.Concurrent.Async
+import           Control.Concurrent.ReadWriteLock
+import           Control.Lens                     hiding ((.=))
 import           Control.Monad.Catch
 import           Data.Aeson
-import qualified Data.ByteString.Lazy      as BL
-import           Data.Conduit.Combinators  hiding (encodeUtf8)
+import qualified Data.ByteString.Lazy             as BL
+import qualified Data.Conduit                     as C
+import           Data.Conduit.Combinators         hiding (encodeUtf8, foldMap,
+                                                   print)
+import qualified Data.Conduit.Combinators         as C hiding (concatMap)
 import           Data.Generics.Product
 import           Data.Generics.Sum
-import qualified Data.HashMap.Strict       as Map
+import qualified Data.HashMap.Strict              as Map
+import qualified Data.HashSet                     as HS
 import           Data.IORef
-import           Data.List                 (isSuffixOf, stripPrefix)
-import           Data.Text                 (pack)
+import           Data.List                        (isSuffixOf, stripPrefix)
+import           Data.String                      (String)
+import           Data.Text                        (pack, splitOn)
 import           Data.Time.Clock
-import           Protolude                 hiding (catch, finally, mapM)
-import           RIO                       (readFileUtf8)
+import qualified Network.Wreq                     as WR
+import qualified Network.Wreq.Types               as WR
+import           Protolude                        hiding (catch, finally,
+                                                   handle, mapM)
+import           RIO                              (fail, readFileUtf8)
 import           System.Directory
+import           System.Environment
+import           System.FilePath
 import           System.IO.Error
 import           System.IO.Temp
 import           System.Log.FastLogger
 import           System.Process
 import           Utopia.ClientModel
-import           Utopia.Web.Database       (projectContentTreeFromDecodedProject)
-import qualified Utopia.Web.Database.Types as DB
+import           Utopia.Web.Database              (projectContentTreeFromDecodedProject)
+import qualified Utopia.Web.Database.Types        as DB
 import           Utopia.Web.Logging
 import           Utopia.Web.Metrics
+import           Utopia.Web.Packager.Locking
 import           Utopia.Web.Utils.Limits
+
+type ConduitBytes m = ConduitT () ByteString m ()
 
 data NPMMetrics = NPMMetrics
                 { npmInstallMetric       :: InvocationMetric
@@ -55,6 +70,12 @@ matchingVersionsCacheTimeLimit = 60 * 60 * 24 -- 1 day.
 
 handleVersionsLookupError :: IOException -> IO (Maybe Value)
 handleVersionsLookupError _ = return Nothing
+
+getRoundedAccessTime :: String -> IO UTCTime
+getRoundedAccessTime filePath = do
+  time <- getAccessTime filePath
+  let roundedDiffTime = fromInteger $ round $ utctDayTime time
+  return $ time { utctDayTime = roundedDiffTime }
 
 fetchVersionWithCache :: MatchingVersionsCache -> Text -> Maybe Text -> IO (Maybe Value) -> IO (Maybe Value)
 fetchVersionWithCache matchingVersionsCache jsPackageName maybePackageVersion fallback = do
@@ -82,7 +103,7 @@ packageAndVersionAsText :: Text -> Maybe Text -> Text
 packageAndVersionAsText jsPackageName (Just maybePackageVersion) = jsPackageName <> "@" <> maybePackageVersion
 packageAndVersionAsText jsPackageName Nothing = jsPackageName
 
--- Find Applicable Versions using `npm view packageName@version version --json
+-- Find Applicable Versions using `npm view packageName@version version --json`.
 findMatchingVersions :: FastLogger -> NPMMetrics -> QSem -> MatchingVersionsCache -> Text -> Maybe Text -> IO (Maybe Value)
 findMatchingVersions logger NPMMetrics{..} semaphore matchingVersionsCache jsPackageName maybePackageVersion = do
   fetchVersionWithCache matchingVersionsCache jsPackageName maybePackageVersion $ do
@@ -114,13 +135,13 @@ withInstalledProject logger NPMMetrics{..} semaphore versionedPackageName withIn
         createTempDirectory tmpDir "packager"
   let deleteDir = ignoringIOErrors . removeDirectoryRecursive
   bracketP createDir deleteDir $ \tempDir -> do
-    -- Run `npm install "packageName@packageVersion"`.
+    -- Run `yarn add "packageName@packageVersion"`.
     let baseProc = proc "yarn" ["add", "--silent", "--ignore-scripts", toS versionedPackageName]
     let procWithCwd = baseProc { cwd = Just tempDir, env = Just [("NODE_OPTIONS", "--max_old_space_size=512")] }
     liftIO $ limitWithSemaphore semaphore $ do
       loggerLn logger ("Starting Yarn Add: " <> toLogStr versionedPackageName)
       _ <- invokeAndMeasure npmInstallMetric $
-          addInvocationDescription npmInstallMetric ("NPM install for " <> versionedPackageName) $
+          addInvocationDescription npmInstallMetric ("Yarn Add for " <> versionedPackageName) $
           readCreateProcess procWithCwd ""
       loggerLn logger ("Yarn Add Finished: " <> toLogStr versionedPackageName)
     -- Invoke action against path.
@@ -154,6 +175,8 @@ data ProjectDependency = ProjectDependency
                        }
                        deriving (Eq, Show, Generic)
 
+instance Hashable ProjectDependency
+
 data MinimalPackageJSON = MinimalPackageJSON
                         { dependencies    :: Maybe (Map.HashMap Text Text)
                         , devDependencies :: Maybe (Map.HashMap Text Text)
@@ -176,8 +199,77 @@ getProjectDependenciesFromPackageJSON decodedProject = either (const []) identit
   contentsTreeRoot <- first toS $ projectContentTreeFromDecodedProject decodedProject
   packageJsonFile <- maybe (Left "No package.json found.") pure $ getProjectContentsTreeFile contentsTreeRoot ["package.json"]
   packageJsonCode <- maybe (Left "package.json not a text file.") pure $ firstOf projectFileToCodeLens packageJsonFile
-  MinimalPackageJSON{..} <- eitherDecode' $ BL.fromStrict $ encodeUtf8 packageJsonCode
-  let fullDependencies = fromMaybe mempty (dependencies <> devDependencies)
-  pure $ Map.foldMapWithKey (\key value -> [ProjectDependency key value]) fullDependencies
+  packageJSON <- eitherDecode' $ BL.fromStrict $ encodeUtf8 packageJsonCode
+  pure $ packageJSONToDependencies packageJSON
 
+getPackageJSONContent :: Text -> IO MinimalPackageJSON
+getPackageJSONContent packageJSONURL = do
+  response <- WR.get $ toS packageJSONURL
+  either fail pure $ eitherDecode $ view WR.responseBody response
 
+packageJSONToDependencies :: MinimalPackageJSON -> [ProjectDependency]
+packageJSONToDependencies MinimalPackageJSON{..} =
+  let dependenciesMap = fromMaybe mempty (dependencies <> devDependencies)
+  in  Map.foldMapWithKey (\key value -> [ProjectDependency key value]) dependenciesMap
+
+cachePackagerContent :: (MonadResource m, MonadMask m) => PackageVersionLocksRef -> Text -> ConduitBytes m -> IO (ConduitBytes m, UTCTime)
+cachePackagerContent locksRef versionedPackageName fallback = do
+  let cacheFileParentPath = ".utopia-cache" </> "packager" </> toS versionedPackageName
+  let cacheFilePath = cacheFileParentPath </> "cache.json"
+  fileExists <- doesFileExist cacheFilePath
+  -- Use the parent path as we can create that and get a last modified date
+  -- from it before the file is fully written to disk.
+  unless fileExists $ createDirectoryIfMissing True cacheFileParentPath
+  lastModified <- getRoundedAccessTime cacheFileParentPath
+  let whenFileExists = sourceFile cacheFilePath
+  let whenFileDoesNotExist =
+            -- Write out the file as well as returning the content.
+            let writeToFile = passthroughSink (sinkFileCautious cacheFilePath) (const $ pure ())
+            -- Include the fallback.
+            in (fallback .| writeToFile)
+  let whenFileDoesNotExistSafe = do
+            lock <- getPackageVersionLock locksRef versionedPackageName
+            pure $ bracketP (tryAcquireWrite lock) (cleanupWriteLock lock) $ \writeAcquired -> do
+              if writeAcquired
+                 then whenFileDoesNotExist
+                 else bracketP (acquireRead lock) (const $ releaseRead lock) (const whenFileExists)
+
+  conduit <- if fileExists then pure whenFileExists else whenFileDoesNotExistSafe
+  pure (conduit, lastModified)
+
+getPackagerContent :: (MonadResource m, MonadMask m) => FastLogger -> NPMMetrics -> QSem -> PackageVersionLocksRef -> Text -> IO (ConduitBytes m, UTCTime)
+getPackagerContent logger npmMetrics npmSemaphore packageLocksRef versionedPackageName = do
+  cachePackagerContent packageLocksRef versionedPackageName $ do
+    withInstalledProject logger npmMetrics npmSemaphore versionedPackageName (filePairsToBytes . getModuleAndDependenciesFiles)
+
+filePairsToBytes :: (Monad m) => ConduitT () (FilePath, Value) m () -> ConduitBytes m
+filePairsToBytes filePairs =
+  let pairToBytes (filePath, pathValue) = BL.toStrict (encode filePath) <> ": " <> BL.toStrict (encode pathValue)
+      pairsAsBytes = filePairs .| C.map pairToBytes
+      withCommas = pairsAsBytes .| C.intersperse ", "
+   in sequence_ [C.yield "{\"contents\": {", withCommas, C.yield "}}"]
+
+preloadNPMDependencies :: FastLogger -> NPMMetrics -> QSem -> PackageVersionLocksRef -> IO ()
+preloadNPMDependencies logger metrics semaphore packageLocksRef = do
+  -- Get the environment variable to see what should be preloaded.
+  preloadEnvVar <- lookupEnv "PRELOAD_DEPENDENCIES"
+  forM_ preloadEnvVar $ \preloadEnvVarText -> do
+    -- Log out that the preloading is starting.
+    loggerLn logger "Preloading NPM dependencies..."
+    -- Split the content of the variable to get the URLs of the package.json files.
+    let packageJsonURLs = splitOn "," (toS preloadEnvVarText)
+    -- Pull the package.json files and parse out the dependencies from them.
+    packageJSONEntries <- mapConcurrently getPackageJSONContent packageJsonURLs
+    let allDependencies = HS.fromList $ foldMap packageJSONToDependencies packageJSONEntries
+    -- Preload the dependencies, doing nothing with their content.
+    let flipMap = flip foldMap
+    _ <- flipMap allDependencies $ \ProjectDependency{..} -> do
+      -- Log out exceptions per dependency.
+      handle (logException logger) $ do
+        -- Get and cache the content of the dependency.
+        let versionedPackageName = packageAndVersionAsText dependencyName (Just dependencyVersion)
+        bytesAndDate <- getPackagerContent logger metrics semaphore packageLocksRef versionedPackageName
+        let (conduitBytes, _) = bytesAndDate
+        runResourceT $ runConduit (conduitBytes .| C.sinkNull)
+    -- Log out that the preloading has finished.
+    loggerLn logger "Finished preloading NPM dependencies..."

--- a/server/src/Utopia/Web/Server.hs
+++ b/server/src/Utopia/Web/Server.hs
@@ -24,6 +24,7 @@ import           System.Log.FastLogger
 import           System.TimeManager
 import           Utopia.Web.Executors.Common
 import           Utopia.Web.Logging
+import           Utopia.Web.Packager.NPM
 import           Utopia.Web.ServantMonitoring
 import           Utopia.Web.Types
 import           Utopia.Web.Utils.Files

--- a/server/utopia-web.cabal
+++ b/server/utopia-web.cabal
@@ -74,6 +74,7 @@ executable utopia-web
       JuicyPixels
     , aeson ==2.0.3.0
     , aeson-pretty
+    , async
     , aws
     , base >=4.7 && <5
     , base16-bytestring
@@ -223,6 +224,7 @@ test-suite utopia-web-test
     , JuicyPixels
     , aeson ==2.0.3.0
     , aeson-pretty
+    , async
     , aws
     , base >=4.7 && <5
     , base16-bytestring

--- a/shell.nix
+++ b/shell.nix
@@ -309,7 +309,7 @@ let
         , ("ghc", ["--version"], ["The Glorious Glasgow Haskell Compilation System, version 9.0.2"])
         , ("cabal", ["--version"], ["cabal-install version 3.8.1.0", "compiled using version 3.8.1.0 of the Cabal library "])
         ]
-
+ 
       checkVersion :: (String, [String], [String]) -> IO All
       checkVersion (executable, arguments, expectedOutput) = do
         let commandToRun = unwords (executable : arguments)

--- a/shell.nix
+++ b/shell.nix
@@ -309,7 +309,6 @@ let
         , ("ghc", ["--version"], ["The Glorious Glasgow Haskell Compilation System, version 9.0.2"])
         , ("cabal", ["--version"], ["cabal-install version 3.8.1.0", "compiled using version 3.8.1.0 of the Cabal library "])
         ]
- 
       checkVersion :: (String, [String], [String]) -> IO All
       checkVersion (executable, arguments, expectedOutput) = do
         let commandToRun = unwords (executable : arguments)


### PR DESCRIPTION
**Problem:**
Cloning new large github projects, and loading large projects (eg the Sample Project) is so slow that it's unclear if the load will succeed. This is due to a number of factors, but a first-load-after-new-deploy is particularly bad, and even worse if multiple people try to do that at the same time. And that's a common scenario.

**Fix:**
Now the server checks for an environment variable `PRELOAD_DEPENDENCIES`, which it splits based on commas expecting URLs for package.json files in the value. The dependencies in the project are then cached as if the editor had requested them.

**Results:**
Testing this locally by timing the point at which a reload of the mock shop project is started until the canvas displays fully:
- Without preloading: `00:34.74`
- With preloading: `00:20.95`

**Commit Details:**
- Moved a few functions relating to the packager from `Common.hs` to `NPM.hs`.
- Added preload trigger to `startup`.
- Extracted out `packageJSONToDependencies` from `getProjectDependenciesFromPackageJSON`.
- Implemented `preloadNPMDependencies` to lookup dependencies and cache them.
- Added `logException` utility function.
- Included `async` project in server.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5205
