### PR TITLE
Don't trigger keyboard events when context menu is open

### DIFF
--- a/editor/src/components/context-menu-wrapper.tsx
+++ b/editor/src/components/context-menu-wrapper.tsx
@@ -170,7 +170,7 @@ export class MomentumContextMenu<T> extends ReactComponent<ContextMenuProps<T>> 
 }
 
 export class ContextMenuWrapper<T> extends ReactComponent<
-  ContextMenuWrapperProps<T> & { dispatch: EditorDispatch; children?: React.ReactNode }
+  ContextMenuWrapperProps<T> & { dispatch?: EditorDispatch; children?: React.ReactNode }
 > {
   getData = () => this.props.data
   wrapperStopPropagation = (event: React.MouseEvent<HTMLElement>) => {

--- a/editor/src/components/context-menu-wrapper.tsx
+++ b/editor/src/components/context-menu-wrapper.tsx
@@ -16,6 +16,7 @@ import type { ContextMenuItem } from './context-menu-items'
 import type { EditorDispatch } from './editor/action-types'
 import type { WindowPoint } from '../core/shared/math-utils'
 import { windowPoint } from '../core/shared/math-utils'
+import { BodyMenuOpenClass } from '../core/shared/utils'
 
 export interface ContextMenuWrapperProps<T> {
   id: string
@@ -138,11 +139,18 @@ export class MomentumContextMenu<T> extends ReactComponent<ContextMenuProps<T>> 
     )
   }
 
+  onShown = () => {
+    document.body.classList.add(BodyMenuOpenClass)
+  }
+  onHidden = () => {
+    document.body.classList.remove(BodyMenuOpenClass)
+  }
+
   render() {
     const { id } = this.props
     const items = this.splitItemsForSubmenu(this.props.items)
     return (
-      <Menu key={id} id={id} animation={false}>
+      <Menu key={id} id={id} animation={false} onShown={this.onShown} onHidden={this.onHidden}>
         {items.map((item: Submenu<T> | SimpleItem<T>, index: number) => {
           if (item.type === 'submenu') {
             return (

--- a/editor/src/components/editor/editor-component-common.tsx
+++ b/editor/src/components/editor/editor-component-common.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { EditorAction, EditorDispatch } from './action-types'
 import { useDispatch } from './store/dispatch-context'
-import { CanvasContextMenuPortalTargetID } from '../../core/shared/utils'
+import { BodyMenuOpenClass } from '../../core/shared/utils'
 
 type EventHandler<K extends keyof WindowEventMap, R> = (this: Window, event: WindowEventMap[K]) => R
 
@@ -54,9 +54,7 @@ function createHandler<K extends keyof WindowEventMap>(
       // check if it's a keyboard event and if .react-contexify exists in the body
       if (
         ['keydown', 'keyup'].includes(event.type) &&
-        document
-          .getElementById(CanvasContextMenuPortalTargetID)
-          ?.querySelector('.react-contexify') != null
+        document.body.classList.contains(BodyMenuOpenClass)
       ) {
         return
       }

--- a/editor/src/components/editor/editor-component-common.tsx
+++ b/editor/src/components/editor/editor-component-common.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import type { EditorAction, EditorDispatch } from './action-types'
 import { useDispatch } from './store/dispatch-context'
+import { CanvasContextMenuPortalTargetID } from '../../core/shared/utils'
 
 type EventHandler<K extends keyof WindowEventMap, R> = (this: Window, event: WindowEventMap[K]) => R
 
@@ -52,8 +53,10 @@ function createHandler<K extends keyof WindowEventMap>(
     const windowEventHandler = (event: WindowEventMap[K]) => {
       // check if it's a keyboard event and if .react-contexify exists in the body
       if (
-        ['keydown', 'keyup', 'keypress'].includes(event.type) &&
-        document.body.querySelector('.react-contexify') != null
+        ['keydown', 'keyup'].includes(event.type) &&
+        document
+          .getElementById(CanvasContextMenuPortalTargetID)
+          ?.querySelector('.react-contexify') != null
       ) {
         return
       }

--- a/editor/src/components/editor/editor-component-common.tsx
+++ b/editor/src/components/editor/editor-component-common.tsx
@@ -50,6 +50,13 @@ function createHandler<K extends keyof WindowEventMap>(
     return null
   } else {
     const windowEventHandler = (event: WindowEventMap[K]) => {
+      // check if it's a keyboard event and if .react-contexify exists in the body
+      if (
+        ['keydown', 'keyup', 'keypress'].includes(event.type) &&
+        document.body.querySelector('.react-contexify') != null
+      ) {
+        return
+      }
       const collatedActions = handlers.flatMap((handler) => {
         return handler.bind(window)(event)
       })

--- a/editor/src/components/editor/editor-component-common.tsx
+++ b/editor/src/components/editor/editor-component-common.tsx
@@ -51,7 +51,7 @@ function createHandler<K extends keyof WindowEventMap>(
     return null
   } else {
     const windowEventHandler = (event: WindowEventMap[K]) => {
-      // check if it's a keyboard event and if .react-contexify exists in the body
+      // check if it's a keyboard event and if react-contexify is open
       if (
         ['keydown', 'keyup'].includes(event.type) &&
         document.body.classList.contains(BodyMenuOpenClass)

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -38,7 +38,7 @@ import type { PreferredChildComponentDescriptor } from '../../custom-code/intern
 import { fixUtopiaElement, generateConsistentUID } from '../../../core/shared/uid-utils'
 import { getAllUniqueUids } from '../../../core/model/get-unique-ids'
 import { elementFromInsertMenuItem } from '../../editor/insert-callbacks'
-import { MomentumContextMenu } from '../../context-menu-wrapper'
+import { ContextMenuWrapper, MomentumContextMenu } from '../../context-menu-wrapper'
 import { NO_OP, assertNever } from '../../../core/shared/utils'
 import { type ContextMenuItem } from '../../context-menu-items'
 import { FlexRow, Icn, type IcnProps } from '../../../uuiui'
@@ -609,7 +609,7 @@ const ComponentPickerContextMenuSimple = React.memo<ComponentPickerContextMenuPr
 
     return (
       <div ref={wrapperRef}>
-        <MomentumContextMenu id={PreferredMenuId} items={items} getData={NO_OP} />
+        <ContextMenuWrapper items={items} data={{}} id={PreferredMenuId} />
       </div>
     )
   },

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -39,7 +39,7 @@ import { fixUtopiaElement, generateConsistentUID } from '../../../core/shared/ui
 import { getAllUniqueUids } from '../../../core/model/get-unique-ids'
 import { elementFromInsertMenuItem } from '../../editor/insert-callbacks'
 import { ContextMenuWrapper, MomentumContextMenu } from '../../context-menu-wrapper'
-import { NO_OP, assertNever } from '../../../core/shared/utils'
+import { BodyMenuOpenClass, NO_OP, assertNever } from '../../../core/shared/utils'
 import { type ContextMenuItem } from '../../context-menu-items'
 import { FlexRow, Icn, type IcnProps } from '../../../uuiui'
 import type {
@@ -662,8 +662,23 @@ const ComponentPickerContextMenuFull = React.memo<ComponentPickerContextMenuProp
       e.stopPropagation()
     }, [])
 
+    const onShown = React.useCallback(() => {
+      document.body.classList.add(BodyMenuOpenClass)
+    }, [])
+
+    const onHidden = React.useCallback(() => {
+      document.body.classList.remove(BodyMenuOpenClass)
+    }, [])
+
     return (
-      <Menu id={FullMenuId} animation={false} style={{ width: 260 }} onClick={squashEvents}>
+      <Menu
+        id={FullMenuId}
+        animation={false}
+        style={{ width: 260 }}
+        onClick={squashEvents}
+        onShown={onShown}
+        onHidden={onHidden}
+      >
         <ComponentPicker allComponents={allInsertableComponents} onItemClick={onItemClick} />
       </Menu>
     )

--- a/editor/src/core/shared/utils.ts
+++ b/editor/src/core/shared/utils.ts
@@ -9,6 +9,7 @@ import { flatMapEither, left, mapEither, right } from './either'
 export const EditorID = 'utopia-editor-root'
 export const PortalTargetID = 'portal-target'
 export const CanvasContextMenuPortalTargetID = 'canvas-contextmenu-portal-target'
+export const BodyMenuOpenClass = 'context-menu-open'
 
 export const RETURN_TO_PREPEND = 'return '
 


### PR DESCRIPTION
**Problem:**
When a context menu is open that doesn't have an input field (like the preferred menu), keyboard events are triggered both for the menu and the editor - causing issues such as pressing `ArrowUp` that moves the element on the canvas.
Note - there is another, separate issue where keyboard events don't change selection in the menu itself - but that's an issue with the internal implementation of react-contexify and should be handled separately.

**Fix:**
Since both handlers are registered on the window, and since the keyboard handler is handled inside `react-contexify` and doesn't call `stopImmediatePropagation`  - the only fix I found was to ignore keyboard events if the context menu is open.

This is **not** a fix for the keyboard selection in the context menu - but just that these events won't effect the canvas and cause more serious issues (if someone will press the keyboard by accident while the menu is open)

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode
