### PR TITLE
Navigator emphasized color

### DIFF
--- a/editor/src/components/navigator/navigator-item/layout-icon.tsx
+++ b/editor/src/components/navigator/navigator-item/layout-icon.tsx
@@ -123,6 +123,7 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
             width={12}
             height={12}
             testId={iconTestId}
+            color={props.color}
           />
         )
       }
@@ -226,6 +227,7 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
       iconTestId,
       addAbsoluteMarkerToIcon,
       props.override,
+      props.color,
     ])
 
     const marker = React.useMemo(() => {

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -1214,6 +1214,8 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
               ? 'component'
               : props.emphasis === 'subdued'
               ? 'subdued'
+              : props.emphasis === 'emphasized'
+              ? 'primary'
               : props.iconColor
           }
           elementWarnings={props.elementWarnings}


### PR DESCRIPTION
Fixes #5482 

Relates to https://github.com/concrete-utopia/hydrogen-november/pull/10

This PR adds handling of the `"emphasized"` `Emphasis` value for components in the navigator so it shows a different color like we do for the `"subdued"` value.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode