### PR TITLE
bumping our hydrogen dependency we provide for user project environments

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -155,7 +155,7 @@
     "@remix-run/server-runtime": "2.3.1",
     "@root/encoding": "1.0.1",
     "@seznam/compose-react-refs": "1.0.6",
-    "@shopify/hydrogen": "2023.10.2",
+    "@shopify/hydrogen": "2024.4.1",
     "@stitches/react": "1.2.8",
     "@svgr/plugin-jsx": "5.5.0",
     "@tippyjs/react": "4.1.0",

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -77,7 +77,7 @@ specifiers:
   '@rollup/plugin-node-resolve': 13.1.3
   '@root/encoding': 1.0.1
   '@seznam/compose-react-refs': 1.0.6
-  '@shopify/hydrogen': 2023.10.2
+  '@shopify/hydrogen': 2024.4.1
   '@shopify/remix-oxygen': 2.0.3
   '@stitches/react': 1.2.8
   '@svgr/plugin-jsx': 5.5.0
@@ -368,7 +368,7 @@ dependencies:
   '@remix-run/server-runtime': 2.3.1_typescript@5.2.2
   '@root/encoding': 1.0.1
   '@seznam/compose-react-refs': 1.0.6
-  '@shopify/hydrogen': 2023.10.2_w6lhquyj4jtuytgedwpbhq3tte
+  '@shopify/hydrogen': 2024.4.1_mm4hmzfspm7s5gpesqzvatlufi
   '@stitches/react': 1.2.8_react@18.1.0
   '@svgr/plugin-jsx': 5.5.0
   '@tippyjs/react': 4.1.0_ef5jwxihqo6n7gxfmzogljlgcm
@@ -2458,7 +2458,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm64/0.18.17:
@@ -2467,7 +2466,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-x64/0.18.17:
@@ -2476,7 +2474,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-arm64/0.18.17:
@@ -2485,7 +2482,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-x64/0.18.17:
@@ -2494,7 +2490,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64/0.18.17:
@@ -2503,7 +2498,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-x64/0.18.17:
@@ -2512,7 +2506,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm/0.18.17:
@@ -2521,7 +2514,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm64/0.18.17:
@@ -2530,7 +2522,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32/0.18.17:
@@ -2539,7 +2530,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-loong64/0.14.54:
@@ -2557,7 +2547,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el/0.18.17:
@@ -2566,7 +2555,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ppc64/0.18.17:
@@ -2575,7 +2563,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64/0.18.17:
@@ -2584,7 +2571,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-s390x/0.18.17:
@@ -2593,7 +2579,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-x64/0.18.17:
@@ -2602,7 +2587,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-x64/0.18.17:
@@ -2611,7 +2595,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-x64/0.18.17:
@@ -2620,7 +2603,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/sunos-x64/0.18.17:
@@ -2629,7 +2611,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-arm64/0.18.17:
@@ -2638,7 +2619,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-ia32/0.18.17:
@@ -2647,7 +2627,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64/0.18.17:
@@ -2656,7 +2635,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@eslint-community/eslint-utils/4.4.0_eslint@7.32.0:
@@ -4353,9 +4331,9 @@ packages:
     resolution: {integrity: sha512-izzOXQfeQLonzrIQb8u6LQ8dk+ymz3WXTIXjvOlTXHq6sbzROg3NWU+9TTAOpEoK9Bth24/6F/XrfHJ5yR5n6Q==}
     dev: false
 
