### PR TITLE
Rename Map to List in labels

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.spec.browser2.tsx
@@ -345,7 +345,7 @@ describe('Navigator item row icons', () => {
     await checkNavigatorLabel(visibleNavigatorTargets[11], null)
     await checkNavigatorLabel(visibleNavigatorTargets[12], 'CODE')
     await checkNavigatorLabel(visibleNavigatorTargets[13], 'div')
-    await checkNavigatorLabel(visibleNavigatorTargets[14], 'MAP')
+    await checkNavigatorLabel(visibleNavigatorTargets[14], 'LIST')
     await checkNavigatorLabel(visibleNavigatorTargets[15], 'div')
     await checkNavigatorLabel(visibleNavigatorTargets[16], 'Fragment')
     await checkNavigatorLabel(visibleNavigatorTargets[17], 'div')

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1609,7 +1609,7 @@ export const MetadataUtils = {
             case 'JSX_TEXT_BLOCK':
               return '(text)'
             case 'JSX_MAP_EXPRESSION':
-              return 'Map'
+              return 'List'
             case 'ATTRIBUTE_OTHER_JAVASCRIPT':
               return 'Code'
             case 'JSX_FRAGMENT':


### PR DESCRIPTION
## Description
Rename `Map` to `List` in the navigator, since for non-technical people List is a more accurate term for what the Map construct does


### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

https://github.com/concrete-utopia/utopia/issues/5392
