### PR TITLE
remove the `Steganography` fs

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -75,7 +75,7 @@ import {
   isUtopiaCommentFlagMapCount,
 } from '../../../core/shared/comment-flags'
 import { RemixSceneComponent } from './remix-scene-component'
-import { isFeatureEnabled } from '../../../utils/feature-switches'
+import { STEGANOGRAPHY_ENABLED } from '../../../utils/feature-switches'
 import { jsxElementChildToText } from './jsx-element-child-to-text'
 
 export interface RenderContext {
@@ -285,7 +285,7 @@ export function renderCoreElement(
           return runJSExpression(element, elementPath, blockScope, renderContext, uid, codeError)
         }
 
-        const originalTextContent = isFeatureEnabled('Steganography') ? runJSExpressionLazy() : null
+        const originalTextContent = STEGANOGRAPHY_ENABLED ? runJSExpressionLazy() : null
 
         const textContent = trimJoinUnescapeTextFromJSXElements([element])
         const textEditorProps: TextEditorProps = {
@@ -662,7 +662,7 @@ function renderJSXElement(
         return result
       }
 
-      const originalTextContent = isFeatureEnabled('Steganography') ? runJSExpressionLazy() : null
+      const originalTextContent = STEGANOGRAPHY_ENABLED ? runJSExpressionLazy() : null
 
       const textContent = trimJoinUnescapeTextFromJSXElements(childrenWithNewTextBlock)
       const textEditorProps: TextEditorProps = {

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -5821,9 +5821,7 @@ export var storyboard = (
       })
     })
 
-    describe('Pasting with steganography enabled', () => {
-      setFeatureForBrowserTestsUseInDescribeBlockOnly('Steganography', true)
-
+    xdescribe('Pasting with steganography enabled', () => {
       it('steganography data is cleaned from replaced props', async () => {
         const editor = await renderTestEditorWithCode(
           `import * as React from 'react'

--- a/editor/src/components/text-editor/text-editor.spec.browser2.tsx
+++ b/editor/src/components/text-editor/text-editor.spec.browser2.tsx
@@ -1728,9 +1728,7 @@ describe('Use the text editor', () => {
     expect(editor.renderedDOM.getByTestId('div').innerText).toEqual('this is just a string')
   })
 
-  describe('Editing with steganograpy enabled', () => {
-    setFeatureForBrowserTestsUseInDescribeBlockOnly('Steganography', true)
-
+  xdescribe('Editing with steganograpy enabled', () => {
     const steganoProject = `import * as React from 'react'
     import { Storyboard, Scene } from 'utopia-api'
 

--- a/editor/src/components/text-editor/text-editor.tsx
+++ b/editor/src/components/text-editor/text-editor.tsx
@@ -46,7 +46,7 @@ import { toString } from '../../core/shared/element-path'
 import type { SteganoTextData } from '../../core/shared/stegano-text'
 import { cleanSteganoTextData, decodeSteganoData } from '../../core/shared/stegano-text'
 import { useUpdateStringRun } from '../../core/model/project-file-helper-hooks'
-import { isFeatureEnabled } from '../../utils/feature-switches'
+import { STEGANOGRAPHY_ENABLED } from '../../utils/feature-switches'
 
 export const TextEditorSpanId = 'text-editor'
 
@@ -300,7 +300,7 @@ function getTextToUse({
   text: string
   originalText: string | null
 }): TextEditedText {
-  if (isFeatureEnabled('Steganography') && originalText != null) {
+  if (STEGANOGRAPHY_ENABLED && originalText != null) {
     const data = decodeSteganoData(originalText)
     if (data != null) {
       const { cleaned } = cleanSteganoTextData(originalText)

--- a/editor/src/core/shared/stegano-text.ts
+++ b/editor/src/core/shared/stegano-text.ts
@@ -1,6 +1,6 @@
 import { vercelStegaCombine, vercelStegaDecode, vercelStegaSplit } from '@vercel/stega'
 import type { SteganographyMode } from '../workers/parser-printer/parser-printer'
-import { isFeatureEnabled } from '../../utils/feature-switches'
+import { STEGANOGRAPHY_ENABLED } from '../../utils/feature-switches'
 
 export interface SteganoTextData {
   filePath: string
@@ -45,7 +45,7 @@ export function cleanSteganoTextData(text: string): { cleaned: string } {
 }
 
 export function isSteganographyEnabled(): SteganographyMode {
-  if (isFeatureEnabled('Steganography')) {
+  if (STEGANOGRAPHY_ENABLED) {
     return 'apply-steganography'
   }
   return 'do-not-apply-steganography'

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -13,7 +13,6 @@ export type FeatureName =
   | 'Canvas Strategies Debug Panel'
   | 'Project Thumbnail Generation'
   | 'Debug - Print UIDs'
-  | 'Steganography'
   | 'Debug – Connections'
   | 'Render Props in Navigator'
 
@@ -29,7 +28,6 @@ export const AllFeatureNames: FeatureName[] = [
   'Canvas Strategies Debug Panel',
   'Project Thumbnail Generation',
   'Debug - Print UIDs',
-  'Steganography',
   'Debug – Connections',
   'Render Props in Navigator',
 ]
@@ -45,10 +43,11 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Canvas Strategies Debug Panel': false,
   'Project Thumbnail Generation': false,
   'Debug - Print UIDs': false,
-  Steganography: false,
   'Debug – Connections': false,
   'Render Props in Navigator': true,
 }
+
+export const STEGANOGRAPHY_ENABLED = false
 
 let FeatureSwitchLoaded: { [feature in FeatureName]?: boolean } = {}
 


### PR DESCRIPTION
## Problem
The stegnography FS messed up projects, because it altered string values in a non-transparent way

## Fix
Delete the FS and replace it with a constant

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
