### PR TITLE
Consistent context menus

### DIFF
--- a/editor/resources/editor/css/ReactContexify.css
+++ b/editor/resources/editor/css/ReactContexify.css
@@ -3,13 +3,13 @@
   position: fixed;
   opacity: 0;
   user-select: none;
-  border-radius: 7px;
+  border-radius: 10px;
   background-color: var(--utopitheme-contextMenuBackground);
   box-sizing: border-box;
   /* the same as boxShadow: UtopiaStyles.shadowStyles.mid.boxShadow */
   box-shadow: 0px 3px 6px -2px var(--utopitheme-shadow80),
     0px 4px 8px -2px var(--utopitheme-shadow40);
-  padding: 4px 0px;
+  padding: 8px 0px;
   font-family: 'utopian-inter';
 }
 .react-contexify .react-contexify__submenu {

--- a/editor/src/components/context-menu-wrapper.tsx
+++ b/editor/src/components/context-menu-wrapper.tsx
@@ -121,7 +121,12 @@ export class MomentumContextMenu<T> extends ReactComponent<ContextMenuProps<T>> 
           contextMenu.hideAll()
         }}
         hidden={this.isHidden(item)}
-        style={{ height: item.isSeparator ? 9 : 24, display: 'flex', alignItems: 'center' }}
+        style={{
+          height: item.isSeparator ? 9 : 28,
+          display: 'flex',
+          alignItems: 'center',
+          borderRadius: 4,
+        }}
       >
         <span style={{ flexGrow: 1, flexShrink: 0 }} className='react-contexify-span'>
           {item.name}
@@ -144,7 +149,7 @@ export class MomentumContextMenu<T> extends ReactComponent<ContextMenuProps<T>> 
               <SubmenuComponent
                 key={`context-menu-${index}`}
                 label={
-                  <span style={{ height: 24, display: 'flex', alignItems: 'center' }}>
+                  <span style={{ height: 28, display: 'flex', alignItems: 'center' }}>
                     {item.label}
                   </span>
                 }

--- a/editor/src/components/inspector/sections/component-section/cartouche-control.tsx
+++ b/editor/src/components/inspector/sections/component-section/cartouche-control.tsx
@@ -31,8 +31,6 @@ export const IdentifierExpressionCartoucheControl = React.memo(
           color:
             props.matchType === 'full'
               ? colorTheme.white.value
-              : props.matchType === 'partial'
-              ? colorTheme.primary.value
               : colorTheme.neutralForeground.value,
           backgroundColor:
             props.matchType === 'full'

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -306,7 +306,7 @@ export const DataPickerPopup = React.memo(
                 height: 28,
               }}
             >
-              <div style={{ fontWeight: 600, flexGrow: 1 }}>Data</div>
+              <div style={{ fontWeight: 600 }}>Data</div>
               <PopupList
                 containerMode='showBorderOnHover'
                 options={filterOptions}

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -77,7 +77,7 @@ export type DataPickerFilterOption = (typeof DataPickerFilterOptions)[number]
 export function dataPickerFilterOptionToString(mode: DataPickerFilterOption): string {
   switch (mode) {
     case 'all':
-      return 'All'
+      return 'All Data'
     case 'preferred':
       return 'Preferred'
     default:
@@ -259,6 +259,14 @@ export const DataPickerPopup = React.memo(
       [],
     )
 
+    const handleFilterOptionClick = useCallback(
+      (option: { value: any }) => (e: React.MouseEvent) => {
+        e.stopPropagation()
+        setMode({ value: option.value })
+      },
+      [setMode],
+    )
+
     return (
       <InspectorModal
         offsetX={10}
@@ -305,7 +313,7 @@ export const DataPickerPopup = React.memo(
                 whiteSpace: 'nowrap',
                 display: 'flex',
                 flexDirection: 'row',
-                gap: 12,
+                gap: 16,
                 padding: '2px',
               }}
             >
@@ -320,10 +328,9 @@ export const DataPickerPopup = React.memo(
                       opacity: 1,
                     },
                   }}
-                  /* eslint-disable-next-line react/jsx-no-bind */
-                  onClick={() => setMode(option)}
+                  onClick={handleFilterOptionClick(option)}
                 >
-                  {option.label + ' ' + 'Data'}
+                  {option.label}
                 </div>
               ))}
             </div>

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -299,24 +299,34 @@ export const DataPickerPopup = React.memo(
             }}
             data-testid={DataPickerPopupTestId}
           >
