### PR TITLE
New swap feature to keep children and style

### DIFF
--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -366,6 +366,19 @@ export function showReplaceComponentPicker(
   return showComponentPicker(target, insertionTarget)
 }
 
+export function showSwapComponentPicker(
+  targetElement: ElementPath,
+  jsxMetadata: ElementInstanceMetadataMap,
+  showComponentPicker: ShowComponentPickerContextMenuCallback,
+): ShowComponentPickerContextMenu {
+  const element = MetadataUtils.findElementByElementPath(jsxMetadata, targetElement)
+  const prop = element?.assignedToProp
+  const target = prop == null ? targetElement : EP.parentPath(targetElement)
+  const insertionTarget: InsertionTarget =
+    prop == null ? EditorActions.replaceKeepChildrenAndStyleTarget : renderPropTarget(prop)
+  return showComponentPicker(target, insertionTarget)
+}
+
 export const convert: ContextMenuItem<CanvasData> = {
   name: 'Swap Element With…',
   shortcut: '',
@@ -381,8 +394,11 @@ export const convert: ContextMenuItem<CanvasData> = {
     )
   },
   action: (data, _dispatch, _coord, event) => {
-    // FIXME Render prop support
-    data.showComponentPicker(data.selectedViews[0], 'replace-target-keep-children-and-style')(event)
+    showSwapComponentPicker(
+      data.selectedViews[0],
+      data.jsxMetadata,
+      data.showComponentPicker,
+    )(event)
   },
 }
 

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -351,7 +351,27 @@ export const insert: ContextMenuItem<CanvasData> = {
 
 export const convert: ContextMenuItem<CanvasData> = {
   name: 'Swap Element With…',
-  shortcut: 'S',
+  shortcut: '',
+  enabled: (data) => {
+    return (
+      data.selectedViews.length > 0 &&
+      data.selectedViews.every((path) => {
+        const element = MetadataUtils.findElementByElementPath(data.jsxMetadata, path)
+        return (
+          element != null && isRight(element.element) && isJSXElementLike(element.element.value)
+        )
+      })
+    )
+  },
+  action: (data, _dispatch, _coord, event) => {
+    // FIXME Render prop support
+    data.showComponentPicker(data.selectedViews[0], 'replace-target-keep-children-and-style')(event)
+  },
+}
+
+export const replace: ContextMenuItem<CanvasData> = {
+  name: 'Replace Element With…',
+  shortcut: '',
   enabled: (data) => {
     return (
       data.selectedViews.length > 0 &&

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -81,6 +81,10 @@ import type { MapLike } from 'typescript'
 import type { CommentFilterMode } from '../inspector/sections/comment-section'
 import type { Collaborator } from '../../core/shared/multiplayer'
 import type { PageTemplate } from '../canvas/remix/remix-utils'
+import type {
+  ChildInsertionTarget,
+  ReplaceInsertionTarget,
+} from '../navigator/navigator-item/component-picker-context-menu'
 export { isLoggedIn, loggedInUser, notLoggedIn } from '../../common/user'
 export type { LoginState, UserDetails } from '../../common/user'
 
@@ -147,7 +151,7 @@ export interface InsertJSXElement {
   jsxElement: JSXElement
   target: ElementPath | null
   importsToAdd: Imports
-  insertionBehaviour: 'insert-as-child' | 'replace-target'
+  insertionBehaviour: ChildInsertionTarget | ReplaceInsertionTarget
 }
 
 export interface ReplaceMappedElement {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -261,6 +261,10 @@ import type { SetHuggingParentToFixed } from '../../canvas/canvas-strategies/str
 import type { CommentFilterMode } from '../../inspector/sections/comment-section'
 import type { Collaborator } from '../../../core/shared/multiplayer'
 import type { PageTemplate } from '../../canvas/remix/remix-utils'
+import type {
+  ChildInsertionTarget,
+  ReplaceInsertionTarget,
+} from '../../navigator/navigator-item/component-picker-context-menu'
 
 export function clearSelection(): EditorAction {
   return {
@@ -272,7 +276,7 @@ export function insertJSXElement(
   element: JSXElement,
   target: ElementPath | null,
   importsToAdd: Imports,
-  insertionBehaviour: 'insert-as-child' | 'replace-target',
+  insertionBehaviour: ChildInsertionTarget | ReplaceInsertionTarget,
 ): InsertJSXElement {
   return {
     action: 'INSERT_JSX_ELEMENT',

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -601,6 +601,7 @@ import type { FixUIDsState } from '../../../core/workers/parser-printer/uid-fix'
 import { fixTopLevelElementsUIDs } from '../../../core/workers/parser-printer/uid-fix'
 import { nextSelectedTab } from '../../navigator/left-pane/left-pane-utils'
 import { getRemixRootDir } from '../store/remix-derived-data'
+import { isReplaceKeepChildrenAndStyleTarget } from '../../navigator/navigator-item/component-picker-context-menu'
 
 export const MIN_CODE_PANE_REOPEN_WIDTH = 100
 
@@ -2366,7 +2367,7 @@ export const UPDATE_FNS = {
           const renamedJsxElement = renameJsxElementChild(action.jsxElement, duplicateNameMapping)
           if (
             originalElement == null ||
-            action.insertionBehaviour !== 'replace-target-keep-children-and-style'
+            !isReplaceKeepChildrenAndStyleTarget(action.insertionBehaviour)
           ) {
             return renamedJsxElement
           }

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -84,7 +84,6 @@ import {
   ZOOM_CANVAS_OUT_SHORTCUT,
   ZOOM_UI_IN_SHORTCUT,
   ZOOM_UI_OUT_SHORTCUT,
-  CONVERT_ELEMENT_SHORTCUT,
   ADD_ELEMENT_SHORTCUT,
   GROUP_ELEMENT_PICKER_SHORTCUT,
   GROUP_ELEMENT_DEFAULT_SHORTCUT,
@@ -744,23 +743,6 @@ export function handleKeyDown(
       },
       [TOGGLE_INSPECTOR_AND_NAVIGATOR_SHORTCUT]: () => {
         return [EditorActions.togglePanel('rightmenu'), EditorActions.togglePanel('leftmenu')]
-      },
-      [CONVERT_ELEMENT_SHORTCUT]: () => {
-        const possibleToConvert = editor.selectedViews.every((path) => {
-          const element = MetadataUtils.findElementByElementPath(editor.jsxMetadata, path)
-          return (
-            element != null && isRight(element.element) && isJSXElementLike(element.element.value)
-          )
-        })
-        if (isSelectMode(editor.mode) && possibleToConvert) {
-          const mousePoint = WindowMousePositionRaw ?? zeroCanvasPoint
-          showComponentPicker(editor.selectedViews[0], 'replace-target')(event, {
-            position: mousePoint,
-          })
-          return []
-        } else {
-          return []
-        }
       },
       [ADD_ELEMENT_SHORTCUT]: () => {
         if (allowedToEdit) {

--- a/editor/src/components/editor/shortcut-definitions.ts
+++ b/editor/src/components/editor/shortcut-definitions.ts
@@ -71,7 +71,6 @@ export const TOGGLE_INSPECTOR = 'toggle-inspector'
 export const TOGGLE_DESIGNER_ADDITIONAL_CONTROLS_SHORTCUT = 'toggle-designer-additional-controls'
 export const TOGGLE_CODE_EDITOR_SHORTCUT = 'toggle-code-editor'
 export const TOGGLE_INSPECTOR_AND_NAVIGATOR_SHORTCUT = 'toggle-inspector-and-navigator'
-export const CONVERT_ELEMENT_SHORTCUT = 'convert-element'
 export const TEXT_EDIT_MODE = 'text-edit-mode'
 export const TOGGLE_TEXT_BOLD = 'toggle-text-bold'
 export const TOGGLE_TEXT_ITALIC = 'toggle-text-italic'
@@ -216,7 +215,6 @@ const shortcutDetailsWithDefaults: ShortcutDetails = {
     'Toggle the inspector and the navigator.',
     key('backslash', 'cmd'),
   ),
-  [CONVERT_ELEMENT_SHORTCUT]: shortcut('Convert selected element to...', key('s', [])),
   [ADD_ELEMENT_SHORTCUT]: shortcut('Add element...', key('a', [])),
   [OPEN_EYEDROPPER]: shortcut('Open the eyedropper', key('c', 'ctrl')),
   [TEXT_EDIT_MODE]: shortcut('Activate text edit mode', key('t', [])),

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -29,6 +29,7 @@ import {
   copyPropertiesMenuItem,
   pasteToReplace,
   pasteHere,
+  replace,
 } from './context-menu-items'
 import { MomentumContextMenu } from './context-menu-wrapper'
 import { useRefEditorState, useEditorState, Substores } from './editor/store/store-hook'
@@ -75,6 +76,7 @@ const ElementContextMenuItems: Array<ContextMenuItem<CanvasData>> = [
   insert,
   lineSeparator,
   convert,
+  replace,
   escapeHatch,
   lineSeparator,
   wrapInPicker,

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -408,16 +408,27 @@ function insertComponentPickerItem(
       ]
     }
 
-    // TODO: proper error message
-    console.warn(
-      insertionTarget === 'replace-target'
-        ? `Component picker error: can not replace to "${toInsert.name}"`
-        : `Component picker error: can not insert "${toInsert.name}"`,
-    )
+    console.warn(errorMessage(insertionTarget, toInsert))
     return []
   })()
 
   dispatch(actions)
+}
+
+function errorMessage(insertionTarget: InsertionTarget, toInsert: InsertableComponent) {
+  switch (insertionTarget) {
+    case 'replace-target':
+      return `Component picker error: can not swap to "${toInsert.name}"`
+    case 'replace-target-keep-children-and-style':
+      return `Component picker error: can not replace to "${toInsert.name}"`
+    case 'insert-as-child':
+      return `Component picker error: can not insert "${toInsert.name}" as child`
+    case 'false-case':
+    case 'true-case':
+      return `Component picker error: can not insert "${toInsert.name}" into conditional`
+    default:
+      return `Component picker error: can not insert "${toInsert.name}" into render prop "${insertionTarget.prop}"`
+  }
 }
 
 function insertPreferredChild(

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -62,42 +62,6 @@ import {
 import type { InsertableComponent } from '../../shared/project-components'
 import type { ConditionalCase } from '../../../core/model/conditionals'
 
-// export type RenderPropInsertionTarget = { prop: string }
-// export type ReplaceInsertionTarget = 'replace-target' | 'replace-target-keep-children-and-style'
-// export type ChildInsertionTarget = 'insert-as-child'
-
-// export type InsertionTarget =
-//   | RenderPropInsertionTarget
-//   | ReplaceInsertionTarget
-//   | ChildInsertionTarget
-//   | ConditionalCase
-
-// export function isRenderPropInsertionTarget(
-//   insertionTarget: InsertionTarget,
-// ): insertionTarget is RenderPropInsertionTarget {
-//   return (
-//     !isChildInsertionTarget(insertionTarget) &&
-//     !isReplaceInsertionTarget(insertionTarget) &&
-//     !isConditionalCaseInsertionTarget(insertionTarget)
-//   )
-// }
-
-// export function isReplaceInsertionTarget(
-//   insertionTarget: InsertionTarget,
-// ): insertionTarget is ReplaceInsertionTarget {
-//   return (
-//     insertionTarget === 'replace-target' ||
-//     insertionTarget === 'replace-target-keep-children-and-style'
-//   )
-// }
-
-// export function isChildInsertionTarget(
-//   insertionTarget: InsertionTarget,
-// ): insertionTarget is ChildInsertionTarget {
-//   return insertionTarget === 'insert-as-child'
-// }
-
-// export function isConditionalCaseInsertionTarget(
 type RenderPropTarget = { type: 'render-prop'; prop: string }
 type ConditionalTarget = { type: 'conditional'; conditionalCase: ConditionalCase }
 

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -258,7 +258,6 @@ const ReplaceElementButton = React.memo((props: ReplaceElementButtonProps) => {
     }
     return {
       target: target,
-      // TODO: not always
       insertionTarget: 'replace-target',
     }
   })()

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -258,7 +258,8 @@ const ReplaceElementButton = React.memo((props: ReplaceElementButtonProps) => {
     }
     return {
       target: target,
-      insertionTarget: 'replace-target',
+      // TODO: not always
+      insertionTarget: 'replace-target-keep-children-and-style',
     }
   })()
 

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -259,7 +259,7 @@ const ReplaceElementButton = React.memo((props: ReplaceElementButtonProps) => {
     return {
       target: target,
       // TODO: not always
-      insertionTarget: 'replace-target-keep-children-and-style',
+      insertionTarget: 'replace-target',
     }
   })()
 

--- a/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
@@ -1242,21 +1242,6 @@ export const Column = () => (
       )
     })
 
-    it('Works when using the S shortcut the navigator button', async () => {
-      const editor = await renderTestEditorWithModel(TestProject, 'await-first-dom-report')
-      await selectComponentsForTest(editor, [target])
-      await pressKey('s')
-
-      const menuButton = await waitFor(() => editor.renderedDOM.getAllByText('FlexCol')[1])
-      await mouseClickAtPoint(menuButton, { x: 3, y: 3 })
-
-      await editor.getDispatchFollowUpActionsFinished()
-
-      expect(getPrintedUiJsCodeWithoutUIDs(editor.getEditorState(), StoryboardFilePath)).toEqual(
-        expectedOutput,
-      )
-    })
-
     it('Works when using the context menu', async () => {
       const editor = await renderTestEditorWithModel(TestProject, 'await-first-dom-report')
       await selectComponentsForTest(editor, [target])
@@ -1279,7 +1264,7 @@ export const Column = () => (
 
       await editor.getDispatchFollowUpActionsFinished()
 
-      const swapButton = await waitFor(() => editor.renderedDOM.getByText('Swap Element With…'))
+      const swapButton = await waitFor(() => editor.renderedDOM.getByText('Replace Element With…'))
       await mouseClickAtPoint(swapButton, { x: 3, y: 3 })
 
       const menuButton = await waitFor(() => editor.renderedDOM.getAllByText('FlexCol')[1])
@@ -1355,21 +1340,6 @@ export const Column = () => (
       )
     })
 
-    it('Works when using the S shortcut the navigator button', async () => {
-      const editor = await renderTestEditorWithModel(TestProject, 'await-first-dom-report')
-      await selectComponentsForTest(editor, [target])
-      await pressKey('s')
-
-      const menuButton = await waitFor(() => editor.renderedDOM.getByText('FlexCol'))
-      await mouseClickAtPoint(menuButton, { x: 3, y: 3 })
-
-      await editor.getDispatchFollowUpActionsFinished()
-
-      expect(getPrintedUiJsCodeWithoutUIDs(editor.getEditorState(), StoryboardFilePath)).toEqual(
-        expectedOutput,
-      )
-    })
-
     it('Works when using the context menu', async () => {
       const editor = await renderTestEditorWithModel(TestProject, 'await-first-dom-report')
       await selectComponentsForTest(editor, [target])
@@ -1392,7 +1362,7 @@ export const Column = () => (
 
       await editor.getDispatchFollowUpActionsFinished()
 
-      const swapButton = await waitFor(() => editor.renderedDOM.getByText('Swap Element With…'))
+      const swapButton = await waitFor(() => editor.renderedDOM.getByText('Replace Element With…'))
       await mouseClickAtPoint(swapButton, { x: 3, y: 3 })
 
       const menuButton = await waitFor(() => editor.renderedDOM.getByText('FlexCol'))

--- a/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
@@ -1264,8 +1264,10 @@ export const Column = () => (
 
       await editor.getDispatchFollowUpActionsFinished()
 
-      const swapButton = await waitFor(() => editor.renderedDOM.getByText('Replace Element With…'))
-      await mouseClickAtPoint(swapButton, { x: 3, y: 3 })
+      const replaceButton = await waitFor(() =>
+        editor.renderedDOM.getByText('Replace Element With…'),
+      )
+      await mouseClickAtPoint(replaceButton, { x: 3, y: 3 })
 
       const menuButton = await waitFor(() => editor.renderedDOM.getAllByText('FlexCol')[1])
       await mouseClickAtPoint(menuButton, { x: 3, y: 3 })
@@ -1362,8 +1364,10 @@ export const Column = () => (
 
       await editor.getDispatchFollowUpActionsFinished()
 
-      const swapButton = await waitFor(() => editor.renderedDOM.getByText('Replace Element With…'))
-      await mouseClickAtPoint(swapButton, { x: 3, y: 3 })
+      const replaceButton = await waitFor(() =>
+        editor.renderedDOM.getByText('Replace Element With…'),
+      )
+      await mouseClickAtPoint(replaceButton, { x: 3, y: 3 })
 
       const menuButton = await waitFor(() => editor.renderedDOM.getByText('FlexCol'))
       await mouseClickAtPoint(menuButton, { x: 3, y: 3 })


### PR DESCRIPTION
**Problem:**
See https://github.com/concrete-utopia/utopia/issues/5441

**Fix:**
I added a new context menu item called ('Replace Element With'). This includes the old behavior! And the existing 'Swap Element With' triggers this new behavior: it keeps style and children of the original element.

The replace button in the navigator item keeps the old behavior (and replaces the whole subtree).

The S (swap) keyboard shortcut is removed (suggested by Malte).

This PR does not include any kind of filtering suggested in the issue:
<img width="641" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/4d3625c9-393e-4083-9b14-7fd26137e3bd">

These can come in subsequent PR(s)

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5441
