### PR TITLE
Filter out non-supported elements from the component picker

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -463,7 +463,13 @@ const ComponentPickerContextMenuFull = React.memo<ComponentPickerContextMenuProp
   ({ target, insertionTarget }) => {
     const allInsertableComponents = useGetInsertableComponents('insert').flatMap((g) => ({
       label: g.label,
-      options: g.options,
+      options: g.options.filter((o) => {
+        if (insertionTarget === 'insert-as-child') {
+          return true
+        }
+        // Right now we only support inserting JSX elements when we insert into a render prop or when replacing elements
+        return o.value.element().type === 'JSX_ELEMENT'
+      }),
     }))
 
     const dispatch = useDispatch()


### PR DESCRIPTION
**Problem:**
As mentioned in the description of https://github.com/concrete-utopia/utopia/pull/5417 , the component picker does not support non-jsx-elements when inserting into a render prop, or when replacing an element.
However, these elements still appear in the component picker, and they just log an error when you try to insert them.
The real solution is to make everything insertable by the component picker, but until then it makes sense to filter those elements out from the menu which are not insertable.

**Fix:**
When the insertion target is not insert-as-child, we should only allow JSXElements.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

