### PR TITLE
Only apply 100 x 100 default sizing to div and button during single-shot insertion

### DIFF
--- a/editor/src/components/editor/canvas-toolbar.spec.browser2.tsx
+++ b/editor/src/components/editor/canvas-toolbar.spec.browser2.tsx
@@ -464,7 +464,7 @@ describe('canvas toolbar', () => {
     data-uid='container'
   >
     <div data-uid='a3d' />
-    <span style={{ width: 100, height: 100, top: 0, left: 0, position: 'absolute' }} data-uid='sample-text'>Sample text</span>
+    <span data-uid='sample-text' style={{ top: 0, left: 0, position: 'absolute' }}>Sample text</span>
   </div>`),
     )
   })
@@ -515,7 +515,7 @@ describe('canvas toolbar', () => {
         data-uid='container'
       >
         <div data-uid='a3d' />
-        <span style={{ width: 100, height: 100, top: 0, left: 0, position: 'absolute' }} data-uid='sample-text'>{myText}</span>
+        <span data-uid='sample-text' style={{ top: 0, left: 0, position: 'absolute' }}>{myText}</span>
   </div>
   )`),
     )
@@ -567,7 +567,7 @@ describe('canvas toolbar', () => {
         data-uid='container'
       >
         <div data-uid='a3d' />
-        <span style={{ width: 100, height: 100, top: 0, left: 0, position: 'absolute' }} data-uid='sample-text'>{myObj.test}</span>
+        <span data-uid='sample-text' style={{ top: 0, left: 0, position: 'absolute' }}>{myObj.test}</span>
         </div>
     )`),
     )
@@ -718,7 +718,7 @@ describe('canvas toolbar', () => {
         data-uid='container'
       >
         <div data-uid='a3d' />
-        <img src={myImage} style={{width: 100, height: 100, top:0, left: 0, position: 'absolute'}} data-uid='ele'/>
+        <img src={myImage} data-uid='ele' style={{top:0, left: 0, position: 'absolute'}}/>
       </div>
     )`),
     )
@@ -825,13 +825,7 @@ export var storyboard = (
         }}
       >
         <DefaultExportedComponent
-          style={{
-            width: 100,
-            height: 100,
-            top: 0,
-            left: 0,
-            position: 'absolute',
-          }}
+          style={{ top: 0, left: 0, position: 'absolute' }}
         />
       </div>
     </Scene>
