### PR TITLE
BFF: GitHub search public repo

### DIFF
--- a/utopia-remix/app/handlers/searchPublicRepository.spec.ts
+++ b/utopia-remix/app/handlers/searchPublicRepository.spec.ts
@@ -1,0 +1,119 @@
+import { prisma } from '../db.server'
+import {
+  createTestGithubAuth,
+  createTestSession,
+  createTestUser,
+  newTestRequest,
+  truncateTables,
+} from '../test-util'
+import * as githubUtil from '../util/github'
+import { toApiFailure, toApiSuccess } from '../types'
+import { handleSearchPublicRepository } from './searchPublicRepository'
+
+describe('handleSearchPublicRepository', () => {
+  let mockOctokit: jest.SpyInstance
+  afterEach(async () => {
+    await truncateTables([
+      prisma.persistentSession,
+      prisma.githubAuthentication,
+      prisma.userDetails,
+    ])
+    mockOctokit.mockRestore()
+  })
+
+  beforeEach(async () => {
+    await createTestUser(prisma, { id: 'bob' })
+    await createTestUser(prisma, { id: 'alice' })
+    await createTestSession(prisma, { userId: 'bob', key: 'bob-key' })
+    await createTestSession(prisma, { userId: 'alice', key: 'alice-key' })
+    await createTestGithubAuth(prisma, { userId: 'alice', token: 'the-token' })
+    mockOctokit = jest.spyOn(githubUtil, 'newOctokitClient')
+  })
+
+  const doRequest = async ({
+    owner,
+    repo,
+    auth,
+  }: {
+    owner?: string
+    repo?: string
+    auth?: string
+  }) =>
+    handleSearchPublicRepository(
+      newTestRequest({ method: 'POST', authCookie: auth, body: JSON.stringify({ owner, repo }) }),
+    )
+
+  it('requires a user', async () => {
+    await expect(doRequest({ owner: 'foo', repo: 'bar' })).rejects.toThrow('missing session cookie')
+  })
+  it('requires a valid request', async () => {
+    await expect(doRequest({ auth: 'bob-key' })).rejects.toThrow('invalid request')
+  })
+  it('requires a valid owner', async () => {
+    await expect(doRequest({ owner: '', repo: 'bar', auth: 'bob-key' })).rejects.toThrow(
+      'invalid owner',
+    )
+  })
+  it('requires a valid repo', async () => {
+    await expect(doRequest({ owner: 'foo', repo: '', auth: 'bob-key' })).rejects.toThrow(
+      'invalid repo',
+    )
+  })
+  it('requires a gh auth token', async () => {
+    await expect(doRequest({ owner: 'foo', repo: 'bar', auth: 'bob-key' })).rejects.toThrow(
+      'missing auth',
+    )
+  })
+  describe('when the gh call fails', () => {
+    it('(generic error) returns the data as a failure', async () => {
+      mockOctokit.mockReturnValue({
+        request: () => {
+          throw new Error('boom')
+        },
+      })
+
+      const got = await doRequest({ owner: 'foo', repo: 'bar', auth: 'alice-key' })
+      if (!(got instanceof Response)) {
+        throw new Error('should be a response')
+      }
+      const body = await got.json()
+      expect(body).toEqual(toApiFailure('Error: boom'))
+    })
+    it('(non 2xx status) returns the data as a failure', async () => {
+      mockOctokit.mockReturnValue({
+        request: () => {
+          return { status: 418 }
+        },
+      })
+
+      const got = await doRequest({ owner: 'foo', repo: 'bar', auth: 'alice-key' })
+      if (!(got instanceof Response)) {
+        throw new Error('should be a response')
+      }
+      const body = await got.json()
+      expect(body).toEqual(toApiFailure('Error: repository not found (418)'))
+    })
+  })
+  describe('when the gh call succeeds', () => {
+    it('returns the data as a success', async () => {
+      mockOctokit.mockReturnValue({
+        request: () => {
+          return {
+            status: 200,
+            data: { owner: { avatar_url: 'test.png' }, name: 'bar', default_branch: 'main' },
+          }
+        },
+      })
+      const got = await doRequest({ owner: 'foo', repo: 'bar', auth: 'alice-key' })
+      expect(got).toEqual(
+        toApiSuccess({
+          repository: {
+            avatarUrl: 'test.png',
+            defaultBranch: 'main',
+            name: 'bar',
+          },
+        }),
+      )
+    })
+  })
+})

