### PR TITLE
Add Tabs to Component Picker

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -3,7 +3,7 @@
 import { jsx } from '@emotion/react'
 import React, { useCallback, useMemo } from 'react'
 import debounce from 'lodash.debounce'
-import { Icn, type IcnProps } from '../../../uuiui'
+import { colorTheme, Icn, type IcnProps } from '../../../uuiui'
 import { dark } from '../../../uuiui/styles/theme/dark'
 import type { JSXElementChild } from '../../../core/shared/element-template'
 import type { ElementPath, Imports } from '../../../core/shared/project-file-types'
@@ -15,13 +15,22 @@ import type {
 } from '../../canvas/ui/floating-insert-menu'
 import { UIGridRow } from '../../../components/inspector/widgets/ui-grid-row'
 import { FlexRow, type Icon } from 'utopia-api'
-import { assertNever } from '../../../core/shared/utils'
 import { insertableComponent } from '../../shared/project-components'
 import type { StylePropOption, InsertableComponent } from '../../shared/project-components'
 import type { Size } from '../../../core/shared/math-utils'
 import { dataPasteHandler } from '../../../utils/paste-handler'
 import { sortBy } from '../../../core/shared/array-utils'
 import { iconPropsForIcon } from './component-picker-context-menu'
+
+const FILTER_CATEGORIES = [
+  'Layout',
+  'Forms',
+  'HTML',
+  'Shopify',
+  'Advanced',
+  'Fragment',
+  'Miscellaneous',
+]
 
 export interface ComponentPickerProps {
   allComponents: Array<InsertMenuItemGroup>
@@ -152,6 +161,37 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
     [flatComponentsToShow, highlightedComponentKey, onItemClick, selectIndex],
   )
 
