### PR TITLE
More specialized navigator icons

### DIFF
--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -325,12 +325,90 @@ export function createElementIconPropsFromMetadata(
     }
   }
 
+  const isHead = element != null && MetadataUtils.isHead(element)
+  if (isHead) {
+    return {
+      iconProps: {
+        category: 'element',
+        type: 'folder',
+        width: 12,
+        height: 12,
+      },
+      isPositionAbsolute: isPositionAbsolute,
+    }
+  }
+
+  const isHeading = element != null && MetadataUtils.isHeading(element)
+  if (isHeading) {
+    return {
+      iconProps: {
+        category: 'element',
+        type: 'headline',
+        width: 12,
+        height: 12,
+      },
+      isPositionAbsolute: isPositionAbsolute,
+    }
+  }
+
   const isButton = MetadataUtils.isButtonFromMetadata(element)
   if (isButton) {
     return {
       iconProps: {
         category: 'element',
         type: 'clickable',
+        width: 18,
+        height: 18,
+      },
+      isPositionAbsolute: isPositionAbsolute,
+    }
+  }
+
+  const isInput = element != null && MetadataUtils.isInput(element)
+  if (isInput) {
+    return {
+      iconProps: {
+        category: 'element',
+        type: 'input',
+        width: 18,
+        height: 18,
+      },
+      isPositionAbsolute: isPositionAbsolute,
+    }
+  }
+
+  const isAnchorLink = element != null && MetadataUtils.isAnchorLink(element)
+  if (isAnchorLink) {
+    return {
+      iconProps: {
+        category: 'element',
+        type: 'link',
+        width: 18,
+        height: 18,
+      },
+      isPositionAbsolute: isPositionAbsolute,
+    }
+  }
+
+  const isParagraph = element != null && MetadataUtils.isParagraph(element)
+  if (isParagraph) {
+    return {
+      iconProps: {
+        category: 'element',
+        type: 'paragraph',
+        width: 18,
+        height: 18,
+      },
+      isPositionAbsolute: isPositionAbsolute,
+    }
+  }
+
+  const isForm = element != null && MetadataUtils.isForm(element)
+  if (isForm) {
+    return {
+      iconProps: {
+        category: 'element',
+        type: 'form',
         width: 18,
         height: 18,
       },

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -926,6 +926,31 @@ export const MetadataUtils = {
   isBody(instance: ElementInstanceMetadata): boolean {
     return this.isElementOfType(instance, 'body')
   },
+  isHead(instance: ElementInstanceMetadata): boolean {
+    return this.isElementOfType(instance, 'head')
+  },
+  isHeading(instance: ElementInstanceMetadata): boolean {
+    return (
+      this.isElementOfType(instance, 'h1') ||
+      this.isElementOfType(instance, 'h2') ||
+      this.isElementOfType(instance, 'h3') ||
+      this.isElementOfType(instance, 'h4') ||
+      this.isElementOfType(instance, 'h5') ||
+      this.isElementOfType(instance, 'h6')
+    )
+  },
+  isInput(instance: ElementInstanceMetadata): boolean {
+    return this.isElementOfType(instance, 'input')
+  },
+  isAnchorLink(instance: ElementInstanceMetadata): boolean {
+    return this.isElementOfType(instance, 'a')
+  },
+  isParagraph(instance: ElementInstanceMetadata): boolean {
+    return this.isElementOfType(instance, 'p')
+  },
+  isForm(instance: ElementInstanceMetadata): boolean {
+    return this.isElementOfType(instance, 'form')
+  },
   isReactSuspense(instance: ElementInstanceMetadata | null): boolean {
     return MetadataUtils.isImportedComponentFromMetadata(instance, 'react', 'Suspense')
   },


### PR DESCRIPTION
Part of #5482 

This PR adds more specialized navigator icons for:
- `h1...h6`
- `p`
- `input`
- `form`
- `head`
- `a`

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

