### PR TITLE
show Pages pane for non-owners

### DIFF
--- a/editor/src/components/navigator/left-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/index.tsx
@@ -136,7 +136,7 @@ export const LeftPaneComponent = React.memo<LeftPaneComponentProps>((props) => {
               />
             </FlexRow>,
           )}
-          {when(isMyProject && isRemixProject && selectedTab === LeftMenuTab.Pages, <PagesPane />)}
+          {when(isRemixProject && selectedTab === LeftMenuTab.Pages, <PagesPane />)}
           {when(selectedTab === LeftMenuTab.Navigator, <NavigatorComponent />)}
           {when(isMyProject && selectedTab === LeftMenuTab.Project, <ContentsPane />)}
           {when(isMyProject && selectedTab === LeftMenuTab.Github, <GithubPane />)}


### PR DESCRIPTION
**Problem:**
We should show the Pages pane even for viewers of a project.
