### PR TITLE
fix the non-wrapping repo name

### DIFF
--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -1192,6 +1192,20 @@ export function githubRepoFullName(repo: GithubRepo | null): string | null {
   return `${repo.owner}/${repo.repository}`
 }
 
+export function githubRepoOwnerName(repo: GithubRepo | null): string | null {
+  if (repo == null) {
+    return null
+  }
+  return repo.owner
+}
+
+export function githubRepositoryName(repo: GithubRepo | null): string | null {
+  if (repo == null) {
+    return null
+  }
+  return repo.repository
+}
+
 export function githubRepo(owner: string, repository: string): GithubRepo {
   return {
     owner: owner,

--- a/editor/src/components/navigator/left-pane/github-pane/block.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/block.tsx
@@ -113,12 +113,12 @@ export const Block = React.memo((props: BlockProps) => {
               alignItems: 'baseline',
               justifyContent: 'space-between',
               padding: '8px 0',
+              gap: 12,
             }}
           >
             <div style={{ fontWeight: 700, color: colorTheme.fg0.value }}>{props.title}</div>
             <div
               style={{
-                maxWidth: 120,
                 textAlign: 'right',
                 overflowWrap: 'break-word',
                 whiteSpace: 'pre-wrap',

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -142,9 +142,9 @@ const RepositoryBlock = () => {
       title={hasRepo ? 'Repository' : 'Select Repository'}
       subtitle={
         <span>
-          repoOwner
+          {repoOwner}
           <br />
-          repositoryName
+          {repositoryName}
         </span>
       }
       status={hasRepo ? 'successful' : 'pending'}

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -33,6 +33,8 @@ import { useDispatch } from '../../../editor/store/dispatch-context'
 import {
   fileChecksumsWithFileToFileChecksums,
   githubRepoFullName,
+  githubRepoOwnerName,
+  githubRepositoryName,
   isGithubCommitting,
   isGithubListingBranches,
   isGithubLoadingAnyBranch,
@@ -115,6 +117,9 @@ const RepositoryBlock = () => {
     'RepositoryBlock authenticated',
   )
   const repoName = React.useMemo(() => githubRepoFullName(repo) ?? undefined, [repo])
+  const repoOwner = React.useMemo(() => githubRepoOwnerName(repo), [repo])
+  const repositoryName = React.useMemo(() => githubRepositoryName(repo), [repo])
+
   const hasRepo = React.useMemo(() => repo != null, [repo])
   const [expanded, setExpanded] = React.useState(false)
   React.useEffect(() => {
@@ -135,7 +140,13 @@ const RepositoryBlock = () => {
   return (
     <Block
       title={hasRepo ? 'Repository' : 'Select Repository'}
-      subtitle={repoName}
+      subtitle={
+        <span>
+          repoOwner
+          <br />
+          repositoryName
+        </span>
+      }
       status={hasRepo ? 'successful' : 'pending'}
       first={true}
       last={!hasRepo}


### PR DESCRIPTION
**Problem:**
- Every view of the github pane looks just a tiny bit embarassing with a long repo name like ours
- wide leftMenu pane (to show navigator) unnecessarily wraps the repo name, even when there's space to show it
<img width="355" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2945037/20ac5c29-e0e8-405d-a31f-f6da11fb9f04">

**Fix:**
- always wrap after repo owner (via `<br/>` like it's 1997)
- remove the 120px max width, and instead use a gap to force distance
<img width="316" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2945037/d3294bc3-0659-4970-a188-7b6762e66106">