+  const fakeCategorizedComponents = [
+    {
+      label: FILTER_CATEGORIES[0],
+      items: flatComponentsToShow.slice(0, 1),
+    },
+    {
+      label: FILTER_CATEGORIES[1],
+      items: flatComponentsToShow.slice(1, 5),
+    },
+    {
+      label: FILTER_CATEGORIES[2],
+      items: flatComponentsToShow.slice(5, 7),
+    },
+    {
+      label: FILTER_CATEGORIES[3],
+      items: flatComponentsToShow.slice(7, 8),
+    },
+    {
+      label: FILTER_CATEGORIES[4],
+      items: flatComponentsToShow.slice(8, 9),
+    },
+    {
+      label: FILTER_CATEGORIES[5],
+      items: flatComponentsToShow.slice(9, 10),
+    },
+    {
+      label: FILTER_CATEGORIES[6],
+      items: flatComponentsToShow.slice(10),
+    },
+  ]
+
   return (
     <div
       style={{
@@ -165,9 +205,13 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
       onKeyDown={onKeyDown}
       ref={menuRef}
     >
-      <ComponentPickerTopSection onFilterChange={setFilter} onKeyDown={onKeyDown} />
+      <ComponentPickerTopSection
+        components={fakeCategorizedComponents}
+        onFilterChange={setFilter}
+        onKeyDown={onKeyDown}
+      />
       <ComponentPickerComponentSection
-        components={flatComponentsToShow}
+        components={fakeCategorizedComponents}
         onItemClick={props.onItemClick}
         onItemHover={onItemHover}
         currentlySelectedKey={highlightedComponentKey}
@@ -177,12 +221,16 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
 })
 
 interface ComponentPickerTopSectionProps {
+  components: Array<{
+    label: string
+    items: Array<InsertMenuItem>
+  }>
   onFilterChange: (filter: string) => void
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void
 }
 
 const ComponentPickerTopSection = React.memo((props: ComponentPickerTopSectionProps) => {
-  const { onFilterChange, onKeyDown } = props
+  const { components, onFilterChange, onKeyDown } = props
 
   return (
     <div
@@ -191,7 +239,9 @@ const ComponentPickerTopSection = React.memo((props: ComponentPickerTopSectionPr
         display: 'flex',
         flexDirection: 'column',
       }}
+      tabIndex={0}
     >
+      <FilterButtons components={components} />
       <FilterBar onFilterChange={onFilterChange} onKeyDown={onKeyDown} />
     </div>
   )
@@ -266,8 +316,142 @@ const FilterBar = React.memo((props: FilterBarProps) => {
   )
 })
 
+interface FilterButtonsProps {
+  components: Array<{
+    label: string
+    items: Array<InsertMenuItem>
+  }>
+}
+
+const FilterButtons = React.memo((props: FilterButtonsProps) => {
+  const { components } = props
+
+  const [focusedIndex, setFocusedIndex] = React.useState(0)
+
+  const setActiveIndexAll = React.useCallback(() => setFocusedIndex(0), [setFocusedIndex])
+
+  return (
+    <div
+      tabIndex={0}
+      aria-describedby='Component categories'
+      css={{
+        display: 'flex',
+        height: 30,
+      }}
+      onKeyDown={(event) => {
+        if (event.key === 'ArrowRight') {
+          setFocusedIndex((prev) => Math.min(prev + 1, FILTER_CATEGORIES.length))
+        } else if (event.key === 'ArrowLeft') {
+          setFocusedIndex((prev) => Math.max(prev - 1, 0))
+        } else if (event.key === 'Enter') {
+          document
+            .getElementById(FILTER_CATEGORIES[Math.max(focusedIndex - 1, 0)])
+            ?.scrollIntoView({ block: 'start', behavior: 'smooth' })
+        } else {
+          return
+        }
+        event.stopPropagation()
+        event.preventDefault()
+      }}
+    >
+      <div css={{ display: 'inline-block', marginRight: 8 }}>
+        <FilterButton
+          highlighted={focusedIndex === 0}
+          index={-1}
+          label='All'
+          setActiveFocus={setActiveIndexAll}
+        />
+      </div>
+      <ul
+        css={{
+          margin: '0 0 8px 0',
+          padding: 0,
+          overflowX: 'scroll',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {components.map(({ label }, index) => (
+          <li key={label} css={{ display: 'inline-block' }}>
+            <FilterButton
+              highlighted={focusedIndex === index + 1}
+              index={index}
+              label={label}
+              setActiveFocus={setFocusedIndex}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+})
+
+interface FilterButtonProps {
+  highlighted: boolean
+  index: number
+  label: string
+  setActiveFocus: (index: number) => void
+}
+
+const FilterButton = React.memo((props: FilterButtonProps) => {
+  const { highlighted, index, label, setActiveFocus } = props
+
+  const ref = React.useRef<HTMLButtonElement>(null)
+
+  React.useEffect(() => {
+    if (highlighted && ref.current !== null) {
+      ref.current.scrollIntoView({
+        block: 'start',
+        behavior: 'instant',
+      })
+    }
+  }, [highlighted])
+
+  return (
+    <button
+      tabIndex={-1}
+      id={`button-${label}`}
+      aria-selected={highlighted}
+      css={{
+        backgroundColor: highlighted ? colorTheme.primary.value : 'transparent',
+        border: 'none',
+        color: highlighted ? 'white' : '#ddd',
+        cursor: 'pointer',
+        fontSize: 12,
+        padding: '4px 8px',
+        borderRadius: 4,
+        outlineOffset: -1,
+        '&:hover': {
+          color: 'white',
+        },
+        '&:focus': {
+          backgroundColor: highlighted ? colorTheme.primary.value : 'transparent',
+          color: highlighted ? 'white' : undefined,
+        },
+      }}
+      onClick={() => {
+        setActiveFocus(index + 1)
+        const element = document.getElementById(`${label}`)
+        if (element !== null) {
+          document.getElementById('filter-container')?.scrollTo({
+            top: element.offsetTop - 75,
+            behavior: 'smooth',
+          })
+        } else {
+          document.getElementById('filter-container')?.scrollTo({ top: 0, behavior: 'smooth' })
+        }
+      }}
+      ref={ref}
+    >
+      {label}
+    </button>
+  )
+})
+
 interface ComponentPickerComponentSectionProps {
-  components: Array<InsertMenuItem>
+  components: Array<{
+    label: string
+    items: Array<InsertMenuItem>
+  }>
   onItemClick: (elementToInsert: InsertableComponent) => React.MouseEventHandler
   onItemHover: (elementToInsert: InsertMenuItemValue) => React.MouseEventHandler
   currentlySelectedKey: string | null
@@ -285,6 +469,7 @@ const ComponentPickerComponentSection = React.memo(
     return (
       <div
         data-role='component-scroll'
+        id='filter-container'
         style={{
           maxHeight: 250,
           overflowY: 'scroll',
@@ -293,62 +478,43 @@ const ComponentPickerComponentSection = React.memo(
         }}
         onScroll={onScroll}
       >
-        {components.map((component) => {
-          const selectedStyle =
-            component.value.key === currentlySelectedKey
-              ? {
-                  background: '#007aff',
-                  color: 'white',
-                }
-              : {}
-
-          return (
-            <FlexRow
-              css={{}}
-              key={component.value.key}
-              style={{
-                marginLeft: 8,
-                marginRight: 8,
-                borderRadius: 4,
-                // indentation!
-                paddingLeft: 8,
-                pointerEvents: isScrolling ? 'none' : 'auto',
-                color: '#EEE',
-                ...selectedStyle,
-              }}
-              onClick={onItemClick(component.value)}
-              onMouseOver={onItemHover(component.value)}
-              data-key={component.value.key}
-            >
-              <FlexRow css={{ gap: 10, height: 28, alignItems: 'center' }}>
-                <Icn
-                  {...iconPropsForIcon(component.value.icon ?? 'component')}
-                  width={12}
-                  height={12}
-                />
-                <label>{component.label}</label>
+        {components.flatMap((category) =>
+          category.items.map((component, index) => {
+            const isSelected = component.value.key === currentlySelectedKey
+            return (
+              <FlexRow
+                css={{}}
+                key={component.value.key}
+                id={index === 0 ? category.label : undefined}
+                style={{
+                  alignItems: 'center',
+                  cursor: 'pointer',
+                  marginLeft: 8,
+                  marginRight: 8,
+                  borderRadius: 4,
+                  // indentation!
+                  paddingLeft: 8,
+                  pointerEvents: isScrolling ? 'none' : 'auto',
+                  color: isSelected ? 'white' : '#EEE',
+                  backgroundColor: isSelected ? colorTheme.primary.value : undefined,
+                }}
+                onClick={onItemClick(component.value)}
+                onMouseOver={onItemHover(component.value)}
+                data-key={component.value.key}
+              >
+                <FlexRow css={{ gap: 10, height: 28, alignItems: 'center' }}>
+                  <Icn
+                    {...iconPropsForIcon(component.value.icon ?? 'component')}
+                    width={12}
+                    height={12}
+                  />
+                  <span>{component.label}</span>
+                </FlexRow>
               </FlexRow>
-            </FlexRow>
-          )
-
-          // return (
-          //   <ComponentPickerOption
-          //     key={`${comp.label}-label`}
-          //     component={comp}
-          //     onItemClick={onItemClick}
-          //     onItemHover={onItemHover}
-          //     currentlySelectedKey={currentlySelectedKey}
-          //   />
-          // )
-        })}
+            )
+          }),
+        )}
       </div>
     )
   },
 )
-
-interface ComponentPickerOptionProps {
-  component: InsertMenuItem
-  onItemClick: (elementToInsert: InsertableComponent) => React.MouseEventHandler
-  onItemHover: (elementToInsert: InsertMenuItemValue) => React.MouseEventHandler
-  currentlySelectedKey: string | null
-}

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -22,15 +22,12 @@ import { dataPasteHandler } from '../../../utils/paste-handler'
 import { sortBy } from '../../../core/shared/array-utils'
 import { iconPropsForIcon } from './component-picker-context-menu'
 
-const FILTER_CATEGORIES = [
-  'Layout',
-  'Forms',
-  'HTML',
-  'Shopify',
-  'Advanced',
-  'Fragment',
-  'Miscellaneous',
-]
+const FILTER_CATEGORIES: Array<string> = ['Everything']
+
+interface Category {
+  label: string
+  items: Array<InsertMenuItem>
+}
 
 export interface ComponentPickerProps {
   allComponents: Array<InsertMenuItemGroup>
@@ -161,34 +158,10 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
     [flatComponentsToShow, highlightedComponentKey, onItemClick, selectIndex],
   )
 
-  const fakeCategorizedComponents = [
+  const categorizedComponents = [
     {
-      label: FILTER_CATEGORIES[0],
-      items: flatComponentsToShow.slice(0, 1),
-    },
-    {
-      label: FILTER_CATEGORIES[1],
-      items: flatComponentsToShow.slice(1, 5),
-    },
-    {
-      label: FILTER_CATEGORIES[2],
-      items: flatComponentsToShow.slice(5, 7),
-    },
-    {
-      label: FILTER_CATEGORIES[3],
-      items: flatComponentsToShow.slice(7, 8),
-    },
-    {
-      label: FILTER_CATEGORIES[4],
-      items: flatComponentsToShow.slice(8, 9),
-    },
-    {
-      label: FILTER_CATEGORIES[5],
-      items: flatComponentsToShow.slice(9, 10),
-    },
-    {
-      label: FILTER_CATEGORIES[6],
-      items: flatComponentsToShow.slice(10),
+      label: 'Everything',
+      items: flatComponentsToShow,
     },
   ]
 
@@ -206,12 +179,12 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
       ref={menuRef}
     >
       <ComponentPickerTopSection
-        components={fakeCategorizedComponents}
+        components={categorizedComponents}
         onFilterChange={setFilter}
         onKeyDown={onKeyDown}
       />
       <ComponentPickerComponentSection
-        components={fakeCategorizedComponents}
+        components={categorizedComponents}
         onItemClick={props.onItemClick}
         onItemHover={onItemHover}
         currentlySelectedKey={highlightedComponentKey}
@@ -221,10 +194,7 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
 })
 
 interface ComponentPickerTopSectionProps {
-  components: Array<{
-    label: string
-    items: Array<InsertMenuItem>
-  }>
+  components: Array<Category>
   onFilterChange: (filter: string) => void
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void
 }
@@ -241,7 +211,7 @@ const ComponentPickerTopSection = React.memo((props: ComponentPickerTopSectionPr
       }}
       tabIndex={0}
     >
-      <FilterButtons components={components} />
+      {components.length > 1 && <FilterButtons components={components} />}
       <FilterBar onFilterChange={onFilterChange} onKeyDown={onKeyDown} />
     </div>
   )
@@ -317,10 +287,7 @@ const FilterBar = React.memo((props: FilterBarProps) => {
 })
 
 interface FilterButtonsProps {
-  components: Array<{
-    label: string
-    items: Array<InsertMenuItem>
-  }>
+  components: Array<Category>
 }
 
 const FilterButtons = React.memo((props: FilterButtonsProps) => {
@@ -448,10 +415,7 @@ const FilterButton = React.memo((props: FilterButtonProps) => {
 })
 
 interface ComponentPickerComponentSectionProps {
-  components: Array<{
-    label: string
-    items: Array<InsertMenuItem>
-  }>
+  components: Array<Category>
   onItemClick: (elementToInsert: InsertableComponent) => React.MouseEventHandler
   onItemHover: (elementToInsert: InsertMenuItemValue) => React.MouseEventHandler
   currentlySelectedKey: string | null


### PR DESCRIPTION
**Problem:**
We want to add tabs to quickly jump to categories within the component picker.

**Fix:**
Focus should to be managed by a single element, and then arrow key navigation within as there may be a large list of categories and we don't want to force users to cycle through them all.

Within the focused element, we highlight an active selection and upon Enter keypress scroll this option in the list into view.

Also, applying design changes as requested to the list items.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

^ didn't do these and would love context on what needs to be done if it's relevant to my PR

Relates to https://github.com/concrete-utopia/utopia/issues/5428
