### PR TITLE
BFF: list GH repo branches

### DIFF
--- a/utopia-remix/app/handlers/listRepoBranches.spec.ts
+++ b/utopia-remix/app/handlers/listRepoBranches.spec.ts
@@ -1,0 +1,105 @@
+import { prisma } from '../db.server'
+import {
+  createTestGithubAuth,
+  createTestSession,
+  createTestUser,
+  newTestRequest,
+  truncateTables,
+} from '../test-util'
+import { handleListRepoBranches } from './listRepoBranches'
+import * as githubUtil from '../util/github'
+import { toApiFailure, toApiSuccess } from '../types'
+
+describe('handleListRepoBranches', () => {
+  let mockOctokit: jest.SpyInstance
+  afterEach(async () => {
+    await truncateTables([
+      prisma.persistentSession,
+      prisma.githubAuthentication,
+      prisma.userDetails,
+    ])
+    mockOctokit.mockRestore()
+  })
+
+  beforeEach(async () => {
+    await createTestUser(prisma, { id: 'bob' })
+    await createTestUser(prisma, { id: 'alice' })
+    await createTestSession(prisma, { userId: 'bob', key: 'bob-key' })
+    await createTestSession(prisma, { userId: 'alice', key: 'alice-key' })
+    await createTestGithubAuth(prisma, { userId: 'alice', token: 'the-token' })
+    mockOctokit = jest.spyOn(githubUtil, 'newOctokitClient')
+  })
+
+  const doRequest = async ({
+    owner,
+    repo,
+    auth,
+  }: {
+    owner?: string
+    repo?: string
+    auth?: string
+  }) => handleListRepoBranches(newTestRequest({ authCookie: auth }), { owner, repo })
+
+  it('requires a user', async () => {
+    await expect(doRequest({ owner: 'foo', repo: 'bar' })).rejects.toThrow('missing session cookie')
+  })
+  it('requires a valid owner', async () => {
+    await expect(doRequest({ repo: 'bar', auth: 'bob-key' })).rejects.toThrow('missing owner')
+  })
+  it('requires a valid repo', async () => {
+    await expect(doRequest({ owner: 'foo', auth: 'bob-key' })).rejects.toThrow('missing repo')
+  })
+  it('requires a gh auth token', async () => {
+    await expect(doRequest({ owner: 'foo', repo: 'bar', auth: 'bob-key' })).rejects.toThrow(
+      'missing auth',
+    )
+  })
+  describe('when the gh call fails', () => {
+    it('(generic error) returns the data as a failure', async () => {
+      mockOctokit.mockReturnValue({
+        request: () => {
+          throw new Error('boom')
+        },
+      })
+
+      const got = await doRequest({ owner: 'foo', repo: 'bar', auth: 'alice-key' })
+      if (!(got instanceof Response)) {
+        throw new Error('should be a response')
+      }
+      const body = await got.json()
+      expect(body).toEqual(toApiFailure('Error: boom'))
+    })
+    it('(non 2xx status) returns the data as a failure', async () => {
+      mockOctokit.mockReturnValue({
+        request: () => {
+          return { status: 418 }
+        },
+      })
+
+      const got = await doRequest({ owner: 'foo', repo: 'bar', auth: 'alice-key' })
+      if (!(got instanceof Response)) {
+        throw new Error('should be a response')
+      }
+      const body = await got.json()
+      expect(body).toEqual(toApiFailure('Error: branches not found (418)'))
+    })
+  })
+  describe('when the gh call succeeds', () => {
+    it('returns the data as a success', async () => {
+      mockOctokit.mockReturnValue({
+        request: () => {
+          return {
+            status: 200,
+            data: [{ name: 'branch-1' }, { name: 'branch-2' }],
+          }
+        },
+      })
+      const got = await doRequest({ owner: 'foo', repo: 'bar', auth: 'alice-key' })
+      expect(got).toEqual(
+        toApiSuccess({
+          branches: [{ name: 'branch-1' }, { name: 'branch-2' }],
+        }),
+      )
+    })
+  })
+})

--- a/utopia-remix/app/handlers/listRepoBranches.ts
+++ b/utopia-remix/app/handlers/listRepoBranches.ts
@@ -1,0 +1,34 @@
+import { type Params } from '@remix-run/react'
+import { getGithubAuthentication } from '../models/githubAuthentication.server'
+import { ensure, requireUser } from '../util/api.server'
+import { ApiError } from '../util/errors'
+import { newOctokitClient, wrapGithubAPIRequest } from '../util/github'
+import { Status } from '../util/statusCodes'
+
+export async function handleListRepoBranches(req: Request, params: Params<string>) {
+  const user = await requireUser(req)
+
+  const { owner, repo } = params
+  ensure(owner != null, 'missing owner', Status.BAD_REQUEST)
+  ensure(repo != null, 'missing repo', Status.BAD_REQUEST)
+
+  const githubAuth = await getGithubAuthentication({ userId: user.user_id })
+  ensure(githubAuth != null, 'missing auth', Status.FORBIDDEN)
+
+  const octokit = newOctokitClient(githubAuth.access_token)
+
+  return wrapGithubAPIRequest(octokit, async (client) => {
+    const branches = await client.request('GET /repos/{owner}/{repo}/branches', {
+      owner: owner,
+      repo: repo,
+    })
+
+    if (branches.status < 200 || branches.status > 299) {
+      throw new ApiError(`branches not found (${branches.status})`, branches.status)
+    }
+
+    return {
+      branches: branches.data.map((branch) => ({ name: branch.name })),
+    }
+  })
+}

--- a/utopia-remix/app/routes/internal.github.branches.$owner.$repo.tsx
+++ b/utopia-remix/app/routes/internal.github.branches.$owner.$repo.tsx
@@ -1,0 +1,14 @@
+import type { LoaderFunctionArgs } from '@remix-run/node'
+import { handle, handleOptions } from '../util/api.server'
+import { ALLOW } from '../handlers/validators'
+import { handleListRepoBranches } from '../handlers/listRepoBranches'
+
+export async function loader(args: LoaderFunctionArgs) {
+  return handle(args, {
+    OPTIONS: handleOptions,
+    GET: {
+      validator: ALLOW,
+      handler: handleListRepoBranches,
+    },
+  })
+}


### PR DESCRIPTION
Shard for #5370

This PR builds on top of https://github.com/concrete-utopia/utopia/pull/5377 and adds a route to list the branches for a given Github repository, and return them as a list of strings.

This is meant to replace the v1 branch listing endpoint, but the swap will be done incrementally for the public clone feature later on.