### PR TITLE
Select new element after inserting into slot

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1765,6 +1765,7 @@ export const UPDATE_FNS = {
   },
   SET_PROP: (action: SetProp, editor: EditorModel): EditorModel => {
     let setPropFailedMessage: string | null = null
+    let newSelectedViews: Array<ElementPath> = editor.selectedViews
     let updatedEditor = modifyUnderlyingTargetElement(
       action.target,
       editor,
@@ -1773,6 +1774,10 @@ export const UPDATE_FNS = {
           return element
         }
         const updatedProps = setJSXValueAtPath(element.props, action.propertyPath, action.value)
+        // when this is a render prop we should select it
+        if (isJSXElement(action.value)) {
+          newSelectedViews = [EP.appendToPath(action.target, action.value.uid)]
+        }
         if (
           isRight(updatedProps) &&
           PP.contains(
@@ -1837,7 +1842,10 @@ export const UPDATE_FNS = {
       updatedEditor = UPDATE_FNS.ADD_TOAST(toastAction, editor)
     }
 
-    return updatedEditor
+    return {
+      ...updatedEditor,
+      selectedViews: newSelectedViews,
+    }
   },
   SET_CANVAS_FRAMES: (action: SetCanvasFrames, editor: EditorModel): EditorModel => {
     return setCanvasFramesInnerNew(editor, action.framesAndTargets, null)


### PR DESCRIPTION
**Problem:**
When you insert an element into a render prop slot, it is not selected after insertion

**Fix:**
The reason is that even though we have selection implemented in our insertion actions (InsertJSXElement, InsertInsertable), but not in the SetProperty action (which is generally not really insertion, just it is like that for render props).

I added a check in the SetProperty action if we are setting a render prop, and when we do, I set the selection to this new element.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5484
