### PR TITLE
Prevent complete project reprint on rename.

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -1,7 +1,7 @@
 import * as Chai from 'chai'
 import type { FramePin } from 'utopia-api/core'
 import { LayoutSystem } from 'utopia-api/core'
-import { contentsTreeOptic } from '../../../components/assets'
+import { contentsTreeOptic, walkContentsTree } from '../../../components/assets'
 import { getLayoutPropertyOr } from '../../../core/layout/getLayoutProperty'
 import { sampleCode } from '../../../core/model/new-project-files'
 import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
@@ -51,6 +51,7 @@ import type { Optic } from '../../../core/shared/optics/optics'
 import { forceNotNull } from '../../../core/shared/optional-utils'
 import type {
   ParseSuccess,
+  RevisionsStateType,
   TextFile,
   TextFileContents,
 } from '../../../core/shared/project-file-types'
@@ -109,7 +110,7 @@ import {
   updateTopLevelElementsFromCollaborationUpdate,
   workerCodeAndParsedUpdate,
 } from './action-creators'
-import { UPDATE_FNS } from './actions'
+import { UPDATE_FNS, replaceFilePath } from './actions'
 import { CURRENT_PROJECT_VERSION } from './migrations/migrations'
 import { getAllUniqueUids } from '../../../core/model/get-unique-ids'
 
@@ -1201,5 +1202,45 @@ describe('UPDATE_TOP_LEVEL_ELEMENTS_FROM_COLLABORATION', () => {
     )
     const uniqueUIDsResult = getAllUniqueUids(updatedEditorState.projectContents)
     expect(uniqueUIDsResult.duplicateIDs).toEqual({})
+  })
+})
+
+describe('replaceFilePath', () => {
+  it('only marks the relevant files as parsed ahead', () => {
+    const project = complexDefaultProjectPreParsed()
+    const editorState = editorModelFromPersistentModel(project, NO_OP)
+    const replaceResults = replaceFilePath(
+      '/src/app.js',
+      '/src/app2.js',
+      editorState.projectContents,
+    )
+    if (replaceResults.type === 'SUCCESS') {
+      expect(replaceResults.updatedFiles).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "newPath": "/src/app2.js",
+            "oldPath": "/src/app.js",
+          },
+        ]
+      `)
+      let textFilesAndRevisionStates: { [filename: string]: RevisionsStateType } = {}
+      walkContentsTree(replaceResults.projectContents, (fullPath, file) => {
+        if (isTextFile(file)) {
+          textFilesAndRevisionStates[fullPath] = file.fileContents.revisionsState
+        }
+      })
+      expect(textFilesAndRevisionStates).toMatchInlineSnapshot(`
+        Object {
+          "/package.json": "BOTH_MATCH",
+          "/public/index.html": "BOTH_MATCH",
+          "/src/app2.js": "BOTH_MATCH",
+          "/src/card.js": "BOTH_MATCH",
+          "/src/index.js": "PARSED_AHEAD",
+          "/utopia/storyboard.js": "PARSED_AHEAD",
+        }
+      `)
+    } else {
+      throw new Error('Should have returned a success.')
+    }
   })
 })

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -1233,7 +1233,7 @@ describe('replaceFilePath', () => {
         Object {
           "/package.json": "BOTH_MATCH",
           "/public/index.html": "BOTH_MATCH",
-          "/src/app2.js": "BOTH_MATCH",
+          "/src/app2.js": "PARSED_AHEAD",
           "/src/card.js": "BOTH_MATCH",
           "/src/index.js": "PARSED_AHEAD",
           "/utopia/storyboard.js": "PARSED_AHEAD",

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1366,8 +1366,12 @@ export function replaceFilePath(
         }
       })
 
-      // Only mark these as parsed ahead if they have meaningfully changed.
+      // Only mark these as parsed ahead if they have meaningfully changed,
+      // or if the filename has been changed for this file.
+      const oldFilename =
+        updatedFiles.find((updatedFile) => updatedFile.newPath === filename) ?? filename
       if (
+        oldFilename !== filename ||
         !ParseSuccessKeepDeepEquality(projectFile.fileContents.parsed, updatedParseResult).areEqual
       ) {
         updatedProjectContents[filename] = saveTextFileContents(

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -450,6 +450,7 @@ import {
   ExportDetailKeepDeepEquality,
   ImportDetailsKeepDeepEquality,
   NavigatorStateKeepDeepEquality,
+  ParseSuccessKeepDeepEquality,
   TopLevelElementKeepDeepEquality,
 } from '../store/store-deep-equality-instances'
 import type { MouseButtonsPressed } from '../../../utils/mouse'
@@ -1243,7 +1244,7 @@ interface ReplaceFilePathFailure {
 
 type ReplaceFilePathResult = ReplaceFilePathFailure | ReplaceFilePathSuccess
 
-function replaceFilePath(
+export function replaceFilePath(
   oldPath: string,
   newPath: string,
   projectContentsTree: ProjectContentTreeRoot,
@@ -1365,15 +1366,20 @@ function replaceFilePath(
         }
       })
 
-      updatedProjectContents[filename] = saveTextFileContents(
-        projectFile,
-        textFileContents(
-          projectFile.fileContents.code,
-          updatedParseResult,
-          RevisionsState.ParsedAhead,
-        ),
-        projectFile.lastSavedContents == null,
-      )
+      // Only mark these as parsed ahead if they have meaningfully changed.
+      if (
+        !ParseSuccessKeepDeepEquality(projectFile.fileContents.parsed, updatedParseResult).areEqual
+      ) {
+        updatedProjectContents[filename] = saveTextFileContents(
+          projectFile,
+          textFileContents(
+            projectFile.fileContents.code,
+            updatedParseResult,
+            RevisionsState.ParsedAhead,
+          ),
+          projectFile.lastSavedContents == null,
+        )
+      }
     }
   })
   // Check if we discovered an error.
@@ -6186,7 +6192,7 @@ function updateFilePath(
     oldPath: string
     newPath: string
   },
-) {
+): EditorState {
   const replaceFilePathResults = replaceFilePath(
     params.oldPath,
     params.newPath,


### PR DESCRIPTION
**Problem:**
After a few edits, our Github integration shows all files as modified.

**Cause:**
This was due to the implementation of `replaceFilePath` marking each and every file that it looks at with `PARSED_AHEAD`, causing everything to be reprinted with prettier being applied as part of that output.

**Fix:**
Now `replaceFilePath` checks to see if the contents of the parse success value has meaningfully changed and only marks it as `PARSED_AHEAD` if that is the case.

**Result:**
Change of `blogs` to `blogginton`:
![image](https://github.com/concrete-utopia/utopia/assets/217400/ef3ac2d3-ad2f-425b-949d-db4a6268c0c0)

**Commit Details:**
- `replaceFilePath` now checks to see if each file that it has potentially updated has actually changed.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #[5248](https://github.com/concrete-utopia/utopia/issues/5248)
