### PR TITLE
Add keyboard navigation to picker

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -553,7 +553,7 @@ const ComponentPickerContextMenuFull = React.memo<ComponentPickerContextMenuProp
     const metadataRef = useRefEditorState((state) => state.editor.jsxMetadata)
 
     const onItemClick = React.useCallback(
-      (preferredChildToInsert: InsertableComponent) => (e: React.MouseEvent) => {
+      (preferredChildToInsert: InsertableComponent) => (e: React.UIEvent) => {
         e.stopPropagation()
         e.preventDefault()
 
@@ -571,7 +571,7 @@ const ComponentPickerContextMenuFull = React.memo<ComponentPickerContextMenuProp
       [target, projectContentsRef, metadataRef, dispatch, insertionTarget],
     )
 
-    const squashEvents = React.useCallback((e: React.MouseEvent<unknown>) => {
+    const squashEvents = React.useCallback((e: React.UIEvent<unknown>) => {
       e.stopPropagation()
     }, [])
 

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -1,13 +1,13 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/react'
-import React from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { Icn, type IcnProps } from '../../../uuiui'
 import { dark } from '../../../uuiui/styles/theme/dark'
 import type { JSXElementChild } from '../../../core/shared/element-template'
 import type { ElementPath, Imports } from '../../../core/shared/project-file-types'
 import { type ComponentElementToInsert } from '../../custom-code/code-file'
-import type { InsertMenuItemGroup } from '../../canvas/ui/floating-insert-menu'
+import type { InsertMenuItemGroup, InsertMenuItemValue } from '../../canvas/ui/floating-insert-menu'
 import { UIGridRow } from '../../../components/inspector/widgets/ui-grid-row'
 import { FlexRow, type Icon } from 'utopia-api'
 import { assertNever } from '../../../core/shared/utils'
@@ -17,7 +17,7 @@ import type { Size } from '../../../core/shared/math-utils'
 
 export interface ComponentPickerProps {
   allComponents: Array<InsertMenuItemGroup>
-  onItemClick: (elementToInsert: InsertableComponent) => React.MouseEventHandler
+  onItemClick: (elementToInsert: InsertableComponent) => React.UIEventHandler
 }
 
 export interface ElementToInsert {
@@ -59,20 +59,86 @@ export function componentPickerOptionTestId(componentName: string, variant?: str
 }
 
 export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
+  const { onItemClick } = props
+  const [selectedComponentKey, setSelectedComponentKey] = React.useState<string | null>(null)
   const [filter, setFilter] = React.useState<string>('')
 
-  const allComponentsToShow: InsertMenuItemGroup[] = []
+  const changeFilter = useCallback(
+    (newFilter: string) => {
+      setFilter(newFilter)
+    },
+    [setFilter],
+  )
 
-  props.allComponents.forEach((c) => {
-    allComponentsToShow.push({
-      ...c,
-      options: c.options.filter((o) =>
-        o.label.toLocaleLowerCase().includes(filter.toLocaleLowerCase().trim()),
-      ),
+  const componentsToShow = useMemo(() => {
+    const allComponentsToShow: InsertMenuItemGroup[] = []
+    props.allComponents.forEach((c) => {
+      allComponentsToShow.push({
+        ...c,
+        options: c.options.filter((o) =>
+          o.label.toLocaleLowerCase().includes(filter.toLocaleLowerCase().trim()),
+        ),
+      })
     })
-  })
+    return allComponentsToShow
+  }, [props.allComponents, filter])
 
-  const componentsToShow = allComponentsToShow
+  const flatComponentsToShow = useMemo(() => {
+    return componentsToShow.flatMap((c) => c.options)
+  }, [componentsToShow])
+
+  const highlightedComponentKey = useMemo(() => {
+    const firstOptionKey =
+      flatComponentsToShow.length > 0 ? flatComponentsToShow[0].value.key : null
+    if (selectedComponentKey == null) {
+      return firstOptionKey
+    }
+    // check if selectedComponentKey is still in the list
+    const found = flatComponentsToShow.some((c) => c.value.key === selectedComponentKey)
+    return found ? selectedComponentKey : firstOptionKey
+  }, [flatComponentsToShow, selectedComponentKey])
+
+  const onItemHover = useCallback(
+    (elementToInsert: InsertMenuItemValue) => {
+      return () => {
+        setSelectedComponentKey(elementToInsert.key)
+      }
+    },
+    [setSelectedComponentKey],
+  )
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'ArrowDown') {
+        const currentIndex = flatComponentsToShow.findIndex(
+          (c) => c.value.key === highlightedComponentKey,
+        )
+        if (currentIndex >= 0 && currentIndex < flatComponentsToShow.length - 1) {
+          setSelectedComponentKey(flatComponentsToShow[currentIndex + 1].value.key)
+        }
+      } else if (e.key === 'ArrowUp') {
+        const currentIndex = flatComponentsToShow.findIndex(
+          (c) => c.value.key === highlightedComponentKey,
+        )
+        if (currentIndex > 0) {
+          setSelectedComponentKey(flatComponentsToShow[currentIndex - 1].value.key)
+        }
+      } else if (e.key === 'Enter') {
+        const selectedComponent = flatComponentsToShow.find(
+          (c) => c.value.key === highlightedComponentKey,
+        )
+        if (selectedComponent != null) {
+          onItemClick(selectedComponent.value)(e)
+        }
+      } else {
+        // we don't want to prevent default for other keys
+        return
+      }
+      e.preventDefault()
+      e.stopPropagation()
+    },
+    [flatComponentsToShow, highlightedComponentKey, onItemClick],
+  )
 
   return (
     <div
@@ -87,11 +153,14 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
         colorScheme: 'dark',
         borderRadius: 10,
       }}
+      onKeyDown={onKeyDown}
     >
-      <ComponentPickerTopSection onFilterChange={setFilter} />
+      <ComponentPickerTopSection onFilterChange={changeFilter} onKeyDown={onKeyDown} />
       <ComponentPickerComponentSection
         components={componentsToShow}
         onItemClick={props.onItemClick}
+        onItemHover={onItemHover}
+        currentlySelectedKey={highlightedComponentKey}
       />
     </div>
   )
@@ -99,10 +168,11 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
 
 interface ComponentPickerTopSectionProps {
   onFilterChange: (filter: string) => void
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void
 }
 
 const ComponentPickerTopSection = React.memo((props: ComponentPickerTopSectionProps) => {
-  const { onFilterChange } = props
+  const { onFilterChange, onKeyDown } = props
 
   return (
     <div
@@ -112,17 +182,18 @@ const ComponentPickerTopSection = React.memo((props: ComponentPickerTopSectionPr
         flexDirection: 'column',
       }}
     >
-      <FilterBar onFilterChange={onFilterChange} />
+      <FilterBar onFilterChange={onFilterChange} onKeyDown={onKeyDown} />
     </div>
   )
 })
 
 interface FilterBarProps {
   onFilterChange: (filter: string) => void
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
 }
 
 const FilterBar = React.memo((props: FilterBarProps) => {
-  const { onFilterChange } = props
+  const { onFilterChange, onKeyDown } = props
 
   const [filter, setFilterState] = React.useState<string>('')
   const setFilter = React.useCallback(
@@ -136,14 +207,19 @@ const FilterBar = React.memo((props: FilterBarProps) => {
   const handleFilterKeydown = React.useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter') {
-        ;(e.target as HTMLInputElement).blur() // Not sure why I need the cast here
+        if (onKeyDown != null) {
+          onKeyDown(e)
+        }
       } else if (e.key === 'Escape') {
         setFilter('')
         ;(e.target as HTMLInputElement).blur()
       }
+      if (onKeyDown != null) {
+        onKeyDown(e)
+      }
       e.stopPropagation()
     },
-    [setFilter],
+    [setFilter, onKeyDown],
   )
   const handleFilterChange = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -184,11 +260,13 @@ const FilterBar = React.memo((props: FilterBarProps) => {
 interface ComponentPickerComponentSectionProps {
   components: Array<InsertMenuItemGroup>
   onItemClick: (elementToInsert: InsertableComponent) => React.MouseEventHandler
+  onItemHover: (elementToInsert: InsertMenuItemValue) => React.MouseEventHandler
+  currentlySelectedKey: string | null
 }
 
 const ComponentPickerComponentSection = React.memo(
   (props: ComponentPickerComponentSectionProps) => {
-    const { components, onItemClick } = props
+    const { components, onItemClick, onItemHover, currentlySelectedKey } = props
     return (
       <div style={{ maxHeight: 250, overflowY: 'scroll', scrollbarWidth: 'auto' }}>
         {components.map((comp) => {
@@ -197,6 +275,8 @@ const ComponentPickerComponentSection = React.memo(
               key={`${comp.label}-label`}
               component={comp}
               onItemClick={onItemClick}
+              onItemHover={onItemHover}
+              currentlySelectedKey={currentlySelectedKey}
             />
           )
         })}
@@ -234,10 +314,12 @@ function iconPropsForIcon(icon: Icon): IcnProps {
 interface ComponentPickerOptionProps {
   component: InsertMenuItemGroup
   onItemClick: (elementToInsert: InsertableComponent) => React.MouseEventHandler
+  onItemHover: (elementToInsert: InsertMenuItemValue) => React.MouseEventHandler
+  currentlySelectedKey: string | null
 }
 
 const ComponentPickerOption = React.memo((props: ComponentPickerOptionProps) => {
-  const { component, onItemClick } = props
+  const { component, onItemClick, onItemHover, currentlySelectedKey } = props
 
   const variants = component.options
 
@@ -245,37 +327,44 @@ const ComponentPickerOption = React.memo((props: ComponentPickerOptionProps) => 
 
   return (
     <div>
-      {variants.map((v) => (
-        <FlexRow
-          key={`${name}-${v.label}`}
-          css={{
-            marginLeft: 8,
-            marginRight: 8,
-            borderRadius: 4,
-            // indentation!
-            paddingLeft: 8,
-            color: '#EEE',
-            '&:hover': {
-              background: '#007aff',
-              color: 'white',
-            },
-          }}
-          onClick={onItemClick(v.value)}
-        >
-          <UIGridRow
-            variant='|--32px--|<--------auto-------->'
-            padded={false}
-            // required to overwrite minHeight on the bloody thing
-            style={{ minHeight: 29 }}
+      {variants.map((v) => {
+        const selectedStyle =
+          v.value.key === currentlySelectedKey
+            ? {
+                background: '#007aff',
+                color: 'white',
+              }
+            : {}
+        return (
+          <FlexRow
+            key={`${name}-${v.label}`}
             css={{
-              height: 27,
+              marginLeft: 8,
+              marginRight: 8,
+              borderRadius: 4,
+              // indentation!
+              paddingLeft: 8,
+              color: '#EEE',
             }}
+            style={selectedStyle}
+            onClick={onItemClick(v.value)}
+            onMouseOver={onItemHover(v.value)}
           >
-            <Icn {...iconPropsForIcon(v.value.icon ?? 'regular')} width={12} height={12} />
-            <label>{v.label}</label>
-          </UIGridRow>
-        </FlexRow>
-      ))}
+            <UIGridRow
+              variant='|--32px--|<--------auto-------->'
+              padded={false}
+              // required to overwrite minHeight on the bloody thing
+              style={{ minHeight: 29 }}
+              css={{
+                height: 27,
+              }}
+            >
+              <Icn {...iconPropsForIcon(v.value.icon ?? 'regular')} width={12} height={12} />
+              <label>{v.label}</label>
+            </UIGridRow>
+          </FlexRow>
+        )
+      })}
     </div>
   )
 })

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -347,16 +347,17 @@ const ComponentPickerOption = React.memo((props: ComponentPickerOptionProps) => 
             : {}
         return (
           <FlexRow
+            css={{}}
             key={`${name}-${v.label}`}
-            css={{
+            style={{
               marginLeft: 8,
               marginRight: 8,
               borderRadius: 4,
               // indentation!
               paddingLeft: 8,
               color: '#EEE',
+              ...selectedStyle,
             }}
-            style={selectedStyle}
             onClick={onItemClick(v.value)}
             onMouseOver={onItemHover(v.value)}
             data-key={v.value.key}

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -62,6 +62,7 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
   const { onItemClick } = props
   const [selectedComponentKey, setSelectedComponentKey] = React.useState<string | null>(null)
   const [filter, setFilter] = React.useState<string>('')
+  const menuRef = React.useRef<HTMLDivElement | null>(null)
 
   const changeFilter = useCallback(
     (newFilter: string) => {
@@ -114,14 +115,24 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
           (c) => c.value.key === highlightedComponentKey,
         )
         if (currentIndex >= 0 && currentIndex < flatComponentsToShow.length - 1) {
-          setSelectedComponentKey(flatComponentsToShow[currentIndex + 1].value.key)
+          const newKey = flatComponentsToShow[currentIndex + 1].value.key
+          setSelectedComponentKey(newKey)
+          const selectedComponent = menuRef.current?.querySelector(`[data-key="${newKey}"]`)
+          if (selectedComponent != null) {
+            selectedComponent.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+          }
         }
       } else if (e.key === 'ArrowUp') {
         const currentIndex = flatComponentsToShow.findIndex(
           (c) => c.value.key === highlightedComponentKey,
         )
         if (currentIndex > 0) {
-          setSelectedComponentKey(flatComponentsToShow[currentIndex - 1].value.key)
+          const newKey = flatComponentsToShow[currentIndex - 1].value.key
+          setSelectedComponentKey(newKey)
+          const selectedComponent = menuRef.current?.querySelector(`[data-key="${newKey}"]`)
+          if (selectedComponent != null) {
+            selectedComponent.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+          }
         }
       } else if (e.key === 'Enter') {
         const selectedComponent = flatComponentsToShow.find(
@@ -154,6 +165,7 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
         borderRadius: 10,
       }}
       onKeyDown={onKeyDown}
+      ref={menuRef}
     >
       <ComponentPickerTopSection onFilterChange={changeFilter} onKeyDown={onKeyDown} />
       <ComponentPickerComponentSection
@@ -212,9 +224,7 @@ const FilterBar = React.memo((props: FilterBarProps) => {
         }
       } else if (e.key === 'Escape') {
         setFilter('')
-        ;(e.target as HTMLInputElement).blur()
-      }
-      if (onKeyDown != null) {
+      } else if (onKeyDown != null) {
         onKeyDown(e)
       }
       e.stopPropagation()
@@ -349,6 +359,7 @@ const ComponentPickerOption = React.memo((props: ComponentPickerOptionProps) => 
             style={selectedStyle}
             onClick={onItemClick(v.value)}
             onMouseOver={onItemHover(v.value)}
+            data-key={v.value.key}
           >
             <UIGridRow
               variant='|--32px--|<--------auto-------->'

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -64,13 +64,6 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
   const [filter, setFilter] = React.useState<string>('')
   const menuRef = React.useRef<HTMLDivElement | null>(null)
 
-  const changeFilter = useCallback(
-    (newFilter: string) => {
-      setFilter(newFilter)
-    },
-    [setFilter],
-  )
-
   const componentsToShow = useMemo(() => {
     const allComponentsToShow: InsertMenuItemGroup[] = []
     props.allComponents.forEach((c) => {
@@ -167,7 +160,7 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
       onKeyDown={onKeyDown}
       ref={menuRef}
     >
-      <ComponentPickerTopSection onFilterChange={changeFilter} onKeyDown={onKeyDown} />
+      <ComponentPickerTopSection onFilterChange={setFilter} onKeyDown={onKeyDown} />
       <ComponentPickerComponentSection
         components={componentsToShow}
         onItemClick={props.onItemClick}


### PR DESCRIPTION
**Problem:**
Currently there is no keyboard navigation possible in component picker

**Fix:**
Capture arrow keys and support insertion with "Enter"
<video src="https://github.com/concrete-utopia/utopia/assets/7003853/13092b4d-ecae-4d54-8a0e-585252c96102" />

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5427
