### PR TITLE
Conditional insertion by the component picker

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -1,16 +1,18 @@
 import React from 'react'
 import { useContextMenu, Menu, type ContextMenuParams, contextMenu } from 'react-contexify'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import type { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
+import type { ElementInstanceMetadataMap, JSXElement } from '../../../core/shared/element-template'
 import {
   getJSXElementNameAsString,
   jsxAttributesFromMap,
   jsxElement,
+  jsxElementFromJSXElementWithoutUID,
 } from '../../../core/shared/element-template'
 import type { ElementPath, Imports } from '../../../core/shared/project-file-types'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { Substores, useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 import {
+  insertInsertable,
   insertJSXElement,
   replaceMappedElement,
   setProp_UNSAFE,
@@ -26,7 +28,7 @@ import { MomentumContextMenu } from '../../context-menu-wrapper'
 import { NO_OP, assertNever } from '../../../core/shared/utils'
 import { type ContextMenuItem } from '../../context-menu-items'
 import { FlexRow, Icn, type IcnProps } from '../../../uuiui'
-import { type EditorDispatch } from '../../editor/action-types'
+import type { EditorAction, EditorDispatch } from '../../editor/action-types'
 import { type ProjectContentTreeRoot } from '../../assets'
 import { type PropertyControlsInfo, type ComponentInfo } from '../../custom-code/code-file'
 import { type Icon } from 'utopia-api'
@@ -34,6 +36,8 @@ import { getRegisteredComponent } from '../../../core/property-controls/property
 import { defaultImportsForComponentModule } from '../../../core/property-controls/property-controls-local'
 import { useGetInsertableComponents } from '../../canvas/ui/floating-insert-menu'
 import { atom, useAtom, useSetAtom } from 'jotai'
+import { childInsertionPath } from '../../editor/store/insertion-path'
+import type { InsertableComponent } from '../../shared/project-components'
 
 export type InsertionTarget = { prop: string } | 'replace-target' | 'insert-as-child'
 interface ComponentPickerContextMenuAtomData {
@@ -251,6 +255,61 @@ function moreItem(
   }
 }
 
+function insertComponentPickerItem(
+  toInsert: InsertableComponent,
+  target: ElementPath,
+  projectContents: ProjectContentTreeRoot,
+  metadata: ElementInstanceMetadataMap,
+  dispatch: EditorDispatch,
+  insertionTarget: InsertionTarget,
+) {
+  const uniqueIds = new Set(getAllUniqueUids(projectContents).uniqueIDs)
+  const uid = generateConsistentUID('prop', uniqueIds)
+  const elementWithoutUID = toInsert.element()
+
+  const actions = ((): Array<EditorAction> => {
+    if (elementWithoutUID.type === 'JSX_ELEMENT') {
+      const element = jsxElementFromJSXElementWithoutUID(elementWithoutUID, uid)
+      const fixedElement = fixUtopiaElement(element, uniqueIds).value
+
+      if (fixedElement.type !== 'JSX_ELEMENT') {
+        throw new Error('JSXElementWithoutUid is not converted to JSXElement')
+      }
+
+      // if we are inserting into a render prop
+      if (insertionTarget !== 'replace-target' && insertionTarget !== 'insert-as-child') {
+        return [
+          setProp_UNSAFE(
+            target,
+            PP.create(insertionTarget.prop),
+            fixedElement,
+            toInsert.importsToAdd ?? undefined,
+          ),
+        ]
+      }
+
+      // if we are inserting into a map expression then we replace the mapped element
+      if (MetadataUtils.isJSXMapExpression(EP.parentPath(target), metadata)) {
+        return [replaceMappedElement(element, target, toInsert.importsToAdd)]
+      }
+
+      return [
+        insertJSXElement(element, target, toInsert.importsToAdd ?? undefined, insertionTarget),
+      ]
+    }
+
+    // TODO: for non-jsx-elements we only support insertion as a child today, this should be extended
+    if (insertionTarget === 'insert-as-child') {
+      return [insertInsertable(childInsertionPath(target), toInsert, 'do-not-add', null)]
+    }
+
+    console.warn(`Component picker error: can not insert "${toInsert.name}" as ${insertionTarget}`)
+    return []
+  })()
+
+  dispatch(actions)
+}
+
 function insertPreferredChild(
   preferredChildToInsert: ElementToInsert,
   target: ElementPath,
@@ -413,11 +472,11 @@ const ComponentPickerContextMenuFull = React.memo<ComponentPickerContextMenuProp
     const metadataRef = useRefEditorState((state) => state.editor.jsxMetadata)
 
     const onItemClick = React.useCallback(
-      (preferredChildToInsert: ElementToInsert) => (e: React.MouseEvent) => {
+      (preferredChildToInsert: InsertableComponent) => (e: React.MouseEvent) => {
         e.stopPropagation()
         e.preventDefault()
 
-        insertPreferredChild(
+        insertComponentPickerItem(
           preferredChildToInsert,
           target,
           projectContentsRef.current,

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -290,11 +290,11 @@ function insertComponentPickerItem(
 
       // if we are inserting into a map expression then we replace the mapped element
       if (MetadataUtils.isJSXMapExpression(EP.parentPath(target), metadata)) {
-        return [replaceMappedElement(element, target, toInsert.importsToAdd)]
+        return [replaceMappedElement(fixedElement, target, toInsert.importsToAdd)]
       }
 
       return [
-        insertJSXElement(element, target, toInsert.importsToAdd ?? undefined, insertionTarget),
+        insertJSXElement(fixedElement, target, toInsert.importsToAdd ?? undefined, insertionTarget),
       ]
     }
 

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -6,16 +6,16 @@ import { Icn, type IcnProps } from '../../../uuiui'
 import { dark } from '../../../uuiui/styles/theme/dark'
 import type { JSXElementChild } from '../../../core/shared/element-template'
 import { type Imports } from '../../../core/shared/project-file-types'
-import { elementFromInsertMenuItem } from '../../editor/insert-callbacks'
 import { type ComponentElementToInsert } from '../../custom-code/code-file'
 import type { InsertMenuItemGroup } from '../../canvas/ui/floating-insert-menu'
 import { UIGridRow } from '../../../components/inspector/widgets/ui-grid-row'
 import { FlexRow, type Icon } from 'utopia-api'
 import { assertNever } from '../../../core/shared/utils'
+import type { InsertableComponent } from '../../shared/project-components'
 
 export interface ComponentPickerProps {
   allComponents: Array<InsertMenuItemGroup>
-  onItemClick: (elementToInsert: ElementToInsert) => React.MouseEventHandler
+  onItemClick: (elementToInsert: InsertableComponent) => React.MouseEventHandler
 }
 
 export interface ElementToInsert {
@@ -159,7 +159,7 @@ const FilterBar = React.memo((props: FilterBarProps) => {
 
 interface ComponentPickerComponentSectionProps {
   components: Array<InsertMenuItemGroup>
-  onItemClick: (elementToInsert: ElementToInsert) => React.MouseEventHandler
+  onItemClick: (elementToInsert: InsertableComponent) => React.MouseEventHandler
 }
 
 const ComponentPickerComponentSection = React.memo(
@@ -207,47 +207,15 @@ function iconPropsForIcon(icon: Icon): IcnProps {
   }
 }
 
-interface ComponentInfoWithIcon {
-  insertMenuLabel: string
-  elementToInsert: () => ComponentElementToInsert
-  importsToAdd: Imports
-  icon: Icon
-}
-
-function componentInfoWithIcon(
-  insertMenuLabel: string,
-  elementToInsert: () => ComponentElementToInsert,
-  importsToAdd: Imports,
-  icon: Icon,
-): ComponentInfoWithIcon {
-  return {
-    insertMenuLabel: insertMenuLabel,
-    elementToInsert: elementToInsert,
-    importsToAdd: importsToAdd,
-    icon: icon,
-  }
-}
-
 interface ComponentPickerOptionProps {
   component: InsertMenuItemGroup
-  onItemClick: (elementToInsert: ElementToInsert) => React.MouseEventHandler
-}
-
-function variantsForComponent(component: InsertMenuItemGroup): ComponentInfoWithIcon[] {
-  return component.options.map((v) =>
-    componentInfoWithIcon(
-      v.label,
-      v.value.element,
-      v.value.importsToAdd,
-      v.value.icon ?? 'regular',
-    ),
-  )
+  onItemClick: (elementToInsert: InsertableComponent) => React.MouseEventHandler
 }
 
 const ComponentPickerOption = React.memo((props: ComponentPickerOptionProps) => {
   const { component, onItemClick } = props
 
-  const variants = variantsForComponent(component)
+  const variants = component.options
 
   const name = component.label
 
@@ -255,7 +223,7 @@ const ComponentPickerOption = React.memo((props: ComponentPickerOptionProps) => 
     <div>
       {variants.map((v) => (
         <FlexRow
-          key={`${name}-${v.insertMenuLabel}`}
+          key={`${name}-${v.label}`}
           css={{
             marginLeft: 8,
             marginRight: 8,
@@ -268,10 +236,7 @@ const ComponentPickerOption = React.memo((props: ComponentPickerOptionProps) => 
               color: 'white',
             },
           }}
-          onClick={onItemClick({
-            elementToInsert: (uid) => elementFromInsertMenuItem(v.elementToInsert(), uid),
-            additionalImports: v.importsToAdd,
-          })}
+          onClick={onItemClick(v.value)}
         >
           <UIGridRow
             variant='|--32px--|<--------auto-------->'
@@ -282,8 +247,8 @@ const ComponentPickerOption = React.memo((props: ComponentPickerOptionProps) => 
               height: 27,
             }}
           >
-            <Icn {...iconPropsForIcon(v.icon)} width={12} height={12} />
-            <label>{v.insertMenuLabel}</label>
+            <Icn {...iconPropsForIcon(v.value.icon ?? 'regular')} width={12} height={12} />
+            <label>{v.label}</label>
           </UIGridRow>
         </FlexRow>
       ))}


### PR DESCRIPTION
**Problem:**
It is not possible to insert non-jsxelements (e.g. conditionals) with the component picker (even though they are listed in the menu)

**Fix:**
This is a partial fix, still not every case is supported, but I extended the valid cases:

1. Setting render props still only works with jsx elements
2. Replacing elements still only works with jsx elements
3. Adding a new child works with all kinds of JSXElementChild

**TODO:**

We should either extend 1 and 2 to all JSXElementChild, or filter them out of the menu when they are not applicable.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5414
