### PR TITLE
Better Matching By Properties In Data Picker

### DIFF
--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.spec.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.spec.ts
@@ -1,0 +1,121 @@
+import { maybeToArray } from '../../../../core/shared/optional-utils'
+import type { ControlDescription } from '../../../custom-code/internal-property-controls'
+import type { PropertyValue, VariableInfo } from './variables-in-scope-utils'
+import { orderVariablesForRelevance, variableInfoFromValue } from './variables-in-scope-utils'
+
+describe('orderVariablesForRelevance', () => {
+  it('should be able to target a given property', () => {
+    const variableNamesInScope: Array<VariableInfo> = maybeToArray(
+      variableInfoFromValue('style', 'style', { left: 300, position: 'relative' }),
+    )
+    const controlDescription: ControlDescription = {
+      control: 'object',
+      object: {
+        left: {
+          control: 'number-input',
+        },
+      },
+    }
+    const currentPropertyValue: PropertyValue = {
+      type: 'existing',
+      value: {
+        left: 200,
+      },
+    }
+    const targetPropertyName = 'left'
+    const actualResult = orderVariablesForRelevance(
+      variableNamesInScope,
+      controlDescription,
+      currentPropertyValue,
+      targetPropertyName,
+      'all',
+    )
+    expect(actualResult).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "expression": "style",
+          "expressionPathPart": "style",
+          "matches": false,
+          "props": Array [
+            Object {
+              "expression": "style['left']",
+              "expressionPathPart": "left",
+              "matches": true,
+              "type": "primitive",
+              "value": 300,
+            },
+            Object {
+              "expression": "style['position']",
+              "expressionPathPart": "position",
+              "matches": false,
+              "type": "primitive",
+              "value": "relative",
+            },
+          ],
+          "type": "object",
+          "value": Object {
+            "left": 300,
+            "position": "relative",
+          },
+        },
+      ]
+    `)
+  })
+  it('handles the case when not targeting a specific property', () => {
+    const variableNamesInScope: Array<VariableInfo> = maybeToArray(
+      variableInfoFromValue('style', 'style', { left: 300, position: 'relative' }),
+    )
+    const controlDescription: ControlDescription = {
+      control: 'object',
+      object: {
+        left: {
+          control: 'number-input',
+        },
+      },
+    }
+    const currentPropertyValue: PropertyValue = {
+      type: 'existing',
+      value: {
+        left: 200,
+      },
+    }
+    const targetPropertyName = null
+    const actualResult = orderVariablesForRelevance(
+      variableNamesInScope,
+      controlDescription,
+      currentPropertyValue,
+      targetPropertyName,
+      'all',
+    )
+    expect(actualResult).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "expression": "style",
+          "expressionPathPart": "style",
+          "matches": true,
+          "props": Array [
+            Object {
+              "expression": "style['left']",
+              "expressionPathPart": "left",
+              "matches": false,
+              "type": "primitive",
+              "value": 300,
+            },
+            Object {
+              "expression": "style['position']",
+              "expressionPathPart": "position",
+              "matches": false,
+              "type": "primitive",
+              "value": "relative",
+            },
+          ],
+          "type": "object",
+          "value": Object {
+            "left": 300,
+            "position": "relative",
+          },
+        },
+      ]
+    `)
+  })
+})


### PR DESCRIPTION
**Problem:**
Certain values are a good match (eg strings) but are not indicated as insertable.

**Fix:**
When a specific property is being targeted, the logic in `orderVariablesForRelevance` was not drilling down into that property. Now the control description used comes from the property specified if there is one.

**Commit Details:**
- Removed `keepOnlyFirstMatch` as it conflicts with the needs we have right now.
- Added `getTargetPropertyFromControlDescription`.
- `orderVariablesForRelevance` uses `getTargetPropertyFromControlDescription` to drill down into the relevant part of the variable.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5603