### PR TITLE
Show scrollbar on scrollable lists

### DIFF
--- a/editor/resources/editor/css/initial-load.css
+++ b/editor/resources/editor/css/initial-load.css
@@ -37,8 +37,8 @@
   font-style: italic;
 }
 
-::-webkit-scrollbar {
-  display: none;
+* {
+  scrollbar-width: none;
 }
 
 body {

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -84,6 +84,7 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
         height: '100%',
         padding: 0,
         color: dark.fg3.value,
+        colorScheme: 'dark',
         borderRadius: 10,
       }}
     >
@@ -189,7 +190,7 @@ const ComponentPickerComponentSection = React.memo(
   (props: ComponentPickerComponentSectionProps) => {
     const { components, onItemClick } = props
     return (
-      <div style={{ maxHeight: 250, overflowY: 'scroll' }}>
+      <div style={{ maxHeight: 250, overflowY: 'scroll', scrollbarWidth: 'auto' }}>
         {components.map((comp) => {
           return (
             <ComponentPickerOption


### PR DESCRIPTION
**Problem:**
Currently we're disabling scrollbars across the editor using the pseudo-element `::-webkit-scrollbar`. This also disables scrollbar to lists such as the component picker which is undesired.

**Fix:**
1. Change the scrollbar disable to use the `scrollbar-width` prop (since the pseudo-element is non-standard)
2. Have our component picker list restore the scrollbar using this prop
3. Change the component picker theme to dark, since we're forcing a black background there
<img width="468" alt="image" src="https://github.com/concrete-utopia/utopia/assets/7003853/f7cf9996-1063-4cf1-b05c-baf49d98f3d6">


**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5411 
