### PR TITLE
Close context menu on escape

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -640,6 +640,10 @@ const ComponentPickerContextMenuFull = React.memo<ComponentPickerContextMenuProp
     const metadataRef = useRefEditorState((state) => state.editor.jsxMetadata)
     const elementPathTreesRef = useRefEditorState((state) => state.editor.elementPathTree)
 
+    const hideAllContextMenus = React.useCallback(() => {
+      contextMenu.hideAll()
+    }, [])
+
     const onItemClick = React.useCallback(
       (preferredChildToInsert: InsertableComponent) => (e: React.UIEvent) => {
         e.stopPropagation()
@@ -655,9 +659,17 @@ const ComponentPickerContextMenuFull = React.memo<ComponentPickerContextMenuProp
           insertionTarget,
         )
 
-        contextMenu.hideAll()
+        hideAllContextMenus()
       },
-      [target, projectContentsRef, metadataRef, elementPathTreesRef, dispatch, insertionTarget],
+      [
+        target,
+        projectContentsRef,
+        metadataRef,
+        elementPathTreesRef,
+        dispatch,
+        insertionTarget,
+        hideAllContextMenus,
+      ],
     )
 
     const squashEvents = React.useCallback((e: React.UIEvent<unknown>) => {
@@ -681,7 +693,11 @@ const ComponentPickerContextMenuFull = React.memo<ComponentPickerContextMenuProp
         onShown={onShown}
         onHidden={onHidden}
       >
-        <ComponentPicker allComponents={allInsertableComponents} onItemClick={onItemClick} />
+        <ComponentPicker
+          allComponents={allInsertableComponents}
+          onItemClick={onItemClick}
+          closePicker={hideAllContextMenus}
+        />
       </Menu>
     )
   },

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -26,6 +26,7 @@ import { iconPropsForIcon } from './component-picker-context-menu'
 export interface ComponentPickerProps {
   allComponents: Array<InsertMenuItemGroup>
   onItemClick: (elementToInsert: InsertableComponent) => React.UIEventHandler
+  closePicker: () => void
 }
 
 export interface ElementToInsert {
@@ -67,7 +68,7 @@ export function componentPickerOptionTestId(componentName: string, variant?: str
 }
 
 export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
-  const { onItemClick } = props
+  const { onItemClick, closePicker } = props
   const [selectedComponentKey, setSelectedComponentKey] = React.useState<string | null>(null)
   const [filter, setFilter] = React.useState<string>('')
   const menuRef = React.useRef<HTMLDivElement | null>(null)
@@ -142,6 +143,8 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
         if (selectedComponent != null) {
           onItemClick(selectedComponent.value)(e)
         }
+      } else if (e.key === 'Escape') {
+        closePicker()
       } else {
         // we don't want to prevent default for other keys
         return
@@ -149,7 +152,7 @@ export const ComponentPicker = React.memo((props: ComponentPickerProps) => {
       e.preventDefault()
       e.stopPropagation()
     },
-    [flatComponentsToShow, highlightedComponentKey, onItemClick, selectIndex],
+    [flatComponentsToShow, highlightedComponentKey, onItemClick, selectIndex, closePicker],
   )
 
   return (
@@ -220,14 +223,16 @@ const FilterBar = React.memo((props: FilterBarProps) => {
         if (onKeyDown != null) {
           onKeyDown(e)
         }
-      } else if (e.key === 'Escape') {
+      } else if (e.key === 'Escape' && filter !== '') {
+        // clear filter only if there is text,
+        // otherwise it will close the picker
         setFilter('')
       } else if (onKeyDown != null) {
         onKeyDown(e)
       }
       e.stopPropagation()
     },
-    [setFilter, onKeyDown],
+    [setFilter, onKeyDown, filter],
   )
   const handleFilterChange = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
**Problem:**
Today "Escape" only clears the filter text but doesn't close the context menu

**Fix:**
Clear the text only if there is a text, otherwise close the context menu

<video src="https://github.com/concrete-utopia/utopia/assets/7003853/26c2e367-c809-42b2-9cbd-4d3973331b2c" />


