### PR TITLE
unaesthetic disconnected github panel

### DIFF
--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -59,6 +59,30 @@ const compactTimeagoFormatter = (value: number, unit: string) => {
 
 type IndicatorState = 'incomplete' | 'failed' | 'successful' | 'pending'
 
+export const AuthenticateWithGithubButton = () => {
+  const triggerAuthentication = useOnClickAuthenticateWithGithub()
+  return (
+    <Button
+      spotlight
+      highlight
+      style={{
+        padding: '1em',
+        borderRadius: 3,
+        background: colorTheme.dynamicBlue.value,
+        color: colorTheme.bg1.value,
+      }}
+      css={{
+        '&:hover': {
+          opacity: 0.7,
+        },
+      }}
+      onMouseUp={triggerAuthentication}
+    >
+      Authenticate With Github
+    </Button>
+  )
+}
+
 const AccountBlock = () => {
   const authenticated = useEditorState(
     Substores.restOfStore,
@@ -67,32 +91,13 @@ const AccountBlock = () => {
   )
   const state = React.useMemo(() => (authenticated ? 'successful' : 'incomplete'), [authenticated])
 
-  const triggerAuthentication = useOnClickAuthenticateWithGithub()
-
   if (authenticated) {
     return null
   }
 
   return (
     <Block title='Account' status={state} first={true} last={true} expanded={true}>
-      <Button
-        spotlight
-        highlight
-        style={{
-          padding: '1em',
-          borderRadius: 3,
-          background: colorTheme.dynamicBlue.value,
-          color: colorTheme.bg1.value,
-        }}
-        css={{
-          '&:hover': {
-            opacity: 0.7,
-          },
-        }}
-        onMouseUp={triggerAuthentication}
-      >
-        Authenticate With Github
-      </Button>
+      <AuthenticateWithGithubButton />
     </Block>
   )
 }
@@ -138,9 +143,7 @@ const RepositoryBlock = () => {
     >
       <FlexColumn style={{ gap: 4 }}>
         <UIGridRow padded={false} variant='<-------------1fr------------->'>
-          <div>
-            We only support <strong>public</strong> repositories at this time.
-          </div>
+          <div>Check your project sharing settings when importing from private repositories</div>
         </UIGridRow>
         <RepositoryListing
           githubAuthenticated={githubAuthenticated}
@@ -1146,8 +1149,7 @@ export const GithubPane = React.memo(() => {
     <div style={{ height: '100%', overflowY: 'scroll' }} onFocus={onFocus}>
       <Section>
         <SectionTitleRow minimised={false} hideButton>
-          <FlexRow>
-            <MenuIcons.Octocat style={{ width: 19, height: 19 }} />
+          <FlexRow style={{ alignItems: 'flex-start' }}>
             {githubUser != null ? (
               <Button
                 style={{ gap: 4, padding: '0 6px' }}
@@ -1160,7 +1162,19 @@ export const GithubPane = React.memo(() => {
               >
                 @{githubUser?.login}
               </Button>
-            ) : null}
+            ) : (
+              <UIGridRow
+                variant='<-auto-><----------1fr--------->'
+                padded
+                style={{
+                  minHeight: UtopiaTheme.layout.rowHeight.normal,
+                  color: colorTheme.fg1.value,
+                }}
+              >
+                <MenuIcons.Octocat style={{ width: 19, height: 19 }} />
+                <AuthenticateWithGithubButton />
+              </UIGridRow>
+            )}
           </FlexRow>
         </SectionTitleRow>
         {unless(
@@ -1176,7 +1190,7 @@ export const GithubPane = React.memo(() => {
         )}
       </Section>
       {when(
-        isLoggedIn,
+        isLoggedIn && githubUser != null,
         <Section style={{ padding: '10px' }}>
           <AccountBlock />
           <RepositoryBlock />

--- a/editor/src/core/shared/github/operations/github-operations.test-utils.ts
+++ b/editor/src/core/shared/github/operations/github-operations.test-utils.ts
@@ -13,6 +13,7 @@ import { GithubAuth } from '../../../../utils/github-auth'
 import {
   setGithubState,
   setLoginState,
+  updateGithubData,
 } from '../../../../components/editor/actions/action-creators'
 import { getUsersPublicGithubRepositories } from './load-repositories'
 import { updateProjectAgainstGithub } from './update-against-branch'
@@ -24,6 +25,9 @@ export async function loginUserToGithubForTests(dispatch: AsyncEditorDispatch) {
     [
       setLoginState({ type: 'LOGGED_IN', user: { userId: 'user' } }),
       setGithubState({ authenticated: true }),
+      updateGithubData({
+        githubUserDetails: { login: 'stub', avatarURL: 'stub', htmlURL: 'stub', name: null },
+      }),
     ],
     true,
   )


### PR DESCRIPTION
**Problem:**
The github panel when the user is logged in but not authenticated with github looks awkward

**Fix:**
Not perfect but better.
<img width="309" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2945037/16eb62ea-a1fa-49fe-9ef3-05712baae46a">


**Commit Details:** 

- make the button independent
- rendered it into a GridRow