### PR TITLE
Tune OptionChainControl Spacing.

### DIFF
--- a/editor/src/components/inspector/controls/option-chain-control.tsx
+++ b/editor/src/components/inspector/controls/option-chain-control.tsx
@@ -74,7 +74,7 @@ export const OptionChainControl: React.FunctionComponent<
         )}`}
         onContextMenu={props.onContextMenu}
       >
-        <FlexRow style={{ gap: 8, width: '100%' }}>
+        <FlexRow style={{ gap: 1, width: '100%' }}>
           {options.map((option: OptionChainOption<number | string>, index) => (
             <OptionControl
               {...props}


### PR DESCRIPTION
**Problem:**
The spacing of the entries in the `OptionChainControl` is a little too large.

**Fix:**
Rather than completely removing the gap as mentioned in the original bug, which doesn't look quite right, it has been turned down to 1 from 8.
![image](https://github.com/concrete-utopia/utopia/assets/217400/eb8f1180-9048-402b-b493-14ad5dab53cc)

**Commit Details:**
- Turned the `gap` setting from `8` to `1`.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5587
