### PR TITLE
Sort the all components insert menu alphabetically

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -61,6 +61,7 @@ import {
 } from '../../editor/store/insertion-path'
 import type { InsertableComponent } from '../../shared/project-components'
 import type { ConditionalCase } from '../../../core/model/conditionals'
+import { sortBy } from '../../../core/shared/array-utils'
 
 type RenderPropTarget = { type: 'render-prop'; prop: string }
 type ConditionalTarget = { type: 'conditional'; conditionalCase: ConditionalCase }


### PR DESCRIPTION
**Problem:**
![image](https://github.com/concrete-utopia/utopia/assets/1044774/0459fbfa-f882-417d-b1b7-d7edf89b287f)

**Fix:**
![image](https://github.com/concrete-utopia/utopia/assets/1044774/278fa73b-a9c2-41b1-8b4b-cab26e1a9579)

**Important note** right now that menu is grouped based on the source of the components, and this fix would bin that off and just list all components in alphabetical order.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5503
