### PR TITLE
EditorComponentInner viewer mode  useSelectorWithCallback  only dispa…

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -407,18 +407,20 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
     Substores.userStateAndProjectServerState,
     (store) => ({ projectServerState: store.projectServerState, userState: store.userState }),
     (state) => {
-      let actions: EditorAction[] = []
-      const permissions = getPermissions(state)
-      if (!permissions.edit && permissions.comment) {
-        actions.push(
-          EditorActions.switchEditorMode(EditorModes.commentMode(null, 'not-dragging')),
-          EditorActions.setRightMenuTab(RightMenuTab.Comments),
-          EditorActions.setCodeEditorVisibility(false),
-        )
-      } else {
-        actions.push(EditorActions.setCodeEditorVisibility(true))
-      }
-      dispatch(actions)
+      setTimeout(() => {
+        let actions: EditorAction[] = []
+        const permissions = getPermissions(state)
+        if (!permissions.edit && permissions.comment) {
+          actions.push(
+            EditorActions.switchEditorMode(EditorModes.commentMode(null, 'not-dragging')),
+            EditorActions.setRightMenuTab(RightMenuTab.Comments),
+            EditorActions.setCodeEditorVisibility(false),
+          )
+        } else {
+          actions.push(EditorActions.setCodeEditorVisibility(true))
+        }
+        dispatch(actions)
+      }, 0)
     },
     'EditorComponentInner viewer mode',
   )


### PR DESCRIPTION
**Problem:**
Dispatch is called from useSelectorWithCallback. Since out dispatch flow calls React.flushSync, we get a big warning from React:
<img width="1605" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/dc3e7590-bb4e-43e1-ac75-eb4e536a11bb">

In general, we shouldn't call dispatch in code which was called because of a dispatch, this kind of recursive dispatching makes debugging the dispatch flow very hard.

**Fix:**
As the react warning tells us, we can move the code to a [microtask](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask). It could be a setTimeout(0) or await wait(0), but I think we can safely use queueMicrotask for this job for more explicitness!