-  /@shopify/hydrogen-react/2023.10.0_2gujrjvyx75a3yizenxbm6c4lu:
-    resolution: {integrity: sha512-fb9UHLF2nzzfHZMCPedT4kRHnCAcdrlCjsa8JUs3HFD0ESBq3VKCOxS5QLzVc5uT9X7ElRp1JnORa7q/qXUaxQ==}
-    engines: {node: '>=14'}
+  /@shopify/hydrogen-react/2024.4.1_2gujrjvyx75a3yizenxbm6c4lu:
+    resolution: {integrity: sha512-rE/JuMsuYRgDgUipDOTfkZq5Vd05y959FJYk5SljWwPJfS1k8fFdt0YFX/42uEDENPoL6qxS2JRMOjwrglE85g==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
@@ -4373,24 +4351,26 @@ packages:
       - xstate
     dev: false
 
-  /@shopify/hydrogen/2023.10.2_w6lhquyj4jtuytgedwpbhq3tte:
-    resolution: {integrity: sha512-p5nhX/k2RebxvA800mX8C/C7yG+yWnNAynOF1/601JePeLjhOlnHd4F8x+duj9fNu1yVbjPM+erUUvuJHij2sg==}
+  /@shopify/hydrogen/2024.4.1_mm4hmzfspm7s5gpesqzvatlufi:
+    resolution: {integrity: sha512-11ES4UBEU4v1frpXZL1rpWWEUlo/yKrXireBwG8RmxHGJjOXCP7LhvxJ1svkAoMAPcNZnnDB0v+HHNe6NR6VCQ==}
     peerDependencies:
       '@remix-run/react': ^2.1.0
       '@remix-run/server-runtime': ^2.1.0
       react: ^18.2.0
+      vite: ^5.1.0
     peerDependenciesMeta:
-      '@remix-run/react':
-        optional: true
-      '@remix-run/server-runtime':
+      vite:
         optional: true
     dependencies:
       '@remix-run/react': 2.0.1_4uzd4uhfxjy6hfd2xmixhrzbqy_njludxb6fcqnim6moy22jieofi
       '@remix-run/server-runtime': 2.3.1_typescript@5.2.2
-      '@shopify/hydrogen-react': 2023.10.0_2gujrjvyx75a3yizenxbm6c4lu
+      '@shopify/hydrogen-react': 2024.4.1_2gujrjvyx75a3yizenxbm6c4lu
       content-security-policy-builder: 2.1.1
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
+      source-map-support: 0.5.21
       type-fest: 4.8.2
+      use-resize-observer: 9.1.0_ef5jwxihqo6n7gxfmzogljlgcm
+      vite: 4.4.8
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
@@ -6987,7 +6967,6 @@ packages:
 
   /buffer-from/1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-    dev: true
 
   /buffer-xor/1.0.3:
     resolution: {integrity: sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=}
@@ -9309,7 +9288,6 @@ packages:
       '@esbuild/win32-arm64': 0.18.17
       '@esbuild/win32-ia32': 0.18.17
       '@esbuild/win32-x64': 0.18.17
-    dev: true
 
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -10424,7 +10402,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /function-bind/1.1.1:
@@ -16972,7 +16949,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /rst-selector-parser/2.2.3:
     resolution: {integrity: sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=}
@@ -17661,6 +17637,13 @@ packages:
       buffer-from: 1.1.2
       source-map: 0.6.1
     dev: true
+
+  /source-map-support/0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    dev: false
 
   /source-map-url/0.4.1:
     resolution: {integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==}
@@ -19007,6 +18990,17 @@ packages:
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
     dev: false
 
+  /use-resize-observer/9.1.0_ef5jwxihqo6n7gxfmzogljlgcm:
+    resolution: {integrity: sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==}
+    peerDependencies:
+      react: 16.8.0 - 18
+      react-dom: 16.8.0 - 18
+    dependencies:
+      '@juggle/resize-observer': 3.4.0
+      react: 18.1.0_47cciibm4ysmleigs33s763fqu
+      react-dom: 18.1.0_abari7w75zfr6mrhvamxwmfpxm_react@18.1.0
+    dev: false
+
   /use-sidecar/1.1.2_7cpxmzzodpxnolj5zcc5cr63ji:
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
     engines: {node: '>=10'}
@@ -19148,7 +19142,6 @@ packages:
       rollup: 3.27.2
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vm-browserify/0.0.4:
     resolution: {integrity: sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=}

--- a/editor/src/core/es-modules/package-manager/group-component.tsx
+++ b/editor/src/core/es-modules/package-manager/group-component.tsx
@@ -146,11 +146,14 @@ export const UtopiaApiGroup: React.FunctionComponent<
     const observer = new MutationObserver((e) => {
       changeSizeToMatchChildren()
     })
-    observer.observe(document, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-    })
+    observer.observe(
+      document as any as Node, // weirdly this broke when I pulled in "@shopify/hydrogen": "2024.4.1",
+      {
+        childList: true,
+        subtree: true,
+        attributes: true,
+      },
+    )
 
     return function cleanup() {
       observer.disconnect()


### PR DESCRIPTION
**Problem:**
Our hydrogen dependency was outdated.

**Fix:**
Bumping it to `"@shopify/hydrogen": "2024.4.1",`

**Notes:**
It doesn't seem to break old projects, but even if it does, it's not a relevant problem, as all of our hydrogen demo projects should be on latest hydrogen