### PR TITLE
Adjust component prop metadata labels

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -418,7 +418,7 @@ const RowForBaseControl = React.memo((props: RowForBaseControlProps) => {
                 dataPickerButtonData.popupIsOpen || isHovered || isConnectedToData
                   ? colorTheme.dynamicBlue.value
                   : undefined,
-              cursor: isHovered ? 'pointer' : 'default',
+              cursor: 'pointer',
             }}
           >
             {title}

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -90,6 +90,7 @@ import {
   modifiableAttributeToValuePath,
   jsExpressionOtherJavaScriptSimple,
   jsIdentifier,
+  isJSXParsedValue,
 } from '../../../../core/shared/element-template'
 import { optionalMap } from '../../../../core/shared/optional-utils'
 import type { VariableData } from '../../../canvas/ui-jsx-canvas'
@@ -388,11 +389,11 @@ const RowForBaseControl = React.memo((props: RowForBaseControlProps) => {
     setIsHovered(false)
   }
 
-  const isValueSet = React.useMemo(() => {
+  const isConnectedToData = React.useMemo(() => {
     return (
       propMetadata.propertyStatus.set &&
       propMetadata.value != null &&
-      !isPossiblyDefaultForPropValue(propMetadata.value)
+      isInternalOrExternalComponent(propMetadata.value)
     )
   }, [propMetadata])
 
@@ -419,7 +420,7 @@ const RowForBaseControl = React.memo((props: RowForBaseControlProps) => {
               alignItems: 'center',
               gap: 6,
               color:
-                dataPickerButtonData.popupIsOpen || isHovered || isValueSet
+                dataPickerButtonData.popupIsOpen || isHovered || isConnectedToData
                   ? colorTheme.dynamicBlue.value
                   : undefined,
               cursor: isHovered ? 'pointer' : 'default',
@@ -435,7 +436,9 @@ const RowForBaseControl = React.memo((props: RowForBaseControlProps) => {
                 category='semantic'
                 type='plus-in-white-translucent-circle'
                 color={
-                  dataPickerButtonData.popupIsOpen || isHovered || !isValueSet ? 'dynamic' : 'main'
+                  dataPickerButtonData.popupIsOpen || isHovered || !isConnectedToData
+                    ? 'dynamic'
+                    : 'main'
                 }
                 width={12}
                 height={12}
@@ -1223,15 +1226,9 @@ const objectPropertyLabelStyle = {
   gap: 4,
 } as const
 
-function isPossiblyDefaultForPropValue(value: unknown) {
-  switch (typeof value) {
-    case 'boolean':
-      return value === false
-    case 'number':
-      return value === 0
-    case 'string':
-      return value === ''
-    default:
-      return false
-  }
+function isInternalOrExternalComponent(value: unknown): boolean {
+  return (
+    isJSXParsedValue(value) &&
+    (value.type === 'external-component' || value.type === 'internal-component')
+  )
 }

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -90,7 +90,6 @@ import {
   modifiableAttributeToValuePath,
   jsExpressionOtherJavaScriptSimple,
   jsIdentifier,
-  isJSXParsedValue,
 } from '../../../../core/shared/element-template'
 import { optionalMap } from '../../../../core/shared/optional-utils'
 import type { VariableData } from '../../../canvas/ui-jsx-canvas'
@@ -390,11 +389,7 @@ const RowForBaseControl = React.memo((props: RowForBaseControlProps) => {
   }
 
   const isConnectedToData = React.useMemo(() => {
-    return (
-      propMetadata.propertyStatus.set &&
-      propMetadata.value != null &&
-      isInternalOrExternalComponent(propMetadata.value)
-    )
+    return propMetadata.propertyStatus.controlled
   }, [propMetadata])
 
   const propertyLabel =
@@ -1225,10 +1220,3 @@ const objectPropertyLabelStyle = {
   fontWeight: 500,
   gap: 4,
 } as const
-
-function isInternalOrExternalComponent(value: unknown): boolean {
-  return (
-    isJSXParsedValue(value) &&
-    (value.type === 'external-component' || value.type === 'internal-component')
-  )
-}

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -389,7 +389,11 @@ const RowForBaseControl = React.memo((props: RowForBaseControlProps) => {
   }
 
   const isValueSet = React.useMemo(() => {
-    return propMetadata.propertyStatus.set
+    return (
+      propMetadata.propertyStatus.set &&
+      propMetadata.value != null &&
+      !isPossiblyDefaultForPropValue(propMetadata.value)
+    )
   }, [propMetadata])
 
   const propertyLabel =
@@ -415,15 +419,16 @@ const RowForBaseControl = React.memo((props: RowForBaseControlProps) => {
               alignItems: 'center',
               gap: 6,
               color:
-                dataPickerButtonData.popupIsOpen || isHovered || !isValueSet
+                dataPickerButtonData.popupIsOpen || isHovered || isValueSet
                   ? colorTheme.dynamicBlue.value
                   : undefined,
+              cursor: isHovered ? 'pointer' : 'default',
             }}
           >
             {title}
             <div
               style={{
-                opacity: isHovered || dataPickerButtonData.popupIsOpen || !isValueSet ? 1 : 0,
+                opacity: isHovered || dataPickerButtonData.popupIsOpen ? 1 : 0,
               }}
             >
               <Icn
@@ -1217,3 +1222,16 @@ const objectPropertyLabelStyle = {
   fontWeight: 500,
   gap: 4,
 } as const
+
+function isPossiblyDefaultForPropValue(value: unknown) {
+  switch (typeof value) {
+    case 'boolean':
+      return value === false
+    case 'number':
+      return value === 0
+    case 'string':
+      return value === ''
+    default:
+      return false
+  }
+}

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -33,6 +33,7 @@ import { allComments } from './comment-flags'
 import type { Optic } from './optics/optics'
 import { fromField } from './optics/optic-creators'
 import { jsxSimpleAttributeToValue } from './jsx-attribute-utils'
+import type { JSXParsedType, JSXParsedValue } from '../../utils/value-parser-utils'
 
 export interface ParsedComments {
   leadingComments: Array<Comment>
@@ -2950,4 +2951,30 @@ export function clearJSArbitraryStatementUniqueIDs(
     default:
       assertNever(statement)
   }
+}
+
+export function isJSXParsedType(value: unknown): value is JSXParsedType {
+  const maybe = value as JSXParsedType
+  if (value == null || typeof value !== 'string') {
+    return false
+  }
+  switch (maybe) {
+    case 'null':
+    case 'string':
+    case 'number':
+    case 'html':
+    case 'internal-component':
+    case 'external-component':
+    case 'unknown':
+      return true
+    default:
+      assertNever(maybe)
+  }
+}
+
+export function isJSXParsedValue(value: unknown): value is JSXParsedValue {
+  const maybe = value as JSXParsedValue
+  return (
+    value != null && typeof value === 'object' && maybe.name != null && isJSXParsedType(maybe.type)
+  )
 }

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -33,7 +33,6 @@ import { allComments } from './comment-flags'
 import type { Optic } from './optics/optics'
 import { fromField } from './optics/optic-creators'
 import { jsxSimpleAttributeToValue } from './jsx-attribute-utils'
-import type { JSXParsedType, JSXParsedValue } from '../../utils/value-parser-utils'
 
 export interface ParsedComments {
   leadingComments: Array<Comment>
@@ -2951,30 +2950,4 @@ export function clearJSArbitraryStatementUniqueIDs(
     default:
       assertNever(statement)
   }
-}
-
-export function isJSXParsedType(value: unknown): value is JSXParsedType {
-  const maybe = value as JSXParsedType
-  if (value == null || typeof value !== 'string') {
-    return false
-  }
-  switch (maybe) {
-    case 'null':
-    case 'string':
-    case 'number':
-    case 'html':
-    case 'internal-component':
-    case 'external-component':
-    case 'unknown':
-      return true
-    default:
-      assertNever(maybe)
-  }
-}
-
-export function isJSXParsedValue(value: unknown): value is JSXParsedValue {
-  const maybe = value as JSXParsedValue
-  return (
-    value != null && typeof value === 'object' && maybe.name != null && isJSXParsedType(maybe.type)
-  )
 }


### PR DESCRIPTION
Part of #5560 

This PR adjusts the coloring of prop metadata labels in the inspector's component section so that:

1. show the blue color only when the prop value is connected to data
2. show the plus icon only on hover


https://github.com/concrete-utopia/utopia/assets/1081051/f2ce79b4-c97f-4f37-9625-6b1bee413ee9



**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
