### PR TITLE
Make the context menu black with white icons

### DIFF
--- a/editor/resources/editor/css/ReactContexify.css
+++ b/editor/resources/editor/css/ReactContexify.css
@@ -4,10 +4,11 @@
   opacity: 0;
   user-select: none;
   border-radius: 3px;
-  background-color: var(--utopitheme-bg1);
+  background-color: var(--utopitheme-contextMenuBackground);
   box-sizing: border-box;
   /* the same as boxShadow: UtopiaStyles.shadowStyles.mid.boxShadow */
-  box-shadow: 0px 3px 6px -2px var(--utopitheme-shadow80), 0px 4px 8px -2px var(--utopitheme-shadow40);
+  box-shadow: 0px 3px 6px -2px var(--utopitheme-shadow80),
+    0px 4px 8px -2px var(--utopitheme-shadow40);
   padding: 4px 0px;
   font-family: 'utopian-inter';
 }

--- a/editor/src/components/context-menu-wrapper.tsx
+++ b/editor/src/components/context-menu-wrapper.tsx
@@ -148,7 +148,7 @@ export class MomentumContextMenu<T> extends ReactComponent<ContextMenuProps<T>> 
                     {item.label}
                   </span>
                 }
-                arrow={<Icons.ExpansionArrowRight style={{ marginLeft: 8 }} />}
+                arrow={<Icons.ExpansionArrowRightWhite style={{ marginLeft: 8 }} />}
               >
                 {item.items.map((submenuItem, submenuIndex) =>
                   this.renderItem(submenuItem, submenuIndex),

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -163,35 +163,10 @@ interface SelectableElementItemProps {
 const SelectableElementItem = (props: SelectableElementItemProps) => {
   const rawRef = React.useRef<HTMLDivElement>(null)
   const { dispatch, path, iconProps, label } = props
-  const isHighlighted = useEditorState(
-    Substores.highlightedHoveredViews,
-    (store) => store.editor.highlightedViews.some((view) => EP.pathsEqual(path, view)),
-    'SelectableElementItem isHighlighted',
-  )
-  const highlightElement = React.useCallback(
-    () => dispatch([setHighlightedView(path)]),
-    [dispatch, path],
-  )
-
-  React.useEffect(() => {
-    const current = rawRef.current
-    if (current != null) {
-      const parent = current.parentElement?.parentElement
-      // eslint-disable-next-line no-unused-expressions
-      parent?.addEventListener('mousemove', highlightElement)
-    }
-    return function cleanup() {
-      if (current != null) {
-        const parent = current.parentElement?.parentElement
-        // eslint-disable-next-line no-unused-expressions
-        parent?.removeEventListener('mousemove', highlightElement)
-      }
-    }
-  }, [highlightElement])
 
   return (
     <FlexRow ref={rawRef}>
-      <Icn {...iconProps} color={isHighlighted ? 'on-highlight-main' : 'main'} />
+      <Icn {...iconProps} color={'white'} />
       <span style={{ paddingLeft: 6 }}>{label}</span>
     </FlexRow>
   )

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -260,19 +260,19 @@ function iconPropsForIcon(icon: Icon): IcnProps {
       return {
         category: 'navigator-element',
         type: 'flex-column',
-        color: 'main',
+        color: 'white',
       }
     case 'row':
       return {
         category: 'navigator-element',
         type: 'flex-row',
-        color: 'main',
+        color: 'white',
       }
     case 'regular':
       return {
         category: 'navigator-element',
         type: 'component',
-        color: 'main',
+        color: 'white',
       }
     default:
       assertNever(icon)

--- a/editor/src/uuiui/icn.tsx
+++ b/editor/src/uuiui/icn.tsx
@@ -20,6 +20,7 @@ export type IcnColor =
   | 'on-light-main'
   | 'darkgray'
   | 'black'
+  | 'white'
   | 'overridden'
   | 'dynamic'
   | 'remix'
@@ -79,6 +80,8 @@ function useIconColor(intent: IcnColor): IcnResultingColor {
         return 'white'
       case 'remix':
         return 'aqua'
+      case 'white':
+        return 'white'
       default:
         return 'white'
     }
@@ -114,6 +117,8 @@ function useIconColor(intent: IcnColor): IcnResultingColor {
         return 'black'
       case 'remix':
         return 'lightaqua'
+      case 'white':
+        return 'white'
       default:
         return 'white'
     }

--- a/editor/src/uuiui/icons.tsx
+++ b/editor/src/uuiui/icons.tsx
@@ -214,6 +214,7 @@ export const Icons = {
   ExpansionArrowControlled: makeIcon({ type: 'expansionarrow-down', color: 'primary' }),
   ExpansionArrowDown: makeIcon({ type: 'expansionarrow-down', color: 'main' }),
   ExpansionArrowRight: makeIcon({ type: 'expansionarrow-right', color: 'main' }),
+  ExpansionArrowRightWhite: makeIcon({ type: 'expansionarrow-right', color: 'white' }),
   ExternalLink: makeIcon({ type: 'externallink', color: 'main' }),
   ExternalLinkSmaller: makeIcon({ type: 'externallink-smaller', color: 'main' }),
   EyeStrikethrough: makeIcon({ type: 'eye-strikethrough', color: 'main' }),

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -213,11 +213,11 @@ const darkTheme: typeof light = {
   navigatorComponentSelected: darkBase.componentChild20,
   navigatorComponentIconBorder: darkBase.componentChild,
 
-  contextMenuBackground: darkPrimitives.secondaryBackground,
-  contextMenuForeground: darkPrimitives.neutralForeground,
+  contextMenuBackground: darkBase.bg1,
+  contextMenuForeground: darkBase.white,
   contextMenuHighlightForeground: darkBase.bg1,
   contextMenuHighlightBackground: darkBase.dynamicBlue,
-  contextMenuSeparator: createUtopiColor('rgba(0,0,0,0.1)'),
+  contextMenuSeparator: createUtopiColor('rgba(255,255,255,0.35)'),
 
   inspectorHoverColor: darkBase.fg8,
   inspectorFocusedColor: darkBase.dynamicBlue,

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -213,11 +213,11 @@ const lightTheme = {
   navigatorComponentSelected: lightBase.componentChild20,
   navigatorComponentIconBorder: lightBase.componentChild,
 
-  contextMenuBackground: lightPrimitives.secondaryBackground,
-  contextMenuForeground: lightPrimitives.neutralForeground,
+  contextMenuBackground: createUtopiColor('#181C20'),
+  contextMenuForeground: lightBase.white,
   contextMenuHighlightForeground: lightBase.white,
   contextMenuHighlightBackground: lightBase.primary,
-  contextMenuSeparator: createUtopiColor('rgba(0,0,0,0.1)'),
+  contextMenuSeparator: createUtopiColor('rgba(255,255,255,0.35)'),
 
   inspectorHoverColor: lightBase.fg8,
   inspectorFocusedColor: lightBase.primary,


### PR DESCRIPTION
**Before:**
<img width="440" alt="image" src="https://github.com/concrete-utopia/utopia/assets/1044774/e394fbc2-8225-479d-9986-82eae041ba75">
<img width="425" alt="image" src="https://github.com/concrete-utopia/utopia/assets/1044774/6596eb8e-2fd8-4f90-a6cc-aceba7951f31">

**After:**
<img width="420" alt="image" src="https://github.com/concrete-utopia/utopia/assets/1044774/a1dc7fef-34b2-4b5f-a021-b46546a698c9">
<img width="428" alt="image" src="https://github.com/concrete-utopia/utopia/assets/1044774/4b37725c-2fd5-422d-a08e-52fffc730b3e">


Fixes #5314 
