### PR TITLE
Remove errors of deleted sidecar file

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -493,6 +493,9 @@ import {
   openCodeEditorFile,
   scrollToPosition,
   selectComponents,
+  setCodeEditorBuildErrors,
+  setCodeEditorComponentDescriptorErrors,
+  setCodeEditorLintErrors,
   setFocusedElement,
   setPackageStatus,
   setScrollAnimation,
@@ -4037,15 +4040,15 @@ export const UPDATE_FNS = {
           projectContents: updatedProjectContents,
         }
         if (isComponentDescriptorFile(action.filename)) {
-          return {
+          const withUpdatedPropertyControls = {
             ...nextEditor,
             propertyControlsInfo: updatePropertyControlsOnDescriptorFileDelete(
               editor.propertyControlsInfo,
               action.filename,
             ),
           }
+          return removeErrorMessagesForFile(withUpdatedPropertyControls, action.filename)
         }
-
         return nextEditor
       }
       case 'ASSET_FILE':
@@ -6382,4 +6385,19 @@ function updateFilePath(
         )
       : withUpdatedPropertyControls
   }
+}
+
+function removeErrorMessagesForFile(editor: EditorState, filename: string): EditorState {
+  const noErrors = { [filename]: [] }
+
+  return UPDATE_FNS.SET_CODE_EDITOR_BUILD_ERRORS(
+    setCodeEditorBuildErrors(noErrors),
+    UPDATE_FNS.SET_CODE_EDITOR_LINT_ERRORS(
+      setCodeEditorLintErrors(noErrors),
+      UPDATE_FNS.SET_CODE_EDITOR_COMPONENT_DESCRIPTOR_ERRORS(
+        setCodeEditorComponentDescriptorErrors(noErrors),
+        editor,
+      ),
+    ),
+  )
 }

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -1856,6 +1856,59 @@ describe('Lifecycle management of registering components', () => {
           `)
     })
   })
+  it('Deleting a component descriptor file removes the error messages of that file', async () => {
+    const renderResult = await renderTestEditorWithModel(
+      project({
+        ['/utopia/components.utopia.js']: `import { Cart } from '../src/card'
+        
+        const Components = {
+      '/src/card': {
+        Card: {
+          component: Cart,
+          properties: { },
+          variants: [ ],
+        },
+      },
+    }
+    
+    export default Components
+  `,
+      }),
+      'await-first-dom-report',
+    )
+
+    // Error messages from the descriptor file
+    expect(
+      renderResult.getEditorState().editor.codeEditorErrors.componentDescriptorErrors[
+        '/utopia/components.utopia.js'
+      ],
+    ).toEqual([
+      {
+        codeSnippet: '',
+        endColumn: null,
+        endLine: null,
+        errorCode: '',
+        fileName: '/utopia/components.utopia.js',
+        message: "Validation failed: Component registered for key 'Card' is undefined",
+        passTime: null,
+        severity: 'fatal',
+        source: 'component-descriptor',
+        startColumn: null,
+        startLine: null,
+        type: '',
+      },
+    ])
+
+    // delete the descriptor file
+    await renderResult.dispatch([deleteFile('/utopia/components.utopia.js')], true)
+
+    // error messages are removed
+    expect(
+      renderResult.getEditorState().editor.codeEditorErrors.componentDescriptorErrors[
+        '/utopia/components.utopia.js'
+      ] ?? [],
+    ).toHaveLength(0)
+  })
   describe('Updating a component descriptor file', () => {
     const descriptorFileContent2 = `import { Card2 } from '../src/card2'
     


### PR DESCRIPTION
**Problem:**
When a component annotation sidecar file is deleted, we remove the property controls defined by it.
However, we do note remove the errors generated by it. So the errors stay in the editor state (and on the canvas, potentially forever)

**Fix:**
I updated the deletion handling to remove the errors too.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5640
