### PR TITLE
Highlight render prop on hover

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -1236,10 +1236,12 @@ function elementContainsExpressions(
 }
 
 function getSelectionTargetForNavigatorEntry(navigatorEntry: NavigatorEntry): ElementPath {
-  const shouldSelectParentInstead = isDataReferenceNavigatorEntry(navigatorEntry)
-  const elementPath = shouldSelectParentInstead
-    ? EP.parentPath(navigatorEntry.elementPath)
-    : navigatorEntry.elementPath
+  if (isDataReferenceNavigatorEntry(navigatorEntry)) {
+    return EP.parentPath(navigatorEntry.elementPath)
+  }
+  if (isRenderPropNavigatorEntry(navigatorEntry) && navigatorEntry.childPath != null) {
+    return navigatorEntry.childPath
+  }
 
-  return elementPath
+  return navigatorEntry.elementPath
 }


### PR DESCRIPTION
## Problem
See issue (https://github.com/concrete-utopia/utopia/issues/5501)

https://screenshot.click/03-18-s9b91-uh2ga.mp4

## Fix
Highlight the child when the render prop label is hvered

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

https://github.com/concrete-utopia/utopia/issues/5501
