### PR TITLE
Replace button in conditional branches

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -536,7 +536,10 @@ const ComponentPickerContextMenuFull = React.memo<ComponentPickerContextMenuProp
     const allInsertableComponents = useGetInsertableComponents('insert').flatMap((g) => ({
       label: g.label,
       options: g.options.filter((o) => {
-        if (insertionTarget === 'insert-as-child') {
+        if (
+          insertionTarget === 'insert-as-child' ||
+          isConditionalCaseInsertionTarget(insertionTarget)
+        ) {
           return true
         }
         // Right now we only support inserting JSX elements when we insert into a render prop or when replacing elements

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -17,7 +17,10 @@ import {
   varSafeNavigatorEntryToKey,
 } from '../../editor/store/editor-state'
 import type { SelectionLocked } from '../../canvas/canvas-types'
+import type { InsertionTarget } from './component-picker-context-menu'
 import { useCreateCallbackToShowComponentPicker } from './component-picker-context-menu'
+import type { ConditionalCase } from '../../../core/model/conditionals'
+import { useConditionalCaseCorrespondingToBranchPath } from '../../../core/model/conditionals'
 
 export const NavigatorHintCircleDiameter = 8
 
@@ -231,14 +234,35 @@ interface ReplaceElementButtonProps {
   target: ElementPath
   iconColor: IcnProps['color']
   prop: string | null
+  conditionalCase: ConditionalCase | null
 }
 
 const ReplaceElementButton = React.memo((props: ReplaceElementButtonProps) => {
-  const { target, prop } = props
-  const onClick = useCreateCallbackToShowComponentPicker()(
-    target,
-    prop == null ? 'replace-target' : { prop: prop },
-  )
+  const { target, prop, conditionalCase } = props
+
+  const { target: realTarget, insertionTarget } = ((): {
+    target: ElementPath
+    insertionTarget: InsertionTarget
+  } => {
+    if (prop != null) {
+      return {
+        target: EP.parentPath(target),
+        insertionTarget: { prop: prop },
+      }
+    }
+    if (conditionalCase != null) {
+      return {
+        target: EP.parentPath(target),
+        insertionTarget: conditionalCase,
+      }
+    }
+    return {
+      target: target,
+      insertionTarget: 'replace-target',
+    }
+  })()
+
+  const onClick = useCreateCallbackToShowComponentPicker()(realTarget, insertionTarget)
 
   return (
     <Button
@@ -423,6 +447,10 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
 
   const isConditionalClauseTitle = isConditionalClauseNavigatorEntry(props.navigatorEntry)
 
+  const conditionalCase = useConditionalCaseCorrespondingToBranchPath(
+    props.navigatorEntry.elementPath,
+  )
+
   return (
     <FlexRow
       style={{
@@ -451,13 +479,10 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
         <>
           <AddChildButton target={navigatorEntry.elementPath} iconColor={props.iconColor} />
           <ReplaceElementButton
-            target={
-              navigatorEntry.type === 'RENDER_PROP_VALUE'
-                ? EP.parentPath(navigatorEntry.elementPath)
-                : navigatorEntry.elementPath
-            }
+            target={navigatorEntry.elementPath}
             iconColor={props.iconColor}
             prop={navigatorEntry.type === 'RENDER_PROP_VALUE' ? navigatorEntry.prop : null}
+            conditionalCase={conditionalCase}
           />
         </>
       ) : null}

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -15,6 +15,7 @@ import {
   isOverriddenConditional,
   maybeConditionalActiveBranch,
   maybeConditionalExpression,
+  useConditionalCaseCorrespondingToBranchPath,
 } from '../../../core/model/conditionals'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import * as EP from '../../../core/shared/element-path'
@@ -829,14 +830,8 @@ export const NavigatorItem: React.FunctionComponent<
     'NavigatorItem isHiddenConditionalBranch',
   )
 
-  const conditionalCase = useEditorState(
-    Substores.metadata,
-    (store) =>
-      getConditionalCaseCorrespondingToBranchPath(
-        props.navigatorEntry.elementPath,
-        store.editor.jsxMetadata,
-      ),
-    'NavigatorItem, conditionalCase',
+  const conditionalCase = useConditionalCaseCorrespondingToBranchPath(
+    props.navigatorEntry.elementPath,
   )
 
   const isPlaceholder = isEntryAPlaceholder(props.navigatorEntry)

--- a/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
@@ -1023,4 +1023,103 @@ export var storyboard = (
 )
 `)
   })
+
+  it('can replace element inside conditional', async () => {
+    const editor = await renderTestEditorWithCode(
+      `import * as React from 'react'
+      import { Scene, Storyboard, FlexRow } from 'utopia-api'
+      
+      export var storyboard = (
+        <Storyboard data-uid='sb'>
+          <Scene
+            id='playground-scene'
+            commentId='playground-scene'
+            style={{
+              width: 700,
+              height: 759,
+              position: 'absolute',
+              left: 212,
+              top: 128,
+            }}
+            data-label='Playground'
+            data-uid='scene'
+          >
+            <FlexRow data-uid='flexrow'>
+              {
+                // @utopia/uid=conditional
+                true ? (
+                  <img
+                    style={{
+                      width: 220,
+                      height: 220,
+                      display: 'inline-block',
+                    }}
+                    src='/editor/utopia-logo-white-fill.png?hash=4c7df4ba0e8686df4fe14e3570f2d3002304b930'
+                    data-uid='img'
+                  />
+                ) : null
+              }
+            </FlexRow>
+          </Scene>
+        </Storyboard>
+      )
+      export const Column = () => (
+        <div
+          style={{ display: 'flex', flexDirection: 'column' }}
+        ></div>
+      )      
+`,
+      'await-first-dom-report',
+    )
+
+    await mouseClickAtPoint(
+      editor.renderedDOM.getByTestId(
+        'NavigatorItemTestId-regular_sb/scene/flexrow/conditional/img-label',
+      ),
+      { x: 2, y: 2 },
+    )
+
+    await mouseClickAtPoint(
+      editor.renderedDOM.getByTestId('replace-element-button-sb/scene/flexrow/conditional/img'),
+      { x: 2, y: 2 },
+    )
+
+    await mouseClickAtPoint(editor.renderedDOM.getByText('Column'), { x: 2, y: 2 })
+
+    // the element inside the map has been changed to a `div`
+    expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(`import * as React from 'react'
+import { Scene, Storyboard, FlexRow } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <Scene
+      id='playground-scene'
+      commentId='playground-scene'
+      style={{
+        width: 700,
+        height: 759,
+        position: 'absolute',
+        left: 212,
+        top: 128,
+      }}
+      data-label='Playground'
+      data-uid='scene'
+    >
+      <FlexRow data-uid='flexrow'>
+        {
+          // @utopia/uid=conditional
+          true ? <Column data-uid='new' /> : null
+        }
+      </FlexRow>
+    </Scene>
+  </Storyboard>
+)
+export const Column = () => (
+  <div
+    style={{ display: 'flex', flexDirection: 'column' }}
+    data-uid='45a'
+  />
+)
+`)
+  })
 })

--- a/editor/src/core/model/conditionals.ts
+++ b/editor/src/core/model/conditionals.ts
@@ -20,6 +20,7 @@ import { findUtopiaCommentFlag, isUtopiaCommentFlagConditional } from '../shared
 import { isLeft, isRight } from '../shared/either'
 import { MetadataUtils } from './element-metadata-utils'
 import { forceNotNull } from '../shared/optional-utils'
+import { Substores, useEditorState } from '../../components/editor/store/store-hook'
 
 export type ConditionalCase = 'true-case' | 'false-case'
 
@@ -361,4 +362,14 @@ export function isTextEditableConditional(
   // because the earlier checks already prove this is a leaf element.
   const activeConditionalBranch = maybeConditionalActiveBranch(path, metadata)
   return activeConditionalBranch != null && isJSExpression(activeConditionalBranch)
+}
+
+export function useConditionalCaseCorrespondingToBranchPath(
+  elementPath: ElementPath,
+): ConditionalCase | null {
+  return useEditorState(
+    Substores.metadata,
+    (store) => getConditionalCaseCorrespondingToBranchPath(elementPath, store.editor.jsxMetadata),
+    'useConditionalCaseCorrespondingToBranchPath conditionalCase',
+  )
 }


### PR DESCRIPTION
**Problem:**
This is a followup to https://github.com/concrete-utopia/utopia/pull/5449
Replace button still does not work on conditional branches.

**Fix:**
We need to set up the replace button callback with the correct new ConditionalCase insertionTarget values.
Make sure we don't filter out any kind of elements from conditional branches, because they support all of them (using InsertInsertable actions, unlike render props)

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

