### PR TITLE
Max block width for repo listing in GH pane

### DIFF
--- a/editor/src/components/navigator/left-pane/github-pane/block.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/block.tsx
@@ -7,8 +7,6 @@ import { when } from '../../../../utils/react-conditionals'
 import { colorTheme, FlexColumn, FlexRow, UtopiaTheme } from '../../../../uuiui'
 import { UIGridRow } from '../../../inspector/widgets/ui-grid-row'
 
-export const MaxBlockWidth = 200
-
 export const IndicatorLight = React.memo((props: { status: BlockStatus }) => (
   <div
     style={{

--- a/editor/src/components/navigator/left-pane/github-pane/block.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/block.tsx
@@ -7,6 +7,8 @@ import { when } from '../../../../utils/react-conditionals'
 import { colorTheme, FlexColumn, FlexRow, UtopiaTheme } from '../../../../uuiui'
 import { UIGridRow } from '../../../inspector/widgets/ui-grid-row'
 
+export const MaxBlockWidth = 200
+
 export const IndicatorLight = React.memo((props: { status: BlockStatus }) => (
   <div
     style={{

--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -29,6 +29,7 @@ import { GithubSpinner } from './github-spinner'
 import { RefreshIcon } from './refresh-icon'
 import { GithubOperations } from '../../../../core/shared/github/operations'
 import type { EditorDispatch } from '../../../editor/action-types'
+import { MaxBlockWidth } from './block'
 
 interface RepositoryRowProps extends RepositoryEntry {
   importPermitted: boolean
@@ -134,11 +135,14 @@ const RepositoryRow = (props: RepositoryRowProps) => {
             color: colorTheme.fg0.value,
           },
         },
+        maxWidth: MaxBlockWidth,
       }}
       onClick={importRepository}
     >
       <div>
-        <Ellipsis style={{ maxWidth: 170 }}>{props.fullName}</Ellipsis>
+        <Ellipsis style={{ maxWidth: 120 }} title={props.fullName}>
+          {props.fullName}
+        </Ellipsis>
         <span style={{ fontSize: 10, opacity: 0.5 }}>
           {unless(
             props.searchable,

--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -29,7 +29,8 @@ import { GithubSpinner } from './github-spinner'
 import { RefreshIcon } from './refresh-icon'
 import { GithubOperations } from '../../../../core/shared/github/operations'
 import type { EditorDispatch } from '../../../editor/action-types'
-import { MaxBlockWidth } from './block'
+import { useGridPanelState } from '../../../canvas/grid-panels-state'
+import { GridMenuMinWidth } from '../../../canvas/stored-layout'
 
 interface RepositoryRowProps extends RepositoryEntry {
   importPermitted: boolean
@@ -115,6 +116,14 @@ const RepositoryRow = (props: RepositoryRowProps) => {
     [dispatch, githubUserDetails, props],
   )
 
+  const [panelState] = useGridPanelState()
+  const panelWidth = React.useMemo(() => {
+    return (
+      panelState.find((panel) => panel.panels.some(({ name }) => name === 'navigator'))
+        ?.menuWidth ?? GridMenuMinWidth
+    )
+  }, [panelState])
+
   return (
     <UIGridRow
       padded
@@ -135,12 +144,12 @@ const RepositoryRow = (props: RepositoryRowProps) => {
             color: colorTheme.fg0.value,
           },
         },
-        maxWidth: MaxBlockWidth,
+        maxWidth: panelWidth,
       }}
       onClick={importRepository}
     >
       <div>
-        <Ellipsis style={{ maxWidth: 120 }} title={props.fullName}>
+        <Ellipsis style={{ maxWidth: panelWidth - 150 }} title={props.fullName}>
           {props.fullName}
         </Ellipsis>
         <span style={{ fontSize: 10, opacity: 0.5 }}>


### PR DESCRIPTION
**Problem:**

The GH pane's repository block can grow horizontally beyond the intended bounds if the repository name's too long.

**Fix:**

Give a max width to the block based on the panel's width.

| Before | After |
|----------|-------------|
| https://github.com/concrete-utopia/utopia/assets/1081051/c23c2085-7631-4ec0-8c5e-fcc837be45f4 | https://github.com/concrete-utopia/utopia/assets/1081051/08e9e008-0c82-4e2e-b5e5-e5cfba804733 |

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5434 
