### PR TITLE
Fix Text editing when Data Entries in Navigator are enabled

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -477,20 +477,6 @@ export function renderCoreElement(
         return <></>
       }
 
-      if (elementPath != null && isFeatureEnabled('Data Entries in the Navigator')) {
-        addFakeSpyEntry(
-          validPaths,
-          metadataContext,
-          elementPath,
-          element,
-          filePath,
-          imports,
-          'not-a-conditional',
-          null,
-          assignedToProp,
-        )
-      }
-
       const lines = element.text.split('<br />').map((line) => unescapeHTML(line))
       return (
         <>

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -22,6 +22,7 @@ import type { ConditionalClauseNavigatorEntry, NavigatorEntry } from '../editor/
 import {
   conditionalClauseNavigatorEntry,
   dataReferenceNavigatorEntry,
+  getElementFromProjectContents,
   invalidOverrideNavigatorEntry,
   isConditionalClauseNavigatorEntry,
   regularNavigatorEntry,
@@ -108,7 +109,10 @@ export function getNavigatorTargets(
       const isHiddenInNavigator = EP.containsPath(path, hiddenInNavigator)
       const isConditional = MetadataUtils.isElementPathConditionalFromMetadata(metadata, path)
       const isMap = MetadataUtils.isJSXMapExpression(path, metadata)
-      const isDataReference = MetadataUtils.isElementDataReference(path, metadata)
+      const elementFromProjectContents = getElementFromProjectContents(path, projectContents)
+      const elementIsDataReferenceFromProjectContents = MetadataUtils.isElementDataReference(
+        elementFromProjectContents,
+      )
 
       const isCollapsed = EP.containsPath(path, collapsedViews)
       const newCollapsedAncestor = collapsedAncestor || isCollapsed || isHiddenInNavigator
@@ -121,12 +125,13 @@ export function getNavigatorTargets(
         visibleNavigatorTargets.push(...entries)
       }
 
-      if (isDataReference && isFeatureEnabled('Data Entries in the Navigator')) {
-        const elementMetadata = MetadataUtils.findElementByElementPath(metadata, path)
-        if (elementMetadata != null && isRight(elementMetadata.element)) {
+      if (
+        elementIsDataReferenceFromProjectContents &&
+        isFeatureEnabled('Data Entries in the Navigator')
+      ) {
+        if (elementFromProjectContents != null) {
           // add synthetic entry
-          const element = elementMetadata.element.value
-          const dataRefEntry = dataReferenceNavigatorEntry(path, element)
+          const dataRefEntry = dataReferenceNavigatorEntry(path, elementFromProjectContents)
           addNavigatorTargetsUnlessCollapsed(dataRefEntry)
         } else {
           throw new Error(`internal error: Unexpected non-element found at ${EP.toString(path)}`)

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -2424,14 +2424,10 @@ export const MetadataUtils = {
     }
     return element.element.value
   },
-  isElementDataReference(target: ElementPath, metadata: ElementInstanceMetadataMap): boolean {
-    const foundMetadata = MetadataUtils.findElementByElementPath(metadata, target)
-    const element: JSXElementChild | null = maybeEitherToMaybe(foundMetadata?.element)
-
+  isElementDataReference(element: JSXElementChild | null): boolean {
     if (element == null) {
       return false
     }
-
     switch (element.type) {
       case 'ATTRIBUTE_FUNCTION_CALL':
       case 'ATTRIBUTE_NESTED_ARRAY': // TODO: reconsider nested array and nested object
@@ -2442,9 +2438,8 @@ export const MetadataUtils = {
       case 'JSX_CONDITIONAL_EXPRESSION':
         return false
       case 'ATTRIBUTE_OTHER_JAVASCRIPT': {
-        const children = MetadataUtils.getChildrenUnordered(metadata, target)
         // Attribute other javascript is only true if it does not have children entries in the metadata
-        return children.length === 0
+        return Object.keys(element.elementsWithin).length === 0
       }
       case 'ATTRIBUTE_VALUE':
       case 'JSX_TEXT_BLOCK':


### PR DESCRIPTION
**Problem:**
the 'Data Entries in the Navigator' FS broke text editing

**Fix:**
The reason was because I added a fake spy entry for text children, which changed the contents of the project-wide metadataMap, which changed how the text editing ruleset evaulates a perfectly text-editable element.

**Details:**
- Do not alter metadata for this feature
- Instead pull in the relevant info from projectContents
