### PR TITLE
Fix overscroll of left pane

### DIFF
--- a/editor/src/components/navigator/left-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/index.tsx
@@ -105,7 +105,7 @@ export const LeftPaneComponent = React.memo<LeftPaneComponentProps>((props) => {
             color: colorTheme.fg1.value,
             display: 'flex',
             flexDirection: 'column',
-            overflowY: 'scroll',
+            overflowY: 'hidden',
           }}
         >
           {when(

--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -283,6 +283,7 @@ export const NavigatorComponent = React.memo(() => {
           '--paneHoverOpacity': 1,
         },
         padding: 5,
+        height: 0,
       }}
       onClick={containerClick}
     >


### PR DESCRIPTION
**Problem:**
When overscrolling the navigator pane, sometimes it scrolls the entire left pane and hides the top tabs
<video src="https://github.com/concrete-utopia/utopia/assets/7003853/f1432b11-8cd0-4600-8cd1-ba65e17a00f4" />

**Fix:**
Changing the overflow of the left pane to "hidden" to prevent scrolling over the top tabs, and giving the pane a concrete initial height
<video src="https://github.com/concrete-utopia/utopia/assets/7003853/ce0e7c7c-4e3a-4b60-8be5-0bdced040129" />

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5416 
