### PR TITLE
Github clone url fix branch + public repo details

### DIFF
--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -41,6 +41,8 @@ import type { LiveObject } from '@liveblocks/client'
 import { projectIdToRoomId } from '../../utils/room-id'
 import { assertNever } from '../../core/shared/utils'
 import { checkOnlineState } from './online-status'
+import type { GithubOperationContext } from '../../core/shared/github/operations/github-operation-context'
+import { GithubEndpoints } from '../../core/shared/github/endpoints'
 
 export { fetchProjectList, fetchShowcaseProjects, getLoginState } from '../../common/server'
 
@@ -672,4 +674,23 @@ export async function updateGithubRepository(
   if (!response.ok) {
     throw new Error(`Update Github repository failed (${response.status}): ${response.statusText}`)
   }
+}
+
+export async function requestSearchPublicGithubRepository(
+  operationContext: GithubOperationContext,
+  params: {
+    owner: string
+    repo: string
+  },
+): Promise<Response> {
+  const url = GithubEndpoints.searchRepository()
+
+  const response = await operationContext.fetch(url, {
+    method: 'POST',
+    credentials: 'include',
+    headers: HEADERS,
+    mode: MODE,
+    body: JSON.stringify({ owner: params.owner, repo: params.repo }),
+  })
+  return response
 }

--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -685,12 +685,11 @@ export async function requestSearchPublicGithubRepository(
 ): Promise<Response> {
   const url = GithubEndpoints.searchRepository()
 
-  const response = await operationContext.fetch(url, {
+  return operationContext.fetch(url, {
     method: 'POST',
     credentials: 'include',
     headers: HEADERS,
     mode: MODE,
     body: JSON.stringify({ owner: params.owner, repo: params.repo }),
   })
-  return response
 }

--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -300,7 +300,7 @@ export const RepositoryListing = React.memo(
     const currentRepo = useEditorState(
       Substores.github,
       (store) => store.editor.githubSettings.targetRepository,
-      'Github targetRepository',
+      'Github currentRepo',
     )
 
     const dispatch = useDispatch()

--- a/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/repository-listing.tsx
@@ -306,15 +306,24 @@ export const RepositoryListing = React.memo(
       () => githubOperations.some((op) => op.name === 'loadRepositories'),
       [githubOperations],
     )
+
+    const currentRepo = useEditorState(
+      Substores.github,
+      (store) => store.editor.githubSettings.targetRepository,
+      'Github targetRepository',
+    )
+
     const dispatch = useDispatch()
 
     const refreshReposOnClick = React.useCallback(() => {
-      void GithubOperations.getUsersPublicGithubRepositories(dispatch, 'user-initiated').then(
-        (actions) => {
-          dispatch(actions, 'everyone')
-        },
-      )
-    }, [dispatch])
+      void GithubOperations.getUsersPublicGithubRepositories(
+        dispatch,
+        'user-initiated',
+        currentRepo,
+      ).then((actions) => {
+        dispatch(actions, 'everyone')
+      })
+    }, [dispatch, currentRepo])
 
     const clearRepository = React.useCallback(() => {
       dispatch([updateGithubSettings(emptyGithubSettings())], 'everyone')

--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -982,7 +982,11 @@ export async function getRefreshGithubActions(
   let actions: EditorAction[] = []
 
   // 1. list the repos
-  const userRepos = await getUsersPublicGithubRepositories(operationContext)(dispatch, initiator)
+  const userRepos = await getUsersPublicGithubRepositories(operationContext)(
+    dispatch,
+    initiator,
+    githubRepo,
+  )
   actions.push(...userRepos)
 
   if (githubRepo != null) {


### PR DESCRIPTION
**Problem:**

Found two issues on the GH clone url:

1. it does not set the branch of the cloned repo, so it won't generate a correct GH state
2. it does not account for non-owned repos, so it won't populate the related repo details and the repo will look as if it's not connected

**Fix:**

1. reuse some of the stuff introduced to support searching for public repos (https://github.com/concrete-utopia/utopia/pull/5377) so that the repo details are obtained before cloning, and then those details are used to populate the state after a successful clone
2. store the branch (or the details default branch name) for the cloned repo too

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5513 
