### PR TITLE
Ugly hack to fix inspector context menu

### DIFF
--- a/editor/src/components/context-menu-wrapper.tsx
+++ b/editor/src/components/context-menu-wrapper.tsx
@@ -279,7 +279,7 @@ export const MenuProvider: React.FunctionComponent<React.PropsWithChildren<MenuP
   const onContextMenu = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       if (props.itemsLength > 0) {
-        show(event)
+        show(event, { position: { x: event.nativeEvent.offsetX, y: event.nativeEvent.pageY } })
       }
     },
     [props.itemsLength, show],

--- a/editor/src/components/context-menu-wrapper.tsx
+++ b/editor/src/components/context-menu-wrapper.tsx
@@ -251,6 +251,7 @@ export class InspectorContextMenuWrapper<T> extends ReactComponent<
               width: '100%',
               height: '100%',
             }}
+            localXHack_KILLME='local-x-coord-KILLME'
           >
             {this.props.children}
           </MenuProvider>
@@ -270,6 +271,7 @@ interface MenuProviderProps {
   id: string
   itemsLength: number
   style?: React.CSSProperties
+  localXHack_KILLME?: 'local-x-coord-KILLME' | 'default' // FIXME: remove this, this is just here because react-contexify positions the context menu to the global position of the mouse, so MomentumContextMenu should in the root
 }
 
 export const MenuProvider: React.FunctionComponent<React.PropsWithChildren<MenuProviderProps>> = (
@@ -279,10 +281,14 @@ export const MenuProvider: React.FunctionComponent<React.PropsWithChildren<MenuP
   const onContextMenu = React.useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       if (props.itemsLength > 0) {
-        show(event, { position: { x: event.nativeEvent.offsetX, y: event.nativeEvent.pageY } })
+        if (props.localXHack_KILLME === 'local-x-coord-KILLME') {
+          show(event, { position: { x: event.nativeEvent.offsetX, y: event.nativeEvent.pageY } })
+        } else {
+          show(event)
+        }
       }
     },
-    [props.itemsLength, show],
+    [props.itemsLength, props.localXHack_KILLME, show],
   )
 
   return (


### PR DESCRIPTION
**Problem:**
react-contexify takes the mouse event and positions the context menu to the global position found in the event.
However, we put the context menu inside the local element where we need it, so the real position will be offset by the global position of that element. I think this is absolutely incompatible with how react-contexify works.

Why does it work mostly still? Because if we launch it from a div which is close to top/left of the screen, then this difference doesn't matter (if we move the inspector there, the context menu works perfectly too, but normally it is on the right, so the menu is somewhere far off-screen.).

**Fix:**
First I thought just use offsetX and offsetY from the mouse event to position the menu, but unfortunately that only works for the x coordinate, because the MenuProvider is outside of the UIGridRow of the item, so it is positioned from the top of the inspector, but the target of the mouse event is the row item itself, so its y position is different.

Because a real solution would be a rather involved refactor (I guess using Portals), I just created a quick hack to make it visible in the inspector. It should not affect other context menus.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5584
