### PR TITLE
update render prop contents in real time

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -341,20 +341,29 @@ export function createComponentRendererComponent(params: {
   return Component
 }
 
+function isRenderProp(prop: any): prop is { [UTOPIA_PATH_KEY]: string; props: MapLike<any> } {
+  return ((prop as any)?.props as any)?.[UTOPIA_PATH_KEY] != null
+}
+
 // Checks if the element with the given elementPath is rendered in the props.children subtree
 // LIMITATION: this function only checks props.children, so if the given element is rendered, but from a
 // different prop, isElementInChildrenPropTree will return false
 // If we will support renderProps, this should be updated to check other props which receive react elements
 function isElementInChildrenPropTree(elementPath: string, props: any): boolean {
   const childrenArr = React.Children.toArray(props.children).filter(React.isValidElement)
-
-  if (childrenArr.length === 0) {
-    return false
-  }
   const elementIsChild = childrenArr.some((c) => (c.props as any)[UTOPIA_PATH_KEY] === elementPath)
   if (elementIsChild) {
     return true
-  } else {
-    return childrenArr.some((c) => isElementInChildrenPropTree(elementPath, c.props))
   }
+
+  const elementsInProps = Object.values(props).filter(isRenderProp)
+  const isElementInProps = elementsInProps.some((p) => p[UTOPIA_PATH_KEY] === elementPath)
+  if (isElementInProps) {
+    return true
+  }
+
+  return (
+    childrenArr.some((c) => isElementInChildrenPropTree(elementPath, c.props)) ||
+    elementsInProps.some((p) => isElementInChildrenPropTree(elementPath, p.props))
+  )
 }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -86,7 +86,7 @@ export function createComponentRendererComponent(params: {
           return (
             (instancePath != null &&
               (EP.pathsEqual(er, instancePath) || EP.isParentComponentOf(instancePath, er))) ||
-            isElementInChildrenPropTree(EP.toString(er), realPassedProps)
+            isElementInChildrenOrPropsTree(EP.toString(er), realPassedProps)
           )
         })
       )
@@ -349,7 +349,7 @@ function isRenderProp(prop: any): prop is { [UTOPIA_PATH_KEY]: string; props: Ma
 // LIMITATION: this function only checks props.children, so if the given element is rendered, but from a
 // different prop, isElementInChildrenPropTree will return false
 // If we will support renderProps, this should be updated to check other props which receive react elements
-function isElementInChildrenPropTree(elementPath: string, props: any): boolean {
+function isElementInChildrenOrPropsTree(elementPath: string, props: any): boolean {
   const childrenArr = React.Children.toArray(props.children).filter(React.isValidElement)
   const elementIsChild = childrenArr.some((c) => (c.props as any)[UTOPIA_PATH_KEY] === elementPath)
   if (elementIsChild) {
@@ -363,7 +363,7 @@ function isElementInChildrenPropTree(elementPath: string, props: any): boolean {
   }
 
   return (
-    childrenArr.some((c) => isElementInChildrenPropTree(elementPath, c.props)) ||
-    elementsInProps.some((p) => isElementInChildrenPropTree(elementPath, p.props))
+    childrenArr.some((c) => isElementInChildrenOrPropsTree(elementPath, c.props)) ||
+    elementsInProps.some((p) => isElementInChildrenOrPropsTree(elementPath, p.props))
   )
 }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -351,10 +351,6 @@ function isRenderProp(prop: any): prop is { [UTOPIA_PATH_KEY]: string; props: Ma
   )
 }
 
-// Checks if the element with the given elementPath is rendered in the props.children subtree
-// LIMITATION: this function only checks props.children, so if the given element is rendered, but from a
-// different prop, isElementInChildrenPropTree will return false
-// If we will support renderProps, this should be updated to check other props which receive react elements
 function isElementInChildrenOrPropsTree(elementPath: string, props: any): boolean {
   const childrenArr = React.Children.toArray(props.children).filter(React.isValidElement)
   const elementIsChild = childrenArr.some((c) => (c.props as any)[UTOPIA_PATH_KEY] === elementPath)

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -342,7 +342,13 @@ export function createComponentRendererComponent(params: {
 }
 
 function isRenderProp(prop: any): prop is { [UTOPIA_PATH_KEY]: string; props: MapLike<any> } {
-  return ((prop as any)?.props as any)?.[UTOPIA_PATH_KEY] != null
+  return (
+    prop != null &&
+    typeof prop === 'object' &&
+    prop.props != null &&
+    typeof prop.props === 'object' &&
+    typeof prop.props[UTOPIA_PATH_KEY] === 'string'
+  )
 }
 
 // Checks if the element with the given elementPath is rendered in the props.children subtree

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -755,7 +755,7 @@ function renderJSXElement(
   const FinalElement = elementIsIntrinsic ? jsx.name.baseVariable : element
   const FinalElementOrFragment = elementIsFragment ? React.Fragment : FinalElement
 
-  let elementProps = { key: key, ...passthroughProps }
+  let elementProps: MapLike<any> = { key: key, ...passthroughProps }
   if (!elementIsFragment) {
     if (isHidden(hiddenInstances, elementPath)) {
       elementProps = hideElement(elementProps)
@@ -764,6 +764,24 @@ function renderJSXElement(
       elementProps = displayNoneElement(elementProps)
     }
     elementProps = streamlineInFileBlobs(elementProps, fileBlobs)
+    for (const prop of jsx.props) {
+      if (prop.type === 'JSX_ATTRIBUTES_ENTRY' && prop.value.type === 'JSX_ELEMENT') {
+        const pathForElementInRenderProp = optionalMap(
+          (p) => EP.appendToPath(p, prop.value.uid),
+          elementPath,
+        )
+        const renderedElement = renderCoreElement(
+          prop.value,
+          pathForElementInRenderProp,
+          inScope,
+          renderContext,
+          prop.value.uid,
+          codeError,
+          `${prop.key}`,
+        )
+        elementProps[prop.key] = renderedElement
+      }
+    }
   }
 
   const elementPropsWithScenePath = isComponentRendererComponent(FinalElement)


### PR DESCRIPTION
# [Try it here](https://utopia.fish/p/ee28bdb8-fate-protocol/?branch_name=fix-render-prop-canvas-real-time)

## Problem
Elements in render props don't update in real time during canvas interaction

https://github.com/concrete-utopia/utopia/issues/5492

## Fix
- fix `renderJSXElement` so that it calls `renderCoreElement` for JSXElement-valued props
- fix `isElementInChildrenOrPropsTree` so that it looks for the element in the props as well

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode