### PR TITLE
List icon in component picker

### DIFF
--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -261,7 +261,7 @@ Array [
       Object {
         "defaultSize": null,
         "element": [Function],
-        "icon": "component",
+        "icon": "lists",
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",
@@ -580,7 +580,7 @@ Array [
       Object {
         "defaultSize": null,
         "element": [Function],
-        "icon": "component",
+        "icon": "lists",
         "importsToAdd": Object {
           "react": Object {
             "importedAs": "React",

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -570,6 +570,7 @@ export const mapElementDescriptors: ComponentDescriptorsForFile = {
     preferredChildComponents: [],
     source: defaultComponentDescriptor(),
     ...ComponentDescriptorDefaults,
+    icon: 'lists',
   },
 }
 

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -71,6 +71,7 @@ export const IconOptions = [
   'irregular-layout',
   'layout',
   'link',
+  'lists',
   'page',
   'paragraph',
   'row',


### PR DESCRIPTION
**Problem:**

#5615 

**Fix:**

Use the `lists` icon for the `mapElementDescriptors` object.

https://github.com/concrete-utopia/utopia/assets/1081051/d3171c29-6d49-4588-821c-cb4058d4b8f4


**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5615 
