### PR TITLE
properly hide the remix navigation bar if there is a canvas interaction

### DIFF
--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -671,7 +671,10 @@ export const CanvasToolbar = React.memo(() => {
           )
         : null}
       {/* Live Mode */}
-      {(canvasToolbarMode.primary === 'edit' && insertMenuMode === 'closed') ||
+      {(canvasToolbarMode.primary === 'edit' &&
+        canvasToolbarMode.secondary === 'selected' &&
+        allowedToEdit &&
+        insertMenuMode === 'closed') ||
       canvasToolbarMode.primary === 'play'
         ? wrapInSubmenu(<RemixNavigationBar />)
         : null}

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -672,7 +672,7 @@ export const CanvasToolbar = React.memo(() => {
         : null}
       {/* Live Mode */}
       {(canvasToolbarMode.primary === 'edit' &&
-        canvasToolbarMode.secondary === 'selected' &&
+        canvasToolbarMode.secondary !== 'strategy-active' &&
         insertMenuMode === 'closed') ||
       canvasToolbarMode.primary === 'play'
         ? wrapInSubmenu(<RemixNavigationBar />)

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -673,7 +673,6 @@ export const CanvasToolbar = React.memo(() => {
       {/* Live Mode */}
       {(canvasToolbarMode.primary === 'edit' &&
         canvasToolbarMode.secondary === 'selected' &&
-        allowedToEdit &&
         insertMenuMode === 'closed') ||
       canvasToolbarMode.primary === 'play'
         ? wrapInSubmenu(<RemixNavigationBar />)


### PR DESCRIPTION
Fixes #5536 

When I added the remix URL bar for edit mode I botched the checks and made it visible for _all_ of editing, not just the select mode phase.