### PR TITLE
Support folder labels in the component API

### DIFF
--- a/editor/src/components/custom-code/internal-property-controls.ts
+++ b/editor/src/components/custom-code/internal-property-controls.ts
@@ -293,12 +293,6 @@ export interface TupleControlDescription {
   defaultValue?: unknown
 }
 
-export interface FolderControlDescription {
-  control: 'folder'
-  label?: string
-  controls: PropertyControls
-}
-
 export type HigherLevelControlDescription =
   | ArrayControlDescription
   | ObjectControlDescription
@@ -306,7 +300,7 @@ export type HigherLevelControlDescription =
   | UnionControlDescription
 
 export type RegularControlDescription = BaseControlDescription | HigherLevelControlDescription
-export type ControlDescription = RegularControlDescription | FolderControlDescription
+export type ControlDescription = RegularControlDescription
 
 export type PropertyControls = {
   [key: string]: ControlDescription
@@ -339,7 +333,6 @@ export function isBaseControlDescription(
     case 'object':
     case 'tuple':
     case 'union':
-    case 'folder':
       return false
     default:
       const _exhaustiveCheck: never = control

--- a/editor/src/components/custom-code/internal-property-controls.ts
+++ b/editor/src/components/custom-code/internal-property-controls.ts
@@ -1,6 +1,14 @@
 import type { CSSProperties } from 'react'
 import type { ComponentInfo } from './code-file'
 
+interface GenericControlProps<T> {
+  label?: string
+  folder?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: T
+}
+
 export type BaseControlType =
   | 'checkbox'
   | 'color'
@@ -21,22 +29,14 @@ export type BaseControlType =
   | 'vector4'
   | 'jsx'
 
-export interface CheckboxControlDescription {
+export interface CheckboxControlDescription extends GenericControlProps<unknown> {
   control: 'checkbox'
-  label?: string
-  visibleByDefault?: boolean
   disabledTitle?: string
   enabledTitle?: string
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface ColorControlDescription {
+export interface ColorControlDescription extends GenericControlProps<unknown> {
   control: 'color'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
 export type AllowedEnumType = string | boolean | number | undefined | null
@@ -48,13 +48,10 @@ export interface BasicControlOption<T> {
 
 export type BasicControlOptions<T> = AllowedEnumType[] | BasicControlOption<T>[]
 
-export interface PopUpListControlDescription {
+export interface PopUpListControlDescription
+  extends GenericControlProps<AllowedEnumType | BasicControlOption<unknown>> {
   control: 'popuplist'
-  label?: string
-  visibleByDefault?: boolean
   options: BasicControlOptions<unknown>
-  required?: boolean
-  defaultValue?: AllowedEnumType | BasicControlOption<unknown>
 }
 export interface ImportType {
   source: string
@@ -69,39 +66,24 @@ export interface ExpressionControlOption<T> {
   requiredImport?: ImportType
 }
 
-export interface ExpressionPopUpListControlDescription {
+export interface ExpressionPopUpListControlDescription extends GenericControlProps<unknown> {
   control: 'expression-popuplist'
-  label?: string
-  visibleByDefault?: boolean
   options: ExpressionControlOption<unknown>[]
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface EulerControlDescription {
+export interface EulerControlDescription
+  extends GenericControlProps<[number, number, number, string]> {
   control: 'euler'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: [number, number, number, string]
 }
 
-export interface NoneControlDescription {
+export interface NoneControlDescription extends GenericControlProps<unknown> {
   control: 'none'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
 export type Matrix3 = [number, number, number, number, number, number, number, number, number]
 
-export interface Matrix3ControlDescription {
+export interface Matrix3ControlDescription extends GenericControlProps<Matrix3> {
   control: 'matrix3'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: Matrix3
 }
 
 export type Matrix4 = [
@@ -123,95 +105,57 @@ export type Matrix4 = [
   number,
 ]
 
-export interface Matrix4ControlDescription {
+export interface Matrix4ControlDescription extends GenericControlProps<Matrix4> {
   control: 'matrix4'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: Matrix4
 }
 
-export interface NumberInputControlDescription {
+export interface NumberInputControlDescription extends GenericControlProps<unknown> {
   control: 'number-input'
-  label?: string
-  visibleByDefault?: boolean
   max?: number
   min?: number
   unit?: string
   step?: number
   displayStepper?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface RadioControlDescription {
+export interface RadioControlDescription
+  extends GenericControlProps<AllowedEnumType | BasicControlOption<unknown>> {
   control: 'radio'
-  label?: string
-  visibleByDefault?: boolean
   options: BasicControlOptions<unknown>
-  required?: boolean
-  defaultValue?: AllowedEnumType | BasicControlOption<unknown>
 }
 
-export interface ExpressionInputControlDescription {
+export interface ExpressionInputControlDescription extends GenericControlProps<unknown> {
   control: 'expression-input'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface StringInputControlDescription {
+export interface StringInputControlDescription extends GenericControlProps<unknown> {
   control: 'string-input'
-  label?: string
-  visibleByDefault?: boolean
   placeholder?: string
   obscured?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface HtmlInputControlDescription {
+export interface HtmlInputControlDescription extends GenericControlProps<unknown> {
   control: 'html-input'
-  label?: string
-  visibleByDefault?: boolean
   placeholder?: string
   obscured?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface StyleControlsControlDescription {
+export interface StyleControlsControlDescription extends GenericControlProps<unknown> {
   control: 'style-controls'
-  label?: string
-  visibleByDefault?: boolean
   placeholder?: CSSProperties
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface Vector2ControlDescription {
+export interface Vector2ControlDescription extends GenericControlProps<[number, number]> {
   control: 'vector2'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: [number, number]
 }
 
-export interface Vector3ControlDescription {
+export interface Vector3ControlDescription extends GenericControlProps<[number, number, number]> {
   control: 'vector3'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: [number, number, number]
 }
 
-export interface Vector4ControlDescription {
+export interface Vector4ControlDescription
+  extends GenericControlProps<[number, number, number, number]> {
   control: 'vector4'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: [number, number, number, number]
 }
 
 export interface PreferredChildComponentDescriptor {
@@ -220,13 +164,9 @@ export interface PreferredChildComponentDescriptor {
   variants: Array<ComponentInfo>
 }
 
-export interface JSXControlDescription {
+export interface JSXControlDescription extends GenericControlProps<unknown> {
   control: 'jsx'
-  label?: string
-  visibleByDefault?: boolean
   preferredChildComponents: Array<PreferredChildComponentDescriptor>
-  required?: boolean
-  defaultValue?: unknown
 }
 export declare type BaseControlDescription =
   | CheckboxControlDescription
@@ -254,43 +194,27 @@ export type RegularControlType = BaseControlType | HigherLevelControlType
 
 export type ControlType = RegularControlType | 'folder'
 
-export interface ArrayControlDescription {
+export interface ArrayControlDescription extends GenericControlProps<unknown> {
   control: 'array'
-  label?: string
-  visibleByDefault?: boolean
   propertyControl: RegularControlDescription
   maxCount?: number
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface ObjectControlDescription {
+export interface ObjectControlDescription extends GenericControlProps<unknown> {
   control: 'object'
-  label?: string
-  visibleByDefault?: boolean
   object: {
     [prop: string]: RegularControlDescription
   }
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface UnionControlDescription {
+export interface UnionControlDescription extends GenericControlProps<unknown> {
   control: 'union'
-  label?: string
-  visibleByDefault?: boolean
   controls: Array<RegularControlDescription>
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface TupleControlDescription {
+export interface TupleControlDescription extends GenericControlProps<unknown> {
   control: 'tuple'
-  label?: string
-  visibleByDefault?: boolean
   propertyControls: RegularControlDescription[]
-  required?: boolean
-  defaultValue?: unknown
 }
 
 export type HigherLevelControlDescription =

--- a/editor/src/components/inspector/sections/component-section/folder-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/folder-section.tsx
@@ -38,8 +38,7 @@ export const FolderSection = React.memo((props: FolderSectionProps) => {
     () =>
       Object.keys(props.propertyControls).filter((prop) => {
         const control = props.propertyControls[prop]
-        const isVisibleByDefault =
-          control.control === 'folder' || (control.visibleByDefault ?? true)
+        const isVisibleByDefault = control.visibleByDefault ?? true
         return (
           !isVisibleByDefault &&
           props.unsetPropNames.includes(prop) &&

--- a/editor/src/components/inspector/sections/component-section/row-or-folder-wrapper.tsx
+++ b/editor/src/components/inspector/sections/component-section/row-or-folder-wrapper.tsx
@@ -3,8 +3,6 @@ import type { ControlDescription } from '../../../custom-code/internal-property-
 import type { PropertyPath } from '../../../../core/shared/project-file-types'
 import type { CSSCursor } from '../../../canvas/canvas-types'
 import { UIGridRow } from '../../widgets/ui-grid-row'
-import { FolderSection } from './folder-section'
-import * as PP from '../../../../core/shared/property-path'
 import { RowForControl } from './component-section'
 
 type RowOrFolderWrapperProps = {
@@ -38,22 +36,4 @@ export const RowOrFolderWrapper = React.memo((props: RowOrFolderWrapperProps) =>
       />
     </UIGridRow>
   )
-
-  // switch (props.controlDescription.control) {
-  //   case 'folder':
-  //     return (
-  //       <FolderSection
-  //         isRoot={false}
-  //         indentationLevel={props.indentationLevel}
-  //         propertyControls={props.controlDescription.controls}
-  //         setGlobalCursor={props.setGlobalCursor}
-  //         title={props.controlDescription.label ?? PP.toString(props.propPath)}
-  //         visibleEmptyControls={props.visibleEmptyControls}
-  //         unsetPropNames={props.unsetPropNames}
-  //         showHiddenControl={props.showHiddenControl}
-  //         detectedPropsAndValuesWithoutControls={{}}
-  //       />
-  //     )
-  //   default:
-  // }
 })

--- a/editor/src/components/inspector/sections/component-section/row-or-folder-wrapper.tsx
+++ b/editor/src/components/inspector/sections/component-section/row-or-folder-wrapper.tsx
@@ -20,39 +20,40 @@ type RowOrFolderWrapperProps = {
 }
 
 export const RowOrFolderWrapper = React.memo((props: RowOrFolderWrapperProps) => {
-  switch (props.controlDescription.control) {
-    case 'folder':
-      return (
-        <FolderSection
-          isRoot={false}
-          indentationLevel={props.indentationLevel}
-          propertyControls={props.controlDescription.controls}
-          setGlobalCursor={props.setGlobalCursor}
-          title={props.controlDescription.label ?? PP.toString(props.propPath)}
-          visibleEmptyControls={props.visibleEmptyControls}
-          unsetPropNames={props.unsetPropNames}
-          showHiddenControl={props.showHiddenControl}
-          detectedPropsAndValuesWithoutControls={{}}
-        />
-      )
-    default:
-      return (
-        <UIGridRow
-          padded
-          tall={false}
-          style={{ paddingLeft: 0 }}
-          variant='<-------------1fr------------->'
-        >
-          <RowForControl
-            propPath={props.propPath}
-            controlDescription={props.controlDescription}
-            isScene={props.isScene}
-            setGlobalCursor={props.setGlobalCursor}
-            indentationLevel={props.indentationLevel}
-            focusOnMount={props.focusOnMount ?? false}
-            showHiddenControl={props.showHiddenControl}
-          />
-        </UIGridRow>
-      )
-  }
+  return (
+    <UIGridRow
+      padded
+      tall={false}
+      style={{ paddingLeft: 0 }}
+      variant='<-------------1fr------------->'
+    >
+      <RowForControl
+        propPath={props.propPath}
+        controlDescription={props.controlDescription}
+        isScene={props.isScene}
+        setGlobalCursor={props.setGlobalCursor}
+        indentationLevel={props.indentationLevel}
+        focusOnMount={props.focusOnMount ?? false}
+        showHiddenControl={props.showHiddenControl}
+      />
+    </UIGridRow>
+  )
+
+  // switch (props.controlDescription.control) {
+  //   case 'folder':
+  //     return (
+  //       <FolderSection
+  //         isRoot={false}
+  //         indentationLevel={props.indentationLevel}
+  //         propertyControls={props.controlDescription.controls}
+  //         setGlobalCursor={props.setGlobalCursor}
+  //         title={props.controlDescription.label ?? PP.toString(props.propPath)}
+  //         visibleEmptyControls={props.visibleEmptyControls}
+  //         unsetPropNames={props.unsetPropNames}
+  //         showHiddenControl={props.showHiddenControl}
+  //         detectedPropsAndValuesWithoutControls={{}}
+  //       />
+  //     )
+  //   default:
+  // }
 })

--- a/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
+++ b/editor/src/core/es-modules/package-manager/utopia-api-typings.ts
@@ -354,7 +354,7 @@ declare module 'utopia-api/primitives/view' {
 
 }
 declare module 'utopia-api/property-controls/factories' {
-  import { ArrayControlDescription, BasicControlOptions, CheckboxControlDescription, ColorControlDescription, EulerControlDescription, ExpressionControlOption, ExpressionInputControlDescription, ExpressionPopUpListControlDescription, FolderControlDescription, ImportType, Matrix3ControlDescription, Matrix4ControlDescription, NoneControlDescription, NumberInputControlDescription, ObjectControlDescription, PopUpListControlDescription, PropertyControls, RadioControlDescription, RegularControlDescription, StringInputControlDescription, StyleControlsControlDescription, TupleControlDescription, UnionControlDescription, Vector2ControlDescription, Vector3ControlDescription, Vector4ControlDescription } from 'utopia-api/property-controls/property-controls';
+  import { ArrayControlDescription, BasicControlOptions, CheckboxControlDescription, ColorControlDescription, EulerControlDescription, ExpressionControlOption, ExpressionInputControlDescription, ExpressionPopUpListControlDescription, ImportType, Matrix3ControlDescription, Matrix4ControlDescription, NoneControlDescription, NumberInputControlDescription, ObjectControlDescription, PopUpListControlDescription, PropertyControls, RadioControlDescription, RegularControlDescription, StringInputControlDescription, StyleControlsControlDescription, TupleControlDescription, UnionControlDescription, Vector2ControlDescription, Vector3ControlDescription, Vector4ControlDescription } from 'utopia-api/property-controls/property-controls';
   export function checkboxControl(): CheckboxControlDescription;
   export function colorControl(): ColorControlDescription;
   export function expressionControl(): ExpressionInputControlDescription;
@@ -383,7 +383,6 @@ declare module 'utopia-api/property-controls/factories' {
   }): ObjectControlDescription;
   export function tupleControl(propertyControls: RegularControlDescription[]): TupleControlDescription;
   export function unionControl(controls: Array<RegularControlDescription>): UnionControlDescription;
-  export function folderControl(controls: PropertyControls): FolderControlDescription;
 
 }
 declare module 'utopia-api/property-controls/property-controls' {
@@ -530,14 +529,10 @@ declare module 'utopia-api/property-controls/property-controls' {
       visibleByDefault?: boolean;
       propertyControls: RegularControlDescription[];
   }
-  export interface FolderControlDescription {
-      control: 'folder';
-      label?: string;
-      controls: PropertyControls;
-  }
+ 
   export type HigherLevelControlDescription = ArrayControlDescription | ObjectControlDescription | TupleControlDescription | UnionControlDescription;
   export type RegularControlDescription = BaseControlDescription | HigherLevelControlDescription;
-  export type ControlDescription = RegularControlDescription | FolderControlDescription;
+  export type ControlDescription = RegularControlDescription;
   export function isBaseControlDescription(control: ControlDescription): control is BaseControlDescription;
   export function isHigherLevelControlDescription(control: ControlDescription): control is HigherLevelControlDescription;
   export type PropertyControls = {

--- a/editor/src/core/property-controls/property-control-values.ts
+++ b/editor/src/core/property-controls/property-control-values.ts
@@ -17,7 +17,6 @@ import type {
   BaseControlDescription,
   ControlDescription,
   UnionControlDescription,
-  FolderControlDescription,
   PropertyControls,
   RegularControlDescription,
 } from '../../components/custom-code/internal-property-controls'
@@ -384,30 +383,10 @@ export function walkRegularControlDescriptions(
   propertyControls: PropertyControls,
   walkWith: (propertyName: string, propertyControl: RegularControlDescription) => void,
 ): void {
-  function addPropertyControl(
-    propertyName: number | string,
-    propertyControl: ControlDescription,
-  ): void {
-    switch (propertyControl.control) {
-      case 'folder':
-        addFolder(propertyControl)
-        break
-      default:
-        if (typeof propertyName === 'string') {
-          walkWith(propertyName, propertyControl)
-        }
-        break
-    }
-  }
-
-  function addFolder(folder: FolderControlDescription): void {
-    forEachValue((propertyControl, propertyName) => {
-      addPropertyControl(propertyName, propertyControl)
-    }, folder.controls)
-  }
-
   forEachValue((propertyControl, propertyName) => {
-    addPropertyControl(propertyName, propertyControl)
+    if (typeof propertyName === 'string') {
+      walkWith(propertyName, propertyControl)
+    }
   }, propertyControls)
 }
 

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -1782,7 +1782,7 @@ describe('registered property controls', () => {
     })
   })
 
-  describe('folderes', () => {
+  describe('folders', () => {
     it('can specify a folder prop', async () => {
       const renderResult = await renderTestEditorWithModel(
         project({

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -1781,6 +1781,68 @@ describe('registered property controls', () => {
       `)
     })
   })
+
+  describe('folderes', () => {
+    it('can specify a folder prop', async () => {
+      const renderResult = await renderTestEditorWithModel(
+        project({
+          ['/utopia/components.utopia.js']: `import { Card } from '../src/card'
+          
+          const Components = {
+        '/src/card': {
+          Card: {
+            component: Card,
+            properties: {
+              label: {
+                control: 'jsx',
+              },
+              header: {
+                control: 'jsx',
+                folder: 'Header',
+              },
+              footer: {
+                control: 'jsx',
+                folder: 'Footer',
+              }
+            }
+          },
+        },
+      }
+      
+      export default Components
+    `,
+        }),
+        'await-first-dom-report',
+      )
+      const editorState = renderResult.getEditorState().editor
+
+      const cardRegistration = editorState.propertyControlsInfo['/src/card']['Card']
+      expect(cardRegistration).not.toBeUndefined()
+
+      const propsToCheck = pick(['properties'], cardRegistration)
+
+      expect(propsToCheck).toMatchInlineSnapshot(`
+        Object {
+          "properties": Object {
+            "footer": Object {
+              "control": "jsx",
+              "folder": "Footer",
+              "preferredChildComponents": Array [],
+            },
+            "header": Object {
+              "control": "jsx",
+              "folder": "Header",
+              "preferredChildComponents": Array [],
+            },
+            "label": Object {
+              "control": "jsx",
+              "preferredChildComponents": Array [],
+            },
+          },
+        }
+      `)
+    })
+  })
 })
 
 describe('Lifecycle management of registering components', () => {

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -50,7 +50,6 @@ import {
   parseArray,
   parseConstant,
   parseEnum,
-  parseNumber,
   parseObject,
   parseString,
 } from '../../utils/value-parser-utils'
@@ -67,7 +66,6 @@ import {
   right,
   sequenceEither,
 } from '../shared/either'
-import { setOptionalProp } from '../shared/object-utils'
 import { assertNever } from '../shared/utils'
 import type { Imports, ParsedTextFile } from '../shared/project-file-types'
 import {
@@ -770,19 +768,11 @@ async function makePropertyDescriptors(
   let result: PropertyControls = {}
 
   for await (const [propertyName, descriptor] of Object.entries(properties)) {
-    if (descriptor.control === 'folder') {
-      const parsedControlsInFolder = await makePropertyDescriptors(descriptor.controls, context)
-      if (isLeft(parsedControlsInFolder)) {
-        return parsedControlsInFolder
-      }
-      result['propertyName'] = { ...descriptor, controls: parsedControlsInFolder.value }
-    } else {
-      const parsedRegularControl = await makeRegularControlDescription(descriptor, context)
-      if (isLeft(parsedRegularControl)) {
-        return parsedRegularControl
-      }
-      result[propertyName] = parsedRegularControl.value
+    const parsedRegularControl = await makeRegularControlDescription(descriptor, context)
+    if (isLeft(parsedRegularControl)) {
+      return parsedRegularControl
     }
+    result[propertyName] = parsedRegularControl.value
   }
 
   return right(result)

--- a/editor/src/core/property-controls/property-controls-parser.spec.ts
+++ b/editor/src/core/property-controls/property-controls-parser.spec.ts
@@ -364,6 +364,7 @@ const validStringInputControlDescriptionValue: StringInputControlDescription = {
   placeholder: 'Enter text',
   obscured: true,
   visibleByDefault: true,
+  folder: 'String Input',
 }
 
 describe('parseStringInputControlDescription', () => {
@@ -503,6 +504,7 @@ const validArrayControlDescriptionValue: ArrayControlDescription = {
   propertyControl: {
     control: 'string-input',
   },
+  folder: 'Array Control',
 }
 
 describe('parseArrayControlDescription', () => {
@@ -527,6 +529,7 @@ const validObjectControlDescriptionValue: ObjectControlDescription = {
       control: 'string-input',
     },
   },
+  folder: 'Object Control',
 }
 
 describe('parseObjectControlDescription', () => {

--- a/editor/src/core/property-controls/property-controls-parser.spec.ts
+++ b/editor/src/core/property-controls/property-controls-parser.spec.ts
@@ -7,7 +7,6 @@ import type {
   ColorControlDescription,
   NoneControlDescription,
   StyleControlsControlDescription,
-  FolderControlDescription,
   ExpressionInputControlDescription,
   Vector2ControlDescription,
   Vector3ControlDescription,
@@ -31,7 +30,6 @@ import {
   parsePropertyControls,
   parseNoneControlDescription,
   parseStyleControlsControlDescription,
-  parseFolderControlDescription,
   parseControlDescription,
   parseExpressionInputControlDescription,
   parseVector2ControlDescription,
@@ -565,25 +563,6 @@ describe('parseTupleControlDescription', () => {
   )
 })
 
-const validFolderControlDescriptionValue: FolderControlDescription = {
-  control: 'folder',
-  controls: {
-    style: validStyleControlsControlDescriptionValue,
-    someSlider: validNumberInputControlDescriptionValue,
-  },
-}
-
-describe('parseFolderControlDescription', () => {
-  runBaseTestSuite(
-    validFolderControlDescriptionValue,
-    ['control', 'controls'],
-    parseFolderControlDescription,
-    'Value was not folder.',
-    'does-not-support-required',
-    [],
-  )
-})
-
 describe('parseControlDescription', () => {
   it('parses a number input description correctly', () => {
     expect(parseControlDescription(validNumberInputControlDescriptionValue)).toEqual(
@@ -643,11 +622,6 @@ describe('parseControlDescription', () => {
   it('parses a tuple description correctly', () => {
     expect(parseControlDescription(validTupleControlDescriptionValue)).toEqual(
       right(validTupleControlDescriptionValue),
-    )
-  })
-  it('parses a folder instance description correctly', () => {
-    expect(parseControlDescription(validFolderControlDescriptionValue)).toEqual(
-      right(validFolderControlDescriptionValue),
     )
   })
   it('parses a vector2 description correctly', () => {

--- a/editor/src/core/property-controls/property-controls-parser.ts
+++ b/editor/src/core/property-controls/property-controls-parser.ts
@@ -43,7 +43,9 @@ import {
   objectFieldNotPresentParseError,
   objectFieldParseError,
   objectKeyParser,
+  objectParser,
   optionalObjectKeyParser,
+  optionalProp,
   parseAlternative,
   parseAny,
   parseArray,
@@ -91,49 +93,19 @@ import {
 
 const requiredFieldParser = optionalObjectKeyParser(parseBoolean, 'required')
 
-export function parseNumberInputControlDescription(
-  value: unknown,
-): ParseResult<NumberInputControlDescription> {
-  return applicative10Either(
-    (
-      label,
-      control,
-      max,
-      min,
-      unit,
-      step,
-      displayStepper,
-      visibleByDefault,
-      required,
-      defaultValue,
-    ) => {
-      let numberInputControlDescription: NumberInputControlDescription = {
-        control: control,
-      }
-      setOptionalProp(numberInputControlDescription, 'label', label)
-      setOptionalProp(numberInputControlDescription, 'max', max)
-      setOptionalProp(numberInputControlDescription, 'min', min)
-      setOptionalProp(numberInputControlDescription, 'unit', unit)
-      setOptionalProp(numberInputControlDescription, 'step', step)
-      setOptionalProp(numberInputControlDescription, 'displayStepper', displayStepper)
-      setOptionalProp(numberInputControlDescription, 'visibleByDefault', visibleByDefault)
-      setOptionalProp(numberInputControlDescription, 'required', required)
-      setOptionalProp(numberInputControlDescription, 'defaultValue', defaultValue)
-
-      return numberInputControlDescription
-    },
-    optionalObjectKeyParser(parseString, 'label')(value),
-    objectKeyParser(parseConstant('number-input'), 'control')(value),
-    optionalObjectKeyParser(parseNumber, 'max')(value),
-    optionalObjectKeyParser(parseNumber, 'min')(value),
-    optionalObjectKeyParser(parseString, 'unit')(value),
-    optionalObjectKeyParser(parseNumber, 'step')(value),
-    optionalObjectKeyParser(parseBoolean, 'displayStepper')(value),
-    optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
-    requiredFieldParser(value),
-    optionalObjectKeyParser(parseNumber, 'defaultValue')(value),
-  )
-}
+export const parseNumberInputControlDescription = objectParser<NumberInputControlDescription>({
+  control: parseConstant('number-input'),
+  label: optionalProp(parseString),
+  folder: optionalProp(parseString),
+  max: optionalProp(parseNumber),
+  min: optionalProp(parseNumber),
+  unit: optionalProp(parseString),
+  step: optionalProp(parseNumber),
+  displayStepper: optionalProp(parseBoolean),
+  visibleByDefault: optionalProp(parseBoolean),
+  required: optionalProp(parseBoolean),
+  defaultValue: optionalProp(parseNumber),
+})
 
 function parseBasicControlOption<V>(valueParser: Parser<V>): Parser<BasicControlOption<V>> {
   return (value: unknown) => {
@@ -166,13 +138,14 @@ const parseEnumValueOrBasicControlOption: Parser<AllowedEnumType | BasicControlO
 export function parsePopUpListControlDescription(
   value: unknown,
 ): ParseResult<PopUpListControlDescription> {
-  return applicative6Either(
-    (label, control, options, visibleByDefault, required, defaultValue) => {
+  return applicative7Either(
+    (label, folder, control, options, visibleByDefault, required, defaultValue) => {
       let popupListControlDescription: PopUpListControlDescription = {
         control: control,
         options: options,
       }
       setOptionalProp(popupListControlDescription, 'label', label)
+      setOptionalProp(popupListControlDescription, 'folder', folder)
       setOptionalProp(popupListControlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(popupListControlDescription, 'required', required)
       setOptionalProp(popupListControlDescription, 'defaultValue', defaultValue)
@@ -180,6 +153,7 @@ export function parsePopUpListControlDescription(
       return popupListControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('popuplist'), 'control')(value),
     objectKeyParser(parseBasicControlOptions, 'options')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
@@ -191,13 +165,14 @@ export function parsePopUpListControlDescription(
 export function parseExpressionPopUpListControlDescription(
   value: unknown,
 ): ParseResult<ExpressionPopUpListControlDescription> {
-  return applicative6Either(
-    (label, control, options, visibleByDefault, required, defaultValue) => {
+  return applicative7Either(
+    (label, folder, control, options, visibleByDefault, required, defaultValue) => {
       let enumControlDescription: ExpressionPopUpListControlDescription = {
         control: control,
         options: options,
       }
       setOptionalProp(enumControlDescription, 'label', label)
+      setOptionalProp(enumControlDescription, 'folder', folder)
       setOptionalProp(enumControlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(enumControlDescription, 'required', required)
       setOptionalProp(enumControlDescription, 'defaultValue', defaultValue)
@@ -205,6 +180,7 @@ export function parseExpressionPopUpListControlDescription(
       return enumControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('expression-popuplist'), 'control')(value),
     objectKeyParser(parseArray(parseExpressionControlOption), 'options')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
@@ -258,12 +234,22 @@ function parseExpressionControlOption(
 export function parseCheckboxControlDescription(
   value: unknown,
 ): ParseResult<CheckboxControlDescription> {
-  return applicative7Either(
-    (label, control, disabledTitle, enabledTitle, visibleByDefault, required, defaultValue) => {
+  return applicative8Either(
+    (
+      label,
+      folder,
+      control,
+      disabledTitle,
+      enabledTitle,
+      visibleByDefault,
+      required,
+      defaultValue,
+    ) => {
       let checkboxControlDescription: CheckboxControlDescription = {
         control: control,
       }
       setOptionalProp(checkboxControlDescription, 'label', label)
+      setOptionalProp(checkboxControlDescription, 'folder', folder)
       setOptionalProp(checkboxControlDescription, 'disabledTitle', disabledTitle)
       setOptionalProp(checkboxControlDescription, 'enabledTitle', enabledTitle)
       setOptionalProp(checkboxControlDescription, 'visibleByDefault', visibleByDefault)
@@ -273,6 +259,7 @@ export function parseCheckboxControlDescription(
       return checkboxControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('checkbox'), 'control')(value),
     optionalObjectKeyParser(parseString, 'disabledTitle')(value),
     optionalObjectKeyParser(parseString, 'enabledTitle')(value),
@@ -285,12 +272,13 @@ export function parseCheckboxControlDescription(
 export function parseStringInputControlDescription(
   value: unknown,
 ): ParseResult<StringInputControlDescription> {
-  return applicative7Either(
-    (label, control, placeholder, obscured, visibleByDefault, required, defaultValue) => {
+  return applicative8Either(
+    (label, folder, control, placeholder, obscured, visibleByDefault, required, defaultValue) => {
       let stringInputControlDescription: StringInputControlDescription = {
         control: control,
       }
       setOptionalProp(stringInputControlDescription, 'label', label)
+      setOptionalProp(stringInputControlDescription, 'folder', folder)
       setOptionalProp(stringInputControlDescription, 'placeholder', placeholder)
       setOptionalProp(stringInputControlDescription, 'obscured', obscured)
       setOptionalProp(stringInputControlDescription, 'visibleByDefault', visibleByDefault)
@@ -300,6 +288,7 @@ export function parseStringInputControlDescription(
       return stringInputControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('string-input'), 'control')(value),
     optionalObjectKeyParser(parseString, 'placeholder')(value),
     optionalObjectKeyParser(parseBoolean, 'obscured')(value),
@@ -312,12 +301,13 @@ export function parseStringInputControlDescription(
 export function parseHtmlInputControlDescription(
   value: unknown,
 ): ParseResult<HtmlInputControlDescription> {
-  return applicative7Either(
-    (label, control, placeholder, obscured, visibleByDefault, required, defaultValue) => {
+  return applicative8Either(
+    (label, folder, control, placeholder, obscured, visibleByDefault, required, defaultValue) => {
       let htmlInputControlDescription: HtmlInputControlDescription = {
         control: control,
       }
       setOptionalProp(htmlInputControlDescription, 'label', label)
+      setOptionalProp(htmlInputControlDescription, 'folder', folder)
       setOptionalProp(htmlInputControlDescription, 'placeholder', placeholder)
       setOptionalProp(htmlInputControlDescription, 'obscured', obscured)
       setOptionalProp(htmlInputControlDescription, 'visibleByDefault', visibleByDefault)
@@ -327,6 +317,7 @@ export function parseHtmlInputControlDescription(
       return htmlInputControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('html-input'), 'control')(value),
     optionalObjectKeyParser(parseString, 'placeholder')(value),
     optionalObjectKeyParser(parseBoolean, 'obscured')(value),
@@ -337,13 +328,14 @@ export function parseHtmlInputControlDescription(
 }
 
 export function parseRadioControlDescription(value: unknown): ParseResult<RadioControlDescription> {
-  return applicative6Either(
-    (label, control, options, visibleByDefault, required, defaultValue) => {
+  return applicative7Either(
+    (label, folder, control, options, visibleByDefault, required, defaultValue) => {
       let radioControlDescription: RadioControlDescription = {
         control: control,
         options: options,
       }
       setOptionalProp(radioControlDescription, 'label', label)
+      setOptionalProp(radioControlDescription, 'folder', folder)
       setOptionalProp(radioControlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(radioControlDescription, 'required', required)
       setOptionalProp(radioControlDescription, 'defaultValue', defaultValue)
@@ -351,6 +343,7 @@ export function parseRadioControlDescription(value: unknown): ParseResult<RadioC
       return radioControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('radio'), 'control')(value),
     objectKeyParser(parseBasicControlOptions, 'options')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
@@ -388,12 +381,13 @@ export function parseStringValidateAsColor(value: unknown): ParseResult<string> 
 }
 
 export function parseColorControlDescription(value: unknown): ParseResult<ColorControlDescription> {
-  return applicative5Either(
-    (label, control, visibleByDefault, required, defaultValue) => {
+  return applicative6Either(
+    (label, folder, control, visibleByDefault, required, defaultValue) => {
       let colorControlDescription: ColorControlDescription = {
         control: control,
       }
       setOptionalProp(colorControlDescription, 'label', label)
+      setOptionalProp(colorControlDescription, 'folder', folder)
       setOptionalProp(colorControlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(colorControlDescription, 'required', required)
       setOptionalProp(colorControlDescription, 'defaultValue', defaultValue)
@@ -401,6 +395,7 @@ export function parseColorControlDescription(value: unknown): ParseResult<ColorC
       return colorControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('color'), 'control')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
     requiredFieldParser(value),
@@ -411,12 +406,13 @@ export function parseColorControlDescription(value: unknown): ParseResult<ColorC
 export function parseExpressionInputControlDescription(
   value: unknown,
 ): ParseResult<ExpressionInputControlDescription> {
-  return applicative5Either(
-    (label, control, visibleByDefault, required, defaultValue) => {
+  return applicative6Either(
+    (label, folder, control, visibleByDefault, required, defaultValue) => {
       let expressionInputControlDescription: ExpressionInputControlDescription = {
         control: control,
       }
       setOptionalProp(expressionInputControlDescription, 'label', label)
+      setOptionalProp(expressionInputControlDescription, 'folder', folder)
       setOptionalProp(expressionInputControlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(expressionInputControlDescription, 'required', required)
       setOptionalProp(expressionInputControlDescription, 'defaultValue', defaultValue)
@@ -424,6 +420,7 @@ export function parseExpressionInputControlDescription(
       return expressionInputControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('expression-input'), 'control')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
     requiredFieldParser(value),
@@ -432,18 +429,20 @@ export function parseExpressionInputControlDescription(
 }
 
 export function parseNoneControlDescription(value: unknown): ParseResult<NoneControlDescription> {
-  return applicative5Either(
-    (label, control, visibleByDefault, required, defaultValue) => {
+  return applicative6Either(
+    (label, folder, control, visibleByDefault, required, defaultValue) => {
       let noneControlDescription: NoneControlDescription = {
         control: control,
       }
       setOptionalProp(noneControlDescription, 'label', label)
+      setOptionalProp(noneControlDescription, 'folder', folder)
       setOptionalProp(noneControlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(noneControlDescription, 'required', required)
       setOptionalProp(noneControlDescription, 'defaultValue', defaultValue)
       return noneControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('none'), 'control')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
     requiredFieldParser(value),
@@ -454,12 +453,13 @@ export function parseNoneControlDescription(value: unknown): ParseResult<NoneCon
 export function parseStyleControlsControlDescription(
   value: unknown,
 ): ParseResult<StyleControlsControlDescription> {
-  return applicative6Either(
-    (label, control, placeholder, visibleByDefault, required, defaultValue) => {
+  return applicative7Either(
+    (label, folder, control, placeholder, visibleByDefault, required, defaultValue) => {
       let styleControlsControlDescription: StyleControlsControlDescription = {
         control: control,
       }
       setOptionalProp(styleControlsControlDescription, 'label', label)
+      setOptionalProp(styleControlsControlDescription, 'folder', folder)
       setOptionalProp(styleControlsControlDescription, 'placeholder', placeholder)
       setOptionalProp(styleControlsControlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(styleControlsControlDescription, 'required', required)
@@ -468,6 +468,7 @@ export function parseStyleControlsControlDescription(
       return styleControlsControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('style-controls'), 'control')(value),
     optionalObjectKeyParser(parseObject(parseAny), 'placeholder')(value), // FIXME
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
@@ -477,13 +478,23 @@ export function parseStyleControlsControlDescription(
 }
 
 export function parseArrayControlDescription(value: unknown): ParseResult<ArrayControlDescription> {
-  return applicative7Either(
-    (label, control, propertyControl, maxCount, visibleByDefault, required, defaultValue) => {
+  return applicative8Either(
+    (
+      label,
+      folder,
+      control,
+      propertyControl,
+      maxCount,
+      visibleByDefault,
+      required,
+      defaultValue,
+    ) => {
       let arrayControlDescription: ArrayControlDescription = {
         control: control,
         propertyControl: propertyControl,
       }
       setOptionalProp(arrayControlDescription, 'label', label)
+      setOptionalProp(arrayControlDescription, 'folder', folder)
       setOptionalProp(arrayControlDescription, 'maxCount', maxCount)
       setOptionalProp(arrayControlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(arrayControlDescription, 'required', required)
@@ -492,6 +503,7 @@ export function parseArrayControlDescription(value: unknown): ParseResult<ArrayC
       return arrayControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('array'), 'control')(value),
     objectKeyParser(parseRegularControlDescription, 'propertyControl')(value),
     optionalObjectKeyParser(parseNumber, 'maxCount')(value),
@@ -502,13 +514,14 @@ export function parseArrayControlDescription(value: unknown): ParseResult<ArrayC
 }
 
 export function parseTupleControlDescription(value: unknown): ParseResult<TupleControlDescription> {
-  return applicative6Either(
-    (label, control, propertyControls, visibleByDefault, required, defaultValue) => {
+  return applicative7Either(
+    (label, folder, control, propertyControls, visibleByDefault, required, defaultValue) => {
       let tupleControlDescription: TupleControlDescription = {
         control: control,
         propertyControls: propertyControls,
       }
       setOptionalProp(tupleControlDescription, 'label', label)
+      setOptionalProp(tupleControlDescription, 'folder', folder)
       setOptionalProp(tupleControlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(tupleControlDescription, 'required', required)
       setOptionalProp(tupleControlDescription, 'defaultValue', defaultValue)
@@ -516,6 +529,7 @@ export function parseTupleControlDescription(value: unknown): ParseResult<TupleC
       return tupleControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('tuple'), 'control')(value),
     objectKeyParser(parseArray(parseRegularControlDescription), 'propertyControls')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
@@ -527,13 +541,14 @@ export function parseTupleControlDescription(value: unknown): ParseResult<TupleC
 export function parseObjectControlDescription(
   value: unknown,
 ): ParseResult<ObjectControlDescription> {
-  return applicative6Either(
-    (label, control, object, visibleByDefault, required, defaultValue) => {
+  return applicative7Either(
+    (label, folder, control, object, visibleByDefault, required, defaultValue) => {
       let objectControlDescription: ObjectControlDescription = {
         control: control,
         object: object,
       }
       setOptionalProp(objectControlDescription, 'label', label)
+      setOptionalProp(objectControlDescription, 'folder', folder)
       setOptionalProp(objectControlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(objectControlDescription, 'required', required)
       setOptionalProp(objectControlDescription, 'defaultValue', defaultValue)
@@ -541,6 +556,7 @@ export function parseObjectControlDescription(
       return objectControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('object'), 'control')(value),
     objectKeyParser(parseObject(parseRegularControlDescription), 'object')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
@@ -550,19 +566,21 @@ export function parseObjectControlDescription(
 }
 
 export function parseUnionControlDescription(value: unknown): ParseResult<UnionControlDescription> {
-  return applicative6Either(
-    (label, control, controls, visibleByDefault, required, defaultValue) => {
+  return applicative7Either(
+    (label, folder, control, controls, visibleByDefault, required, defaultValue) => {
       let unionControlDescription: UnionControlDescription = {
         control: control,
         controls: controls,
       }
       setOptionalProp(unionControlDescription, 'label', label)
+      setOptionalProp(unionControlDescription, 'folder', folder)
       setOptionalProp(unionControlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(unionControlDescription, 'required', required)
       setOptionalProp(unionControlDescription, 'defaultValue', defaultValue)
       return unionControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('union'), 'control')(value),
     objectKeyParser(parseArray(parseRegularControlDescription), 'controls')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
@@ -587,12 +605,13 @@ export const parseVector2 = flatMapParser<Array<number>, [number, number]>(
 export function parseVector2ControlDescription(
   value: unknown,
 ): ParseResult<Vector2ControlDescription> {
-  return applicative5Either(
-    (label, control, visibleByDefault, required, defaultValue) => {
+  return applicative6Either(
+    (label, folder, control, visibleByDefault, required, defaultValue) => {
       let controlDescription: Vector2ControlDescription = {
         control: control,
       }
       setOptionalProp(controlDescription, 'label', label)
+      setOptionalProp(controlDescription, 'folder', folder)
       setOptionalProp(controlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(controlDescription, 'required', required)
       setOptionalProp(controlDescription, 'defaultValue', defaultValue)
@@ -600,6 +619,7 @@ export function parseVector2ControlDescription(
       return controlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('vector2'), 'control')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
     requiredFieldParser(value),
@@ -623,12 +643,13 @@ export const parseVector3 = flatMapParser<Array<number>, [number, number, number
 export function parseVector3ControlDescription(
   value: unknown,
 ): ParseResult<Vector3ControlDescription> {
-  return applicative5Either(
-    (label, control, visibleByDefault, required, defaultValue) => {
+  return applicative6Either(
+    (label, folder, control, visibleByDefault, required, defaultValue) => {
       let controlDescription: Vector3ControlDescription = {
         control: control,
       }
       setOptionalProp(controlDescription, 'label', label)
+      setOptionalProp(controlDescription, 'folder', folder)
       setOptionalProp(controlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(controlDescription, 'required', required)
       setOptionalProp(controlDescription, 'defaultValue', defaultValue)
@@ -636,6 +657,7 @@ export function parseVector3ControlDescription(
       return controlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('vector3'), 'control')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
     requiredFieldParser(value),
@@ -659,12 +681,13 @@ export const parseVector4 = flatMapParser<Array<number>, [number, number, number
 export function parseVector4ControlDescription(
   value: unknown,
 ): ParseResult<Vector4ControlDescription> {
-  return applicative5Either(
-    (label, control, visibleByDefault, required, defaultValue) => {
+  return applicative6Either(
+    (label, folder, control, visibleByDefault, required, defaultValue) => {
       let controlDescription: Vector4ControlDescription = {
         control: control,
       }
       setOptionalProp(controlDescription, 'label', label)
+      setOptionalProp(controlDescription, 'folder', folder)
       setOptionalProp(controlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(controlDescription, 'required', required)
       setOptionalProp(controlDescription, 'defaultValue', defaultValue)
@@ -672,6 +695,7 @@ export function parseVector4ControlDescription(
       return controlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('vector4'), 'control')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
     requiredFieldParser(value),
@@ -703,12 +727,13 @@ export const parseEuler = flatMapParser<Array<unknown>, [number, number, number,
 )
 
 export function parseEulerControlDescription(value: unknown): ParseResult<EulerControlDescription> {
-  return applicative5Either(
-    (label, control, visibleByDefault, required, defaultValue) => {
+  return applicative6Either(
+    (label, folder, control, visibleByDefault, required, defaultValue) => {
       let controlDescription: EulerControlDescription = {
         control: control,
       }
       setOptionalProp(controlDescription, 'label', label)
+      setOptionalProp(controlDescription, 'folder', folder)
       setOptionalProp(controlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(controlDescription, 'required', required)
       setOptionalProp(controlDescription, 'defaultValue', defaultValue)
@@ -716,6 +741,7 @@ export function parseEulerControlDescription(value: unknown): ParseResult<EulerC
       return controlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('euler'), 'control')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
     requiredFieldParser(value),
@@ -739,12 +765,13 @@ export const parseMatrix3 = flatMapParser<Array<number>, Matrix3>(
 export function parseMatrix3ControlDescription(
   value: unknown,
 ): ParseResult<Matrix3ControlDescription> {
-  return applicative5Either(
-    (label, control, visibleByDefault, required, defaultValue) => {
+  return applicative6Either(
+    (label, folder, control, visibleByDefault, required, defaultValue) => {
       let controlDescription: Matrix3ControlDescription = {
         control: control,
       }
       setOptionalProp(controlDescription, 'label', label)
+      setOptionalProp(controlDescription, 'folder', folder)
       setOptionalProp(controlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(controlDescription, 'required', required)
       setOptionalProp(controlDescription, 'defaultValue', defaultValue)
@@ -752,6 +779,7 @@ export function parseMatrix3ControlDescription(
       return controlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('matrix3'), 'control')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
     requiredFieldParser(value),
@@ -775,12 +803,13 @@ export const parseMatrix4 = flatMapParser<Array<number>, Matrix4>(
 export function parseMatrix4ControlDescription(
   value: unknown,
 ): ParseResult<Matrix4ControlDescription> {
-  return applicative5Either(
-    (label, control, visibleByDefault, required, defaultValue) => {
+  return applicative6Either(
+    (label, folder, control, visibleByDefault, required, defaultValue) => {
       let controlDescription: Matrix4ControlDescription = {
         control: control,
       }
       setOptionalProp(controlDescription, 'label', label)
+      setOptionalProp(controlDescription, 'folder', folder)
       setOptionalProp(controlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(controlDescription, 'required', required)
       setOptionalProp(controlDescription, 'defaultValue', defaultValue)
@@ -788,6 +817,7 @@ export function parseMatrix4ControlDescription(
       return controlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('matrix4'), 'control')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
     requiredFieldParser(value),
@@ -796,12 +826,13 @@ export function parseMatrix4ControlDescription(
 }
 
 export function parseJSXControlDescription(value: unknown): ParseResult<JSXControlDescription> {
-  return applicative6Either(
-    (label, control, visibleByDefault, preferredContents, required, defaultValue) => {
+  return applicative7Either(
+    (label, folder, control, visibleByDefault, preferredContents, required, defaultValue) => {
       let jsxControlDescription: JSXControlDescription = {
         control: control,
       }
       setOptionalProp(jsxControlDescription, 'label', label)
+      setOptionalProp(jsxControlDescription, 'folder', folder)
       setOptionalProp(jsxControlDescription, 'visibleByDefault', visibleByDefault)
       setOptionalProp(jsxControlDescription, 'preferredContents', preferredContents)
       setOptionalProp(jsxControlDescription, 'required', required)
@@ -810,6 +841,7 @@ export function parseJSXControlDescription(value: unknown): ParseResult<JSXContr
       return jsxControlDescription
     },
     optionalObjectKeyParser(parseString, 'label')(value),
+    optionalObjectKeyParser(parseString, 'folder')(value),
     objectKeyParser(parseConstant('jsx'), 'control')(value),
     optionalObjectKeyParser(parseBoolean, 'visibleByDefault')(value),
     optionalObjectKeyParser(

--- a/utopia-api/src/property-controls/factories.ts
+++ b/utopia-api/src/property-controls/factories.ts
@@ -10,7 +10,6 @@ import type {
   ExpressionControlOption,
   ExpressionInputControlDescription,
   ExpressionPopUpListControlDescription,
-  FolderControlDescription,
   HtmlInputControlDescription,
   ImportType,
   JSXControlDescription,
@@ -381,13 +380,6 @@ export function unionControl(
   mutateControlWithOptions(result, options)
 
   return result
-}
-
-export function folderControl(controls: PropertyControls): FolderControlDescription {
-  return {
-    control: 'folder',
-    controls: controls,
-  }
 }
 
 function mutateControlWithOptions<T, U extends PropertyControlsOptions<T>>(

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -1,14 +1,18 @@
 import type { CSSProperties } from 'react'
 import type { PreferredContents } from '../core'
 
-// these fields are shared among all RegularControlDescription. the helper function getControlSharedFields makes sure the types line up
-// Ensure that the fields are also added to the object within `getControlSharedFields` for that typechecking.
-interface ControlBaseFields {
-  control: RegularControlType
+interface GenericControlProps<T> {
   label?: string
+  folder?: string
   visibleByDefault?: boolean
   required?: boolean
-  defaultValue?: unknown
+  defaultValue?: T
+}
+
+// these fields are shared among all RegularControlDescription. the helper function getControlSharedFields makes sure the types line up
+// Ensure that the fields are also added to the object within `getControlSharedFields` for that typechecking.
+interface ControlBaseFields extends GenericControlProps<unknown> {
+  control: RegularControlType
 }
 
 // Base Level Controls
@@ -33,22 +37,14 @@ export type BaseControlType =
   | 'vector4'
   | 'jsx'
 
-export interface CheckboxControlDescription {
+export interface CheckboxControlDescription extends GenericControlProps<unknown> {
   control: 'checkbox'
-  label?: string
-  visibleByDefault?: boolean
   disabledTitle?: string
   enabledTitle?: string
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface ColorControlDescription {
+export interface ColorControlDescription extends GenericControlProps<unknown> {
   control: 'color'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
 export type AllowedEnumType = string | boolean | number | undefined | null
@@ -59,13 +55,10 @@ export interface BasicControlOption<T> {
 
 export type BasicControlOptions<T> = AllowedEnumType[] | BasicControlOption<T>[]
 
-export interface PopUpListControlDescription {
+export interface PopUpListControlDescription
+  extends GenericControlProps<AllowedEnumType | BasicControlOption<unknown>> {
   control: 'popuplist'
-  label?: string
-  visibleByDefault?: boolean
   options: BasicControlOptions<unknown>
-  required?: boolean
-  defaultValue?: AllowedEnumType | BasicControlOption<unknown>
 }
 
 export interface ImportType {
@@ -81,29 +74,18 @@ export interface ExpressionControlOption<T> {
   requiredImport?: ImportType
 }
 
-export interface ExpressionPopUpListControlDescription {
+export interface ExpressionPopUpListControlDescription extends GenericControlProps<unknown> {
   control: 'expression-popuplist'
-  label?: string
-  visibleByDefault?: boolean
   options: ExpressionControlOption<unknown>[]
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface EulerControlDescription {
+export interface EulerControlDescription
+  extends GenericControlProps<[number, number, number, string]> {
   control: 'euler'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: [number, number, number, string]
 }
 
-export interface NoneControlDescription {
+export interface NoneControlDescription extends GenericControlProps<unknown> {
   control: 'none'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
 // prettier-ignore
@@ -113,12 +95,8 @@ export type Matrix3 = [
   number, number, number,
 ]
 
-export interface Matrix3ControlDescription {
+export interface Matrix3ControlDescription extends GenericControlProps<Matrix3> {
   control: 'matrix3'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: Matrix3
 }
 
 // prettier-ignore
@@ -129,52 +107,33 @@ export type Matrix4 = [
   number, number, number, number,
 ]
 
-export interface Matrix4ControlDescription {
+export interface Matrix4ControlDescription extends GenericControlProps<Matrix4> {
   control: 'matrix4'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: Matrix4
 }
 
-export interface NumberInputControlDescription {
+export interface NumberInputControlDescription extends GenericControlProps<unknown> {
   control: 'number-input'
-  label?: string
-  visibleByDefault?: boolean
   max?: number
   min?: number
   unit?: string
   step?: number
   displayStepper?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface RadioControlDescription {
+export interface RadioControlDescription
+  extends GenericControlProps<AllowedEnumType | BasicControlOption<unknown>> {
   control: 'radio'
-  label?: string
-  visibleByDefault?: boolean
   options: BasicControlOptions<unknown>
-  required?: boolean
-  defaultValue?: AllowedEnumType | BasicControlOption<unknown>
 }
 
-export interface ExpressionInputControlDescription {
+export interface ExpressionInputControlDescription extends GenericControlProps<unknown> {
   control: 'expression-input'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface StringInputControlDescription {
+export interface StringInputControlDescription extends GenericControlProps<unknown> {
   control: 'string-input'
-  label?: string
-  visibleByDefault?: boolean
   placeholder?: string
   obscured?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
 export interface HtmlInputControlDescription {
@@ -198,41 +157,25 @@ export interface StyleControlsControlDescription {
 
 export type Vector2 = [number, number]
 
-export interface Vector2ControlDescription {
+export interface Vector2ControlDescription extends GenericControlProps<Vector2> {
   control: 'vector2'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: Vector2
 }
 
 export type Vector3 = [number, number, number]
 
-export interface Vector3ControlDescription {
+export interface Vector3ControlDescription extends GenericControlProps<Vector3> {
   control: 'vector3'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: Vector3
 }
 
 export type Vector4 = [number, number, number, number]
 
-export interface Vector4ControlDescription {
+export interface Vector4ControlDescription extends GenericControlProps<Vector4> {
   control: 'vector4'
-  label?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: Vector4
 }
 
-export interface JSXControlDescription {
+export interface JSXControlDescription extends GenericControlProps<unknown> {
   control: 'jsx'
-  label?: string
-  visibleByDefault?: boolean
   preferredContents?: PreferredContents | PreferredContents[]
-  required?: boolean
-  defaultValue?: unknown
 }
 
 export type BaseControlDescription =
@@ -263,40 +206,24 @@ export type HigherLevelControlType = 'array' | 'tuple' | 'object' | 'union'
 export type RegularControlType = BaseControlType | HigherLevelControlType
 export type ControlType = RegularControlType | 'folder'
 
-export interface ArrayControlDescription {
+export interface ArrayControlDescription extends GenericControlProps<unknown> {
   control: 'array'
-  label?: string
-  visibleByDefault?: boolean
   propertyControl: RegularControlDescription
   maxCount?: number
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface ObjectControlDescription {
+export interface ObjectControlDescription extends GenericControlProps<unknown> {
   control: 'object'
-  label?: string
-  visibleByDefault?: boolean
   object: { [prop: string]: RegularControlDescription }
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface UnionControlDescription {
+export interface UnionControlDescription extends GenericControlProps<unknown> {
   control: 'union'
-  label?: string
-  visibleByDefault?: boolean
   controls: Array<RegularControlDescription>
-  required?: boolean
-  defaultValue?: unknown
 }
-export interface TupleControlDescription {
+export interface TupleControlDescription extends GenericControlProps<unknown> {
   control: 'tuple'
-  label?: string
-  visibleByDefault?: boolean
   propertyControls: RegularControlDescription[]
-  required?: boolean
-  defaultValue?: unknown
 }
 
 export type HigherLevelControlDescription =

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -136,23 +136,15 @@ export interface StringInputControlDescription extends GenericControlProps<unkno
   obscured?: boolean
 }
 
-export interface HtmlInputControlDescription {
+export interface HtmlInputControlDescription extends GenericControlProps<unknown> {
   control: 'html-input'
-  label?: string
-  visibleByDefault?: boolean
   placeholder?: string
   obscured?: boolean
-  required?: boolean
-  defaultValue?: unknown
 }
 
-export interface StyleControlsControlDescription {
+export interface StyleControlsControlDescription extends GenericControlProps<unknown> {
   control: 'style-controls'
-  label?: string
-  visibleByDefault?: boolean
   placeholder?: CSSProperties
-  required?: boolean
-  defaultValue?: unknown
 }
 
 export type Vector2 = [number, number]

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -1,18 +1,15 @@
 import type { CSSProperties } from 'react'
 import type { PreferredContents } from '../core'
 
-interface GenericControlProps<T> {
-  label?: string
-  folder?: string
-  visibleByDefault?: boolean
-  required?: boolean
-  defaultValue?: T
-}
-
 // these fields are shared among all RegularControlDescription. the helper function getControlSharedFields makes sure the types line up
 // Ensure that the fields are also added to the object within `getControlSharedFields` for that typechecking.
-interface ControlBaseFields extends GenericControlProps<unknown> {
+interface ControlBaseFields {
   control: RegularControlType
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
 
 // Base Level Controls
@@ -37,14 +34,24 @@ export type BaseControlType =
   | 'vector4'
   | 'jsx'
 
-export interface CheckboxControlDescription extends GenericControlProps<unknown> {
+export interface CheckboxControlDescription {
   control: 'checkbox'
+  label?: string
+  visibleByDefault?: boolean
   disabledTitle?: string
   enabledTitle?: string
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
 
-export interface ColorControlDescription extends GenericControlProps<unknown> {
+export interface ColorControlDescription {
   control: 'color'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
 
 export type AllowedEnumType = string | boolean | number | undefined | null
@@ -55,10 +62,14 @@ export interface BasicControlOption<T> {
 
 export type BasicControlOptions<T> = AllowedEnumType[] | BasicControlOption<T>[]
 
-export interface PopUpListControlDescription
-  extends GenericControlProps<AllowedEnumType | BasicControlOption<unknown>> {
+export interface PopUpListControlDescription {
   control: 'popuplist'
+  label?: string
+  visibleByDefault?: boolean
   options: BasicControlOptions<unknown>
+  required?: boolean
+  defaultValue?: AllowedEnumType | BasicControlOption<unknown>
+  folder?: string
 }
 
 export interface ImportType {
@@ -74,18 +85,32 @@ export interface ExpressionControlOption<T> {
   requiredImport?: ImportType
 }
 
-export interface ExpressionPopUpListControlDescription extends GenericControlProps<unknown> {
+export interface ExpressionPopUpListControlDescription {
   control: 'expression-popuplist'
+  label?: string
+  visibleByDefault?: boolean
   options: ExpressionControlOption<unknown>[]
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
 
-export interface EulerControlDescription
-  extends GenericControlProps<[number, number, number, string]> {
+export interface EulerControlDescription {
   control: 'euler'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: [number, number, number, string]
+  folder?: string
 }
 
-export interface NoneControlDescription extends GenericControlProps<unknown> {
+export interface NoneControlDescription {
   control: 'none'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
 
 // prettier-ignore
@@ -95,8 +120,13 @@ export type Matrix3 = [
   number, number, number,
 ]
 
-export interface Matrix3ControlDescription extends GenericControlProps<Matrix3> {
+export interface Matrix3ControlDescription {
   control: 'matrix3'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: Matrix3
+  folder?: string
 }
 
 // prettier-ignore
@@ -107,67 +137,120 @@ export type Matrix4 = [
   number, number, number, number,
 ]
 
-export interface Matrix4ControlDescription extends GenericControlProps<Matrix4> {
+export interface Matrix4ControlDescription {
   control: 'matrix4'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: Matrix4
 }
 
-export interface NumberInputControlDescription extends GenericControlProps<unknown> {
+export interface NumberInputControlDescription {
   control: 'number-input'
+  label?: string
+  visibleByDefault?: boolean
   max?: number
   min?: number
   unit?: string
   step?: number
   displayStepper?: boolean
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
 
-export interface RadioControlDescription
-  extends GenericControlProps<AllowedEnumType | BasicControlOption<unknown>> {
+export interface RadioControlDescription {
   control: 'radio'
+  label?: string
+  visibleByDefault?: boolean
   options: BasicControlOptions<unknown>
+  required?: boolean
+  defaultValue?: AllowedEnumType | BasicControlOption<unknown>
+  folder?: string
 }
 
-export interface ExpressionInputControlDescription extends GenericControlProps<unknown> {
+export interface ExpressionInputControlDescription {
   control: 'expression-input'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
 
-export interface StringInputControlDescription extends GenericControlProps<unknown> {
+export interface StringInputControlDescription {
   control: 'string-input'
+  label?: string
+  visibleByDefault?: boolean
   placeholder?: string
   obscured?: boolean
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
 
-export interface HtmlInputControlDescription extends GenericControlProps<unknown> {
+export interface HtmlInputControlDescription {
   control: 'html-input'
+  label?: string
+  visibleByDefault?: boolean
   placeholder?: string
   obscured?: boolean
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
 
-export interface StyleControlsControlDescription extends GenericControlProps<unknown> {
+export interface StyleControlsControlDescription {
   control: 'style-controls'
+  label?: string
+  visibleByDefault?: boolean
   placeholder?: CSSProperties
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
 
 export type Vector2 = [number, number]
 
-export interface Vector2ControlDescription extends GenericControlProps<Vector2> {
+export interface Vector2ControlDescription {
   control: 'vector2'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: Vector2
+  folder?: string
 }
 
 export type Vector3 = [number, number, number]
 
-export interface Vector3ControlDescription extends GenericControlProps<Vector3> {
+export interface Vector3ControlDescription {
   control: 'vector3'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: Vector3
+  folder?: string
 }
 
 export type Vector4 = [number, number, number, number]
 
-export interface Vector4ControlDescription extends GenericControlProps<Vector4> {
+export interface Vector4ControlDescription {
   control: 'vector4'
+  label?: string
+  visibleByDefault?: boolean
+  required?: boolean
+  defaultValue?: Vector4
+  folder?: string
 }
 
-export interface JSXControlDescription extends GenericControlProps<unknown> {
+export interface JSXControlDescription {
   control: 'jsx'
+  label?: string
+  visibleByDefault?: boolean
   preferredContents?: PreferredContents | PreferredContents[]
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
 
 export type BaseControlDescription =
@@ -198,24 +281,44 @@ export type HigherLevelControlType = 'array' | 'tuple' | 'object' | 'union'
 export type RegularControlType = BaseControlType | HigherLevelControlType
 export type ControlType = RegularControlType | 'folder'
 
-export interface ArrayControlDescription extends GenericControlProps<unknown> {
+export interface ArrayControlDescription {
   control: 'array'
+  label?: string
+  visibleByDefault?: boolean
   propertyControl: RegularControlDescription
   maxCount?: number
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
 
-export interface ObjectControlDescription extends GenericControlProps<unknown> {
+export interface ObjectControlDescription {
   control: 'object'
+  label?: string
+  visibleByDefault?: boolean
   object: { [prop: string]: RegularControlDescription }
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
 
-export interface UnionControlDescription extends GenericControlProps<unknown> {
+export interface UnionControlDescription {
   control: 'union'
+  label?: string
+  visibleByDefault?: boolean
   controls: Array<RegularControlDescription>
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
-export interface TupleControlDescription extends GenericControlProps<unknown> {
+export interface TupleControlDescription {
   control: 'tuple'
+  label?: string
+  visibleByDefault?: boolean
   propertyControls: RegularControlDescription[]
+  required?: boolean
+  defaultValue?: unknown
+  folder?: string
 }
 
 export type HigherLevelControlDescription =

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -143,6 +143,7 @@ export interface Matrix4ControlDescription {
   visibleByDefault?: boolean
   required?: boolean
   defaultValue?: Matrix4
+  folder?: string
 }
 
 export interface NumberInputControlDescription {

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -299,12 +299,6 @@ export interface TupleControlDescription {
   defaultValue?: unknown
 }
 
-export interface FolderControlDescription {
-  control: 'folder'
-  label?: string
-  controls: PropertyControls
-}
-
 export type HigherLevelControlDescription =
   | ArrayControlDescription
   | ObjectControlDescription
@@ -315,7 +309,7 @@ export type RegularControlDescription = BaseControlDescription | HigherLevelCont
 
 // Please ensure that `property-controls-utils.ts` is kept up to date
 // with any changes to this or the component types.
-export type ControlDescription = RegularControlDescription | FolderControlDescription
+export type ControlDescription = RegularControlDescription
 
 export function isBaseControlDescription(
   control: ControlDescription,
@@ -344,7 +338,6 @@ export function isBaseControlDescription(
     case 'object':
     case 'tuple':
     case 'union':
-    case 'folder':
       return false
     default:
       const _exhaustiveCheck: never = control


### PR DESCRIPTION
https://github.com/concrete-utopia/utopia/issues/5649

## Problem
Organizing properties into folders via the folder control is not ergonomic in practice

## Fix
Use a folder label (in the form of a `folder?: string` prop) instead to organise props into folders

### Scope
To keep the PR scoped, this PR only adds the new prop to the property controls and removes the folder control. Automatically assembling the folders on the UI will come on a subsequent PR

### Commit Details
- the folder property control is removed
- `GenericControlProps` is added to group the props shared by all property controls (`folder` is added on here)

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
