### PR TITLE
Override navigator icon via component

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -7,7 +7,7 @@ import {
   type TriggerEvent,
 } from 'react-contexify'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import type { ElementInstanceMetadataMap, JSXElement } from '../../../core/shared/element-template'
+import type { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
 import {
   type ElementInstanceMetadata,
   getJSXElementNameAsString,
@@ -63,7 +63,6 @@ import {
 } from '../../editor/store/insertion-path'
 import type { InsertableComponent } from '../../shared/project-components'
 import type { ConditionalCase } from '../../../core/model/conditionals'
-import { sortBy } from '../../../core/shared/array-utils'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import { absolute } from '../../../utils/utils'
 import { notice } from '../../common/notice'
@@ -557,6 +556,24 @@ function iconPropsForIcon(icon: Icon): IcnProps {
         color: 'white',
       }
     case 'regular':
+      return {
+        category: 'navigator-element',
+        type: 'component',
+        color: 'white',
+      }
+    case 'headline':
+      return {
+        category: 'navigator-element',
+        type: 'headline',
+        color: 'white',
+      }
+    case 'dashedframe':
+      return {
+        category: 'navigator-element',
+        type: 'dashedframe',
+        color: 'white',
+      }
+    case 'component':
       return {
         category: 'navigator-element',
         type: 'component',

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -357,6 +357,24 @@ function iconPropsForIcon(icon: Icon): IcnProps {
         type: 'component',
         color: 'white',
       }
+    case 'headline':
+      return {
+        category: 'navigator-element',
+        type: 'headline',
+        color: 'white',
+      }
+    case 'dashedframe':
+      return {
+        category: 'navigator-element',
+        type: 'dashedframe',
+        color: 'white',
+      }
+    case 'component':
+      return {
+        category: 'navigator-element',
+        type: 'component',
+        color: 'white',
+      }
     default:
       assertNever(icon)
   }

--- a/editor/src/components/navigator/navigator-item/layout-icon.tsx
+++ b/editor/src/components/navigator/navigator-item/layout-icon.tsx
@@ -5,9 +5,7 @@ import {
   navigatorEntryToKey,
 } from '../../../components/editor/store/editor-state'
 import type { IcnProps } from '../../../uuiui'
-import { colorTheme } from '../../../uuiui'
 import { Icn, Icons } from '../../../uuiui'
-import { WarningIcon } from '../../../uuiui/warning-icon'
 import { invalidGroupStateToString } from '../../canvas/canvas-strategies/strategies/group-helpers'
 import { ChildWithPercentageSize } from '../../common/size-warnings'
 import { useLayoutOrElementIcon } from '../layout-element-icons'
@@ -22,9 +20,11 @@ import { metadataSelector } from '../../inspector/inpector-selectors'
 import type { MetadataSubstate } from '../../editor/store/store-hook-substore-types'
 import * as EP from '../../../core/shared/element-path'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
+import type { Icon } from 'utopia-api'
 
 interface LayoutIconProps {
   navigatorEntry: NavigatorEntry
+  override?: Icon | null
   color: IcnProps['color']
   warningText?: string | null
   elementWarnings?: ElementWarnings | null
@@ -108,6 +108,17 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
         ...iconProps,
         color: color,
         style: { opacity: 'var(--iconOpacity)' },
+      }
+      if (props.override != null && props.override !== 'regular') {
+        return (
+          <Icn
+            category='navigator-element'
+            type={props.override}
+            width={12}
+            height={12}
+            testId={iconTestId}
+          />
+        )
       }
       if (isZeroSized) {
         return (
@@ -208,6 +219,7 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
       isErroredGroupChild,
       iconTestId,
       addAbsoluteMarkerToIcon,
+      props.override,
     ])
 
     const marker = React.useMemo(() => {

--- a/editor/src/components/navigator/navigator-item/layout-icon.tsx
+++ b/editor/src/components/navigator/navigator-item/layout-icon.tsx
@@ -110,10 +110,16 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
         style: { opacity: 'var(--iconOpacity)' },
       }
       if (props.override != null && props.override !== 'regular') {
+        const type =
+          props.override === 'column'
+            ? 'flex-column'
+            : props.override === 'row'
+            ? 'flex-row'
+            : props.override
         return (
           <Icn
             category='navigator-element'
-            type={props.override}
+            type={type}
             width={12}
             height={12}
             testId={iconTestId}

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -76,7 +76,7 @@ import {
   sendMessage,
 } from '../../../core/vscode/vscode-bridge'
 import { toVSCodeExtensionMessage } from 'utopia-vscode-common'
-import type { Emphasis } from 'utopia-api'
+import type { Emphasis, Icon } from 'utopia-api'
 import { contextMenu } from 'react-contexify'
 import { DataReferenceCartoucheControl } from '../../inspector/sections/component-section/data-reference-cartouche'
 
@@ -758,6 +758,17 @@ export const NavigatorItem: React.FunctionComponent<
     'NavigatorItem emphasis',
   )
 
+  const iconOverride = useEditorState(
+    Substores.propertyControlsInfo,
+    (store) =>
+      MetadataUtils.getIconOfComponent(
+        navigatorEntry.elementPath,
+        store.editor.propertyControlsInfo,
+        store.editor.projectContents,
+      ),
+    'NavigatorItem iconOverride',
+  )
+
   const isInsideComponent = isInFocusedComponentSubtree
   const fullyVisible = useStyleFullyVisible(navigatorEntry, autoFocusedPaths)
   const isProbablyScene = useIsProbablyScene(navigatorEntry)
@@ -1026,6 +1037,7 @@ export const NavigatorItem: React.FunctionComponent<
                 dispatch={props.dispatch}
                 isDynamic={isDynamic}
                 iconColor={iconColor}
+                iconOverride={iconOverride}
                 elementWarnings={!isConditional ? elementWarnings : null}
                 childComponentCount={childComponentCount}
                 insideFocusedComponent={isInsideComponent && isDescendantOfSelected}
@@ -1155,6 +1167,7 @@ const PlaceholderSlot = React.memo((props: PlaceholderSlotProps) => {
 interface NavigatorRowLabelProps {
   navigatorEntry: NavigatorEntry
   iconColor: IcnProps['color']
+  iconOverride: Icon | null
   elementWarnings: ElementWarnings | null
   label: string
   isDynamic: boolean
@@ -1193,6 +1206,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
         <LayoutIcon
           key={`layout-type-${props.label}`}
           navigatorEntry={props.navigatorEntry}
+          override={props.iconOverride}
           color={
             props.selected
               ? 'white'

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1,5 +1,5 @@
 import * as OPI from 'object-path-immutable'
-import type { Emphasis, FlexLength, Sides } from 'utopia-api/core'
+import type { Emphasis, FlexLength, Icon, Sides } from 'utopia-api/core'
 import { sides } from 'utopia-api/core'
 import { getReorderDirection } from '../../components/canvas/controls/select-mode/yoga-utils'
 import { getImageSize, scaleImageDimensions } from '../../components/images'
@@ -2114,6 +2114,18 @@ export const MetadataUtils = {
 
     // Default to regular.
     return 'regular'
+  },
+  getIconOfComponent(
+    path: ElementPath,
+    propertyControlsInfo: PropertyControlsInfo,
+    projectContents: ProjectContentTreeRoot,
+  ): Icon | null {
+    const componentDescriptor = getComponentDescriptorForTarget(
+      path,
+      propertyControlsInfo,
+      projectContents,
+    )
+    return componentDescriptor?.icon ?? null
   },
   isEmotionOrStyledComponent(path: ElementPath, metadata: ElementInstanceMetadataMap): boolean {
     const element = MetadataUtils.findElementByElementPath(metadata, path)

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -50,7 +50,14 @@ export type InspectorSpec = 'all' | Styling[]
 export const EmphasisOptions = ['subdued', 'regular', 'emphasized'] as const
 export type Emphasis = (typeof EmphasisOptions)[number]
 
-export const IconOptions = ['column', 'row', 'regular'] as const // and others
+export const IconOptions = [
+  'flex-column',
+  'flex-row',
+  'regular',
+  'headline',
+  'dashedframe',
+  'component',
+] as const // and others
 export type Icon = (typeof IconOptions)[number]
 
 export interface ComponentToRegister {

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -51,8 +51,8 @@ export const EmphasisOptions = ['subdued', 'regular', 'emphasized'] as const
 export type Emphasis = (typeof EmphasisOptions)[number]
 
 export const IconOptions = [
-  'flex-column',
-  'flex-row',
+  'column',
+  'row',
   'regular',
   'headline',
   'dashedframe',


### PR DESCRIPTION
Part of #5482 

This PR allows the components to override the default navigator icons, when passed via the `icon` prop.

**IMPORTANT!** This also needs https://github.com/concrete-utopia/hydrogen-november/pull/9 to be merged to avoid issues with mismatching enum values.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode