### PR TITLE
Remove render props navigator FS

### DIFF
--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -188,7 +188,7 @@ export function getNavigatorTargets(
         projectContents,
       )
 
-      if (isFeatureEnabled('Render Props in Navigator') && propertyControls != null) {
+      if (propertyControls != null) {
         walkPropertyControls(propertyControls)
       }
 

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -14,7 +14,6 @@ export type FeatureName =
   | 'Project Thumbnail Generation'
   | 'Debug - Print UIDs'
   | 'Debug – Connections'
-  | 'Render Props in Navigator'
 
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
@@ -29,7 +28,6 @@ export const AllFeatureNames: FeatureName[] = [
   'Project Thumbnail Generation',
   'Debug - Print UIDs',
   'Debug – Connections',
-  'Render Props in Navigator',
 ]
 
 let FeatureSwitches: { [feature in FeatureName]: boolean } = {
@@ -44,7 +42,6 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Project Thumbnail Generation': false,
   'Debug - Print UIDs': false,
   'Debug – Connections': false,
-  'Render Props in Navigator': true,
 }
 
 export const STEGANOGRAPHY_ENABLED = false


### PR DESCRIPTION
**Problem:**
`Render props in navigator` feature switch is not necessary anymore.

**Fix:**
Remove it.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

