### PR TITLE
Remove duplicate slashes

### DIFF
--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -101,7 +101,8 @@ export const PagesPane = React.memo((props) => {
       function processRoutes(routes: Array<any>, prefix: string): RouteMatches {
         let result: RouteMatches = {}
         for (const route of routes) {
-          const path = urljoin(prefix, route.path ?? '')
+          const delimiter = prefix.startsWith('/') ? '' : '/'
+          const path = urljoin(prefix, delimiter, route.path ?? '')
           const firstMatchingFavorite = mapFirstApplicable(
             [...featuredRoutes, activeRoute],
             (favorite) => matchPath(path, favorite)?.pathname ?? null,

--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -101,7 +101,7 @@ export const PagesPane = React.memo((props) => {
       function processRoutes(routes: Array<any>, prefix: string): RouteMatches {
         let result: RouteMatches = {}
         for (const route of routes) {
-          const path = urljoin(prefix, '/', route.path ?? '')
+          const path = urljoin(prefix, route.path ?? '')
           const firstMatchingFavorite = mapFirstApplicable(
             [...featuredRoutes, activeRoute],
             (favorite) => matchPath(path, favorite)?.pathname ?? null,

--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -101,7 +101,7 @@ export const PagesPane = React.memo((props) => {
       function processRoutes(routes: Array<any>, prefix: string): RouteMatches {
         let result: RouteMatches = {}
         for (const route of routes) {
-          const delimiter = prefix.startsWith('/') ? '' : '/'
+          const delimiter = prefix == '' ? '/' : ''
           const path = urljoin(prefix, delimiter, route.path ?? '')
           const firstMatchingFavorite = mapFirstApplicable(
             [...featuredRoutes, activeRoute],


### PR DESCRIPTION
**Problem**
`urljoin` automatically adds another slash when joining
<img width="314" alt="image" src="https://github.com/concrete-utopia/utopia/assets/7003853/5df1da88-22f1-4025-b94f-01e895e4a5e6">


**Fix:**
Don't add this slash manually if not needed
<img width="316" alt="image" src="https://github.com/concrete-utopia/utopia/assets/7003853/3b15d4f5-c56d-4e7b-b22e-17079fb33b46">

Fixes #5353
