### PR TITLE
Non-jsx element insertion from the context menu for preferredContents

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -334,7 +334,14 @@ function insertPreferredChild(
 ) {
   const uniqueIds = new Set(getAllUniqueUids(projectContents).uniqueIDs)
   const uid = generateConsistentUID('prop', uniqueIds)
-  const toInsert = elementToInsertToInsertableComponent(preferredChildToInsert, uid, ['do-not-add'])
+  const toInsert = elementToInsertToInsertableComponent(
+    preferredChildToInsert,
+    uid,
+    ['do-not-add'],
+    null,
+    null,
+    null,
+  )
 
   insertComponentPickerItem(toInsert, target, projectContents, metadata, dispatch, insertionTarget)
 }

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -11,7 +11,8 @@ import type { InsertMenuItemGroup } from '../../canvas/ui/floating-insert-menu'
 import { UIGridRow } from '../../../components/inspector/widgets/ui-grid-row'
 import { FlexRow, type Icon } from 'utopia-api'
 import { assertNever } from '../../../core/shared/utils'
-import type { InsertableComponent } from '../../shared/project-components'
+import { insertableComponent } from '../../shared/project-components'
+import type { StylePropOption, InsertableComponent } from '../../shared/project-components'
 
 export interface ComponentPickerProps {
   allComponents: Array<InsertMenuItemGroup>
@@ -19,8 +20,26 @@ export interface ComponentPickerProps {
 }
 
 export interface ElementToInsert {
+  name: string
   elementToInsert: (uid: string) => JSXElementChild
   additionalImports: Imports
+}
+
+export function elementToInsertToInsertableComponent(
+  elementToInsert: ElementToInsert,
+  uid: string,
+  stylePropOptions: Array<StylePropOption>,
+): InsertableComponent {
+  const element = elementToInsert.elementToInsert(uid)
+  return insertableComponent(
+    elementToInsert.additionalImports,
+    () => element as ComponentElementToInsert,
+    elementToInsert.name,
+    stylePropOptions,
+    null,
+    null,
+    null,
+  )
 }
 
 export function componentPickerTestIdForProp(prop: string): string {

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { Icn, type IcnProps } from '../../../uuiui'
 import { dark } from '../../../uuiui/styles/theme/dark'
 import type { JSXElementChild } from '../../../core/shared/element-template'
-import { type Imports } from '../../../core/shared/project-file-types'
+import type { ElementPath, Imports } from '../../../core/shared/project-file-types'
 import { type ComponentElementToInsert } from '../../custom-code/code-file'
 import type { InsertMenuItemGroup } from '../../canvas/ui/floating-insert-menu'
 import { UIGridRow } from '../../../components/inspector/widgets/ui-grid-row'
@@ -13,6 +13,7 @@ import { FlexRow, type Icon } from 'utopia-api'
 import { assertNever } from '../../../core/shared/utils'
 import { insertableComponent } from '../../shared/project-components'
 import type { StylePropOption, InsertableComponent } from '../../shared/project-components'
+import type { Size } from '../../../core/shared/math-utils'
 
 export interface ComponentPickerProps {
   allComponents: Array<InsertMenuItemGroup>
@@ -29,6 +30,9 @@ export function elementToInsertToInsertableComponent(
   elementToInsert: ElementToInsert,
   uid: string,
   stylePropOptions: Array<StylePropOption>,
+  defaultSize: Size | null,
+  insertionCeiling: ElementPath | null,
+  icon: Icon | null,
 ): InsertableComponent {
   const element = elementToInsert.elementToInsert(uid)
   return insertableComponent(
@@ -36,9 +40,9 @@ export function elementToInsertToInsertableComponent(
     () => element as ComponentElementToInsert,
     elementToInsert.name,
     stylePropOptions,
-    null,
-    null,
-    null,
+    defaultSize,
+    insertionCeiling,
+    icon,
   )
 }
 

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -1476,6 +1476,83 @@ describe('registered property controls', () => {
         }
       `)
     })
+    it('can use conditional for children', async () => {
+      const renderResult = await renderTestEditorWithModel(
+        project({
+          ['/utopia/components.utopia.js']: `import { Card } from '../src/card'
+          import { Card2 } from '../src/card2'
+          
+          const Components = {
+        '/src/card': {
+          Card: {
+            component: Card,
+            properties: { },
+            children: {
+              preferredContents: [
+                { component: 'span', variants: { name: 'span' } },
+                {
+                  component: 'Conditional',
+                  moduleName: '',
+                  variants: [
+                    {
+                      code: 'true ? <div /> : null',
+                      label: 'Conditional',
+                      imports: '',
+                    }
+                  ]
+                },
+              ]
+            }
+          },
+        },
+      }
+      
+      export default Components
+    `,
+        }),
+        'await-first-dom-report',
+      )
+      const editorState = renderResult.getEditorState().editor
+
+      const cardRegistration = editorState.propertyControlsInfo['/src/card']['Card']
+      expect(cardRegistration).not.toBeUndefined()
+
+      const propsToCheck = pick(['preferredChildComponents', 'supportsChildren'], cardRegistration)
+
+      expect(propsToCheck).toMatchInlineSnapshot(`
+        Object {
+          "preferredChildComponents": Array [
+            Object {
+              "moduleName": null,
+              "name": "span",
+              "variants": Array [
+                Object {
+                  "elementToInsert": [Function],
+                  "importsToAdd": Object {},
+                  "insertMenuLabel": "span",
+                },
+              ],
+            },
+            Object {
+              "moduleName": "",
+              "name": "Conditional",
+              "variants": Array [
+                Object {
+                  "elementToInsert": [Function],
+                  "importsToAdd": Object {},
+                  "insertMenuLabel": "Conditional",
+                },
+              ],
+            },
+          ],
+          "supportsChildren": true,
+        }
+      `)
+
+      expect(propsToCheck.preferredChildComponents[1].variants[0].elementToInsert().type).toEqual(
+        'JSX_CONDITIONAL_EXPRESSION',
+      )
+    })
   })
 
   describe('registering the jsx controls', () => {


### PR DESCRIPTION
**Problem:**
(https://github.com/concrete-utopia/utopia/pull/5417) introduced inserting non-jsxelements (e.g. conditionals) from the component picker.
However, non-jsxelements still can not be added from preferredContents using the context menu.

**Fix:**
First of all, non-jsxelements are not even valid according to the component descriptor parser, so I extended those to all `ComponentElementToInsert` (which is fragment, jsx elements, conditionals and maps)

I also unified the preferredContent and component picker insertion by converting ElementToInsert objects to ComponentElementToInsert ones.

**Manual Tests:**

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5424
