### PR TITLE
Give remix scenes a scene-id for dom invalidation

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -789,7 +789,7 @@ function renderJSXElement(
     : elementProps
 
   const elementPropsWithSceneID =
-    elementIsScene && elementPath != null
+    (elementIsScene || elementIsRemixScene) && elementPath != null
       ? { ...elementPropsWithScenePath, [UTOPIA_SCENE_ID_KEY]: EP.toString(elementPath) }
       : elementPropsWithScenePath
 


### PR DESCRIPTION
**Problem:**
Remix scenes aren't being correctly invalidated by the resize and mutation observers, meaning metadata (and therefore the frames used for highlighting on the canvas) is stale.

**Fix:**
The problem here is that we invalidate paths for the dom walker using the scene ID (so that every descendant is updated), but weren't putting the scene ID on Remix scenes.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5554