@@ -889,8 +883,8 @@ export var storyboard = (
     <div data-uid='a3d' />
     <img
       style={{
-        width: 100,
-        height: 100,
+        width: '64px',
+        height: '64px',
         position: 'absolute',
         top: 0,
         left: 0,
@@ -900,8 +894,8 @@ export var storyboard = (
     />
     <img
       style={{
-        width: 100,
-        height: 100,
+        width: '64px',
+        height: '64px',
         position: 'absolute',
         top: 0,
         left: 0,
@@ -947,8 +941,8 @@ export var storyboard = (
           }
           <img
             style={{
-              width: 100,
-              height: 100,
+              width: '64px',
+              height: '64px',
               position: 'absolute',
               top: 0,
               left: 0,
@@ -990,8 +984,8 @@ export var storyboard = (
           [].length === 0 ? (
             <img
               style={{
-                width: 100,
-                height: 100,
+                width: '64px',
+                height: '64px',
                 position: 'absolute',
                 top: 0,
                 left: 0,
@@ -1040,8 +1034,8 @@ export var storyboard = (
         ) : (
           <img
             style={{
-              width: 100,
-              height: 100,
+              width: '64px',
+              height: '64px',
               position: 'absolute',
               top: 0,
               left: 0,
@@ -1098,8 +1092,8 @@ export var storyboard = (
             <React.Fragment>
               <img
                 style={{
-                  width: 100,
-                  height: 100,
+                  width: '64px',
+                  height: '64px',
                   position: 'absolute',
                 }}
                 src='/editor/utopia-logo-white-fill.png?hash=nocommit'
@@ -1176,8 +1170,8 @@ export var storyboard = (
           >
             <img
               style={{
-                width: 100,
-                height: 100,
+                width: '64px',
+                height: '64px',
                 position: 'absolute',
                 top: 0,
                 left: 0,

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -250,10 +250,6 @@ export const CanvasToolbar = React.memo(() => {
 
   const canvasToolbarMode = useToolbarMode()
 
-  const editorStateRef = useRefEditorState((store) => store.editor)
-  const selectedViewsRef = useRefEditorState((store) => store.editor.selectedViews)
-  const projectContentsRef = useRefEditorState((store) => store.editor.projectContents)
-
   const insertDivCallback = useEnterDrawToInsertForDiv()
   const insertImgCallback = useEnterDrawToInsertForImage()
   const insertTextCallback = useEnterTextEditMode()
@@ -269,43 +265,6 @@ export const CanvasToolbar = React.memo(() => {
 
   const convertToCallback = useConvertTo()
   const toInsertCallback = useToInsert()
-
-  const openFloatingConvertMenuCallback = React.useCallback(() => {
-    dispatch([openFloatingInsertMenu(floatingInsertMenuStateSwap())])
-  }, [dispatch])
-
-  const openFloatingWrapInMenuCallback = React.useCallback(() => {
-    dispatch([
-      openFloatingInsertMenu({
-        insertMenuMode: 'wrap',
-      }),
-    ])
-  }, [dispatch])
-
-  const wrapInGroupCallback = React.useCallback(() => {
-    dispatch([
-      wrapInElement(selectedViewsRef.current, {
-        element: defaultTransparentViewElement(
-          generateUidWithExistingComponents(projectContentsRef.current),
-        ),
-        importsToAdd: {},
-      }),
-    ])
-  }, [dispatch, selectedViewsRef, projectContentsRef])
-
-  const toggleAbsolutePositioningCallback = React.useCallback(() => {
-    const editorState = editorStateRef.current
-    const commands = toggleAbsolutePositioningCommands(
-      editorState.jsxMetadata,
-      editorState.allElementProps,
-      editorState.elementPathTree,
-      editorState.selectedViews,
-    )
-    if (commands.length === 0) {
-      return
-    }
-    dispatch([applyCommandsAction(commands)])
-  }, [dispatch, editorStateRef])
 
   // Back to select mode, close the "floating" menu and turn off the forced insert mode.
   const dispatchSwitchToSelectModeCloseMenus = React.useCallback(() => {

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -13,7 +13,6 @@ import {
 } from '../../core/shared/element-template'
 import type { NormalisedFrame } from 'utopia-api/core'
 import { defaultImageAttributes } from '../shared/project-components'
-import { type Size } from '../../core/shared/math-utils'
 
 export function defaultSceneElement(
   uid: string,
@@ -40,12 +39,11 @@ export function defaultSceneElementStyle(frame: NormalisedFrame | null): JSExpre
   )
 }
 
-export function defaultElementStyle(size?: Size): JSExpression {
+export function defaultElementStyle(): JSExpression {
   return jsExpressionValue(
     {
       backgroundColor: '#aaaaaa33',
       position: 'absolute',
-      ...(size ?? {}),
     },
     emptyComments,
   )

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -13,6 +13,7 @@ import {
 } from '../../core/shared/element-template'
 import type { NormalisedFrame } from 'utopia-api/core'
 import { defaultImageAttributes } from '../shared/project-components'
+import { type Size } from '../../core/shared/math-utils'
 
 export function defaultSceneElement(
   uid: string,
@@ -39,11 +40,12 @@ export function defaultSceneElementStyle(frame: NormalisedFrame | null): JSExpre
   )
 }
 
-export function defaultElementStyle(): JSExpression {
+export function defaultElementStyle(size?: Size): JSExpression {
   return jsExpressionValue(
     {
       backgroundColor: '#aaaaaa33',
       position: 'absolute',
+      ...(size ?? {}),
     },
     emptyComments,
   )

--- a/editor/src/components/editor/insert-callbacks.ts
+++ b/editor/src/components/editor/insert-callbacks.ts
@@ -192,7 +192,7 @@ export function useToInsert(): (elementToInsert: InsertMenuItem | null) => void 
 
       const element = elementToReparent(
         fixUtopiaElement(
-          elementFromInsertMenuItem(elementToInsert.value.element(), elementUid, 'use-defaults'),
+          elementFromInsertMenuItem(elementToInsert.value.element(), elementUid),
           allElementUids,
         ).value,
         elementToInsert.value.importsToAdd,
@@ -254,42 +254,14 @@ export function useToInsert(): (elementToInsert: InsertMenuItem | null) => void 
   )
 }
 
-function attributesWithDefaults(initialProps: JSXAttributes): JSXAttributes {
-  const styleAttributes =
-    getJSXAttribute(initialProps, 'style') ?? jsExpressionValue({}, emptyComments)
-
-  const styleWithWidth = defaultEither(
-    styleAttributes,
-    setJSXValueInAttributeAtPath(
-      styleAttributes,
-      PP.fromString('width'),
-      jsExpressionValue(100, emptyComments),
-    ),
-  )
-  const styleWithHeight = defaultEither(
-    styleAttributes,
-    setJSXValueInAttributeAtPath(
-      styleWithWidth,
-      PP.fromString('height'),
-      jsExpressionValue(100, emptyComments),
-    ),
-  )
-
-  return setJSXAttributesAttribute(initialProps, 'style', styleWithHeight)
-}
-
 export function elementFromInsertMenuItem(
   element: ComponentElementToInsert,
   uid: string,
-  useDefaults: 'use-defaults' | 'no-defaults',
 ): JSXElementChild {
   switch (element.type) {
     case 'JSX_ELEMENT':
-      const attributes =
-        useDefaults === 'use-defaults' ? attributesWithDefaults(element.props) : element.props
-
       const attributesWithUid = setJSXAttributesAttribute(
-        attributes,
+        element.props,
         'data-uid',
         jsExpressionValue(uid, emptyComments),
       )

--- a/editor/src/components/editor/variablesmenu.spec.browser2.tsx
+++ b/editor/src/components/editor/variablesmenu.spec.browser2.tsx
@@ -154,7 +154,7 @@ describe('variables menu', () => {
             data-uid='container'
           >
             <div data-uid='a3d' />
-            <img src={imgProp} style={{width: 100, height: 100, top:0, left: 0, position: 'absolute'}} data-uid='ele'/>
+            <img src={imgProp} data-uid='ele' style={{top:0, left: 0, position: 'absolute'}}/>
           </div>
           )
         }
@@ -263,12 +263,8 @@ describe('variables menu', () => {
                         data-uid='img-2'
                       />
                       <span
-                        style={{
-                          width: 100,
-                          height: 100,
-                          position: 'absolute',
-                        }}
                         data-uid='ele'
+                        style={{ position: 'absolute' }}
                       >
                         {index}
                       </span>
@@ -348,12 +344,8 @@ describe('variables menu', () => {
                         data-uid='img-2'
                       />
                       <span
-                        style={{
-                          width: 100,
-                          height: 100,
-                          position: 'absolute',
-                        }}
                         data-uid='ele'
+                        style={{ position: 'absolute' }}
                       >
                         {JSON.stringify(unusedProp)}
                       </span>
@@ -434,12 +426,8 @@ describe('variables menu', () => {
                         data-uid='img-2'
                       />
                       <span
-                        style={{
-                          width: 100,
-                          height: 100,
-                          position: 'absolute',
-                        }}
                         data-uid='ele'
+                        style={{ position: 'absolute' }}
                       >
                         {JSON.stringify(bestProp)}
                       </span>
@@ -520,12 +508,8 @@ describe('variables menu', () => {
                         data-uid='img-2'
                       />
                       <span
-                        style={{
-                          width: 100,
-                          height: 100,
-                          position: 'absolute',
-                        }}
                         data-uid='ele'
+                        style={{ position: 'absolute' }}
                       >
                         {background}
                       </span>
@@ -606,12 +590,8 @@ describe('variables menu', () => {
                         data-uid='img-2'
                       />
                       <span
-                        style={{
-                          width: 100,
-                          height: 100,
-                          position: 'absolute',
-                        }}
                         data-uid='ele'
+                        style={{ position: 'absolute' }}
                       >
                         {rightThere}
                       </span>
@@ -695,12 +675,8 @@ describe('variables menu', () => {
                         data-uid='img-2'
                       />
                       <span
-                        style={{
-                          width: 100,
-                          height: 100,
-                          position: 'absolute',
-                        }}
                         data-uid='ele'
+                        style={{ position: 'absolute' }}
                       >
                         {index}
                       </span>
@@ -769,7 +745,7 @@ describe('variables menu', () => {
           data-uid='container'
         >
           <div data-uid='a3d' />
-          <img src={myObj.image} style={{width: 100, height: 100, top:0, left: 0, position: 'absolute'}} data-uid='ele'/>
+          <img src={myObj.image} data-uid='ele' style={{top:0, left: 0, position: 'absolute'}}/>
           </div>
       )`),
       )
@@ -825,7 +801,7 @@ describe('variables menu', () => {
           data-uid='container'
         >
           <div data-uid='a3d' />
-          <span style={{ width: 100, height: 100, top: 0, left: 0, position: 'absolute' }} data-uid='ele'>{myText}</span>
+          <span data-uid='ele' style={{ top: 0, left: 0, position: 'absolute' }}>{myText}</span>
           </div>
       )`),
       )

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -165,8 +165,7 @@ function variantItem(
     enabled: true,
     action: () =>
       onItemClick({
-        elementToInsert: (uid: string) =>
-          elementFromInsertMenuItem(variant.elementToInsert(), uid, 'no-defaults'),
+        elementToInsert: (uid: string) => elementFromInsertMenuItem(variant.elementToInsert(), uid),
         additionalImports: variant.importsToAdd,
       }),
   }

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -420,8 +420,7 @@ const ComponentPickerVariant = React.memo((props: ComponentPickerVariantProps) =
   return (
     <div
       onClick={onItemClick({
-        elementToInsert: (uid) =>
-          elementFromInsertMenuItem(variant.elementToInsert(), uid, 'no-defaults'),
+        elementToInsert: (uid) => elementFromInsertMenuItem(variant.elementToInsert(), uid),
         additionalImports: variant.importsToAdd,
       })}
       css={{

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -37,7 +37,10 @@ Array [
   Object {
     "insertableComponents": Array [
       Object {
-        "defaultSize": null,
+        "defaultSize": Object {
+          "height": 100,
+          "width": 100,
+        },
         "element": [Function],
         "importsToAdd": Object {
           "react": Object {
@@ -306,7 +309,10 @@ Array [
   Object {
     "insertableComponents": Array [
       Object {
-        "defaultSize": null,
+        "defaultSize": Object {
+          "height": 100,
+          "width": 100,
+        },
         "element": [Function],
         "importsToAdd": Object {
           "react": Object {

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -389,12 +389,7 @@ const basicHTMLElementsDescriptors = {
   h1: makeHTMLDescriptor('h1', {}),
   h2: makeHTMLDescriptor('h2', {}),
   p: makeHTMLDescriptor('p', {}),
-  button: makeHTMLDescriptor('button', {}, () => [
-    simpleAttribute('style', {
-      width: '100px',
-      height: '100px',
-    }),
-  ]),
+  button: makeHTMLDescriptor('button', {}),
   input: makeHTMLDescriptor('input', {}),
   video: makeHTMLDescriptor(
     'video',
@@ -444,7 +439,7 @@ const basicHTMLElementsDescriptors = {
 const divComponentGroup = {
   div: makeHTMLDescriptor('div', {}, () =>
     jsxAttributesFromMap({
-      style: defaultElementStyle({ width: 100, height: 100 }),
+      style: defaultElementStyle(),
     }),
   ),
 }
@@ -709,6 +704,7 @@ export function getComponentGroups(
   function addDependencyDescriptor(
     groupType: InsertableComponentGroupType,
     components: ComponentDescriptorsForFile,
+    defaultSize?: Size,
   ): void {
     let insertableComponents: Array<InsertableComponent> = []
     fastForEach(Object.keys(components), (componentName) => {
@@ -726,7 +722,7 @@ export function getComponentGroups(
               insertOption.elementToInsert,
               insertOption.insertMenuLabel,
               stylePropOptions,
-              null,
+              defaultSize ?? null,
               null,
             ),
           )

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -389,7 +389,12 @@ const basicHTMLElementsDescriptors = {
   h1: makeHTMLDescriptor('h1', {}),
   h2: makeHTMLDescriptor('h2', {}),
   p: makeHTMLDescriptor('p', {}),
-  button: makeHTMLDescriptor('button', {}),
+  button: makeHTMLDescriptor('button', {}, () => [
+    simpleAttribute('style', {
+      width: '100px',
+      height: '100px',
+    }),
+  ]),
   input: makeHTMLDescriptor('input', {}),
   video: makeHTMLDescriptor(
     'video',
@@ -439,7 +444,7 @@ const basicHTMLElementsDescriptors = {
 const divComponentGroup = {
   div: makeHTMLDescriptor('div', {}, () =>
     jsxAttributesFromMap({
-      style: defaultElementStyle(),
+      style: defaultElementStyle({ width: 100, height: 100 }),
     }),
   ),
 }

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -732,7 +732,10 @@ export function getComponentGroups(
     result.push(insertableComponentGroup(groupType, insertableComponents))
   }
 
-  addDependencyDescriptor(insertableComponentGroupDiv(), divComponentGroup)
+  addDependencyDescriptor(insertableComponentGroupDiv(), divComponentGroup, {
+    width: 100,
+    height: 100,
+  })
 
   // Add HTML entries.
   addDependencyDescriptor(insertableComponentGroupHTML(), basicHTMLElementsDescriptors)


### PR DESCRIPTION
**Problem:**
Single shot insertion (via the canvas toolbar shown below) will insert a default sizing of 100 x 100 if the inserted element doesn't provide a `style` prop. This is bad for many many reasons, especially since users can register components with the code they actually want to insert.
![image](https://github.com/concrete-utopia/utopia/assets/1044774/88ac4ded-5e7f-453f-a7c6-28083930770e)


**Fix:**
Rather than add the default styling when creating the `JSXElement` to insert, instead just include that size in the default `div` and `button` component descriptors.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5341 
