### PR TITLE
In view-only mode, do not show the code editor

### DIFF
--- a/editor/src/components/canvas/grid-panels-state.tsx
+++ b/editor/src/components/canvas/grid-panels-state.tsx
@@ -74,9 +74,9 @@ export function useGridPanelState() {
   const permissions = usePermissions()
   React.useEffect(() => {
     if (!permissions.edit) {
-      setState(filterCodeEditorFromPanelState(state))
+      setState((s) => filterCodeEditorFromPanelState(s))
     }
-  }, [permissions.edit, setState, state])
+  }, [permissions.edit, setState])
 
   return stateAtom
 }
@@ -267,7 +267,7 @@ export function updateLayout(
 }
 
 export function useUpdateGridPanelLayout(): (panelName: PanelName, update: LayoutUpdate) => void {
-  const setStoredState = useSetAtom(GridPanelsStateAtom)
+  const [, setStoredState] = useGridPanelState()
 
   return React.useCallback(
     (panelName: PanelName, update: LayoutUpdate) => {
@@ -290,7 +290,7 @@ export function useUpdateGridPanelLayout(): (panelName: PanelName, update: Layou
 }
 
 export function useUpdateGridPanelLayoutPutCodeEditorBelowNavigator(): () => void {
-  const setStoredState = useSetAtom(GridPanelsStateAtom)
+  const [, setStoredState] = useGridPanelState()
 
   return React.useCallback(() => {
     setStoredState((stored) => {
@@ -329,7 +329,7 @@ export function useColumnWidths(): [
   Array<number>,
   (columnIndex: number, newWidth: number) => void,
 ] {
-  const [panelState, setPanelState] = useAtom(GridPanelsStateAtom)
+  const [, setPanelState] = useGridPanelState()
   const visiblePanels = useVisibleGridPanels()
 
   // start with the default value

--- a/editor/src/components/canvas/grid-panels-state.tsx
+++ b/editor/src/components/canvas/grid-panels-state.tsx
@@ -1,5 +1,5 @@
 import immutableUpdate from 'immutability-helper'
-import { atom, useAtom, useSetAtom } from 'jotai'
+import { atom, useAtom } from 'jotai'
 import findLastIndex from 'lodash.findlastindex'
 import React from 'react'
 import { accumulate, insert, removeAll, removeIndexFromArray } from '../../core/shared/array-utils'
@@ -41,7 +41,10 @@ function filterCodeEditorFromPanelState(layout: StoredLayout): StoredLayout {
   }))
 }
 
-export function useGridPanelState() {
+export function useGridPanelState(): [
+  StoredLayout,
+  (cb: StoredLayout | ((prev: StoredLayout) => StoredLayout)) => void,
+] {
   const [loaded, setLoaded] = React.useState(false)
   const stateAtom = useAtom(GridPanelsStateAtom)
   const [state, setState] = stateAtom
@@ -72,13 +75,9 @@ export function useGridPanelState() {
   }, [loaded, state, projectId])
 
   const permissions = usePermissions()
-  React.useEffect(() => {
-    if (!permissions.edit) {
-      setState((s) => filterCodeEditorFromPanelState(s))
-    }
-  }, [permissions.edit, setState])
+  const filteredState = permissions.edit ? state : filterCodeEditorFromPanelState(state)
 
-  return stateAtom
+  return [filteredState, setState]
 }
 
 function useVisibleGridPanels() {

--- a/editor/src/components/canvas/grid-panels-state.tsx
+++ b/editor/src/components/canvas/grid-panels-state.tsx
@@ -30,8 +30,16 @@ import {
   getProjectStoredLayoutOrDefault,
   saveUserPreferencesProjectLayout,
 } from '../common/user-preferences'
+import { usePermissions } from '../editor/store/permissions'
 
 export const GridPanelsStateAtom = atom(gridMenuDefaultPanels())
+
+function filterCodeEditorFromPanelState(layout: StoredLayout): StoredLayout {
+  return layout.map((column) => ({
+    ...column,
+    panels: column.panels.filter((panel) => panel.name !== 'code-editor'),
+  }))
+}
 
 export function useGridPanelState() {
   const [loaded, setLoaded] = React.useState(false)
@@ -62,6 +70,13 @@ export function useGridPanelState() {
     }
     void saveUserPreferencesProjectLayout(projectId, state)
   }, [loaded, state, projectId])
+
+  const permissions = usePermissions()
+  React.useEffect(() => {
+    if (!permissions.edit) {
+      setState(filterCodeEditorFromPanelState(state))
+    }
+  }, [permissions.edit, setState, state])
 
   return stateAtom
 }

--- a/editor/src/components/editor/closed-panels.tsx
+++ b/editor/src/components/editor/closed-panels.tsx
@@ -11,8 +11,7 @@ import { Substores, useEditorState } from './store/store-hook'
 import { togglePanel } from './actions/action-creators'
 import { stopPropagation } from '../inspector/common/inspector-utils'
 import { setFocus } from '../common/actions'
-import { useAtom } from 'jotai'
-import { GridPanelsStateAtom } from '../canvas/grid-panels-state'
+import { useGridPanelState } from '../canvas/grid-panels-state'
 import type { StoredLayout, StoredPanel } from '../canvas/stored-layout'
 import { assertNever } from '../../core/shared/utils'
 import { TestMenu } from '../titlebar/test-menu'
@@ -31,7 +30,7 @@ function getPanelColumn(side: 'left' | 'right', panels: StoredLayout): Array<Sto
 
 export const ClosedPanels = React.memo((props: { side: 'left' | 'right' }) => {
   const dispatch = useDispatch()
-  const [panelState] = useAtom(GridPanelsStateAtom)
+  const [panelState] = useGridPanelState()
   const thisColumn = getPanelColumn(props.side, panelState)
 
   const inspectorInvisible = useEditorState(


### PR DESCRIPTION
# [Try it here](https://utopia.fish/p/619f6880-accidental-munchkin/?branch_name=feature-do-not-show-github-panel-logged-out)



## Problem
The code editor is shown for viewers.

## Fix
If a user doesn't have edit permission, the code editor panel is filtered from the available grid panels.

Since we don't support more than 1 editor yet, this PR doesn't handle adding back the code editor if a user is somehow granted edit permissions


**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5327
