### PR TITLE
supportsChildren and Add Child button improvements

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -942,8 +942,7 @@ export async function componentDescriptorForComponentToRegister(
     return properties
   }
 
-  const supportsChildren =
-    componentToRegister.children != null && componentToRegister.children !== 'not-supported'
+  const supportsChildren = componentToRegister.children !== 'not-supported'
 
   return right({
     componentName: componentName,


### PR DESCRIPTION
**Problem:**
1. We show the add child button even when the element clearly doesn't support children
2. Component annotations are too sctict with the false default of supportsChildren

**Fix:**
I replaced the default supportsChildren value to `true`
I added back the check to show the Add Child button, but in a more permissive way: we always show the Add Child button, except if (1) the component annotation explicitly does not allow children or (2) it is ain intrinsic html element which does not support children (e.g. img)

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5496
Note: the issue is about the component annotation of the Placeholder component, but the real problem was not in the component annotation, but that the editor always rendered the Add Child button regardless of what is in the annotation.
