### PR TITLE
Remove placeholders from the component API.

### DIFF
--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -124,19 +124,10 @@ export function componentInfo(
   }
 }
 
-export type PlaceholderSpec =
-  // a placeholder that inserts a span that wraps `contents`. This will be
-  // editable with the text editor
-  | { type: 'text'; contents: string }
-  // inserts a `div` with the specified width and height
-  | { type: 'spacer'; width: number; height: number }
-  | { type: 'fill' }
-
 export interface ComponentDescriptor {
   properties: PropertyControls
   supportsChildren: boolean
   preferredChildComponents: Array<PreferredChildComponentDescriptor>
-  childrenPropPlaceholder: PlaceholderSpec | null
   variants: ComponentInfo[]
   source: ComponentDescriptorSource
   focus: Focus
@@ -147,13 +138,12 @@ export interface ComponentDescriptor {
 
 export const ComponentDescriptorDefaults: Pick<
   ComponentDescriptor,
-  'focus' | 'inspector' | 'emphasis' | 'icon' | 'childrenPropPlaceholder'
+  'focus' | 'inspector' | 'emphasis' | 'icon'
 > = {
   focus: 'default',
   inspector: 'all',
   emphasis: 'regular',
   icon: 'regular',
-  childrenPropPlaceholder: null,
 }
 
 export function componentDescriptor(
@@ -161,7 +151,6 @@ export function componentDescriptor(
   supportsChildren: boolean,
   variants: Array<ComponentInfo>,
   preferredChildComponents: Array<PreferredChildComponentDescriptor>,
-  childrenPropPlaceholder: PlaceholderSpec | null,
   source: ComponentDescriptorSource,
   focus: Focus,
   inspector: InspectorSpec,
@@ -173,7 +162,6 @@ export function componentDescriptor(
     supportsChildren: supportsChildren,
     variants: variants,
     preferredChildComponents: preferredChildComponents,
-    childrenPropPlaceholder: childrenPropPlaceholder,
     source: source,
     focus: focus,
     inspector: inspector,

--- a/editor/src/components/custom-code/internal-property-controls.ts
+++ b/editor/src/components/custom-code/internal-property-controls.ts
@@ -1,6 +1,5 @@
 import type { CSSProperties } from 'react'
-import type { ComponentInfo, PlaceholderSpec } from './code-file'
-import type { Imports } from '../../core/shared/project-file-types'
+import type { ComponentInfo } from './code-file'
 
 export type BaseControlType =
   | 'checkbox'
@@ -226,7 +225,6 @@ export interface JSXControlDescription {
   label?: string
   visibleByDefault?: boolean
   preferredChildComponents: Array<PreferredChildComponentDescriptor>
-  placeholder: PlaceholderSpec | null
   required?: boolean
   defaultValue?: unknown
 }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -472,7 +472,6 @@ import type {
   CurriedUtopiaRequireFn,
   PropertyControlsInfo,
   ComponentDescriptorFromDescriptorFile,
-  PlaceholderSpec,
 } from '../../custom-code/code-file'
 import {
   codeResult,
@@ -3395,33 +3394,6 @@ export function ComponentDescriptorSourceKeepDeepEquality(): KeepDeepEqualityCal
   }
 }
 
-export function PlaceholderKeepDeepEquality(): KeepDeepEqualityCall<PlaceholderSpec> {
-  return (oldValue, newValue) => {
-    switch (oldValue.type) {
-      case 'text':
-        if (oldValue.type === newValue.type) {
-          const areEqual = oldValue.contents === newValue.contents
-          return { areEqual: areEqual, value: areEqual ? oldValue : newValue }
-        }
-        break
-      case 'spacer':
-        if (oldValue.type === newValue.type) {
-          const areEqual = oldValue.width === newValue.width && oldValue.height === newValue.height
-          return { areEqual: areEqual, value: areEqual ? oldValue : newValue }
-        }
-        break
-      case 'fill':
-        if (oldValue.type === newValue.type) {
-          return { areEqual: true, value: oldValue }
-        }
-        break
-      default:
-        assertNever(oldValue)
-    }
-    return keepDeepEqualityResult(newValue, false)
-  }
-}
-
 const InspectorSpecKeepDeepEquality: KeepDeepEqualityCall<InspectorSpec> = (oldValue, newValue) => {
   if (typeof oldValue === 'string' && typeof newValue === 'string') {
     return StringKeepDeepEquality(oldValue, newValue) as KeepDeepEqualityResult<InspectorSpec>
@@ -3435,7 +3407,7 @@ const InspectorSpecKeepDeepEquality: KeepDeepEqualityCall<InspectorSpec> = (oldV
 }
 
 export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<ComponentDescriptor> =
-  combine10EqualityCalls(
+  combine9EqualityCalls(
     (descriptor) => descriptor.properties,
     PropertyControlsKeepDeepEquality,
     (descriptor) => descriptor.supportsChildren,
@@ -3444,8 +3416,6 @@ export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<Component
     arrayDeepEquality(ComponentInfoKeepDeepEquality),
     (descriptor) => descriptor.preferredChildComponents,
     arrayDeepEquality(PreferredChildComponentDescriptorKeepDeepEquality),
-    (descriptor) => descriptor.childrenPropPlaceholder,
-    nullableDeepEquality(PlaceholderKeepDeepEquality()),
     (descriptor) => descriptor.source,
     ComponentDescriptorSourceKeepDeepEquality(),
     (descriptor) => descriptor.focus,

--- a/editor/src/components/inspector/sections/component-section/component-section-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/component-section-utils.ts
@@ -24,7 +24,6 @@ function inferControlTypeBasedOnValueInner(
     return {
       control: 'jsx',
       label: propName,
-      placeholder: null,
       preferredChildComponents: [],
     }
   }

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -1324,7 +1324,6 @@ describe('registered property controls', () => {
             component: Card,
             properties: { },
             children: {
-              placeholder: { text: "Content" },
               preferredContents: [
                 { component: 'span', variants: { name: 'span' } },
                 {
@@ -1442,15 +1441,12 @@ describe('registered property controls', () => {
             properties: {
               label: {
                 control: 'jsx',
-                placeholder: { width: 200, height: 200 }
               },
               header: {
                 control: 'jsx',
-                placeholder: { text: 'Header' }
               },
               footer: {
                 control: 'jsx',
-                placeholder: 'fill'
               }
             }
           },
@@ -1502,7 +1498,6 @@ describe('registered property controls', () => {
             properties: {
               label: {
                 control: 'jsx',
-                placeholder: { width: 200, height: 200 },
                 preferredContents: [
                   { component: 'span', variants: { name: 'span' } },
                   {

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -114,7 +114,6 @@ describe('registered property controls', () => {
     expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`
       Object {
         "Card": Object {
-          "childrenPropPlaceholder": null,
           "emphasis": "regular",
           "focus": "default",
           "icon": "regular",
@@ -221,7 +220,6 @@ describe('registered property controls', () => {
     expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`
       Object {
         "Card": Object {
-          "childrenPropPlaceholder": null,
           "emphasis": "regular",
           "focus": "default",
           "icon": "regular",
@@ -785,7 +783,6 @@ describe('registered property controls', () => {
     expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`
       Object {
         "Card": Object {
-          "childrenPropPlaceholder": null,
           "emphasis": "regular",
           "focus": "default",
           "icon": "regular",
@@ -1186,14 +1183,10 @@ describe('registered property controls', () => {
       const cardRegistration = editorState.propertyControlsInfo['/src/card']['Card']
       expect(cardRegistration).not.toBeUndefined()
 
-      const propsToCheck = pick(
-        ['childrenPropPlaceholder', 'preferredChildComponents', 'supportsChildren'],
-        cardRegistration,
-      )
+      const propsToCheck = pick(['preferredChildComponents', 'supportsChildren'], cardRegistration)
 
       expect(propsToCheck).toMatchInlineSnapshot(`
         Object {
-          "childrenPropPlaceholder": null,
           "preferredChildComponents": Array [],
           "supportsChildren": false,
         }
@@ -1225,14 +1218,10 @@ describe('registered property controls', () => {
       const cardRegistration = editorState.propertyControlsInfo['/src/card']['Card']
       expect(cardRegistration).not.toBeUndefined()
 
-      const propsToCheck = pick(
-        ['childrenPropPlaceholder', 'preferredChildComponents', 'supportsChildren'],
-        cardRegistration,
-      )
+      const propsToCheck = pick(['preferredChildComponents', 'supportsChildren'], cardRegistration)
 
       expect(propsToCheck).toMatchInlineSnapshot(`
         Object {
-          "childrenPropPlaceholder": null,
           "preferredChildComponents": Array [],
           "supportsChildren": true,
         }
@@ -1264,14 +1253,10 @@ describe('registered property controls', () => {
       const cardRegistration = editorState.propertyControlsInfo['/src/card']['Card']
       expect(cardRegistration).not.toBeUndefined()
 
-      const propsToCheck = pick(
-        ['childrenPropPlaceholder', 'preferredChildComponents', 'supportsChildren'],
-        cardRegistration,
-      )
+      const propsToCheck = pick(['preferredChildComponents', 'supportsChildren'], cardRegistration)
 
       expect(propsToCheck).toMatchInlineSnapshot(`
         Object {
-          "childrenPropPlaceholder": null,
           "preferredChildComponents": Array [],
           "supportsChildren": false,
         }
@@ -1305,14 +1290,10 @@ describe('registered property controls', () => {
       const cardRegistration = editorState.propertyControlsInfo['/src/card']['Card']
       expect(cardRegistration).not.toBeUndefined()
 
-      const propsToCheck = pick(
-        ['childrenPropPlaceholder', 'preferredChildComponents', 'supportsChildren'],
-        cardRegistration,
-      )
+      const propsToCheck = pick(['preferredChildComponents', 'supportsChildren'], cardRegistration)
 
       expect(propsToCheck).toMatchInlineSnapshot(`
         Object {
-          "childrenPropPlaceholder": null,
           "preferredChildComponents": Array [
             Object {
               "moduleName": null,
@@ -1377,17 +1358,10 @@ describe('registered property controls', () => {
       const cardRegistration = editorState.propertyControlsInfo['/src/card']['Card']
       expect(cardRegistration).not.toBeUndefined()
 
-      const propsToCheck = pick(
-        ['childrenPropPlaceholder', 'preferredChildComponents', 'supportsChildren'],
-        cardRegistration,
-      )
+      const propsToCheck = pick(['preferredChildComponents', 'supportsChildren'], cardRegistration)
 
       expect(propsToCheck).toMatchInlineSnapshot(`
         Object {
-          "childrenPropPlaceholder": Object {
-            "contents": "Content",
-            "type": "text",
-          },
           "preferredChildComponents": Array [
             Object {
               "moduleName": null,
@@ -1500,26 +1474,14 @@ describe('registered property controls', () => {
           "properties": Object {
             "footer": Object {
               "control": "jsx",
-              "placeholder": Object {
-                "type": "fill",
-              },
               "preferredChildComponents": Array [],
             },
             "header": Object {
               "control": "jsx",
-              "placeholder": Object {
-                "contents": "Header",
-                "type": "text",
-              },
               "preferredChildComponents": Array [],
             },
             "label": Object {
               "control": "jsx",
-              "placeholder": Object {
-                "height": 200,
-                "type": "spacer",
-                "width": 200,
-              },
               "preferredChildComponents": Array [],
             },
           },
@@ -1575,7 +1537,6 @@ describe('registered property controls', () => {
       expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`
         Object {
           "Card": Object {
-            "childrenPropPlaceholder": null,
             "emphasis": "regular",
             "focus": "default",
             "icon": "regular",
@@ -1584,11 +1545,6 @@ describe('registered property controls', () => {
             "properties": Object {
               "label": Object {
                 "control": "jsx",
-                "placeholder": Object {
-                  "height": 200,
-                  "type": "spacer",
-                  "width": 200,
-                },
                 "preferredChildComponents": Array [
                   Object {
                     "moduleName": null,

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -35,7 +35,6 @@ import type {
   ComponentDescriptorSource,
   ComponentDescriptorWithName,
   ComponentInfo,
-  PlaceholderSpec,
   PropertyControlsInfo,
 } from '../../components/custom-code/code-file'
 import { dependenciesFromPackageJson } from '../../components/editor/npm-dependency/npm-dependency'
@@ -559,7 +558,6 @@ export function updatePropertyControlsOnDescriptorFileUpdate(
         supportsChildren: descriptor.supportsChildren,
         preferredChildComponents: descriptor.preferredChildComponents,
         variants: descriptor.variants,
-        childrenPropPlaceholder: descriptor.childrenPropPlaceholder,
         source: descriptor.source,
         focus: descriptor.focus,
         inspector: descriptor.inspector,
@@ -683,14 +681,10 @@ async function parseJSXControlDescription(
   descriptor: JSXControlDescriptionFromUtopia,
   context: { moduleName: string; workers: UtopiaTsWorkers },
 ): Promise<PropertyDescriptorResult<JSXControlDescription>> {
-  const placeholder =
-    descriptor.placeholder == null ? null : placeholderFromJSPlaceholder(descriptor.placeholder)
-
   if (descriptor.preferredContents == null) {
     return right({
       ...descriptor,
       preferredChildComponents: [],
-      placeholder: placeholder,
     })
   }
 
@@ -707,7 +701,6 @@ async function parseJSXControlDescription(
 
   return right({
     ...descriptor,
-    placeholder: placeholder,
     preferredChildComponents: preferredChildComponents.value,
   })
 }
@@ -797,16 +790,6 @@ async function makePropertyDescriptors(
   return right(result)
 }
 
-function placeholderFromJSPlaceholder(placeholder: PlaceholderSpecFromUtopia): PlaceholderSpec {
-  if (typeof placeholder === 'string') {
-    return { type: 'fill' }
-  }
-  if ('text' in placeholder) {
-    return { type: 'text', contents: placeholder.text }
-  }
-  return { type: 'spacer', width: placeholder.width, height: placeholder.height }
-}
-
 async function parsePreferredChildren(
   preferredContents: PreferredContents[],
   componentName: string,
@@ -888,20 +871,6 @@ export async function parsePreferredChildrenExamples(
   return descriptors
 }
 
-function parseChildrenPlaceholder(
-  componentToRegister: ComponentToRegister,
-): PlaceholderSpec | null {
-  if (
-    componentToRegister.children == null ||
-    typeof componentToRegister.children === 'string' ||
-    componentToRegister.children.placeholder == null
-  ) {
-    return null
-  }
-
-  return placeholderFromJSPlaceholder(componentToRegister.children.placeholder)
-}
-
 async function parseComponentVariants(
   componentToRegister: ComponentToRegister,
   componentName: string,
@@ -974,8 +943,6 @@ export async function componentDescriptorForComponentToRegister(
     return properties
   }
 
-  const placeholder = parseChildrenPlaceholder(componentToRegister)
-
   const supportsChildren =
     componentToRegister.children != null && componentToRegister.children !== 'not-supported'
 
@@ -987,7 +954,6 @@ export async function componentDescriptorForComponentToRegister(
     source: source,
     supportsChildren: supportsChildren,
     preferredChildComponents: childrenPropSpec.value,
-    childrenPropPlaceholder: placeholder,
     focus: componentToRegister.focus ?? ComponentDescriptorDefaults.focus,
     inspector: componentToRegister.inspector ?? ComponentDescriptorDefaults.inspector,
     emphasis: componentToRegister.emphasis ?? ComponentDescriptorDefaults.emphasis,

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -7,7 +7,6 @@ import type {
   ComponentInsertOption,
   ComponentExample,
   ChildrenSpec,
-  PlaceholderSpec as PlaceholderSpecFromUtopia,
   Children,
   PreferredContents,
 } from 'utopia-api/core'
@@ -1024,26 +1023,9 @@ export function parsePreferredContents(value: unknown): ParseResult<PreferredCon
   )(value)
 }
 
-function parseTextPlaceholder(value: unknown): ParseResult<PlaceholderSpecFromUtopia> {
-  return mapEither((text) => ({ text }), objectKeyParser(parseString, 'text')(value))
-}
-
-function parseSpacerPlaceholder(value: unknown): ParseResult<PlaceholderSpecFromUtopia> {
-  return applicative2Either(
-    (width, height) => ({ width, height }),
-    objectKeyParser(parseNumber, 'width')(value),
-    objectKeyParser(parseNumber, 'height')(value),
-  )
-}
-
-export const parsePlaceholder = parseAlternative(
-  [parseConstant('fill'), parseTextPlaceholder, parseSpacerPlaceholder],
-  'Invalid placeholder value',
-)
-
-export function parseChildrenSpec(value: unknown): ParseResult<ChildrenSpec> {
-  return applicative2Either(
-    (preferredContents, placeholder) => ({ preferredContents, placeholder }),
+export const parseChildrenSpec = (value: unknown): ParseResult<ChildrenSpec> => {
+  return mapEither(
+    (preferredContents) => ({ preferredContents }),
     optionalObjectKeyParser(
       parseAlternative<PreferredContents | PreferredContents[]>(
         [parsePreferredContents, parseArray(parsePreferredContents)],
@@ -1051,7 +1033,6 @@ export function parseChildrenSpec(value: unknown): ParseResult<ChildrenSpec> {
       ),
       'preferredContents',
     )(value),
-    optionalObjectKeyParser(parsePlaceholder, 'placeholder')(value),
   )
 }
 

--- a/editor/src/core/property-controls/property-controls-parser.ts
+++ b/editor/src/core/property-controls/property-controls-parser.ts
@@ -87,7 +87,6 @@ import { parseEnumValue } from './property-control-values'
 import {
   parseComponentExample,
   parseComponentInsertOption,
-  parsePlaceholder,
   parsePreferredContents,
 } from './property-controls-local'
 

--- a/editor/src/core/property-controls/property-controls-parser.ts
+++ b/editor/src/core/property-controls/property-controls-parser.ts
@@ -840,15 +840,14 @@ export function parseFolderControlDescription(
 }
 
 export function parseJSXControlDescription(value: unknown): ParseResult<JSXControlDescription> {
-  return applicative7Either(
-    (label, control, visibleByDefault, preferredContents, placeholder, required, defaultValue) => {
+  return applicative6Either(
+    (label, control, visibleByDefault, preferredContents, required, defaultValue) => {
       let jsxControlDescription: JSXControlDescription = {
         control: control,
       }
       setOptionalProp(jsxControlDescription, 'label', label)
       setOptionalProp(jsxControlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(jsxControlDescription, 'preferredContents', preferredContents)
-      setOptionalProp(jsxControlDescription, 'placeholder', placeholder)
       setOptionalProp(jsxControlDescription, 'required', required)
       setOptionalProp(jsxControlDescription, 'defaultValue', defaultValue)
 
@@ -864,7 +863,6 @@ export function parseJSXControlDescription(value: unknown): ParseResult<JSXContr
       ),
       'preferredContents',
     )(value),
-    optionalObjectKeyParser(parsePlaceholder, 'placeholder')(value),
     requiredFieldParser(value),
     optionalObjectKeyParser(parseAny, 'defaultValue')(value),
   )

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -21,15 +21,6 @@ export type ComponentExample =
   // variants
   | ComponentInsertOption
 
-export type PlaceholderSpec =
-  // a placeholder that inserts a span that wraps `text`. This will be
-  // editable with the text editor
-  | { text: string }
-  // inserts a `div` with the specified width and height
-  | { width: number; height: number }
-  // inserts a spacer that completely fills the available space
-  | 'fill'
-
 export type PreferredContents =
   | 'text'
   | {
@@ -44,9 +35,6 @@ export interface ChildrenSpec {
   // `'text'`: means only JSX text is accepted
   // `RendersComponent`: detailed spec
   preferredContents?: PreferredContents | PreferredContents[]
-
-  // specifies the placeholder to use
-  placeholder?: PlaceholderSpec
 }
 
 export type Children = 'supported' | 'not-supported' | ChildrenSpec

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -1,6 +1,5 @@
 import type { CSSProperties } from 'react'
-import { fastForEach } from '../utils'
-import type { PlaceholderSpec, PreferredContents } from '../core'
+import type { PreferredContents } from '../core'
 
 // these fields are shared among all RegularControlDescription. the helper function getControlSharedFields makes sure the types line up
 // Ensure that the fields are also added to the object within `getControlSharedFields` for that typechecking.
@@ -10,15 +9,6 @@ interface ControlBaseFields {
   visibleByDefault?: boolean
   required?: boolean
   defaultValue?: unknown
-}
-function getControlSharedFields(control: RegularControlDescription): ControlBaseFields {
-  return {
-    control: control.control,
-    label: control.label,
-    visibleByDefault: control.visibleByDefault,
-    required: control.required,
-    defaultValue: control.defaultValue,
-  }
 }
 
 // Base Level Controls
@@ -241,7 +231,6 @@ export interface JSXControlDescription {
   label?: string
   visibleByDefault?: boolean
   preferredContents?: PreferredContents | PreferredContents[]
-  placeholder?: PlaceholderSpec
   required?: boolean
   defaultValue?: unknown
 }


### PR DESCRIPTION
## Problem
Placeholder-related props on the component API have become unnecessary 

## Fix
Remove them

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