--- a/utopia-remix/app/handlers/searchPublicRepository.ts
+++ b/utopia-remix/app/handlers/searchPublicRepository.ts
@@ -1,0 +1,47 @@
+import { getGithubAuthentication } from '../models/githubAuthentication.server'
+import { isSearchPublicRepositoriesRequest } from '../types'
+import { ensure, requireUser } from '../util/api.server'
+import { ApiError } from '../util/errors'
+import { newOctokitClient, wrapGithubAPIRequest } from '../util/github'
+import { Status } from '../util/statusCodes'
+
+export async function handleSearchPublicRepository(req: Request) {
+  const user = await requireUser(req)
+
+  const body = await req.json()
+  ensure(isSearchPublicRepositoriesRequest(body), 'invalid request', Status.BAD_REQUEST)
+
+  const owner = body.owner.trim()
+  ensure(owner.length > 0, 'invalid owner', Status.BAD_REQUEST)
+  const repo = body.repo.trim()
+  ensure(repo.length > 0, 'invalid repo', Status.BAD_REQUEST)
+
+  const githubAuth = await getGithubAuthentication({ userId: user.user_id })
+  ensure(githubAuth != null, 'missing auth', Status.FORBIDDEN)
+
+  const octokit = newOctokitClient(githubAuth.access_token)
+
+  return wrapGithubAPIRequest(octokit, async (client) => {
+    const response = await client.request('GET /repos/{owner}/{repo}', {
+      owner: owner,
+      repo: repo,
+    })
+
+    if (response.status < 200 || response.status > 299) {
+      throw new ApiError(`repository not found (${response.status})`, response.status)
+    }
+
+    return {
+      repository: {
+        avatarUrl: response.data.owner.avatar_url,
+        defaultBranch: response.data.default_branch,
+        description: response.data.description,
+        fullName: response.data.full_name,
+        isPrivate: response.data.private,
+        name: response.data.name,
+        permissions: response.data.permissions,
+        updatedAt: response.data.updated_at,
+      },
+    }
+  })
+}

--- a/utopia-remix/app/routes/internal.github.repositories.search.tsx
+++ b/utopia-remix/app/routes/internal.github.repositories.search.tsx
@@ -1,7 +1,14 @@
+import type { LoaderFunctionArgs } from '@remix-run/node'
 import { type ActionFunctionArgs } from '@remix-run/node'
 import { handleSearchPublicRepository } from '../handlers/searchPublicRepository'
 import { ALLOW } from '../handlers/validators'
