### PR TITLE
Fix empty uids after insertion

### DIFF
--- a/editor/src/core/property-controls/property-controls-local-parser-bridge.ts
+++ b/editor/src/core/property-controls/property-controls-local-parser-bridge.ts
@@ -69,7 +69,7 @@ async function getParseResultForUserStrings(
           topLevelElement.definedWithin.includes('Utopia$$$Component'),
       )
       if (parsedWrapperComponent != null) {
-        const elementToInsert = clearJSXElementChildUniqueIDs(parsedWrapperComponent.rootElement)
+        const elementToInsert = parsedWrapperComponent.rootElement
 
         if (elementToInsert.type === 'JSX_ELEMENT') {
           return right({

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -318,12 +318,7 @@ export function fixUtopiaElement(
 
     const uid = element.uid
     const uidProp = getJSXAttribute(fixedProps, 'data-uid')
-    if (
-      uidProp == null ||
-      uid === '' ||
-      !isJSXAttributeValue(uidProp) ||
-      uniqueIDsMutable.has(uid)
-    ) {
+    if (uidProp == null || !isJSXAttributeValue(uidProp) || uniqueIDsMutable.has(uid)) {
       const newUID = generateConsistentUID(uid, uniqueIDsMutable)
       mappings.push({ originalUID: uid, newUID: newUID })
       uniqueIDsMutable.add(newUID)
@@ -361,10 +356,9 @@ export function fixUtopiaElement(
   }
 
   function addAndMaybeUpdateUID(currentUID: string): string {
-    const fixedUID =
-      uniqueIDsMutable.has(currentUID) || currentUID === ''
-        ? generateConsistentUID(currentUID, uniqueIDsMutable)
-        : currentUID
+    const fixedUID = uniqueIDsMutable.has(currentUID)
+      ? generateConsistentUID(currentUID, uniqueIDsMutable)
+      : currentUID
     if (fixedUID !== currentUID) {
       mappings.push({ originalUID: currentUID, newUID: fixedUID })
     }

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -361,9 +361,10 @@ export function fixUtopiaElement(
   }
 
   function addAndMaybeUpdateUID(currentUID: string): string {
-    const fixedUID = uniqueIDsMutable.has(currentUID)
-      ? generateConsistentUID(currentUID, uniqueIDsMutable)
-      : currentUID
+    const fixedUID =
+      uniqueIDsMutable.has(currentUID) || currentUID === ''
+        ? generateConsistentUID(currentUID, uniqueIDsMutable)
+        : currentUID
     if (fixedUID !== currentUID) {
       mappings.push({ originalUID: currentUID, newUID: fixedUID })
     }

--- a/editor/src/core/shared/uid-utils.ts
+++ b/editor/src/core/shared/uid-utils.ts
@@ -318,7 +318,12 @@ export function fixUtopiaElement(
 
     const uid = element.uid
     const uidProp = getJSXAttribute(fixedProps, 'data-uid')
-    if (uidProp == null || !isJSXAttributeValue(uidProp) || uniqueIDsMutable.has(uid)) {
+    if (
+      uidProp == null ||
+      uid === '' ||
+      !isJSXAttributeValue(uidProp) ||
+      uniqueIDsMutable.has(uid)
+    ) {
       const newUID = generateConsistentUID(uid, uniqueIDsMutable)
       mappings.push({ originalUID: uid, newUID: newUID })
       uniqueIDsMutable.add(newUID)


### PR DESCRIPTION
**Problem:**
If you insert a TrippyButton component using the insert menu (hydrogen-november project), and you wrap the "Buy me" text content of the component into a `span` in the code editor, you can not select that span later, and can not text edit its contents.

**Root cause:**
When you insert a component variant with text content in an element, the JSX_TEXT_BLOCK inside receives an empty string uid.
After that, even if you wrap that text into a span in the code editor, that span keeps the uid of the text content.

Why?
The code of the variant is parsed using `getParseResultForUserStrings`. This function uses `clearJSXElementChildUniqueIDs` to wipe all uids from the element and its descendants and replace them with an empty string.
I believe this problem was not visible until now because we only inserted flat components using the insert menu, and not whole snippets with embedded code.

**Fix:**
I believe clearing the uids is unnecessary. Even if define uid-s with data-uid in the code, and even if that would cause duplications, we fix that later down the line.
So I removed `clearJSXElementChildUniqueIDs` from `getParseResultForUserStrings`

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5372
