### PR TITLE
Harden the ancestor metastrategy

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -590,6 +590,18 @@ export function isStrategyActive(strategyState: StrategyState): boolean {
   return strategyState.currentStrategyCommands.length > 0
 }
 
+export function onlyFitWhenThisControlIsActive(
+  interactionSession: InteractionSession | null,
+  controlType: CanvasControlType['type'],
+  fitnessWhenFit: number,
+): number {
+  if (interactionSession != null && interactionSession.activeControl.type === controlType) {
+    return fitnessWhenFit
+  } else {
+    return 0
+  }
+}
+
 export function onlyFitWhenDraggingThisControl(
   interactionSession: InteractionSession | null,
   controlType: CanvasControlType['type'],

--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
@@ -11,7 +11,7 @@ import { highlightElementsCommand } from '../../commands/highlight-element-comma
 import { setCursorCommand } from '../../commands/set-cursor-command'
 import { appendElementsToRerenderCommand } from '../../commands/set-elements-to-rerender-command'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
-import { onlyFitWhenDraggingThisControl, type MetaCanvasStrategy } from '../canvas-strategies'
+import { onlyFitWhenThisControlIsActive, type MetaCanvasStrategy } from '../canvas-strategies'
 import type {
   CanvasStrategy,
   InteractionCanvasState,
@@ -113,10 +113,15 @@ export function ancestorMetaStrategy(
     )
 
     if (nextAncestorResult.length > 0) {
+      const fitness = (s: CanvasStrategy) =>
+        Math.max(
+          onlyFitWhenThisControlIsActive(interactionSession, 'BOUNDING_AREA', s.fitness),
+          onlyFitWhenThisControlIsActive(interactionSession, 'KEYBOARD_CATCHER_CONTROL', s.fitness),
+        )
       // A length of > 0 means that we should be bubbling up to the next ancestor
       return nextAncestorResult.map((s) => ({
         ...s,
-        fitness: onlyFitWhenDraggingThisControl(interactionSession, 'BOUNDING_AREA', s.fitness),
+        fitness: fitness(s),
         apply: appendCommandsToApplyResult(
           s.apply,
           [appendElementsToRerenderCommand([target])],
@@ -125,16 +130,19 @@ export function ancestorMetaStrategy(
       }))
     } else {
       // Otherwise we should stop at this ancestor and return the strategies for this ancestor
+      const fitness = (s: CanvasStrategy) => {
+        const value = s.fitness > 0 ? s.fitness + 10 : s.fitness
+        return Math.max(
+          onlyFitWhenThisControlIsActive(interactionSession, 'BOUNDING_AREA', value),
+          onlyFitWhenThisControlIsActive(interactionSession, 'KEYBOARD_CATCHER_CONTROL', value),
+        )
+      }
       return allOtherStrategies.flatMap((metaStrategy) =>
         metaStrategy(adjustedCanvasState, interactionSession, customStrategyState).map((s) => ({
           ...s,
           id: `${s.id}_ANCESTOR_${level}`,
           name: applyLevelSuffix(s.name, level),
-          fitness: onlyFitWhenDraggingThisControl(
-            interactionSession,
-            'BOUNDING_AREA',
-            s.fitness > 0 ? s.fitness + 10 : s.fitness, // Ancestor strategies should always take priority
-          ),
+          fitness: fitness(s),
           apply: appendCommandsToApplyResult(
             s.apply,
             [

--- a/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/ancestor-metastrategy.tsx
@@ -11,7 +11,7 @@ import { highlightElementsCommand } from '../../commands/highlight-element-comma
 import { setCursorCommand } from '../../commands/set-cursor-command'
 import { appendElementsToRerenderCommand } from '../../commands/set-elements-to-rerender-command'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
-import type { MetaCanvasStrategy } from '../canvas-strategies'
+import { onlyFitWhenDraggingThisControl, type MetaCanvasStrategy } from '../canvas-strategies'
 import type {
   CanvasStrategy,
   InteractionCanvasState,
@@ -116,6 +116,7 @@ export function ancestorMetaStrategy(
       // A length of > 0 means that we should be bubbling up to the next ancestor
       return nextAncestorResult.map((s) => ({
         ...s,
+        fitness: onlyFitWhenDraggingThisControl(interactionSession, 'BOUNDING_AREA', s.fitness),
         apply: appendCommandsToApplyResult(
           s.apply,
           [appendElementsToRerenderCommand([target])],
@@ -129,7 +130,11 @@ export function ancestorMetaStrategy(
           ...s,
           id: `${s.id}_ANCESTOR_${level}`,
           name: applyLevelSuffix(s.name, level),
-          fitness: s.fitness > 0 ? s.fitness + 10 : s.fitness, // Ancestor strategies should always take priority
+          fitness: onlyFitWhenDraggingThisControl(
+            interactionSession,
+            'BOUNDING_AREA',
+            s.fitness > 0 ? s.fitness + 10 : s.fitness, // Ancestor strategies should always take priority
+          ),
           apply: appendCommandsToApplyResult(
             s.apply,
             [


### PR DESCRIPTION
## Problem
https://github.com/concrete-utopia/utopia/issues/5535

## Fix
The cause of the problem was that even though the border radius control was actiev, the ancestor metastrategy took precedence. This PR tweaks the ancestor metastrategy so that ti's only fit if the BOUNDING_AREA control is active

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

