### PR TITLE
navigator fixes: full scroll, component icon only on hover

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-preview.tsx
+++ b/editor/src/components/navigator/navigator-item/component-preview.tsx
@@ -24,6 +24,7 @@ export const ComponentPreview: React.FunctionComponent<
           justifyItems: 'center',
           alignItems: 'center',
           position: 'relative',
+          opacity: 'var(--paneHoverOpacity)',
         }}
       >
         <Icn {...iconProps} color={props.color} />

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -272,7 +272,6 @@ export const NavigatorComponent = React.memo(() => {
       tabIndex={-1}
       css={{
         flexGrow: 1,
-        height: '100%',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'stretch',

--- a/editor/src/uuiui/icons.tsx
+++ b/editor/src/uuiui/icons.tsx
@@ -307,6 +307,12 @@ export const Icons = {
     width: 18,
     height: 18,
   }),
+  ComponentInstance: makeIcon({
+    category: 'element',
+    type: 'componentinstance',
+    width: 18,
+    height: 18,
+  }),
   CircleSmall: makeIcon({ type: 'circle-small', color: 'secondary' }),
   CrossSmall: makeIcon({ type: 'cross-small', color: 'secondary' }),
   CrossInTranslucentCircle: makeIcon({ type: 'cross-in-translucent-circle', color: 'main' }),


### PR DESCRIPTION
**Problem:**
- Navigator didn't fully scroll
- Navigator clutter: component postfix icons were always visible
- missing componentInstance icon

**Fix:**
- Remove unnecessary `height: 100%` (we already had `flexGrow: 1`)
- show component postfix icons only on navigator hover
- add missing componentInstance icon (not yet used)

Fixes #5329 