### PR TITLE
Ellipse too-long project titles through grid powers

### DIFF
--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -58,7 +58,6 @@ const ProjectTitle: React.FC<React.PropsWithChildren<ProjectTitleProps>> = ({ ch
         whiteSpace: 'nowrap',
         textOverflow: 'ellipsis',
       }}
-      css={undefined}
     >
       {children}
     </span>

--- a/editor/src/components/titlebar/title-bar.tsx
+++ b/editor/src/components/titlebar/title-bar.tsx
@@ -46,7 +46,7 @@ export const TitleHeight = 40
 
 const ProjectTitle: React.FC<React.PropsWithChildren<ProjectTitleProps>> = ({ children }) => {
   return (
-    <FlexRow
+    <span
       style={{
         fontWeight: 400,
         fontSize: 12,
@@ -54,11 +54,14 @@ const ProjectTitle: React.FC<React.PropsWithChildren<ProjectTitleProps>> = ({ ch
         color: colorTheme.fg0.value,
         height: TitleHeight,
         alignItems: 'center',
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
       }}
       css={undefined}
     >
       {children}
-    </FlexRow>
+    </span>
   )
 }
 
@@ -193,59 +196,71 @@ export const TitleBarProjectTitle = React.memo((props: { panelData: StoredPanel 
       onMouseEnter={setIsHoveredTrue}
       onMouseLeave={setIsHoveredFalse}
     >
-      <FlexRow css={{ gap: 10, alignItems: 'center' }}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '22px 1fr auto',
+          width: '100%',
+          alignItems: 'center',
+          gap: 4,
+        }}
+      >
         <FlexRow css={{ gap: 6 }}>
           <PanelButton onClick={toggleNavigatorVisible} color='#FF5F57' isHovered={isHovered} />
           <PanelButton isHovered={isHovered} color={colorTheme.unavailableGrey.value} />
         </FlexRow>
-        {currentBranch != null ? (
-          <SimpleFlexRow
-            onClick={showMergeConflict}
-            style={{
-              gap: 4,
-              color: hasMergeConflicts ? colorTheme.error.value : colorTheme.fg1.value,
-            }}
-          >
-            {hasMergeConflicts ? (
-              <Icons.WarningTriangle style={{ width: 18, height: 18 }} color={'error'} />
-            ) : (
-              <Icons.Branch style={{ width: 18, height: 18 }} />
-            )}
-            {currentBranch}
-          </SimpleFlexRow>
-        ) : (
-          <ProjectTitle>{projectName}</ProjectTitle>
-        )}
-      </FlexRow>
-      {when(
-        loggedIn && currentBranch != null,
-        <FlexRow
-          css={{
-            gap: 2,
-          }}
-        >
-          {when(
-            hasUpstreamChanges,
-            <RoundButton
-              color={colorTheme.secondaryOrange.value}
-              onClick={openLeftPaneltoGithubTab}
-              onMouseDown={onMouseDown}
+        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {currentBranch != null ? (
+            <SimpleFlexRow
+              onClick={showMergeConflict}
+              style={{
+                gap: 4,
+                color: hasMergeConflicts ? colorTheme.error.value : colorTheme.fg1.value,
+              }}
             >
-              {<Icons.Download style={{ width: 18, height: 18 }} color={'component-orange'} />}
-            </RoundButton>,
+              {hasMergeConflicts ? (
+                <Icons.WarningTriangle style={{ width: 18, height: 18 }} color={'error'} />
+              ) : (
+                <Icons.Branch style={{ width: 18, height: 18 }} />
+              )}
+              {currentBranch}
+            </SimpleFlexRow>
+          ) : (
+            <ProjectTitle>{projectName}</ProjectTitle>
           )}
+        </span>
+        <span>
           {when(
-            hasDownstreamChanges,
-            <RoundButton
-              color={colorTheme.secondaryBlue.value}
-              onClick={openLeftPaneltoGithubTab}
-              onMouseDown={onMouseDown}
+            loggedIn && currentBranch != null,
+            <FlexRow
+              css={{
+                gap: 2,
+              }}
             >
-              {<Icons.Upload style={{ width: 18, height: 18 }} color={'dynamic'} />}
-            </RoundButton>,
+              {when(
+                hasUpstreamChanges,
+                <RoundButton
+                  color={colorTheme.secondaryOrange.value}
+                  onClick={openLeftPaneltoGithubTab}
+                  onMouseDown={onMouseDown}
+                >
+                  {<Icons.Download style={{ width: 18, height: 18 }} color={'component-orange'} />}
+                </RoundButton>,
+              )}
+              {when(
+                hasDownstreamChanges,
+                <RoundButton
+                  color={colorTheme.secondaryBlue.value}
+                  onClick={openLeftPaneltoGithubTab}
+                  onMouseDown={onMouseDown}
+                >
+                  {<Icons.Upload style={{ width: 18, height: 18 }} color={'dynamic'} />}
+                </RoundButton>,
+              )}
+            </FlexRow>,
           )}
-        </FlexRow>,
-      )}
+        </span>
+      </div>
     </div>
   )
 })


### PR DESCRIPTION
**Problem:**
Describe the problem being addressed as succinctly as possible.

**Fix:**
Why does this work? Well, for ellipsis to kick in you need three things:

1. `text-overflow: ellipsis`
2. `overflow: hidden`
3. _and_ a fixed-width container! Which flex containers are not. But grid columns _are_ - even if they are set to dynamic widths like `1fr`. So, use that (and make the last (optional) column with github buttons collapse if empty.

![Large GIF (544x444)](https://github.com/concrete-utopia/utopia/assets/2945037/e41f0da7-cf63-4afb-8962-54237f348a36)
