### PR TITLE
Fix insertion into and replacement of children of lists

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -395,8 +395,11 @@ function insertComponentPickerItem(
         ]
       }
 
-      // if we are inserting into a map expression then we replace the mapped element
-      if (MetadataUtils.isJSXMapExpression(EP.parentPath(target), metadata)) {
+      // Replacing a mapped element requires a different function
+      if (
+        isReplaceTarget(insertionTarget) &&
+        MetadataUtils.isJSXMapExpression(EP.parentPath(target), metadata)
+      ) {
         return [replaceMappedElement(fixedElement, target, toInsert.importsToAdd)]
       }
 


### PR DESCRIPTION
**Problem:**
The "add element" functionality on a child of a list will replace the element.

**Fix:**
We had some code which incorrectly runs the replace functionality on children of lists regardless of the insertion target, whereas it should only be running for replace element targets. Note that this doesn't yet cover the "Replace This" functionality.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5611 
