### PR TITLE
Update vscode-overrides.css

### DIFF
--- a/editor/resources/editor/css/vscode-overrides.css
+++ b/editor/resources/editor/css/vscode-overrides.css
@@ -49,8 +49,8 @@
 }
 
 /* smaller 'edited / close'  marker, to match Utopia house style */
-.monaco-action-bar .actions-container {
-  transform: scale(0.7);
+.monaco-menu-container {
+  transform: scale(0.8);
 }
 
 /* Tab bar heights */


### PR DESCRIPTION
Fixes #5336 

**Problem:**
<img width="613" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2945037/928138a5-a5c5-4620-b09d-63ad0cfcf83a">

This is self-induced, since we scaled down that context menu some (but, as it turns out, on the wrong element)

**Fix:**
Scale down the right element instead. And, while we're there, scale it a tad less

<img width="461" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2945037/55942d01-2d08-431f-b3fd-0d67d13c6ccc">
