### PR TITLE
Tweak The Navigator Scroll To Item Logic

### DIFF
--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -184,7 +184,7 @@ export const NavigatorComponent = React.memo(() => {
 
   React.useEffect(() => {
     if (selectionIndex >= 0) {
-      itemListRef.current?.scrollToItem(selectionIndex)
+      itemListRef.current?.scrollToItem(selectionIndex, 'center')
     }
   }, [selectionIndex, itemListRef])
 


### PR DESCRIPTION
**Problem:**
We had some issues with the navigator scroll to logic:
- Does not scroll at all sometimes.
- When expanding the structure, the selected item doesn't quite come into view.

**Fix:**
This sets an option for the `scrollToItem` function used in the 3rd party component that handles the navigator listing. It _seemed_ more reliable when testing it.

**Commit Details:**
- Use the align option `center` when calling `scrollToItem`.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5490
