### PR TITLE
When renaming an navigation entry, don't show buttons

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -1034,11 +1034,6 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
     ? colorTheme.componentPurple.value
     : undefined
 
-  const currentlyRenaming = useMemo(
-    () => EP.pathsEqual(props.renamingTarget, props.navigatorEntry.elementPath),
-    [props.renamingTarget, props.navigatorEntry.elementPath],
-  )
-
   return (
     <div
       style={{
@@ -1074,7 +1069,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
         target={props.navigatorEntry}
         selected={props.selected}
         dispatch={props.dispatch}
-        inputVisible={currentlyRenaming}
+        inputVisible={EP.pathsEqual(props.renamingTarget, props.navigatorEntry.elementPath)}
         remixItemType={props.remixItemType}
       />
       <MapCounter navigatorEntry={props.navigatorEntry} dispatch={props.dispatch} />

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -2,7 +2,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react'
 import createCachedSelector from 're-reselect'
-import React from 'react'
+import React, { useMemo } from 'react'
 import type { ConditionalCase } from '../../../core/model/conditionals'
 import {
   findMaybeConditionalExpression,
@@ -844,6 +844,11 @@ export const NavigatorItem: React.FunctionComponent<
     ? 'component'
     : resultingStyle.iconColor
 
+  const currentlyRenaming = useMemo(
+    () => EP.pathsEqual(props.renamingTarget, props.navigatorEntry.elementPath),
+    [props.renamingTarget, props.navigatorEntry.elementPath],
+  )
+
   return (
     <div
       onClick={hideContextMenu}
@@ -927,8 +932,15 @@ export const NavigatorItem: React.FunctionComponent<
             {props.label}
           </div>
         ) : (
-          <FlexRow style={{ justifyContent: 'space-between', ...containerStyle, padding: '0 5px' }}>
-            <FlexRow>
+          <FlexRow
+            style={{
+              justifyContent: 'space-between',
+              ...containerStyle,
+              padding: '0 5px',
+              width: '100%',
+            }}
+          >
+            <FlexRow style={{ width: '100%' }}>
               {unless(
                 props.navigatorEntry.type === 'CONDITIONAL_CLAUSE',
                 <ExpandableIndicator
@@ -960,7 +972,7 @@ export const NavigatorItem: React.FunctionComponent<
               />
             </FlexRow>
             {unless(
-              props.navigatorEntry.type === 'CONDITIONAL_CLAUSE',
+              currentlyRenaming || props.navigatorEntry.type === 'CONDITIONAL_CLAUSE',
               <NavigatorItemActionSheet
                 navigatorEntry={navigatorEntry}
                 selected={selected}
@@ -1022,6 +1034,11 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
     ? colorTheme.componentPurple.value
     : undefined
 
+  const currentlyRenaming = useMemo(
+    () => EP.pathsEqual(props.renamingTarget, props.navigatorEntry.elementPath),
+    [props.renamingTarget, props.navigatorEntry.elementPath],
+  )
+
   return (
     <div
       style={{
@@ -1057,7 +1074,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
         target={props.navigatorEntry}
         selected={props.selected}
         dispatch={props.dispatch}
-        inputVisible={EP.pathsEqual(props.renamingTarget, props.navigatorEntry.elementPath)}
+        inputVisible={currentlyRenaming}
         remixItemType={props.remixItemType}
       />
       <MapCounter navigatorEntry={props.navigatorEntry} dispatch={props.dispatch} />

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -2,7 +2,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react'
 import createCachedSelector from 're-reselect'
-import React, { useMemo } from 'react'
+import React from 'react'
 import type { ConditionalCase } from '../../../core/model/conditionals'
 import {
   findMaybeConditionalExpression,
@@ -844,10 +844,7 @@ export const NavigatorItem: React.FunctionComponent<
     ? 'component'
     : resultingStyle.iconColor
 
-  const currentlyRenaming = useMemo(
-    () => EP.pathsEqual(props.renamingTarget, props.navigatorEntry.elementPath),
-    [props.renamingTarget, props.navigatorEntry.elementPath],
-  )
+  const currentlyRenaming = EP.pathsEqual(props.renamingTarget, props.navigatorEntry.elementPath)
 
   return (
     <div


### PR DESCRIPTION
When renaming a navigation entry - don't show action buttons.
Fixes #5323 
<table>
<tr>
<td>
<b>Before:</b>
<video style="display:block" src="https://github.com/concrete-utopia/utopia/assets/7003853/57e5189c-c84c-4d4b-a680-f937bd4a9256" />
</td>
<td>
<b>After:</b>
<video style="display:block" src="https://github.com/concrete-utopia/utopia/assets/7003853/4b7ab18c-0ed6-4143-90d3-1726728aa126" />
</td>
</tr>
</table>
