### PR TITLE
Fixes for replace functionality

### DIFF
--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -380,7 +380,7 @@ export function showSwapComponentPicker(
 }
 
 export const convert: ContextMenuItem<CanvasData> = {
-  name: 'Swap Element With…',
+  name: 'Replace This…',
   shortcut: '',
   enabled: (data) => {
     return (
@@ -403,7 +403,7 @@ export const convert: ContextMenuItem<CanvasData> = {
 }
 
 export const replace: ContextMenuItem<CanvasData> = {
-  name: 'Replace Element With…',
+  name: 'Replace Everything…',
   shortcut: '',
   enabled: (data) => {
     return (

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2393,11 +2393,14 @@ export const UPDATE_FNS = {
             },
           )
 
-          // apply the children of original element on the new element
-          return {
-            ...renamedJsxElementWithOriginalStyle,
-            children: originalElement.children,
+          if (originalElement.children.length > 0) {
+            // apply the children of original element on the new element
+            return {
+              ...renamedJsxElementWithOriginalStyle,
+              children: originalElement.children,
+            }
           }
+          return renamedJsxElementWithOriginalStyle
         })()
 
         const withInsertedElement = insertJSXElementChildren(

--- a/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
@@ -1264,9 +1264,7 @@ export const Column = () => (
 
       await editor.getDispatchFollowUpActionsFinished()
 
-      const replaceButton = await waitFor(() =>
-        editor.renderedDOM.getByText('Replace Element With…'),
-      )
+      const replaceButton = await waitFor(() => editor.renderedDOM.getByText('Replace Everything…'))
       await mouseClickAtPoint(replaceButton, { x: 3, y: 3 })
 
       const menuButton = await waitFor(() => editor.renderedDOM.getAllByText('FlexCol')[1])
@@ -1364,9 +1362,7 @@ export const Column = () => (
 
       await editor.getDispatchFollowUpActionsFinished()
 
-      const replaceButton = await waitFor(() =>
-        editor.renderedDOM.getByText('Replace Element With…'),
-      )
+      const replaceButton = await waitFor(() => editor.renderedDOM.getByText('Replace Everything…'))
       await mouseClickAtPoint(replaceButton, { x: 3, y: 3 })
 
       const menuButton = await waitFor(() => editor.renderedDOM.getByText('FlexCol'))


### PR DESCRIPTION
**Problem:**
Better context menu item names.
Replace this should keep the children of the inserted variant when the original element did not have children

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

