### PR TITLE
Context Menus small fixes

### DIFF
--- a/editor/resources/editor/css/ReactContexify.css
+++ b/editor/resources/editor/css/ReactContexify.css
@@ -58,6 +58,7 @@
 }
 .react-contexify__item__content {
   min-width: 190px;
+  width: 100%;
   padding-left: 8px;
   padding-right: 8px;
   display: flex;

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -355,6 +355,7 @@ export const DataPickerPopup = React.memo(
                 width: '100%',
                 scrollbarWidth: 'auto',
                 colorScheme: 'dark',
+                scrollbarColor: 'gray transparent',
               }}
             >
               <DataPickerPopupSubvariables

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -579,7 +579,7 @@ const ComponentPickerContextMenuSimple = React.memo<ComponentPickerContextMenuPr
 
         const submenuLabel = (
           <FlexRow
-            style={{ gap: 10 }}
+            style={{ gap: 10, width: 228 }}
             data-testId={labelTestIdForComponentIcon(data.name, data.moduleName ?? '', data.icon)}
           >
             <Icn {...iconProps} width={12} height={12} />

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -285,7 +285,12 @@ const ComponentPickerComponentSection = React.memo(
     return (
       <div
         data-role='component-scroll'
-        style={{ maxHeight: 250, overflowY: 'scroll', scrollbarWidth: 'auto' }}
+        style={{
+          maxHeight: 250,
+          overflowY: 'scroll',
+          scrollbarWidth: 'auto',
+          scrollbarColor: 'gray transparent',
+        }}
         onScroll={onScroll}
       >
         {components.map((component) => {


### PR DESCRIPTION
- making small insert menu and full insert menu same width
- making the scrollbars in the component insert menu and data picker menus have a transparent background
- hovered rows in the data picker get `primary` blue background color

Fixes https://github.com/concrete-utopia/utopia/issues/5580

![06-57-t5fjv-gku3a](https://github.com/concrete-utopia/utopia/assets/47405698/8c37f2ae-fe13-41d3-80c8-9ce56241e65b)
![06-59-7xbh3-awhl0](https://github.com/concrete-utopia/utopia/assets/47405698/198b3470-73c9-4f5f-b4d8-219a92c17593)
