### PR TITLE
Encode branch names for GH calls

### DIFF
--- a/editor/src/core/shared/github/endpoints.ts
+++ b/editor/src/core/shared/github/endpoints.ts
@@ -18,7 +18,7 @@ export const GithubEndpoints = {
       githubRepo.owner,
       githubRepo.repository,
       'branch',
-      branchName,
+      encodeURIComponent(branchName),
     ),
   defaultBranchContents: (githubRepo: GithubRepo) =>
     urljoin(
@@ -47,7 +47,7 @@ export const GithubEndpoints = {
       githubRepo.owner,
       githubRepo.repository,
       'branch',
-      branchName,
+      encodeURIComponent(branchName),
       'pullrequest',
     ),
   authenticationStatus: () => urljoin(UTOPIA_BACKEND, 'github', 'authentication', 'status'),


### PR DESCRIPTION
**Problem:**

Working with branches that contain slashes in their names fails.

**Fix:**

Branch names should be url-encoded in order to be usable by both remix and haskell endpoints, so just do that in the editor's endpoint calls.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5500 
