### PR TITLE
Paste handlers for floating insert menu and remix url bar

### DIFF
--- a/editor/src/components/editor/remix-navigation-bar.tsx
+++ b/editor/src/components/editor/remix-navigation-bar.tsx
@@ -194,6 +194,7 @@ export const RemixNavigationBar = React.memo(() => {
           includeBoxShadow={false}
           onSubmitValue={changeRemixURLInEditor}
           onEscape={resetURL}
+          pasteHandler={true}
         />
         <StarUnstarIcon
           url={currentURL ?? ''}

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -14,6 +14,7 @@ import { assertNever } from '../../../core/shared/utils'
 import { insertableComponent } from '../../shared/project-components'
 import type { StylePropOption, InsertableComponent } from '../../shared/project-components'
 import type { Size } from '../../../core/shared/math-utils'
+import { dataPasteHandler } from '../../../utils/paste-handler'
 
 export interface ComponentPickerProps {
   allComponents: Array<InsertMenuItemGroup>
@@ -176,6 +177,7 @@ const FilterBar = React.memo((props: FilterBarProps) => {
       onChange={handleFilterChange}
       value={filter}
       data-testId={componentPickerFilterInputTestId}
+      {...dataPasteHandler(true)}
     />
   )
 })


### PR DESCRIPTION
Continuing from https://github.com/concrete-utopia/utopia/pull/5439, this PR makes the floating insert menu's search field and the remix url bar inputs able to receive paste events.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
