### PR TITLE
Remove double mouse up event handler

### DIFF
--- a/editor/src/components/editor/editor-component-common.tsx
+++ b/editor/src/components/editor/editor-component-common.tsx
@@ -77,7 +77,7 @@ function recreateEventHandlers(dispatch: EditorDispatch): void {
 
 export interface EditorCommonProps {
   mouseDown: MouseHandlerActions
-  mouseUp: MouseHandlerActions
+  mouseUp?: MouseHandlerActions
   keyDown?: KeyboardHandlerActions
   keyUp?: KeyboardHandlerActions
 }
@@ -88,7 +88,9 @@ export function EditorCommon(props: EditorCommonProps): React.ReactElement | nul
   const dispatch = useDispatch()
   React.useEffect(() => {
     mouseDownHandlers = [...mouseDownHandlers, props.mouseDown]
-    mouseUpHandlers = [...mouseUpHandlers, props.mouseUp]
+    if (props.mouseUp != null) {
+      mouseUpHandlers = [...mouseUpHandlers, props.mouseUp]
+    }
     if (props.keyDown != null) {
       keyDownHandlers = [...keyDownHandlers, props.keyDown]
     }

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -1073,7 +1073,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
       React.createElement(CanvasComponentEntry, {}),
       canvasControls,
       React.createElement(CursorComponent, {}),
-      <EditorCommon mouseDown={this.handleMouseDown} mouseUp={this.handleMouseUp} />,
+      <EditorCommon mouseDown={this.handleMouseDown} />,
     )
   }
 


### PR DESCRIPTION
**Problem:**
Recently we added a window-scoped `mouseup` event handler to handle clicks outside of the canvas (#5183).
Since we already had a `mouseup` handler on the canvas, this caused double-triggerring of mouseup events.

**Fix:**
Remove the "old" mouseup event handler on the canvas.

Fixes #5397 
