### PR TITLE
hide code editor by default

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -437,8 +437,6 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
             EditorActions.setRightMenuTab(RightMenuTab.Comments),
             EditorActions.setCodeEditorVisibility(false),
           )
-        } else {
-          actions.push(EditorActions.setCodeEditorVisibility(true))
         }
         dispatch(actions)
       })

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -2595,7 +2595,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
       visible: true,
     },
     interfaceDesigner: {
-      codePaneVisible: true,
+      codePaneVisible: false,
       additionalControls: true,
     },
     canvas: {
@@ -2992,7 +2992,7 @@ export function editorModelFromPersistentModel(
       visible: true,
     },
     interfaceDesigner: {
-      codePaneVisible: true,
+      codePaneVisible: false,
       additionalControls: true,
     },
     canvas: {

--- a/editor/src/components/editor/store/store-hook-substore-helpers.ts
+++ b/editor/src/components/editor/store/store-hook-substore-helpers.ts
@@ -51,7 +51,7 @@ export const EmptyEditorStateForKeysOnly: EditorState = {
     visible: true,
   },
   interfaceDesigner: {
-    codePaneVisible: true,
+    codePaneVisible: false,
     additionalControls: true,
   },
   canvas: {


### PR DESCRIPTION
## Problem
https://github.com/concrete-utopia/utopia/issues/5520

## Fix
Hide it

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
