### PR TITLE
Fixed icon usage

### DIFF
--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -148,7 +148,7 @@ export const ComponentDescriptorDefaults: Pick<
   focus: 'default',
   inspector: [],
   emphasis: 'regular',
-  icon: 'regular',
+  icon: 'component',
 }
 
 export function componentDescriptor(

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -133,12 +133,12 @@ function getIconForComponent(
   propertyControlsInfo: PropertyControlsInfo,
 ): Icon {
   if (moduleName == null) {
-    return 'regular'
+    return 'component'
   }
 
   const registeredComponent = getRegisteredComponent(targetName, moduleName, propertyControlsInfo)
 
-  return registeredComponent?.icon ?? 'regular'
+  return registeredComponent?.icon ?? 'component'
 }
 
 interface PreferredChildComponentDescriptorWithIcon extends PreferredChildComponentDescriptor {

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -317,7 +317,7 @@ const ComponentPickerComponentSection = React.memo(
             >
               <FlexRow css={{ gap: 10, height: 28, alignItems: 'center' }}>
                 <Icn
-                  {...iconPropsForIcon(component.value.icon ?? 'regular')}
+                  {...iconPropsForIcon(component.value.icon ?? 'component')}
                   width={12}
                   height={12}
                 />

--- a/editor/src/components/navigator/navigator-item/layout-icon.tsx
+++ b/editor/src/components/navigator/navigator-item/layout-icon.tsx
@@ -109,17 +109,11 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
         color: color,
         style: { opacity: 'var(--iconOpacity)' },
       }
-      if (props.override != null && props.override !== 'regular') {
-        const type =
-          props.override === 'column'
-            ? 'flex-column'
-            : props.override === 'row'
-            ? 'flex-row'
-            : props.override
+      if (props.override != null) {
         return (
           <Icn
             category='navigator-element'
-            type={type}
+            type={props.override}
             width={12}
             height={12}
             testId={iconTestId}

--- a/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
@@ -120,7 +120,7 @@ describe('The navigator component picker context menu', () => {
         },
         FlexCol: {
           component: FlexCol,
-          icon: 'regular',
+          icon: 'component',
           properties: {},
         },
         RandomComponent: {
@@ -536,7 +536,7 @@ describe('The navigator component picker context menu', () => {
     expect(flexColRow).not.toBeNull()
 
     const randomComponentRow = editor.renderedDOM.queryByTestId(
-      labelTestIdForComponentIcon('RandomComponent', '/src/utils', 'regular'),
+      labelTestIdForComponentIcon('RandomComponent', '/src/utils', 'component'),
     )
     expect(randomComponentRow).not.toBeNull()
   })
@@ -560,7 +560,7 @@ describe('The navigator component picker context menu', () => {
     expect(flexColRow).not.toBeNull()
 
     const randomComponentRow = editor.renderedDOM.queryByTestId(
-      labelTestIdForComponentIcon('RandomComponent', '/src/utils', 'regular'),
+      labelTestIdForComponentIcon('RandomComponent', '/src/utils', 'component'),
     )
     expect(randomComponentRow).not.toBeNull()
   })

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -84,7 +84,7 @@ describe('registered property controls', () => {
           focus: 'default',
           inspector: ['visual', 'typography'],
           emphasis: 'regular',
-          icon: 'regular',
+          icon: 'component',
           variants: [
             {
               code: '<Card />',

--- a/editor/src/core/shared/github/github.spec.browser2.ts
+++ b/editor/src/core/shared/github/github.spec.browser2.ts
@@ -89,7 +89,7 @@ describe('Github integration', () => {
                   focus: 'default',
                   inspector: ['visual', 'typography'],
                   emphasis: 'regular',
-                  icon: 'regular',
+                  icon: 'component',
                   variants: [
                     {
                       code: '<Card />',

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -73,15 +73,16 @@ export const IconOptions = [
   'link',
   'page',
   'paragraph',
-  'regular',
   'row',
   'section',
   'sfx',
   'solidframe',
   'star',
   'starfilled',
+  'text',
+  'title',
   'xframe',
-]
+] as const
 export type Icon = (typeof IconOptions)[number]
 
 export interface ComponentToRegister {


### PR DESCRIPTION
**Problem:**
- Icons had been updated in #5573 but we were still incorrectly using the non-existent 'regular' (which previously mapped to 'component')
- The Navigator had been updated to use the component descriptor icons in #5555 but also mapped as the row and column icons didn't exist then (I believe)

**Fix:**
Now that the mapping is unnecessary, I've removed that mapping and part of the check from #5555, and have updated the 'regular' icon to 'component' everywhere. I've also added back in an `as const` to narrow back down the type of those icons to catch typos.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5594 
