### PR TITLE
No inspector sections by default

### DIFF
--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -146,7 +146,7 @@ export const ComponentDescriptorDefaults: Pick<
   'focus' | 'inspector' | 'emphasis' | 'icon'
 > = {
   focus: 'default',
-  inspector: 'all',
+  inspector: [],
   emphasis: 'regular',
   icon: 'regular',
 }

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -838,7 +838,7 @@ describe('registered property controls', () => {
           "emphasis": "regular",
           "focus": "default",
           "icon": "regular",
-          "inspector": "all",
+          "inspector": Array [],
           "preferredChildComponents": Array [],
           "properties": Object {
             "background": Object {
@@ -1662,7 +1662,7 @@ describe('registered property controls', () => {
             "emphasis": "regular",
             "focus": "default",
             "icon": "regular",
-            "inspector": "all",
+            "inspector": Array [],
             "preferredChildComponents": Array [],
             "properties": Object {
               "label": Object {

--- a/editor/src/core/third-party/antd-components.ts
+++ b/editor/src/core/third-party/antd-components.ts
@@ -56,6 +56,7 @@ function createBasicComponent(
     ],
     source: defaultComponentDescriptor(),
     ...ComponentDescriptorDefaults,
+    inspector: 'all',
   }
 }
 

--- a/editor/src/core/third-party/remix-controls.ts
+++ b/editor/src/core/third-party/remix-controls.ts
@@ -43,6 +43,7 @@ export const RemixRunReactComponents: ComponentDescriptorsForFile = {
     ],
     source: defaultComponentDescriptor(),
     ...ComponentDescriptorDefaults,
+    inspector: 'all',
   },
   Outlet: {
     properties: {},

--- a/editor/src/core/third-party/utopia-api-components.ts
+++ b/editor/src/core/third-party/utopia-api-components.ts
@@ -52,6 +52,7 @@ const BasicUtopiaComponentDescriptor = (
     ],
     source: defaultComponentDescriptor(),
     ...ComponentDescriptorDefaults,
+    inspector: 'all',
   }
 }
 
@@ -100,6 +101,7 @@ const BasicUtopiaSceneDescriptor = (
     ],
     source: defaultComponentDescriptor(),
     ...ComponentDescriptorDefaults,
+    inspector: 'all',
   }
 }
 


### PR DESCRIPTION
**Problem:**
No inspector section should be shown by default for annotated components.

**Fix:**
Switch the default value from `'all'` to `[]`

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5470
