### PR TITLE
Correctly check unused imports after element deletion

### DIFF
--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -2814,6 +2814,11 @@ export function walkElement(
         const path = EP.appendToElementPath(parentPath, uidAttr.value)
         forEach(element, path, depth)
         fastForEach(element.children, (child) => walkElement(child, path, depth + 1, forEach))
+        element.props.forEach((prop) => {
+          if (prop.type === 'JSX_ATTRIBUTES_ENTRY') {
+            walkElement(prop.value, path, depth + 1, forEach)
+          }
+        })
       }
       break
     case 'JSX_FRAGMENT':

--- a/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-bugs.spec.ts
@@ -56,7 +56,9 @@ export var App = props => {
                 JSX_ELEMENT - div - bbb
                   JS_IDENTIFIER - 833
                   JSX_TEXT_BLOCK - d01
-                  JS_IDENTIFIER - b90"
+                  JS_IDENTIFIER - b90
+              ATTRIBUTE_VALUE - 74a
+              ATTRIBUTE_VALUE - 207"
       `)
 
       const aaaElement = findJSXElementAtStaticPath(
@@ -190,7 +192,14 @@ export var App = props => {
             JS_PROPERTY_ACCESS - 4f7
               JS_IDENTIFIER - 09c
             ATTRIBUTE_OTHER_JAVASCRIPT - f44
-              JSX_ELEMENT - Card - card"
+              JSX_ELEMENT - Card - card
+                  ATTRIBUTE_VALUE - da1
+                JS_PROPERTY_ACCESS - 711
+                  JS_IDENTIFIER - fc3
+                JS_PROPERTY_ACCESS - 18e
+                  JS_IDENTIFIER - 913
+                JS_PROPERTY_ACCESS - 2a0
+                  JS_IDENTIFIER - fd6"
     `)
     expect(elementsStructure((testParseCode(spreadCode) as any).topLevelElements))
       .toMatchInlineSnapshot(`
@@ -205,7 +214,8 @@ export var App = props => {
             JS_PROPERTY_ACCESS - 4f7
               JS_IDENTIFIER - 09c
             ATTRIBUTE_OTHER_JAVASCRIPT - 8a6
-              JSX_ELEMENT - Card - card"
+              JSX_ELEMENT - Card - card
+                  ATTRIBUTE_VALUE - da1"
     `)
   })
 })

--- a/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-conditionals.spec.ts
@@ -36,6 +36,16 @@ describe('Conditonals JSX parser', () => {
           JSX_ELEMENT - Storyboard - eee
             JSX_ELEMENT - Scene - fff
               JSX_ELEMENT - App - app
+                  ATTRIBUTE_VALUE - 207
+                  ATTRIBUTE_VALUE - 791
+                  ATTRIBUTE_VALUE - bd1
+                  ATTRIBUTE_VALUE - a4b
+                  ATTRIBUTE_VALUE - da5
+                ATTRIBUTE_VALUE - 09a
+                ATTRIBUTE_VALUE - 78a
+                ATTRIBUTE_VALUE - d89
+                ATTRIBUTE_VALUE - 4bd
+                ATTRIBUTE_VALUE - e9e
         UNPARSED_CODE"
       `)
 
@@ -71,6 +81,16 @@ describe('Conditonals JSX parser', () => {
           JSX_ELEMENT - Storyboard - eee
             JSX_ELEMENT - Scene - fff
               JSX_ELEMENT - App - app
+                  ATTRIBUTE_VALUE - 207
+                  ATTRIBUTE_VALUE - 791
+                  ATTRIBUTE_VALUE - bd1
+                  ATTRIBUTE_VALUE - a4b
+                  ATTRIBUTE_VALUE - da5
+                ATTRIBUTE_VALUE - 09a
+                ATTRIBUTE_VALUE - 78a
+                ATTRIBUTE_VALUE - d89
+                ATTRIBUTE_VALUE - 4bd
+                ATTRIBUTE_VALUE - e9e
         UNPARSED_CODE"
       `)
 
@@ -108,6 +128,16 @@ describe('Conditonals JSX printer', () => {
           JSX_ELEMENT - Storyboard - eee
             JSX_ELEMENT - Scene - fff
               JSX_ELEMENT - App - app
+                  ATTRIBUTE_VALUE - 207
+                  ATTRIBUTE_VALUE - 791
+                  ATTRIBUTE_VALUE - bd1
+                  ATTRIBUTE_VALUE - a4b
+                  ATTRIBUTE_VALUE - da5
+                ATTRIBUTE_VALUE - 09a
+                ATTRIBUTE_VALUE - 78a
+                ATTRIBUTE_VALUE - d89
+                ATTRIBUTE_VALUE - 4bd
+                ATTRIBUTE_VALUE - e9e
         UNPARSED_CODE"
       `)
 

--- a/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-fragments.spec.ts
@@ -21,13 +21,30 @@ describe('JSX parser', () => {
                 JSX_TEXT_BLOCK - 3ed
                 JSX_FRAGMENT - 7fd
                   JSX_ELEMENT - div - ccc
+                      ATTRIBUTE_VALUE - 842
+                      ATTRIBUTE_VALUE - 2a9
+                  ATTRIBUTE_VALUE - c56
+                  ATTRIBUTE_VALUE - f10
             JSX_ELEMENT - div - ddd
               JSX_TEXT_BLOCK - 3d0
+              JS_PROPERTY_ACCESS - 296
+              ATTRIBUTE_VALUE - 683
+              ATTRIBUTE_VALUE - ab2
         UNPARSED_CODE
         UTOPIA_JSX_COMPONENT - storyboard
           JSX_ELEMENT - Storyboard - eee
             JSX_ELEMENT - Scene - fff
               JSX_ELEMENT - App - app
+                  ATTRIBUTE_VALUE - 207
+                  ATTRIBUTE_VALUE - 791
+                  ATTRIBUTE_VALUE - bd1
+                  ATTRIBUTE_VALUE - a4b
+                  ATTRIBUTE_VALUE - da5
+                ATTRIBUTE_VALUE - 09a
+                ATTRIBUTE_VALUE - 78a
+                ATTRIBUTE_VALUE - d89
+                ATTRIBUTE_VALUE - 4bd
+                ATTRIBUTE_VALUE - e9e
         UNPARSED_CODE"
       `)
 

--- a/editor/src/core/workers/parser-printer/parser-printer.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.spec.ts
@@ -6108,7 +6108,9 @@ export var App = props => {
                 JS_IDENTIFIER - 09c
           UNPARSED_CODE
           UTOPIA_JSX_COMPONENT - App
-            JSX_ELEMENT - MyComp - e13"
+            JSX_ELEMENT - MyComp - e13
+              JSX_ELEMENT - h1 - dff
+                JSX_TEXT_BLOCK - 9e1"
         `)
 
         const appComponent = success.topLevelElements.find(
@@ -6169,7 +6171,8 @@ export var App = props => {
                 JS_IDENTIFIER - 09c
           UNPARSED_CODE
           UTOPIA_JSX_COMPONENT - App
-            JSX_ELEMENT - MyComp - 26c"
+            JSX_ELEMENT - MyComp - 26c
+              JSX_ELEMENT - div - 4cf"
         `)
 
         const appComponent = success.topLevelElements.find(


### PR DESCRIPTION
## Problem
When removing unused imports after an element is deleted, we didn't check whether the removed element was used in any render props. As a result, sometimes we removed the import even if the element was used inside a render prop

## Fix
Check render props too


## Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

https://github.com/concrete-utopia/utopia/issues/5485
