### PR TITLE
Exclude zero size elements from auto-layout siblings calculation

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -84,6 +84,7 @@ import {
   sizeToVisualDimensions,
 } from '../../../inspector/inspector-common'
 import { getDescriptiveStrategyLabelWithRetargetedPaths } from '../canvas-strategies'
+import { isZeroSizedElement } from '../../controls/outline-utils'
 
 export type SetHuggingParentToFixed =
   | 'set-hugging-parent-to-fixed'
@@ -339,7 +340,10 @@ function getAutoLayoutSiblingsBoundsInner(
   targets: Array<ElementPath>,
 ): CanvasRectangle | null {
   const autoLayoutSiblings = getAutoLayoutSiblings(jsxMetadata, pathTrees, targets)
-  const autoLayoutSiblingsFrames = autoLayoutSiblings.map((e) => nullIfInfinity(e.globalFrame))
+  const autoLayoutSiblingsFrames = autoLayoutSiblings.flatMap((e) => {
+    const frame = nullIfInfinity(e.globalFrame)
+    return frame == null || isZeroSizedElement(frame) ? [] : [frame]
+  })
   return boundingRectangleArray(autoLayoutSiblingsFrames)
 }
 


### PR DESCRIPTION
# [Try it here](https://utopia.fish/p/767098cb-cactus-snowboard/?branch_name=fix-auto-layout-siblings-zero-sized-elements) 

## Problem
https://github.com/concrete-utopia/utopia/issues/5471

## Fix
The culprit was `AutoLayoutSiblingsOutline`, exculding zero-sized elements from that calculation fixes the issue.

Alternatively, we could temporarily disable showing `AutoLayoutSiblingsOutline` here https://github.com/concrete-utopia/utopia/blob/20d8555024627c0cd2c96db83ac8c10c92e756f0/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx#L228 and re-enable if necessary

## Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