-            <FlexRow
+            <div
               css={{
-                gap: 10,
-                alignItems: 'center',
-                height: 28,
+                overflowX: 'scroll',
+                whiteSpace: 'nowrap',
+                display: 'flex',
+                flexDirection: 'row',
+                gap: 12,
+                padding: '2px',
               }}
             >
-              <div style={{ fontWeight: 600 }}>Data</div>
-              <PopupList
-                containerMode='showBorderOnHover'
-                options={filterOptions}
-                value={{
-                  value: preferredAllState,
-                  label: dataPickerFilterOptionToString(preferredAllState),
-                }}
-                onSubmitValue={setMode}
-              />
-            </FlexRow>
+              {filterOptions.map((option, index) => (
+                <div
+                  key={index}
+                  css={{
+                    color: colorTheme.white.value,
+                    fontWeight: 500,
+                    opacity: preferredAllState === option.value ? 1 : 0.4,
+                    '&:hover': {
+                      opacity: 1,
+                    },
+                  }}
+                  /* eslint-disable-next-line react/jsx-no-bind */
+                  onClick={() => setMode(option)}
+                >
+                  {option.label + ' ' + 'Data'}
+                </div>
+              ))}
+            </div>
             <DataPickerPopupSubvariables
               preferredAllState={preferredAllState}
               pickerType={pickerType}

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -6,7 +6,7 @@ import React, { useCallback } from 'react'
 import { jsExpressionOtherJavaScriptSimple } from '../../../../core/shared/element-template'
 import { optionalMap } from '../../../../core/shared/optional-utils'
 import type { ElementPath, PropertyPath } from '../../../../core/shared/project-file-types'
