### PR TITLE
Show connected to data but not if JSXElement

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -389,7 +389,10 @@ const RowForBaseControl = React.memo((props: RowForBaseControlProps) => {
   }
 
   const isConnectedToData = React.useMemo(() => {
-    return propMetadata.propertyStatus.controlled
+    return (
+      propMetadata.propertyStatus.controlled &&
+      propMetadata.attributeExpression?.type !== 'JSX_ELEMENT'
+    )
   }, [propMetadata])
 
   const propertyLabel =


### PR DESCRIPTION
**Problem:**

The inspector should show prop labels in blue if their property status is `controlled` _and_ the value is not a `JSXElement`.

**Fix:**

Update the `isConnectedToData` value.

**Commit Details:** (< vv pls delete this section if's not relevant)

- Renamed `thing` to `otherThing`
- Removed `cake` from `fridge-contents.ts`
- Did [other things]

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5589 
