### PR TITLE
clear selection on Remix route change

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -454,6 +454,8 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
 
   useGithubPolling()
 
+  useClearSelectionOnNavigation()
+
   const portalTarget = document.getElementById(CanvasContextMenuPortalTargetID)
 
   return (
@@ -562,7 +564,6 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
         keyUp={onWindowKeyUp}
       />
       <CommentMaintainer />
-      <ClearSelectionOnNavigation />
     </>
   )
 })
@@ -798,7 +799,7 @@ const LockedOverlay = React.memo(() => {
   )
 })
 
-const ClearSelectionOnNavigation = () => {
+const useClearSelectionOnNavigation = () => {
   const dispatch = useDispatch()
   const [remixNavigation] = useAtom(RemixNavigationAtom)
   const paths = Object.values(remixNavigation)
@@ -808,6 +809,4 @@ const ClearSelectionOnNavigation = () => {
   React.useEffect(() => {
     dispatch([EditorActions.clearSelection()])
   }, [dispatch, paths])
-
-  return <></>
 }

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -81,13 +81,17 @@ import {
   CloneParamKey,
   GithubBranchParamKey,
 } from './persistence/persistence-backend'
-import { useUpdateActiveRemixSceneOnSelectionChange } from '../canvas/remix/utopia-remix-root-component'
+import {
+  RemixNavigationAtom,
+  useUpdateActiveRemixSceneOnSelectionChange,
+} from '../canvas/remix/utopia-remix-root-component'
 import { useDefaultCollapsedViews } from './use-default-collapsed-views'
 import {
   ComponentPickerContextMenu,
   useCreateCallbackToShowComponentPicker,
 } from '../navigator/navigator-item/component-picker-context-menu'
 import { useGithubPolling } from '../../core/shared/github/helpers'
+import { useAtom } from 'jotai'
 
 const liveModeToastId = 'play-mode-toast'
 
@@ -558,6 +562,7 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
         keyUp={onWindowKeyUp}
       />
       <CommentMaintainer />
+      <ClearSelectionOnNavigation />
     </>
   )
 })
@@ -792,3 +797,17 @@ const LockedOverlay = React.memo(() => {
     </div>
   )
 })
+
+const ClearSelectionOnNavigation = () => {
+  const dispatch = useDispatch()
+  const [remixNavigation] = useAtom(RemixNavigationAtom)
+  const paths = Object.values(remixNavigation)
+    .map((n) => n?.location.pathname ?? '')
+    .join('-')
+
+  React.useEffect(() => {
+    dispatch([EditorActions.clearSelection()])
+  }, [dispatch, paths])
+
+  return <></>
+}


### PR DESCRIPTION
## Problem
https://github.com/concrete-utopia/utopia/issues/5561

## Fix
This PR adds an editor-wide effect that clears the selection whenever a remix route changes.

### Caveats
- The selection is cleared for all remix scenes even if there are multiple remix scenes and the route is only changed in one of them. We could only keep selected paths that aren't descended from the remix container where the navigation happened, but this would need some more involved logic and I'd like to keep this PR simple. Also this problem is only relevant when there's a multiselection that spans Remix scenes, which is not that common
- `pathname` is used to check whether a navigation has happened, because a change in query params doesn't mean a full navigation, so we should keep the selection in that case

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