-import { handle } from '../util/api.server'
+import { handle, handleOptions } from '../util/api.server'
+
+export async function loader(args: LoaderFunctionArgs) {
+  return handle(args, {
+    OPTIONS: handleOptions,
+  })
+}
 
 export async function action(args: ActionFunctionArgs) {
   return handle(args, {

--- a/utopia-remix/app/routes/internal.github.repositories.search.tsx
+++ b/utopia-remix/app/routes/internal.github.repositories.search.tsx
@@ -1,0 +1,13 @@
+import { type ActionFunctionArgs } from '@remix-run/node'
+import { handleSearchPublicRepository } from '../handlers/searchPublicRepository'
+import { ALLOW } from '../handlers/validators'
+import { handle } from '../util/api.server'
+
+export async function action(args: ActionFunctionArgs) {
+  return handle(args, {
+    POST: {
+      validator: ALLOW,
+      handler: handleSearchPublicRepository,
+    },
+  })
+}

--- a/utopia-remix/app/types.ts
+++ b/utopia-remix/app/types.ts
@@ -344,3 +344,55 @@ export function isProjectMetadataV1(u: unknown): u is ProjectMetadataV1 {
 export type ProjectMetadataForEditor = {
   hasPendingRequests: boolean
 }
+
+export type SearchPublicRepositoriesRequest = {
+  owner: string
+  repo: string
+}
+
+export function isSearchPublicRepositoriesRequest(
+  u: unknown,
+): u is SearchPublicRepositoriesRequest {
+  const maybe = u as SearchPublicRepositoriesRequest
+  return u != null && typeof u === 'object' && maybe.owner != null && maybe.repo != null
+}
+
+type ApiSuccess<T> = T & { type: 'SUCCESS' }
+
+export function toApiSuccess<T>(data: T): ApiSuccess<T> {
+  return {
+    type: 'SUCCESS',
+    ...data,
+  }
+}
+
+type ApiFailure = {
+  type: 'FAILURE'
+  failureReason: string
+}
+
+export function toApiFailure(reason: string): ApiFailure {
+  return {
+    type: 'FAILURE',
+    failureReason: reason,
+  }
+}
+
+interface WithMessageData {
+  status: number
+  response: {
+    data: { message: string }
+  }
+}
+
+export function isResponseWithMessageData(u: unknown): u is WithMessageData {
+  const maybe = u as WithMessageData
+  return (
+    u != null &&
+    typeof u === 'object' &&
+    maybe.response != null &&
+    maybe.response.data != null &&
+    maybe.response.data.message != null &&
+    maybe.status != null
+  )
+}

--- a/utopia-remix/app/util/github.ts
+++ b/utopia-remix/app/util/github.ts
@@ -1,3 +1,9 @@
+import { Octokit } from '@octokit/rest'
+import type { RequestInterface } from '@octokit/types'
+import { toApiSuccess, isResponseWithMessageData, toApiFailure } from '../types'
+import { Status } from './statusCodes'
+import { json } from '@remix-run/node'
+
 export function githubRepositoryPrettyName(repo: string | null): string {
   if (repo == null) {
     return ''
@@ -9,4 +15,32 @@ export function githubRepositoryPrettyName(repo: string | null): string {
     return `${name} (${branch})`
   }
   return name
+}
+
+export interface OctokitClient {
+  request: RequestInterface
+}
+
+export function newOctokitClient(auth: string): OctokitClient {
+  return new Octokit({ auth: auth })
+}
+
+export async function wrapGithubAPIRequest(
+  client: OctokitClient,
+  fn: (client: OctokitClient) => Promise<unknown>,
+) {
+  try {
+    const result = await fn(client)
+    return toApiSuccess(result)
+  } catch (err) {
+    return isResponseWithMessageData(err)
+      ? json(toApiFailure(err.response.data.message), {
+          status: err.status,
+          headers: { 'cache-control': 'no-cache' },
+        })
+      : json(toApiFailure(`${err}`), {
+          status: Status.INTERNAL_ERROR,
+          headers: { 'cache-control': 'no-cache' },
+        })
+  }
 }

--- a/utopia-remix/package.json
+++ b/utopia-remix/package.json
@@ -15,6 +15,9 @@
   },
   "dependencies": {
     "@headlessui/react": "1.7.18",
+    "@octokit/request-error": "6.1.1",
+    "@octokit/rest": "20.1.0",
+    "@octokit/types": "13.4.1",
     "@openfga/sdk": "0.3.2",
     "@prisma/client": "5.9.0",
     "@radix-ui/primitive": "1.0.1",

--- a/utopia-remix/pnpm-lock.yaml
+++ b/utopia-remix/pnpm-lock.yaml
@@ -4,6 +4,9 @@ specifiers:
   '@babel/core': 7.23.9
   '@babel/preset-env': 7.23.9
   '@headlessui/react': 1.7.18
+  '@octokit/request-error': 6.1.1
+  '@octokit/rest': 20.1.0
+  '@octokit/types': 13.4.1
   '@openfga/sdk': 0.3.2
   '@prisma/client': 5.9.0
   '@radix-ui/primitive': 1.0.1
@@ -78,6 +81,9 @@ specifiers:
 
 dependencies:
   '@headlessui/react': 1.7.18_biqbaboplfbrettd7655fr4n2y
+  '@octokit/request-error': 6.1.1
+  '@octokit/rest': 20.1.0
+  '@octokit/types': 13.4.1
   '@openfga/sdk': 0.3.2
   '@prisma/client': 5.9.0_prisma@5.9.0
   '@radix-ui/primitive': 1.0.1
@@ -2295,6 +2301,126 @@ packages:
     dependencies:
       which: 3.0.1
     dev: true
+
+  /@octokit/auth-token/4.0.0:
+    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
+    engines: {node: '>= 18'}
+    dev: false
+
+  /@octokit/core/5.2.0:
+    resolution: {integrity: sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/auth-token': 4.0.0
+      '@octokit/graphql': 7.1.0
+      '@octokit/request': 8.4.0
+      '@octokit/request-error': 5.1.0
+      '@octokit/types': 13.4.1
+      before-after-hook: 2.2.3
+      universal-user-agent: 6.0.1
+    dev: false
+
+  /@octokit/endpoint/9.0.5:
+    resolution: {integrity: sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/types': 13.4.1
+      universal-user-agent: 6.0.1
+    dev: false
+
+  /@octokit/graphql/7.1.0:
+    resolution: {integrity: sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/request': 8.4.0
+      '@octokit/types': 13.4.1
+      universal-user-agent: 6.0.1
+    dev: false
+
+  /@octokit/openapi-types/20.0.0:
+    resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
+    dev: false
+
+  /@octokit/openapi-types/22.1.0:
+    resolution: {integrity: sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q==}
+    dev: false
+
+  /@octokit/plugin-paginate-rest/9.2.1_@octokit+core@5.2.0:
+    resolution: {integrity: sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+    dependencies:
+      '@octokit/core': 5.2.0
+      '@octokit/types': 12.6.0
+    dev: false
+
+  /@octokit/plugin-request-log/4.0.1_@octokit+core@5.2.0:
+    resolution: {integrity: sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+    dependencies:
+      '@octokit/core': 5.2.0
+    dev: false
+
+  /@octokit/plugin-rest-endpoint-methods/10.4.1_@octokit+core@5.2.0:
+    resolution: {integrity: sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+    dependencies:
+      '@octokit/core': 5.2.0
+      '@octokit/types': 12.6.0
+    dev: false
+
+  /@octokit/request-error/5.1.0:
+    resolution: {integrity: sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/types': 13.4.1
+      deprecation: 2.3.1
+      once: 1.4.0
+    dev: false
+
+  /@octokit/request-error/6.1.1:
+    resolution: {integrity: sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/types': 13.4.1
+    dev: false
+
+  /@octokit/request/8.4.0:
+    resolution: {integrity: sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/endpoint': 9.0.5
+      '@octokit/request-error': 5.1.0
+      '@octokit/types': 13.4.1
+      universal-user-agent: 6.0.1
+    dev: false
+
+  /@octokit/rest/20.1.0:
+    resolution: {integrity: sha512-STVO3itHQLrp80lvcYB2UIKoeil5Ctsgd2s1AM+du3HqZIR35ZH7WE9HLwUOLXH0myA0y3AGNPo8gZtcgIbw0g==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/core': 5.2.0
+      '@octokit/plugin-paginate-rest': 9.2.1_@octokit+core@5.2.0
+      '@octokit/plugin-request-log': 4.0.1_@octokit+core@5.2.0
+      '@octokit/plugin-rest-endpoint-methods': 10.4.1_@octokit+core@5.2.0
+    dev: false
+
+  /@octokit/types/12.6.0:
+    resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
+    dependencies:
+      '@octokit/openapi-types': 20.0.0
+    dev: false
+
+  /@octokit/types/13.4.1:
+    resolution: {integrity: sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==}
+    dependencies:
+      '@octokit/openapi-types': 22.1.0
+    dev: false
 
   /@openfga/sdk/0.3.2:
     resolution: {integrity: sha512-vchULTcwSsCF/c43Yx6GkX2FvMXAyjww32ePzb8KTfOGE4i5L4+WrhosBCBV3HaURJWUQz42w3kPPbcPe7XDnw==}
@@ -4858,6 +4984,10 @@ packages:
     dependencies:
       safe-buffer: 5.1.2
 
+  /before-after-hook/2.2.3:
+    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+    dev: false
+
   /binary-extensions/2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
@@ -5377,6 +5507,10 @@ packages:
   /depd/2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  /deprecation/2.3.1:
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+    dev: false
 
   /dequal/2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -8527,7 +8661,6 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
-    dev: true
 
   /onetime/5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -10175,6 +10308,10 @@ packages:
       unist-util-visit-parents: 5.1.3
     dev: true
 
+  /universal-user-agent/6.0.1:
+    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
+    dev: false
+
   /universalify/2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -10483,7 +10620,6 @@ packages:
 
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-    dev: true
 
   /write-file-atomic/4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}


### PR DESCRIPTION
Shard for #5370 

Add a BFF route to search for a public repository via Github REST API.
The endpoint is intentionally using a `POST` request for future use, since this should/will be soon extended with more specialized tweaks.

The endpoint returns data in the HS convention of `SUCCESS | FAILURE` for easier integration with the editor.

This PR is a shard for the larger public repo cloning feature.

