### PR TITLE
Add sample text to inserted 'text' variant child

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -804,7 +804,8 @@ async function parsePreferredChildren(
         variants: [
           {
             insertMenuLabel: 'text',
-            elementToInsert: () => jsxElement('span', '', jsxAttributesFromMap({}), []),
+            elementToInsert: () =>
+              jsxElement('span', '', jsxAttributesFromMap({}), [jsxTextBlock('Sample text')]),
             importsToAdd: {},
           },
         ],


### PR DESCRIPTION
**Problem:**
In the component annotation we can mark text preferred children as `preferredContents: 'text'`
But when you insert this variant we only insert an empty span (which is invisible on the canvas)

**Fix:**
Add sample content to the inserted span

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5433
