### PR TITLE
Use `smart` in the navigator to scroll to selected

### DIFF
--- a/editor/src/components/navigator/navigator.tsx
+++ b/editor/src/components/navigator/navigator.tsx
@@ -184,7 +184,7 @@ export const NavigatorComponent = React.memo(() => {
 
   React.useEffect(() => {
     if (selectionIndex >= 0) {
-      itemListRef.current?.scrollToItem(selectionIndex, 'center')
+      itemListRef.current?.scrollToItem(selectionIndex, 'smart')
     }
   }, [selectionIndex, itemListRef])
 


### PR DESCRIPTION
# [Try it here](https://utopia.fish/p/48ed6a03-cuddly-route/?branch_name=fix-navigator-scroll-to-selected-smart)

## Problem
https://github.com/concrete-utopia/utopia/issues/5490

## Fix
Use the `smart` option in `VariableSizeList` to scroll to the selected item

### Manual Tests
I hereby swear that:

- [ ] I opened a hydrogen project and it loaded
- [ ] I could navigate to various routes in Preview mode
