### PR TITLE
disable pushIntendedBoundsAndUpdateHuggingElements

### DIFF
--- a/editor/src/components/canvas/commands/push-intended-bounds-and-update-targets-command.spec.browser2.tsx
+++ b/editor/src/components/canvas/commands/push-intended-bounds-and-update-targets-command.spec.browser2.tsx
@@ -19,7 +19,7 @@ function makeScenePath(trailingPath: string): ElementPath {
 describe('push intended bounds', () => {
   describe('hugging elements', () => {
     describe('flex containers', () => {
-      it('keeps the container dimensions when becoming empty (flex) (delete, single element)', async () => {
+      xit('keeps the container dimensions when becoming empty (flex) (delete, single element)', async () => {
         const renderResult = await renderTestEditorWithCode(
           formatTestProjectCode(
             makeTestProjectCodeWithSnippet(`
@@ -74,7 +74,7 @@ describe('push intended bounds', () => {
           ),
         )
       })
-      it('keeps the container dimensions when becoming empty (flex) (delete, multiple elements)', async () => {
+      xit('keeps the container dimensions when becoming empty (flex) (delete, multiple elements)', async () => {
         const renderResult = await renderTestEditorWithCode(
           formatTestProjectCode(
             makeTestProjectCodeWithSnippet(`
@@ -177,7 +177,7 @@ describe('push intended bounds', () => {
           ),
         )
       })
-      it('keeps the container dimensions when becoming empty (zero-sized)', async () => {
+      xit('keeps the container dimensions when becoming empty (zero-sized)', async () => {
         const renderResult = await renderTestEditorWithCode(
           formatTestProjectCode(`
 				import * as React from 'react'
@@ -211,7 +211,7 @@ describe('push intended bounds', () => {
 		`),
         )
       })
-      it('keeps the container dimensions when becoming empty (inside a flex container)', async () => {
+      xit('keeps the container dimensions when becoming empty (inside a flex container)', async () => {
         const renderResult = await renderTestEditorWithCode(
           formatTestProjectCode(`
 				import * as React from 'react'

--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -420,68 +420,68 @@ describe('actions', () => {
         `,
         wantSelection: [makeTargetPath('view/group/child1')],
       },
-      {
-        name: 'delete group child selects next sibling (multiple selection)',
-        input: `
-          <View data-uid='view'>
-            <Group data-uid='group'>
-              <div data-uid='child1' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 0, background: 'blue' }} />
-              <div data-uid='child2' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 40, background: 'blue' }} />
-              <div data-uid='child3' style={{ position: 'absolute', width: 10, height: 10, top: 40, left: 0, background: 'blue' }} />
-              <div data-uid='child4' style={{ position: 'absolute', width: 10, height: 10, top: 40, left: 40, background: 'blue' }} />
-            </Group>
-            <div data-uid='foo'>
-              <div data-uid='bar' />
-            </div>
-          </View>
-        `,
-        targets: [makeTargetPath('view/group/child3'), makeTargetPath('view/foo/bar')],
-        wantCode: `
-          <View data-uid='view'>
-            <Group data-uid='group'>
-              <div data-uid='child1' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 0, background: 'blue' }} />
-              <div data-uid='child2' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 40, background: 'blue' }} />
-              <div data-uid='child4' style={{ position: 'absolute', width: 10, height: 10, top: 40, left: 40, background: 'blue' }} />
-            </Group>
-            <div data-uid='foo' style={{ width: 400, height: 0, position: 'absolute', left: 0, top: 50 }} />
-          </View>
-        `,
-        wantSelection: [makeTargetPath('view/group/child1'), makeTargetPath('view/foo')],
-      },
-      {
-        name: 'delete last group child deletes the group',
-        input: `
-          <View data-uid='view'>
-            <Group data-uid='group'>
-              <div data-uid='child1' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 0, background: 'blue' }} />
-            </Group>
-          </View>
-        `,
-        targets: [makeTargetPath('view/group/child1')],
-        wantCode: `
-          <View data-uid='view' style={{ width: 400, height: 10, position: 'absolute', left: 0, top: 0 }} />
-        `,
-        wantSelection: [makeTargetPath('view')],
-      },
-      {
-        name: 'recursively delete empty parents when groups or fragments',
-        input: `
-        <div data-uid='root'>
-          <Group data-uid='g1'>
-            <Group data-uid='g2'>
-              <React.Fragment data-uid='f1'>
-                <div data-uid='child' />
-              </React.Fragment>
-            </Group>
-          </Group>
-        </div>
-        `,
-        targets: [makeTargetPath(`root/g1/g2/f1/child`)],
-        wantCode: `
-          <div data-uid='root' style={{ width: 400, height: 0, position: 'absolute', left: 0, top: 0 }} />
-        `,
-        wantSelection: [makeTargetPath(`root`)],
-      },
+      // {
+      //   name: 'delete group child selects next sibling (multiple selection)',
+      //   input: `
+      //     <View data-uid='view'>
+      //       <Group data-uid='group'>
+      //         <div data-uid='child1' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 0, background: 'blue' }} />
+      //         <div data-uid='child2' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 40, background: 'blue' }} />
+      //         <div data-uid='child3' style={{ position: 'absolute', width: 10, height: 10, top: 40, left: 0, background: 'blue' }} />
+      //         <div data-uid='child4' style={{ position: 'absolute', width: 10, height: 10, top: 40, left: 40, background: 'blue' }} />
+      //       </Group>
+      //       <div data-uid='foo'>
+      //         <div data-uid='bar' />
+      //       </div>
+      //     </View>
+      //   `,
+      //   targets: [makeTargetPath('view/group/child3'), makeTargetPath('view/foo/bar')],
+      //   wantCode: `
+      //     <View data-uid='view'>
+      //       <Group data-uid='group'>
+      //         <div data-uid='child1' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 0, background: 'blue' }} />
+      //         <div data-uid='child2' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 40, background: 'blue' }} />
+      //         <div data-uid='child4' style={{ position: 'absolute', width: 10, height: 10, top: 40, left: 40, background: 'blue' }} />
+      //       </Group>
+      //       <div data-uid='foo' style={{ width: 400, height: 0, position: 'absolute', left: 0, top: 50 }} />
+      //     </View>
+      //   `,
+      //   wantSelection: [makeTargetPath('view/group/child1'), makeTargetPath('view/foo')],
+      // },
+      // {
+      //   name: 'delete last group child deletes the group',
+      //   input: `
+      //     <View data-uid='view'>
+      //       <Group data-uid='group'>
+      //         <div data-uid='child1' style={{ position: 'absolute', width: 10, height: 10, top: 0, left: 0, background: 'blue' }} />
+      //       </Group>
+      //     </View>
+      //   `,
+      //   targets: [makeTargetPath('view/group/child1')],
+      //   wantCode: `
+      //     <View data-uid='view' style={{ width: 400, height: 10, position: 'absolute', left: 0, top: 0 }} />
+      //   `,
+      //   wantSelection: [makeTargetPath('view')],
+      // },
+      // {
+      //   name: 'recursively delete empty parents when groups or fragments',
+      //   input: `
+      //   <div data-uid='root'>
+      //     <Group data-uid='g1'>
+      //       <Group data-uid='g2'>
+      //         <React.Fragment data-uid='f1'>
+      //           <div data-uid='child' />
+      //         </React.Fragment>
+      //       </Group>
+      //     </Group>
+      //   </div>
+      //   `,
+      //   targets: [makeTargetPath(`root/g1/g2/f1/child`)],
+      //   wantCode: `
+      //     <div data-uid='root' style={{ width: 400, height: 0, position: 'absolute', left: 0, top: 0 }} />
+      //   `,
+      //   wantSelection: [makeTargetPath(`root`)],
+      // },
       {
         name: 'recursively delete empty parents when groups or fragments and stops',
         input: `
@@ -506,26 +506,26 @@ describe('actions', () => {
         `,
         wantSelection: [makeTargetPath(`root/g1/stop-here`)],
       },
-      {
-        name: 'recursively delete empty parents when groups or fragments with multiselect',
-        input: `
-        <div data-uid='root'>
-          <Group data-uid='g1'>
-            <div data-uid='delete-me' />
-            <Group data-uid='g2'>
-              <React.Fragment data-uid='f1'>
-                <div data-uid='child' />
-              </React.Fragment>
-            </Group>
-          </Group>
-        </div>
-        `,
-        targets: [makeTargetPath(`root/g1/g2/f1/child`), makeTargetPath(`root/g1/delete-me`)],
-        wantCode: `
-          <div data-uid='root' style={{ width: 400, height: 0, position: 'absolute', left: 0, top: 0 }} />
-        `,
-        wantSelection: [makeTargetPath(`root`)],
-      },
+      // {
+      //   name: 'recursively delete empty parents when groups or fragments with multiselect',
+      //   input: `
+      //   <div data-uid='root'>
+      //     <Group data-uid='g1'>
+      //       <div data-uid='delete-me' />
+      //       <Group data-uid='g2'>
+      //         <React.Fragment data-uid='f1'>
+      //           <div data-uid='child' />
+      //         </React.Fragment>
+      //       </Group>
+      //     </Group>
+      //   </div>
+      //   `,
+      //   targets: [makeTargetPath(`root/g1/g2/f1/child`), makeTargetPath(`root/g1/delete-me`)],
+      //   wantCode: `
+      //     <div data-uid='root' style={{ width: 400, height: 0, position: 'absolute', left: 0, top: 0 }} />
+      //   `,
+      //   wantSelection: [makeTargetPath(`root`)],
+      // },
     ]
     tests.forEach((tt, idx) => {
       it(`(${idx + 1}) ${tt.name}`, async () => {

--- a/editor/src/components/editor/conditionals.spec.browser2.tsx
+++ b/editor/src/components/editor/conditionals.spec.browser2.tsx
@@ -264,7 +264,7 @@ describe('conditionals', () => {
       expect(EP.isParentOf(conditionalPath, selectedViews[0])).toBe(true)
       expect(EP.toUid(selectedViews[0])).not.toBe('ccc')
     })
-    it('keeps the selection on the null branch (multiple targets)', async () => {
+    xit('keeps the selection on the null branch (multiple targets)', async () => {
       const startSnippet = `
         <div data-uid='aaa' data-testid='aaa'>
           {

--- a/editor/src/core/model/true-up-targets.ts
+++ b/editor/src/core/model/true-up-targets.ts
@@ -81,7 +81,8 @@ export function getCommandsForPushIntendedBounds(
 
   return [
     pushIntendedBoundsAndUpdateGroups(groupTargets, isStartingMetadata),
-    pushIntendedBoundsAndUpdateHuggingElements(huggingElementTargets),
+    // disabling this as the collapsed elements detection is way too agressive and converts too many elements to absolute
+    // pushIntendedBoundsAndUpdateHuggingElements(huggingElementTargets),
   ]
 }
 


### PR DESCRIPTION
**Problem:**
Deleting the last child of a component with no style prop results in the `pushIntendedBoundsAndUpdateHuggingElements` agressively adding width / height and sometimes even converting it to absolute.

**Fix:**
Disable it for now.

