### PR TITLE
Make List a default option in the insert menu

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -333,6 +333,24 @@ function defaultVariantItem(
   }
 }
 
+function singletonItem(
+  label: string | React.ReactNode,
+  variant: ComponentInfo,
+  onItemClick: (preferredChildToInsert: ElementToInsert) => void,
+): ContextMenuItem<unknown> {
+  return {
+    name: label,
+    submenuName: null,
+    enabled: true,
+    action: () =>
+      onItemClick({
+        name: variant.insertMenuLabel,
+        elementToInsert: (uid: string) => elementFromInsertMenuItem(variant.elementToInsert(), uid),
+        additionalImports: variant.importsToAdd,
+      }),
+  }
+}
+
 function variantItem(
   variant: ComponentInfo,
   submenuName: string | React.ReactNode | null,
@@ -594,15 +612,7 @@ function contextMenuItemsFromVariants(
   }
 
   if (preferredChildComponentDescriptor.variants.length === 1) {
-    return [
-      defaultVariantItem(
-        preferredChildComponentDescriptor.variants[0].insertMenuLabel,
-        submenuLabel,
-        preferredChildComponentDescriptor.variants[0].importsToAdd,
-        null,
-        onItemClick,
-      ),
-    ]
+    return [singletonItem(submenuLabel, preferredChildComponentDescriptor.variants[0], onItemClick)]
   }
 
   return preferredChildComponentDescriptor.variants.map((variant) => {

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -61,7 +61,7 @@ import {
   conditionalClauseInsertionPath,
   replaceWithSingleElement,
 } from '../../editor/store/insertion-path'
-import type { InsertableComponent } from '../../shared/project-components'
+import { mapComponentInfo, type InsertableComponent } from '../../shared/project-components'
 import type { ConditionalCase } from '../../../core/model/conditionals'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import { absolute } from '../../../utils/utils'
@@ -195,6 +195,25 @@ export function preferredChildrenForTarget(
   return []
 }
 
+function augmentPreferredChildren(
+  preferredChildren: PreferredChildComponentDescriptorWithIcon[],
+  insertionTarget: InsertionTarget,
+): PreferredChildComponentDescriptorWithIcon[] {
+  if (insertionTarget.type === 'insert-as-child') {
+    return [
+      ...preferredChildren,
+      {
+        name: 'List',
+        moduleName: null,
+        variants: [mapComponentInfo],
+        icon: 'code',
+      },
+    ]
+  }
+
+  return preferredChildren
+}
+
 const usePreferredChildrenForTarget = (
   target: ElementPath,
   insertionTarget: InsertionTarget,
@@ -210,7 +229,7 @@ const usePreferredChildrenForTarget = (
     'usePreferredChildrenForTarget targetElement',
   )
 
-  return useEditorState(
+  const preferredChildren = useEditorState(
     Substores.restOfEditor,
     (store) => {
       return preferredChildrenForTarget(
@@ -221,6 +240,8 @@ const usePreferredChildrenForTarget = (
     },
     'usePreferredChildrenForSelectedElement propertyControlsInfo',
   )
+
+  return augmentPreferredChildren(preferredChildren, insertionTarget)
 }
 
 export type ShowComponentPickerContextMenuCallback = (
@@ -547,6 +568,48 @@ export function labelTestIdForComponentIcon(
   return `variant-label-${componentName}-${moduleName}-${icon}`
 }
 
+function contextMenuItemsFromVariants(
+  preferredChildComponentDescriptor: PreferredChildComponentDescriptorWithIcon,
+  submenuLabel: React.ReactElement,
+  defaultVariantImports: Imports,
+  onItemClick: (_: ElementToInsert) => void,
+): ContextMenuItem<unknown>[] {
+  const allJSXElements = preferredChildComponentDescriptor.variants.every(
+    (v) => v.elementToInsert().type === 'JSX_ELEMENT',
+  )
+
+  if (allJSXElements) {
+    return [
+      defaultVariantItem(
+        preferredChildComponentDescriptor.name,
+        '(empty)',
+        defaultVariantImports,
+        submenuLabel,
+        onItemClick,
+      ),
+      ...preferredChildComponentDescriptor.variants.map((variant) => {
+        return variantItem(variant, submenuLabel, onItemClick)
+      }),
+    ]
+  }
+
+  if (preferredChildComponentDescriptor.variants.length === 1) {
+    return [
+      defaultVariantItem(
+        preferredChildComponentDescriptor.variants[0].insertMenuLabel,
+        submenuLabel,
+        preferredChildComponentDescriptor.variants[0].importsToAdd,
+        null,
+        onItemClick,
+      ),
+    ]
+  }
+
+  return preferredChildComponentDescriptor.variants.map((variant) => {
+    return variantItem(variant, submenuLabel, onItemClick)
+  })
+}
+
 const ComponentPickerContextMenuSimple = React.memo<ComponentPickerContextMenuProps>(
   ({ target, insertionTarget }) => {
     const showFullMenu = useCreateCallbackToShowComponentPicker()(target, insertionTarget, 'full')
@@ -594,20 +657,9 @@ const ComponentPickerContextMenuSimple = React.memo<ComponentPickerContextMenuPr
           return [
             defaultVariantItem(data.name, submenuLabel, defaultVariantImports, null, onItemClick),
           ]
-        } else {
-          return [
-            defaultVariantItem(
-              data.name,
-              '(empty)',
-              defaultVariantImports,
-              submenuLabel,
-              onItemClick,
-            ),
-            ...data.variants.map((variant) => {
-              return variantItem(variant, submenuLabel, onItemClick)
-            }),
-          ]
         }
+
+        return contextMenuItemsFromVariants(data, submenuLabel, defaultVariantImports, onItemClick)
       })
       .concat([separatorItem, moreItem(wrapperRef, showFullMenu)])
 

--- a/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
@@ -563,6 +563,11 @@ describe('The navigator component picker context menu', () => {
       labelTestIdForComponentIcon('RandomComponent', '/src/utils', 'component'),
     )
     expect(randomComponentRow).not.toBeNull()
+
+    const listRow = editor.renderedDOM.queryByTestId(
+      labelTestIdForComponentIcon('List', '', 'code'),
+    )
+    expect(listRow).not.toBeNull()
   })
 
   it('Selecting a component with no variants from the simple picker for a render prop should insert that component into the render prop', async () => {
@@ -845,6 +850,67 @@ describe('The navigator component picker context menu', () => {
           }}
         >
           <FlexRow>three totally real placeholders</FlexRow>
+        </Card>
+        <Card
+          style={{
+            backgroundColor: '#aaaaaa33',
+            position: 'absolute',
+            left: 800,
+            top: 111,
+            width: 139,
+            height: 87,
+          }}
+          title={<div />}
+        />
+      </Storyboard>
+    )
+    `),
+    )
+  })
+
+  it('Selecting a List from the simple picker for adding a child should insert the code for the List', async () => {
+    const editor = await renderTestEditorWithModel(TestProject, 'await-first-dom-report')
+    await selectComponentsForTest(editor, [EP.fromString('sb/card')])
+    const addChildButton = editor.renderedDOM.getByTestId(
+      addChildButtonTestId(EP.fromString('sb/card')),
+    )
+    await mouseClickAtPoint(addChildButton, { x: 2, y: 2 })
+
+    const submenuButton = await waitFor(() => editor.renderedDOM.getByText('List'))
+    await mouseClickAtPoint(submenuButton, { x: 2, y: 2 })
+
+    await editor.getDispatchFollowUpActionsFinished()
+
+    expect(getPrintedUiJsCodeWithoutUIDs(editor.getEditorState(), StoryboardFilePath)).toEqual(
+      formatTestProjectCode(`
+    import * as React from 'react'
+    import { Storyboard } from 'utopia-api'
+    import { Placeholder } from 'utopia-api'
+
+    export const Card = (props) => {
+      return (
+        <div style={props.style}>
+          {props.title}
+          {props.children}
+        </div>
+      )
+    }
+
+    export var storyboard = (
+      <Storyboard>
+        <Card
+          style={{
+            backgroundColor: '#aaaaaa33',
+            position: 'absolute',
+            left: 945,
+            top: 111,
+            width: 139,
+            height: 87,
+          }}
+        >
+          {[1, 2, 3].map((listItem) => (
+            <Placeholder />
+          ))}
         </Card>
         <Card
           style={{

--- a/editor/src/core/property-controls/property-controls-local-parser-bridge.ts
+++ b/editor/src/core/property-controls/property-controls-local-parser-bridge.ts
@@ -40,7 +40,7 @@ async function getParseResultForUserStrings(
 
   function Utopia$$$Component(props) {
      return (
-      ${toInsert}
+       ${toInsert}
      )
     }`
   const parseResult = await getParseResult(

--- a/editor/src/core/property-controls/property-controls-local-parser-bridge.ts
+++ b/editor/src/core/property-controls/property-controls-local-parser-bridge.ts
@@ -40,7 +40,7 @@ async function getParseResultForUserStrings(
 
   function Utopia$$$Component(props) {
      return (
-       <container>${toInsert}</container>
+      ${toInsert}
      )
     }`
   const parseResult = await getParseResult(

--- a/editor/src/core/property-controls/property-controls-local-parser-bridge.ts
+++ b/editor/src/core/property-controls/property-controls-local-parser-bridge.ts
@@ -40,7 +40,7 @@ async function getParseResultForUserStrings(
 
   function Utopia$$$Component(props) {
      return (
-       ${toInsert}
+       <container>${toInsert}</container>
      )
     }`
   const parseResult = await getParseResult(


### PR DESCRIPTION
## Problem
https://github.com/concrete-utopia/utopia/issues/5605

The ticket has a comment about parsing, this PR does not address that problem

<img width="414" alt="image" src="https://github.com/concrete-utopia/utopia/assets/16385508/d1bd571c-c1d6-4b6f-a8de-5cd3d771d193">


## Fix
- List is made available as a default option in the insert menu for preferred children (it was already there in the More section)
- Since an `(empty)` variant doesn't make sense for List, the empty variant generation code is tweaked so that the `(empty)` variants are only added for jsx elements
- To avoid having a submenu for items that only have one variant (such as `List > List`), the menu element generation code is tweaked so that single-variant items are displayed in the root of the menu, not hidden in a submenu

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
