### PR TITLE
Disable Insert Menu Sidebar

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../uuiui'
 import { ConsoleAndErrorsPane } from '../code-editor/console-and-errors-pane'
 import { CanvasStrategyInspector } from './canvas-strategies/canvas-strategy-inspector'
-import { getQueryParam } from '../../common/env-vars'
+import { IS_TEST_ENVIRONMENT, getQueryParam } from '../../common/env-vars'
 import { when } from '../../utils/react-conditionals'
 import { InsertMenuPane } from '../navigator/insert-menu-pane'
 import { VariablesMenuPane } from '../navigator/variables-menu-pane'
@@ -199,11 +199,14 @@ export const RightPane = React.memo<ResizableRightPaneProps>((props) => {
         {when(
           allowedToEdit,
           <>
-            <MenuTab
-              label={'Insert'}
-              selected={selectedTab === RightMenuTab.Insert}
-              onClick={onClickInsertTab}
-            />
+            {when(
+              IS_TEST_ENVIRONMENT,
+              <MenuTab
+                label={'Insert'}
+                selected={selectedTab === RightMenuTab.Insert}
+                onClick={onClickInsertTab}
+              />,
+            )}
             <MenuTab
               label={'Variables'}
               selected={selectedTab === RightMenuTab.Variables}

--- a/editor/src/components/navigator/insert-menu-pane.tsx
+++ b/editor/src/components/navigator/insert-menu-pane.tsx
@@ -12,6 +12,8 @@ import type { DerivedState, EditorState } from '../editor/store/editor-state'
 import { RightMenuTab } from '../editor/store/editor-state'
 import { Substores, useEditorState } from '../editor/store/store-hook'
 import { setRightMenuTab } from '../editor/actions/action-creators'
+import { unless, when } from '../../utils/react-conditionals'
+import { IS_TEST_ENVIRONMENT } from '../../common/env-vars'
 
 export interface LeftPaneProps {
   editorState: EditorState
@@ -53,7 +55,7 @@ export const InsertMenuPane = React.memo(() => {
       style={{ width: '100%', height: '100%' }}
     >
       <SectionBodyArea minimised={false} style={{ height: '100%' }}>
-        <InsertMenu />
+        {when(IS_TEST_ENVIRONMENT, <InsertMenu />)}
       </SectionBodyArea>
     </Section>
   )


### PR DESCRIPTION
**Problem:**
The insert menu sidebar crashes the editor if it gets too many insert options.

**Fix:**
Since we don't actually want that menu to exist anymore, I'm not fixing it now.

But because tests rely on it, I only disable it if IS_TEST_ENVIRONMENT is false