### PR TITLE
Show registered component props in the Inspector by default

### DIFF
--- a/editor/src/components/inspector/sections/component-section/folder-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/folder-section.tsx
@@ -39,7 +39,7 @@ export const FolderSection = React.memo((props: FolderSectionProps) => {
       Object.keys(props.propertyControls).filter((prop) => {
         const control = props.propertyControls[prop]
         const isVisibleByDefault =
-          control.control === 'folder' || (control.visibleByDefault ?? false)
+          control.control === 'folder' || (control.visibleByDefault ?? true)
         return (
           !isVisibleByDefault &&
           props.unsetPropNames.includes(prop) &&


### PR DESCRIPTION
**Problem:**
Registered component props are by default hidden in the Inspector, and require clicking on their subdued names to show their controls.

**Fix:**
This was because of a default in the Inspector. The controls have a `visibleByDefault` option, which is optional. When we use that, if the value isn't set we'll default to `false`. This PR simply changes that default behaviour to `true`.

**Before (default):**
<img width="252" alt="image" src="https://github.com/concrete-utopia/utopia/assets/1044774/f760d7c5-0560-487b-b89c-11e874bd141e">

**After (default):**
<img width="266" alt="image" src="https://github.com/concrete-utopia/utopia/assets/1044774/592e611f-8002-4dc8-9bc2-862a9d364b7c">

You can still hide individual props by setting the `visibleByDefault` to `false`.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5338
