### PR TITLE
Paste handlers

### DIFF
--- a/editor/src/components/filebrowser/fileitem.tsx
+++ b/editor/src/components/filebrowser/fileitem.tsx
@@ -403,6 +403,7 @@ class FileBrowserItemInner extends React.PureComponent<
             <StringInput
               testId=''
               value={this.state.filename}
+              pasteHandler={true}
               onChange={this.onChangeFilename}
               onKeyDown={this.onKeyDownFilename}
               onFocus={this.onFocusFilename}

--- a/editor/src/components/inspector/controls/control.ts
+++ b/editor/src/components/inspector/controls/control.ts
@@ -59,4 +59,5 @@ export interface InspectorControlProps {
   className?: string
   controlStatus?: ControlStatus
   DEPRECATED_labelBelow?: React.ReactChild
+  pasteHandler?: boolean
 }

--- a/editor/src/components/navigator/left-pane/settings-pane.tsx
+++ b/editor/src/components/navigator/left-pane/settings-pane.tsx
@@ -260,6 +260,7 @@ export const SettingsPane = React.memo(() => {
               onChange={onChangeProjectName}
               onKeyDown={handleKeyPress}
               onBlur={handleBlurProjectName}
+              pasteHandler={true}
             />
           </UIGridRow>
           <UIGridRow padded variant='|--80px--|<--------1fr-------->'>
@@ -270,6 +271,7 @@ export const SettingsPane = React.memo(() => {
               onChange={onChangeProjectDescription}
               onKeyDown={handleKeyPress}
               onBlur={handleBlurProjectDescription}
+              pasteHandler={true}
             />
           </UIGridRow>
           <UIGridRow padded variant='|--80px--|<--------1fr-------->' style={{ marginBottom: 10 }}>

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -1317,7 +1317,7 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
     const selectedViews = editor.selectedViews
 
     if (isPasteHandler(event.target)) {
-      // components with data-pastehandler have precedence
+      // components with data-pastehandler='true' have precedence
       return
     }
 

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -105,6 +105,7 @@ import * as ResizeObserverSyntheticDefault from 'resize-observer-polyfill'
 import { isFeatureEnabled } from '../utils/feature-switches'
 import { getCanvasViewportCenter } from './paste-helpers'
 import { InsertMenuId } from '../components/editor/insertmenu'
+import { DataPasteHandler, isPasteHandler } from '../utils/paste-handler'
 const ResizeObserver = ResizeObserverSyntheticDefault.default ?? ResizeObserverSyntheticDefault
 
 const webFrame = PROBABLY_ELECTRON ? requireElectron().webFrame : null
@@ -1314,6 +1315,11 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
   handlePaste = (event: ClipboardEvent) => {
     const editor = this.props.editor
     const selectedViews = editor.selectedViews
+
+    if (isPasteHandler(event.target)) {
+      // components with data-pastehandler have precedence
+      return
+    }
 
     // Utopia handles all paste events for these panes first
     const paneFocusedWhereUtopiaHandlesPasteEvents =

--- a/editor/src/utils/paste-handler.ts
+++ b/editor/src/utils/paste-handler.ts
@@ -1,0 +1,13 @@
+export const DataPasteHandler = 'data-pastehandler'
+
+export function dataPasteHandler(value: boolean | undefined) {
+  return { [DataPasteHandler]: value }
+}
+
+export function isPasteHandler(target: EventTarget | null): boolean {
+  return (
+    target != null &&
+    target instanceof HTMLElement &&
+    target.getAttribute(DataPasteHandler) === 'true'
+  )
+}

--- a/editor/src/uuiui/inputs/base-input.tsx
+++ b/editor/src/uuiui/inputs/base-input.tsx
@@ -4,6 +4,7 @@ import { getChainSegmentEdge } from '../../utils/utils'
 import type { ControlStyles, ControlStatus } from '../../uuiui-deps'
 import { colorTheme, UtopiaTheme } from '../styles/theme'
 import React from 'react'
+import { dataPasteHandler } from '../../utils/paste-handler'
 
 export type ChainedType = 'not-chained' | 'first' | 'last' | 'middle'
 
@@ -116,6 +117,7 @@ interface InspectorInputProps extends React.InputHTMLAttributes<HTMLInputElement
   roundCorners?: BoxCorners
   mixed?: boolean
   value?: string | readonly string[] | number
+  pasteHandler?: boolean
 }
 
 type InspectorInputEmotionStyleProps = {
@@ -163,6 +165,7 @@ export const InspectorInput = React.memo(
         data-inspector-input={true}
         data-testid={props.testId}
         data-controlstatus={props.controlStatus}
+        {...dataPasteHandler(props.pasteHandler)}
       />
     )
   }),

--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -136,6 +136,7 @@ export interface NumberInputOptions {
   roundCorners?: BoxCorners
   numberType: CSSNumberType
   defaultUnitToHide: CSSNumberUnit | null
+  pasteHandler?: boolean
 }
 
 export interface AbstractNumberInputProps<T extends CSSNumber | number>
@@ -186,6 +187,7 @@ export const NumberInput = React.memo<NumberInputProps>(
     onMouseEnter,
     onMouseLeave,
     invalid,
+    pasteHandler,
   }) => {
     const ref = React.useRef<HTMLInputElement>(null)
     const colorTheme = useColorTheme()
@@ -834,6 +836,7 @@ export const NumberInput = React.memo<NumberInputProps>(
             controlStyles={controlStyles}
             controlStatus={controlStatus}
             testId={testId}
+            pasteHandler={pasteHandler}
             disabled={disabled}
             focused={isFocused}
             hasLabel={labelInner != null}

--- a/editor/src/uuiui/inputs/string-input.tsx
+++ b/editor/src/uuiui/inputs/string-input.tsx
@@ -11,6 +11,7 @@ import { preventDefault, stopPropagation } from '../../components/inspector/comm
 import { useColorTheme } from '../styles/theme'
 import { InspectorInputEmotionStyle, getControlStylesAwarePlaceholder } from './base-input'
 import { useControlsDisabledInSubtree } from '../utilities/disable-subtree'
+import { dataPasteHandler } from '../../utils/paste-handler'
 
 interface StringInputOptions {
   focusOnMount?: boolean
@@ -30,6 +31,7 @@ export interface StringInputProps
   includeBoxShadow?: boolean
   onSubmitValue?: (value: string) => void
   onEscape?: () => void
+  pasteHandler?: boolean
 }
 
 export const StringInput = React.memo(
@@ -159,6 +161,7 @@ export type HeadlessStringInputProps = React.InputHTMLAttributes<HTMLInputElemen
   onEscape?: () => void
   growInputAutomatically?: boolean
   testId: string
+  pasteHandler?: boolean
 }
 
 export const HeadlessStringInput = React.forwardRef<HTMLInputElement, HeadlessStringInputProps>(
@@ -171,6 +174,7 @@ export const HeadlessStringInput = React.forwardRef<HTMLInputElement, HeadlessSt
       style = {},
       value,
       testId,
+      pasteHandler,
       ...otherProps
     } = props
     const { disabled, onKeyDown, onFocus } = otherProps
@@ -222,6 +226,7 @@ export const HeadlessStringInput = React.forwardRef<HTMLInputElement, HeadlessSt
       <input
         ref={composeRefs(ref, propsRef)}
         data-testid={testId}
+        {...dataPasteHandler(props.pasteHandler)}
         {...otherProps}
         disabled={disabled}
         onKeyDown={handleOnKeyDown}


### PR DESCRIPTION
**Problem:**

The editor intercepts all paste events. We want to be able to make individual inputs capable of handling paste events themselves without having to use a dedicated panel for it.

**Fix:**

With this PR we can now mark any component capable of receiving events as a "paste handler" via `data-pastehandler="true"`.
If such a component is targeted by a paste event, the catchall handler in `editor-canvas` will bail and the event lifecycle will continue so it's handled by the target itself.

For convenience I added an explicit `pasteHandler` optional prop to our inputs (strings, numbers, etc), but it's not doing anything special besides adding `data-pastehandler={value?}` (so we can benefit from this on non-utopia components too!).

I only enabled this flag on file explorer items and project settings (description/name), we should add them to the new insert menu and the Remix url bar - but I wanted to have a separate PR to highlight the functionality more clearly.

Demo:

![Kapture 2024-04-30 at 18 20 09](https://github.com/concrete-utopia/utopia/assets/1081051/9f717174-9ae6-430a-b500-7af6a87f108d)


**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5413 
