### PR TITLE
Fix positioning of advanced context menu

### DIFF
--- a/editor/src/components/context-menu-wrapper.tsx
+++ b/editor/src/components/context-menu-wrapper.tsx
@@ -29,6 +29,7 @@ export interface ContextMenuWrapperProps<T> {
   style?: React.CSSProperties
   providerStyle?: React.CSSProperties
   testId?: string
+  forwardRef?: React.RefObject<HTMLDivElement>
 }
 
 export interface ContextMenuProps<T> {
@@ -178,7 +179,10 @@ export class MomentumContextMenu<T> extends ReactComponent<ContextMenuProps<T>> 
 }
 
 export class ContextMenuWrapper<T> extends ReactComponent<
-  ContextMenuWrapperProps<T> & { dispatch?: EditorDispatch; children?: React.ReactNode }
+  ContextMenuWrapperProps<T> & {
+    dispatch?: EditorDispatch
+    children?: React.ReactNode
+  }
 > {
   getData = () => this.props.data
   wrapperStopPropagation = (event: React.MouseEvent<HTMLElement>) => {
@@ -194,6 +198,7 @@ export class ContextMenuWrapper<T> extends ReactComponent<
         onMouseDown={this.wrapperStopPropagation}
         onMouseUp={this.wrapperStopPropagation}
         onClick={this.wrapperStopPropagation}
+        ref={this.props.forwardRef}
       >
         <MenuProvider
           key={`${this.props.id}-provider`}

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -345,7 +345,8 @@ function moreItem(
     name: <FlexRow style={{ paddingLeft: 22 }}>More…</FlexRow>,
     enabled: true,
     action: (_data, _dispatch, _rightClickCoordinate, e) => {
-      const currentMenu = (menuWrapperRef.current?.childNodes[0] as HTMLDivElement) ?? null
+      // FIXME Yeah this is horrific
+      const currentMenu = (menuWrapperRef.current?.childNodes[1] as HTMLDivElement) ?? null
       const position =
         currentMenu == null
           ? undefined
@@ -611,9 +612,7 @@ const ComponentPickerContextMenuSimple = React.memo<ComponentPickerContextMenuPr
       .concat([separatorItem, moreItem(wrapperRef, showFullMenu)])
 
     return (
-      <div ref={wrapperRef}>
-        <ContextMenuWrapper items={items} data={{}} id={PreferredMenuId} />
-      </div>
+      <ContextMenuWrapper items={items} data={{}} id={PreferredMenuId} forwardRef={wrapperRef} />
     )
   },
 )


### PR DESCRIPTION
**Problem:**
When opening the component picker for the preferred content, and then clicking the "more" button, the advanced menu opens at 0,0

**Fix:**
We rely on a ref to the wrapper div to find the offset, but recently an extra layer was added to the dom, so this PR moves the ref.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5621 
