### PR TITLE
Safer render prop parsing

### DIFF
--- a/editor/src/utils/value-parser-utils.ts
+++ b/editor/src/utils/value-parser-utils.ts
@@ -399,7 +399,7 @@ export function parseJsx(_: unknown, value: unknown): ParseResult<JSXParsedValue
       if (props.hasOwnProperty('elementToRender') === true) {
         return right({
           type: 'internal-component',
-          name: (props as any).elementToRender,
+          name: typeof props.elementToRender === 'string' ? props.elementToRender : 'JSX',
         })
       }
     }


### PR DESCRIPTION
**Problem:**
https://github.com/concrete-utopia/utopia/issues/5607

**Fix:**
We have an error in the function which tries to extract the name of a runtime component, that it can set the name property a full jsx component function, which later throws an error when rendered into the control.

I did not have time to deeply understand the issue, so I just made sure in this case we fall back to the default 'JSX' name.

**Commit Details:** (< vv pls delete this section if's not relevant)

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5607
