### PR TITLE
Sample project navigator icons

### DIFF
--- a/editor/src/components/navigator/layout-element-icons.ts
+++ b/editor/src/components/navigator/layout-element-icons.ts
@@ -519,6 +519,41 @@ export function createElementIconPropsFromMetadata(
     }
   }
 
+  // sample project-specific icons
+  const maybeSampleProjectElement = MetadataUtils.maybeSampleProjectElement(element)
+  switch (maybeSampleProjectElement) {
+    case 'spacer':
+      return {
+        iconProps: {
+          category: 'element',
+          type: 'dashedframe',
+          width: 18,
+          height: 18,
+        },
+        isPositionAbsolute: isPositionAbsolute,
+      }
+    case 'title':
+      return {
+        iconProps: {
+          category: 'element',
+          type: 'headline',
+          width: 18,
+          height: 18,
+        },
+        isPositionAbsolute: isPositionAbsolute,
+      }
+    case 'woman-seeking':
+      return {
+        iconProps: {
+          category: 'element',
+          type: 'component',
+          width: 18,
+          height: 18,
+        },
+        isPositionAbsolute: isPositionAbsolute,
+      }
+  }
+
   return {
     iconProps: {
       category: 'element',

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -1200,6 +1200,8 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
               ? 'component'
               : props.emphasis === 'subdued'
               ? 'subdued'
+              : props.emphasis === 'emphasized'
+              ? 'primary'
               : props.iconColor
           }
           elementWarnings={props.elementWarnings}

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -2058,6 +2058,30 @@ export const MetadataUtils = {
       return false
     }
   },
+  maybeSampleProjectElement(element: ElementInstanceMetadata | null): SampleProjectElement | null {
+    if (element != null && isRight(element.element) && isJSXElement(element.element.value)) {
+      switch (element.importInfo?.filePath) {
+        case '/app/components/Components':
+          switch (element.element.value.name.baseVariable) {
+            case 'Spacer':
+              return 'spacer'
+            case 'PageTitle':
+            case 'SectionTitle':
+            case 'SectionSubtitle':
+            case 'SubsectionTitle':
+              return 'title'
+          }
+          break
+        case '/app/routes/_index.jsx':
+          switch (element.element.value.name.baseVariable) {
+            case 'WomanSeeking':
+              return 'woman-seeking'
+          }
+          break
+      }
+    }
+    return null
+  },
   getEmphasisOfComponent(
     path: ElementPath,
     metadata: ElementInstanceMetadataMap,
@@ -2078,7 +2102,8 @@ export const MetadataUtils = {
     // Element with flex or grid get high emphasis.
     if (
       MetadataUtils.isFlexLayoutedContainer(element) ||
-      MetadataUtils.isGridLayoutedContainer(element)
+      MetadataUtils.isGridLayoutedContainer(element) ||
+      MetadataUtils.maybeSampleProjectElement(element) === 'woman-seeking'
     ) {
       return 'emphasized'
     }
@@ -3041,3 +3066,5 @@ export function getZIndexOrderedViewsWithoutDirectChildren(
   })
   return filteredTargets
 }
+
+type SampleProjectElement = 'spacer' | 'title' | 'woman-seeking'


### PR DESCRIPTION
This PR adds icons to navigator elements specific to some sample project components:

- Frame for the `Spacer` component
- Headline for all four titles
- Component (w/ primary emphasis) for `WomanSeeking`

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5482 