-import { useColorTheme, Button, FlexColumn, UtopiaStyles, PopupList } from '../../../../uuiui'
+import { useColorTheme, Button, FlexColumn, UtopiaStyles } from '../../../../uuiui'
 import {
   insertJSXElement,
   setProp_UNSAFE,

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -6,15 +6,7 @@ import React, { useCallback } from 'react'
 import { jsExpressionOtherJavaScriptSimple } from '../../../../core/shared/element-template'
 import { optionalMap } from '../../../../core/shared/optional-utils'
 import type { ElementPath, PropertyPath } from '../../../../core/shared/project-file-types'
-import {
-  useColorTheme,
-  Button,
-  FlexColumn,
-  UtopiaStyles,
-  UtopiaTheme,
-  SquareButton,
-  PopupList,
-} from '../../../../uuiui'
+import { useColorTheme, Button, FlexColumn, UtopiaStyles, PopupList } from '../../../../uuiui'
 import {
   insertJSXElement,
   setProp_UNSAFE,
@@ -296,11 +288,10 @@ export const DataPickerPopup = React.memo(
             style={{
               ...props.style,
               left: -16, // to make it align with the cartouche control
-              backgroundColor: colorTheme.bg0.value,
-              color: colorTheme.fg1.value,
-              padding: 4,
+              backgroundColor: colorTheme.contextMenuBackground.value,
+              color: colorTheme.contextMenuForeground.value,
+              padding: 8,
               boxShadow: UtopiaStyles.shadowStyles.low.boxShadow,
-              border: `.2px solid ${colorTheme.popupBorder.value}`,
               borderRadius: 10,
               alignItems: 'flex-start',
               width: '96%',
@@ -308,12 +299,14 @@ export const DataPickerPopup = React.memo(
             }}
             data-testid={DataPickerPopupTestId}
           >
-            <UIGridRow
-              padded
-              variant='<-------1fr------>|----80px----|'
-              css={{ marginBottom: 4, alignSelf: 'stretch' }}
+            <FlexRow
+              css={{
+                gap: 10,
+                alignItems: 'center',
+                height: 28,
+              }}
             >
-              <div style={{ fontWeight: 600, flexGrow: 1, color: colorTheme.fg1.value }}>Data</div>
+              <div style={{ fontWeight: 600, flexGrow: 1 }}>Data</div>
               <PopupList
                 containerMode='showBorderOnHover'
                 options={filterOptions}
@@ -323,7 +316,7 @@ export const DataPickerPopup = React.memo(
                 }}
                 onSubmitValue={setMode}
               />
-            </UIGridRow>
+            </FlexRow>
             <DataPickerPopupSubvariables
               preferredAllState={preferredAllState}
               pickerType={pickerType}
@@ -396,21 +389,18 @@ function ValueRow({
       <Button
         data-testid={VariableFromScopeOptionTestId(idx)}
         style={{
-          borderRadius: 8,
+          borderRadius: 4,
           width: '100%',
-          height: 29,
-          marginTop: variableChildren != null && variableOption.depth === 0 ? 12 : 0, // add some space between top-level variables
+          height: 28,
+          marginTop: variableChildren != null && variableOption.depth === 0 ? 6 : 0, // add some space between top-level variables
           cursor: variableOption.variableInfo.matches ? 'pointer' : 'default',
-          background: currentExpressionExactMatch
-            ? colorTheme.secondaryBackground.value
-            : undefined,
+          background: currentExpressionExactMatch ? colorTheme.primary.value : undefined,
+          color: currentExpressionExactMatch ? colorTheme.white.value : undefined,
         }}
         onClick={isArray ? stopPropagation : tweakProperty}
         css={{
           '&:hover': {
-            backgroundColor: variableOption.variableInfo.matches
-              ? colorTheme.secondaryBackground.value
-              : 'inherit',
+            backgroundColor: colorTheme.primary30.value,
           },
         }}
       >
@@ -420,7 +410,7 @@ function ValueRow({
           style={{
             justifyContent: 'space-between',
             alignItems: 'flex-start',
-            gap: 8,
+            gap: 10,
             width: '100%',
             minHeight: 'auto',
             gridTemplateColumns: '48% 48%',
@@ -461,7 +451,6 @@ function ValueRow({
             <span
               style={{
                 fontWeight: 400,
-                color: colorTheme.neutralForeground.value,
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
                 maxWidth: 130,
@@ -543,7 +532,7 @@ function PrefixIcon({
       onClick={onClick}
     >
       {hasObjectChildren ? (
-        <ExpandableIndicator visible collapsed={!open} selected={false} />
+        <ExpandableIndicator visible collapsed={!open} selected={false} iconColor='white' />
       ) : null}
     </span>
   )
@@ -558,7 +547,6 @@ function ArrayPaginator({
   totalChildCount: number
   setSelectedIndex: (index: number) => void
 }) {
-  const colorTheme = useColorTheme()
   const increaseIndex = useCallback(() => {
     setSelectedIndex(Math.min(totalChildCount - 1, selectedIndex + 1))
   }, [selectedIndex, setSelectedIndex, totalChildCount])
@@ -570,7 +558,6 @@ function ArrayPaginator({
       css={{
         alignItems: 'center',
         fontSize: 10,
-        color: colorTheme.neutralForeground.value,
       }}
     >
       <div onClick={decreaseIndex} style={{ cursor: 'pointer', paddingLeft: 4, paddingRight: 4 }}>

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -342,7 +342,7 @@ function moreItem(
   showComponentPickerContextMenu: ShowComponentPickerContextMenu,
 ): ContextMenuItem<unknown> {
   return {
-    name: <FlexRow style={{ paddingLeft: 22 }}>More...</FlexRow>,
+    name: <FlexRow style={{ paddingLeft: 22 }}>More…</FlexRow>,
     enabled: true,
     action: (_data, _dispatch, _rightClickCoordinate, e) => {
       const currentMenu = (menuWrapperRef.current?.childNodes[0] as HTMLDivElement) ?? null

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -342,21 +342,7 @@ function moreItem(
   showComponentPickerContextMenu: ShowComponentPickerContextMenu,
 ): ContextMenuItem<unknown> {
   return {
-    name: (
-      <FlexRow>
-        <div
-          style={{
-            width: 18,
-            height: 18,
-            display: 'flex',
-            justifyItems: 'center',
-            alignItems: 'center',
-            position: 'relative',
-          }}
-        ></div>{' '}
-        More...
-      </FlexRow>
-    ),
+    name: <FlexRow style={{ paddingLeft: 22 }}>More...</FlexRow>,
     enabled: true,
     action: (_data, _dispatch, _rightClickCoordinate, e) => {
       const currentMenu = (menuWrapperRef.current?.childNodes[0] as HTMLDivElement) ?? null
@@ -625,7 +611,7 @@ const ComponentPickerContextMenuSimple = React.memo<ComponentPickerContextMenuPr
 
         const submenuLabel = (
           <FlexRow
-            style={{ gap: 5 }}
+            style={{ gap: 10 }}
             data-testId={labelTestIdForComponentIcon(data.name, data.moduleName ?? '', data.icon)}
           >
             <Icn {...iconProps} width={12} height={12} />

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -159,9 +159,6 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
         gap: 0,
         width: '100%',
         height: '100%',
-        padding: 0,
-        color: dark.fg3.value,
-        colorScheme: 'dark',
         borderRadius: 10,
       }}
       onKeyDown={onKeyDown}
@@ -189,7 +186,7 @@ const ComponentPickerTopSection = React.memo((props: ComponentPickerTopSectionPr
   return (
     <div
       style={{
-        padding: '8px 8px',
+        padding: '0px 8px 8px 8px',
         display: 'flex',
         flexDirection: 'column',
       }}
@@ -241,7 +238,7 @@ const FilterBar = React.memo((props: FilterBarProps) => {
   return (
     <input
       css={{
-        height: 25,
+        height: 28,
         paddingLeft: 8,
         paddingRight: 8,
         background: 'transparent',
@@ -317,22 +314,14 @@ const ComponentPickerComponentSection = React.memo(
               onMouseOver={onItemHover(component.value)}
               data-key={component.value.key}
             >
-              <UIGridRow
-                variant='|--32px--|<--------auto-------->'
-                padded={false}
-                // required to overwrite minHeight on the bloody thing
-                style={{ minHeight: 29 }}
-                css={{
-                  height: 27,
-                }}
-              >
+              <FlexRow css={{ gap: 10, height: 28, alignItems: 'center' }}>
                 <Icn
                   {...iconPropsForIcon(component.value.icon ?? 'regular')}
                   width={12}
                   height={12}
                 />
                 <label>{component.label}</label>
-              </UIGridRow>
+              </FlexRow>
             </FlexRow>
           )
 

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -218,7 +218,7 @@ const darkTheme: typeof light = {
   navigatorComponentSelected: darkBase.componentChild20,
   navigatorComponentIconBorder: darkBase.componentChild,
 
-  contextMenuBackground: darkBase.bg1,
+  contextMenuBackground: darkBase.bg0,
   contextMenuForeground: darkBase.white,
   contextMenuHighlightForeground: darkBase.white,
   contextMenuHighlightBackground: darkBase.primary,

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -220,8 +220,8 @@ const darkTheme: typeof light = {
 
   contextMenuBackground: darkBase.bg1,
   contextMenuForeground: darkBase.white,
-  contextMenuHighlightForeground: darkBase.bg1,
-  contextMenuHighlightBackground: darkBase.dynamicBlue,
+  contextMenuHighlightForeground: darkBase.white,
+  contextMenuHighlightBackground: darkBase.primary,
   contextMenuSeparator: createUtopiColor('rgba(255,255,255,0.35)'),
 
   inspectorHoverColor: darkBase.fg8,


### PR DESCRIPTION
1) Making the Quick Component Picker and Full Component Picker (the one behind MORE...) visually consistent (spacing, gaps, highlights, etc). TABLESS . The background colors are slightly different so that it still contrasts with the default bg color in dark theme.
2) Making the Data Picker visually consistent with those two (same box shadow, same dark bg, same blue highlight, same icon - label spacing
3) Making the context menu styling visually consistent with those two (padding, box shadow, row spacing etc)
4) Using tabs in the Data Picker instead of the popup menu because the popup menu is theme-aware, and the context menu should not be - so there was no simple way to edit the style of the popup menu without changing it in the whole app. If we don't want to show these filter options at all yet we can get rid of these tabs entirely.

Fixes #[[5459](https://github.com/concrete-utopia/utopia/issues/5459)] 

Dark:
![data-picker](https://github.com/concrete-utopia/utopia/assets/47405698/2d7a3558-c5a9-4b11-84bd-07d5f4acd1b3)
<img width="250" alt="Screenshot 2024-05-05 at 1 19 16 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/bef34447-c9a7-4bd9-a680-1d2215ecb542">
<img width="220" alt="Screenshot 2024-05-05 at 1 18 26 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/50e79ec9-3ef5-4769-a992-66ad1c5385a6">
<img width="250" alt="Screenshot 2024-05-05 at 1 18 40 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/0aea000c-dfbb-4c01-b1fb-626da44a56a9">

Light:
<img width="250" alt="Screenshot 2024-05-05 at 1 56 26 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/aa7bbb65-2663-46c3-a7be-f36e1f414fa0">
<img width="250" alt="Screenshot 2024-05-05 at 1 22 58 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/7b53df7b-885e-4caa-b772-b90e0c8d4333">
<img width="220" alt="Screenshot 2024-05-05 at 1 57 07 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/cb661278-d141-4e25-b6cd-e7795c4fb0e7">
<img width="250" alt="Screenshot 2024-05-05 at 1 57 16 AM" src="https://github.com/concrete-utopia/utopia/assets/47405698/8deb60a4-54c9-40bd-9bb7-f2b64beaf490">

