### PR TITLE
Chore: more api icons

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -527,46 +527,11 @@ interface ComponentPickerContextMenuProps {
   insertionTarget: InsertionTarget
 }
 
-function iconPropsForIcon(icon: Icon): IcnProps {
-  switch (icon) {
-    case 'column':
-      return {
-        category: 'navigator-element',
-        type: 'flex-column',
-        color: 'white',
-      }
-    case 'row':
-      return {
-        category: 'navigator-element',
-        type: 'flex-row',
-        color: 'white',
-      }
-    case 'regular':
-      return {
-        category: 'navigator-element',
-        type: 'component',
-        color: 'white',
-      }
-    case 'headline':
-      return {
-        category: 'navigator-element',
-        type: 'headline',
-        color: 'white',
-      }
-    case 'dashedframe':
-      return {
-        category: 'navigator-element',
-        type: 'dashedframe',
-        color: 'white',
-      }
-    case 'component':
-      return {
-        category: 'navigator-element',
-        type: 'component',
-        color: 'white',
-      }
-    default:
-      assertNever(icon)
+export function iconPropsForIcon(icon: Icon): IcnProps {
+  return {
+    category: 'navigator-element',
+    type: icon,
+    color: 'white',
   }
 }
 

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -21,6 +21,7 @@ import type { StylePropOption, InsertableComponent } from '../../shared/project-
 import type { Size } from '../../../core/shared/math-utils'
 import { dataPasteHandler } from '../../../utils/paste-handler'
 import { sortBy } from '../../../core/shared/array-utils'
+import { iconPropsForIcon } from './component-picker-context-menu'
 
 export interface ComponentPickerProps {
   allComponents: Array<InsertMenuItemGroup>
@@ -340,96 +341,9 @@ const ComponentPickerComponentSection = React.memo(
   },
 )
 
-// FIXME Copy pasted from component-picker-context-menu.tsx
-function iconPropsForIcon(icon: Icon): IcnProps {
-  switch (icon) {
-    case 'column':
-      return {
-        category: 'navigator-element',
-        type: 'flex-column',
-        color: 'white',
-      }
-    case 'row':
-      return {
-        category: 'navigator-element',
-        type: 'flex-row',
-        color: 'white',
-      }
-    case 'regular':
-      return {
-        category: 'navigator-element',
-        type: 'component',
-        color: 'white',
-      }
-    case 'headline':
-      return {
-        category: 'navigator-element',
-        type: 'headline',
-        color: 'white',
-      }
-    case 'dashedframe':
-      return {
-        category: 'navigator-element',
-        type: 'dashedframe',
-        color: 'white',
-      }
-    case 'component':
-      return {
-        category: 'navigator-element',
-        type: 'component',
-        color: 'white',
-      }
-    default:
-      assertNever(icon)
-  }
-}
-
 interface ComponentPickerOptionProps {
   component: InsertMenuItem
   onItemClick: (elementToInsert: InsertableComponent) => React.MouseEventHandler
   onItemHover: (elementToInsert: InsertMenuItemValue) => React.MouseEventHandler
   currentlySelectedKey: string | null
 }
-
-const ComponentPickerOption = React.memo((props: ComponentPickerOptionProps) => {
-  const { component, onItemClick, onItemHover, currentlySelectedKey } = props
-
-  const selectedStyle =
-    component.value.key === currentlySelectedKey
-      ? {
-          background: '#007aff',
-          color: 'white',
-        }
-      : {}
-
-  return (
-    <FlexRow
-      css={{}}
-      style={{
-        marginLeft: 8,
-        marginRight: 8,
-        borderRadius: 4,
-        // indentation!
-        paddingLeft: 8,
-        color: '#EEE',
-        ...selectedStyle,
-      }}
-      onClick={onItemClick(component.value)}
-      onMouseOver={onItemHover(component.value)}
-      data-key={component.value.key}
-    >
-      <UIGridRow
-        variant='|--32px--|<--------auto-------->'
-        padded={false}
-        // required to overwrite minHeight on the bloody thing
-        style={{ minHeight: 29 }}
-        css={{
-          height: 27,
-        }}
-      >
-        <Icn {...iconPropsForIcon(component.value.icon ?? 'regular')} width={12} height={12} />
-        <label>{component.label}</label>
-      </UIGridRow>
-    </FlexRow>
-  )
-})

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -50,14 +50,38 @@ export type InspectorSpec = 'all' | Styling[]
 export const EmphasisOptions = ['subdued', 'regular', 'emphasized'] as const
 export type Emphasis = (typeof EmphasisOptions)[number]
 
-export const IconOptions = [
+export declare const IconOptions: readonly [
+  'body',
+  'clickable',
+  'code',
   'column',
-  'row',
-  'regular',
-  'headline',
-  'dashedframe',
   'component',
-] as const // and others
+  'conditional',
+  'dashedframe',
+  'data',
+  'div',
+  'folder',
+  'form',
+  'grid',
+  'headline',
+  'home',
+  'image',
+  'video',
+  'input',
+  'irregular-layout',
+  'layout',
+  'link',
+  'page',
+  'paragraph',
+  'regular',
+  'row',
+  'section',
+  'sfx',
+  'solidframe',
+  'star',
+  'starfilled',
+  'xframe',
+]
 export type Icon = (typeof IconOptions)[number]
 
 export interface ComponentToRegister {

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -50,7 +50,7 @@ export type InspectorSpec = 'all' | Styling[]
 export const EmphasisOptions = ['subdued', 'regular', 'emphasized'] as const
 export type Emphasis = (typeof EmphasisOptions)[number]
 
-export const IconOptions: readonly [
+export const IconOptions = [
   'body',
   'clickable',
   'code',

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -50,7 +50,7 @@ export type InspectorSpec = 'all' | Styling[]
 export const EmphasisOptions = ['subdued', 'regular', 'emphasized'] as const
 export type Emphasis = (typeof EmphasisOptions)[number]
 
-export declare const IconOptions: readonly [
+export const IconOptions: readonly [
   'body',
   'clickable',
   'code',


### PR DESCRIPTION
**Problem:**
More icons that can be used as the `ComponentToRegister.icon`

**Commit Details:**

- Malte added more options
- now **every** icon option corresponds to an icon file, so there's no need for indirection in `iconPropsForIcon`
- there were two `iconPropsForIcon`s with a FIXME that one was the clone of the other, so I just deleted one