### PR TITLE
Add route for asset display

### DIFF
--- a/utopia-remix/app/routes/p.$id.assets.$filename.tsx
+++ b/utopia-remix/app/routes/p.$id.assets.$filename.tsx
@@ -1,0 +1,16 @@
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { validateProjectAccess } from '../handlers/validators'
+import { proxy } from '../util/proxy.server'
+import { handle } from '../util/api.server'
+import { UserProjectPermission } from '../types'
+
+export async function loader(args: LoaderFunctionArgs) {
+  return handle(args, {
+    GET: {
+      validator: validateProjectAccess(UserProjectPermission.CAN_VIEW_PROJECT, {
+        getProjectId: (params) => params.id?.split('-')[0] ?? null,
+      }),
+      handler: (req) => proxy(req, { rawOutput: true }),
+    },
+  })
+}


### PR DESCRIPTION
**Problem:**

The editor can't show asset images from the BFF backend.

**Fix:**

Add a missing route for `/p/$id/assets/$filename`.

**Manual Tests:**
I hereby swear that:

- [ ] I opened a hydrogen project and it loaded
- [ ] I could navigate to various routes in Preview mode

Fixes #5355 
