### PR TITLE
BFF: support splat-loading assets for Remix projects

### DIFF
--- a/utopia-remix/app/handlers/splatLoad.spec.ts
+++ b/utopia-remix/app/handlers/splatLoad.spec.ts
@@ -1,0 +1,35 @@
+import { newTestRequest } from '../test-util'
+import { handleSplatLoad } from './splatLoad'
+import * as proxyUtil from '../util/proxy.server'
+
+describe('handleSplatLoad', () => {
+  let proxyMock: jest.SpyInstance
+
+  afterEach(async () => {
+    proxyMock.mockRestore()
+  })
+
+  beforeEach(async () => {
+    proxyMock = jest.spyOn(proxyUtil, 'proxy')
+  })
+
+  it('errors if the path does not have an allowed extension', async () => {
+    const fn = (path: string) => async () =>
+      handleSplatLoad(newTestRequest({ method: 'GET', path: path }))
+    await expect(fn('')).rejects.toThrow('invalid extension')
+    await expect(fn('/foo')).rejects.toThrow('invalid extension')
+    await expect(fn('/foo/bar')).rejects.toThrow('invalid extension')
+    await expect(fn('/foo/bar/wrong.zip')).rejects.toThrow('invalid extension')
+  })
+
+  it('forwards the request to the desired file', async () => {
+    proxyMock.mockImplementation((req) => {
+      return req.url
+    })
+    const fn = (path: string) => handleSplatLoad(newTestRequest({ method: 'GET', path: path }))
+
+    expect(await fn('foo.png')).toBe('http://localhost:8000/foo.png')
+    expect(await fn('foo/bar/baz.png')).toBe('http://localhost:8000/foo/bar/baz.png')
+    expect(await fn('foo/bar/baz.jpg')).toBe('http://localhost:8000/foo/bar/baz.jpg')
+  })
+})

--- a/utopia-remix/app/handlers/splatLoad.ts
+++ b/utopia-remix/app/handlers/splatLoad.ts
@@ -1,0 +1,36 @@
+import path from 'path'
+import { ensure } from '../util/api.server'
+import { proxy } from '../util/proxy.server'
+import { Status } from '../util/statusCodes'
+
+const allowedExtensions = [
+  // images
+  '.bmp',
+  '.gif',
+  '.ico',
+  '.jpeg',
+  '.jpg',
+  '.png',
+  '.svg',
+  '.webm',
+  '.webp',
+  // fonts
+  '.eot',
+  '.ttf',
+  '.woff',
+  '.woff2',
+  // other
+  '.css',
+  '.json',
+  '.txt',
+  '.xml',
+]
+
+export async function handleSplatLoad(req: Request) {
+  const url = new URL(req.url)
+
+  const extension = path.extname(url.pathname).toLowerCase()
+  ensure(allowedExtensions.includes(extension), 'invalid extension', Status.BAD_REQUEST)
+
+  return proxy(req, { rawOutput: true })
+}

--- a/utopia-remix/app/routes/p.$id.$.tsx
+++ b/utopia-remix/app/routes/p.$id.$.tsx
@@ -1,0 +1,25 @@
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { validateProjectAccess } from '../handlers/validators'
+import { UserProjectPermission } from '../types'
+import { handle } from '../util/api.server'
+import { handleSplatLoad } from '../handlers/splatLoad'
+
+/**
+ * This is the splat route for project assets served from the editor
+ * that don't go through the `/assets/` path, for example
+ * Remix assets served from the `public` folder.
+ *
+ * Only links to static files with the allowed extensions will be allowed
+ * to be loaded.
+ */
+
+export async function loader(args: LoaderFunctionArgs) {
+  return handle(args, {
+    GET: {
+      validator: validateProjectAccess(UserProjectPermission.CAN_VIEW_PROJECT, {
+        getProjectId: (params) => params.id?.split('-')[0] ?? null,
+      }),
+      handler: handleSplatLoad,
+    },
+  })
+}

--- a/utopia-remix/app/routes/p.$id.assets.$filename.tsx
+++ b/utopia-remix/app/routes/p.$id.assets.$filename.tsx
@@ -1,0 +1,16 @@
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { validateProjectAccess } from '../handlers/validators'
+import { proxy } from '../util/proxy.server'
+import { handle } from '../util/api.server'
+import { UserProjectPermission } from '../types'
+
+export async function loader(args: LoaderFunctionArgs) {
+  return handle(args, {
+    GET: {
+      validator: validateProjectAccess(UserProjectPermission.CAN_VIEW_PROJECT, {
+        getProjectId: (params) => params.id?.split('-')[0] ?? null,
+      }),
+      handler: (req) => proxy(req, { rawOutput: true }),
+    },
+  })
+}


### PR DESCRIPTION
**Problem:**

Remix projects which have assets served from the `public` folder don't load those assets correctly via the BFF/backend because they don't hit the `/assets/` route but rather go straight to `/p/{id}/{filename}`.

**Fix:**

Add a splat route for assets under `/p`. To limit this to only reasonable resources, make sure the requested path has a supported extension. It's obviously a simplistic approach but it should work fine for the time being.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5363
