### PR TITLE
Fixed Radio Control Current Value And Updates

### DIFF
--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -50,6 +50,7 @@ import * as PP from '../../../../core/shared/property-path'
 import { ColorControl } from '../../controls/color-control'
 import { StringControl } from '../../controls/string-control'
 import type { SelectOption } from '../../controls/select-control'
+import type { OptionChainOption } from '../../controls/option-chain-control'
 import { OptionChainControl } from '../../controls/option-chain-control'
 import { useKeepReferenceEqualityIfPossible } from '../../../../utils/react-performance'
 import { UIGridRow } from '../../widgets/ui-grid-row'
@@ -393,7 +394,7 @@ export const RadioPropertyControl = React.memo(
     // TS baulks at the map below for some reason if we don't first do this
     const controlOptions: Array<IndividualOption> = controlDescription.options
 
-    const options: Array<SelectOption> = useKeepReferenceEqualityIfPossible(
+    const options: Array<OptionChainOption<unknown>> = useKeepReferenceEqualityIfPossible(
       controlOptions.map((option) => {
         return {
           value: valueForIndividualOption(option),
@@ -401,12 +402,8 @@ export const RadioPropertyControl = React.memo(
         }
       }),
     )
-    const currentValue = options.find((option) => {
-      return fastDeepEquals(option.value, value)
-    })
-
-    function submitValue(option: SelectOption): void {
-      propMetadata.onSubmitValue(option.value)
+    function submitValue(valueToSubmit: unknown): void {
+      propMetadata.onSubmitValue(valueToSubmit)
     }
 
     return (
@@ -414,7 +411,7 @@ export const RadioPropertyControl = React.memo(
         key={controlId}
         id={controlId}
         testId={controlId}
-        value={currentValue}
+        value={value}
         controlStatus={propMetadata.controlStatus}
         controlStyles={propMetadata.controlStyles}
         // eslint-disable-next-line react/jsx-no-bind


### PR DESCRIPTION
**Problem:**
The radio control buttons don't change anything when pressed and the buttons don't indicate the currently picked option.

**Fix:**
`RadioPropertyControl` defers to `OptionChainControl`, but was not appropriately stripping away the structure of `OptionChainOption` or in the case of `submitValue` was assuming it would get a value wrapped into a `SelectOption`.

**Commit Details:**
- Used `OptionChainOption` instead of `SelectOption` for the value `options`.
- `currentValue` removed and `value` used in its place.
- `submitValue` takes the direct value not the `SelectOption` as it previously pretended to do.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5583
