### PR TITLE
support replacing with maps

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -449,12 +449,12 @@ function insertComponentPickerItem(
     if (isReplaceTarget(insertionTarget)) {
       if (
         MetadataUtils.isJSXMapExpression(EP.parentPath(target), metadata) &&
-        elementWithoutUID.type === 'JSX_MAP_EXPRESSION'
+        elementWithoutUID.type !== 'JSX_ELEMENT'
       ) {
         return [
           showToast(
             notice(
-              'Nested Lists are not supported yet',
+              'Only JSX elements are supported inside Lists',
               'INFO',
               false,
               'insert-component-picker-item-nested-map',
@@ -474,25 +474,33 @@ function insertComponentPickerItem(
       ]
     }
 
-    console.warn(errorMessage(insertionTarget, toInsert))
-    return []
+    return [
+      showToast(
+        notice(
+          toastMessage(insertionTarget, toInsert),
+          'INFO',
+          false,
+          'insert-component-picker-item-nested-map',
+        ),
+      ),
+    ]
   })()
 
   dispatch(actions)
 }
 
-function errorMessage(insertionTarget: InsertionTarget, toInsert: InsertableComponent) {
+function toastMessage(insertionTarget: InsertionTarget, toInsert: InsertableComponent) {
   switch (insertionTarget.type) {
     case 'replace-target':
-      return `Component picker error: can not swap to "${toInsert.name}"`
+      return `Swapping to ${toInsert.name} isn't supported yet`
     case 'replace-target-keep-children-and-style':
-      return `Component picker error: can not replace to "${toInsert.name}"`
+      return `Replacing with ${toInsert.name} isn't supported yet`
     case 'insert-as-child':
-      return `Component picker error: can not insert "${toInsert.name}" as child`
+      return `Inserting ${toInsert.name} as child isn't supported yet`
     case 'conditional':
-      return `Component picker error: can not insert "${toInsert.name}" into conditional "${insertionTarget.type}`
+      return `Inserting ${toInsert.name} into conditional ${insertionTarget.type} isn't supported yet`
     case 'render-prop':
-      return `Component picker error: can not insert "${toInsert.name}" into render prop "${insertionTarget.prop}"`
+      return `Inserting ${toInsert.name} into render prop ${insertionTarget.prop} isn't supported yet`
     default:
       assertNever(insertionTarget)
   }

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -25,6 +25,7 @@ import {
   insertJSXElement,
   replaceMappedElement,
   setProp_UNSAFE,
+  showToast,
 } from '../../editor/actions/action-creators'
 import * as EP from '../../../core/shared/element-path'
 import * as PP from '../../../core/shared/property-path'
@@ -65,6 +66,7 @@ import type { ConditionalCase } from '../../../core/model/conditionals'
 import { sortBy } from '../../../core/shared/array-utils'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import { absolute } from '../../../utils/utils'
+import { notice } from '../../common/notice'
 
 type RenderPropTarget = { type: 'render-prop'; prop: string }
 type ConditionalTarget = { type: 'conditional'; conditionalCase: ConditionalCase }
@@ -445,6 +447,21 @@ function insertComponentPickerItem(
     }
 
     if (isReplaceTarget(insertionTarget)) {
+      if (
+        MetadataUtils.isJSXMapExpression(EP.parentPath(target), metadata) &&
+        elementWithoutUID.type === 'JSX_MAP_EXPRESSION'
+      ) {
+        return [
+          showToast(
+            notice(
+              'Nested Lists are not supported yet',
+              'INFO',
+              false,
+              'insert-component-picker-item-nested-map',
+            ),
+          ),
+        ]
+      }
       const index = MetadataUtils.getIndexInParent(metadata, pathTrees, target)
       return [
         deleteView(target),

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -454,7 +454,7 @@ function insertComponentPickerItem(
         return [
           showToast(
             notice(
-              'Only JSX elements are supported inside Lists',
+              'We are working on support to insert Lists, Conditionals and Fragments into Lists',
               'INFO',
               false,
               'insert-component-picker-item-nested-map',


### PR DESCRIPTION
## Problem
https://github.com/concrete-utopia/utopia/issues/5523 Lists are not available as an element to replace with

## Fix
Make them available and improve `insertComponentPickerItem` so that it can actually replace a target with a list.

### Scope
- Replacing an element with a list works if the element is in the `children` array of another element\
- Replacing an element with a list works if the element is in a conditional branch
- Replacing an element with a list does not work if the element is in a render prop, because for now we only support JSXElements in render props
- Replacing an element with a list does not work if the element is the returned by the map function in a list, because for now we only support JSXElements there (through `ElementsWithin`)

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
