### PR TITLE
Manual github refresh

### DIFF
--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -854,16 +854,18 @@ export function mergeProjectContentsTree(
   }
 }
 
-const GITHUB_REFRESH_INTERVAL_MILLISECONDS = 15_000
+// TODO reenable this!
+// const GITHUB_REFRESH_INTERVAL_MILLISECONDS = 15_000
 
 type GithubAuthState = 'not-authenticated' | 'missing-user-details' | 'ready'
 
 export function useGithubPolling() {
   const dispatch = useDispatch()
 
-  const [tick, setTick] = React.useState(0)
-  const [lastTick, setLastTick] = React.useState<number | null>(null)
-  const [timeoutId, setTimeoutId] = React.useState<number | null>(null)
+  // TODO reenable this!
+  //   const [tick, setTick] = React.useState(0)
+  //   const [lastTick, setLastTick] = React.useState<number | null>(null)
+  //   const [timeoutId, setTimeoutId] = React.useState<number | null>(null)
 
   const githubAuthenticated = useEditorState(
     Substores.userState,
@@ -899,12 +901,13 @@ export function useGithubPolling() {
       'polling',
     )
 
-    // schedule a new tick for the next Xms
-    setTimeoutId(
-      window.setTimeout(() => {
-        setTick((t) => t + 1)
-      }, GITHUB_REFRESH_INTERVAL_MILLISECONDS),
-    )
+    // TODO reenable this!
+    // // schedule a new tick for the next Xms
+    // setTimeoutId(
+    //   window.setTimeout(() => {
+    //     setTick((t) => t + 1)
+    //   }, GITHUB_REFRESH_INTERVAL_MILLISECONDS),
+    // )
   }, [dispatch, branchOriginContentsChecksums, githubData])
 
   const authState = React.useMemo((): GithubAuthState => {
@@ -940,10 +943,11 @@ export function useGithubPolling() {
         assertNever(authState)
     }
 
-    if (timeoutId != null) {
-      window.clearTimeout(timeoutId)
-    }
-  }, [authState, dispatch, timeoutId])
+    // TODO fix this!
+    // if (timeoutId != null) {
+    //   window.clearTimeout(timeoutId)
+    // }
+  }, [authState, dispatch])
 
   // react to ready auth state and tick changes
   React.useEffect(() => {
@@ -951,13 +955,16 @@ export function useGithubPolling() {
       return
     }
 
-    if (lastTick == null || lastTick < tick) {
-      setLastTick(() => {
-        void refreshAndScheduleGithubData()
-        return tick
-      })
-    }
-  }, [authState, refreshAndScheduleGithubData, tick, lastTick])
+    // TODO reenable/fix this!
+    // if (lastTick == null || lastTick < tick) {
+    //   setLastTick(() => {
+    //     void refreshAndScheduleGithubData()
+    //     return tick
+    //   })
+    // }
+
+    void refreshAndScheduleGithubData()
+  }, [authState, refreshAndScheduleGithubData])
 }
 
 export async function getRefreshGithubActions(


### PR DESCRIPTION
**Problem:**

https://github.com/concrete-utopia/utopia/pull/5389 introduced a race condition issue that can cause the polling logic to terminate silently.

**(temporary!) Fix:**

Temporarily disable the polling logic and instead:
1. just do a single refresh when the auth is ready
2. add a button at the top of the GH pane to manually refresh 

<img width="315" alt="Screenshot 2024-05-02 at 4 09 06 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/bbab3843-980d-4d4e-89c8-472aded7ec90">


**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5467 
