### PR TITLE
Fix vite hosts for local dev via BFF

### DIFF
--- a/editor/vite.config.js
+++ b/editor/vite.config.js
@@ -22,7 +22,7 @@ export default defineConfig(({ mode }) => {
     publicDir: '../../resources/editor',
     server: {
       port: 8088,
-      host: '0.0.0.0',
+      host: '127.0.0.1',
       fs: {
         allow: [
           '../..',
@@ -34,7 +34,7 @@ export default defineConfig(({ mode }) => {
       },
       hmr: {
         protocol: 'ws',
-        host: '0.0.0.0',
+        host: '127.0.0.1',
         port: 8088,
       },
     },

--- a/editor/vite.config.js
+++ b/editor/vite.config.js
@@ -22,7 +22,7 @@ export default defineConfig(({ mode }) => {
     publicDir: '../../resources/editor',
     server: {
       port: 8088,
-      host: '127.0.0.1',
+      host: 'localhost',
       fs: {
         allow: [
           '../..',
@@ -34,7 +34,7 @@ export default defineConfig(({ mode }) => {
       },
       hmr: {
         protocol: 'ws',
-        host: '127.0.0.1',
+        host: 'localhost',
         port: 8088,
       },
     },


### PR DESCRIPTION
**Problem:**

Hot reload in local development is glitchy.

**Fix:**

Use `127.0.0.1` instead of `0.0.0.0` for local development. (https://stackoverflow.com/questions/70694187/vite-server-is-running-but-not-working-on-localhost)

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
