### PR TITLE
Fix data picker indendation

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -449,6 +449,7 @@ function ValueRow({
           cursor: variableOption.variableInfo.matches ? 'pointer' : 'default',
           background: currentExpressionExactMatch ? colorTheme.primary.value : undefined,
           color: currentExpressionExactMatch ? colorTheme.white.value : undefined,
+          paddingLeft: variableOption.depth * 8,
         }}
         onClick={onClickTopLevelButton}
         css={{


### PR DESCRIPTION
This PR adds indentation to the data picker
<img width="398" alt="image" src="https://github.com/concrete-utopia/utopia/assets/7003853/efe0996f-d331-4bb3-acd5-4e1d36a50c45">

Fixes #5601
