### PR TITLE
WIP - Cache parse results

### DIFF
--- a/editor/src/core/workers/parser-printer/parser-printer-worker.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-worker.ts
@@ -1,4 +1,4 @@
-import type { ParseSuccess, ParsedTextFile } from '../../shared/project-file-types'
+import type { ParseSuccess } from '../../shared/project-file-types'
 import type { SteganographyMode } from './parser-printer'
 import { printCodeOptions, printCode, lintAndParse } from './parser-printer'
 import type {

--- a/editor/src/core/workers/parser-printer/parser-printer-worker.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-worker.ts
@@ -65,8 +65,6 @@ function getCacheKey(filename: string, versionNumber: number): string {
   return `${filename}::${versionNumber}::${devVer}`
 }
 
-type CachedParseResult = { [fileContent: string]: ParseFileResult }
-
 async function getParseFileResultWithCache(
   filename: string,
   content: string,
@@ -122,6 +120,8 @@ function getParseFileResult(
 
   return result
 }
+
+type CachedParseResult = { [fileContent: string]: ParseFileResult }
 
 async function getParseResultFromCache(
   filename: string,

--- a/editor/src/core/workers/parser-printer/parser-printer-worker.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-worker.ts
@@ -61,7 +61,8 @@ export async function handleMessage(
 }
 
 function getCacheKey(filename: string, content: string, versionNumber: number): string {
-  return `${filename}::${content}::${versionNumber}`
+  const devVer = 1 // TEMP - use it for hard cache invalidation if needed now as we're developing this feature
+  return `${filename}::${content}::${versionNumber}::${devVer}`
 }
 
 async function getParseFileResultWithCache(
@@ -78,9 +79,11 @@ async function getParseFileResultWithCache(
     //check localforage for cache
     const cachedResult = await localforage.getItem<ParseFileResult>(cacheKey)
     if (cachedResult?.parseResult?.type === 'PARSE_SUCCESS') {
+      console.info('Cache hit for', filename)
       return cachedResult
     }
   }
+  console.info('Cache miss for', filename)
 
   const parseResult = getParseFileResult(
     filename,
@@ -114,6 +117,7 @@ function getParseFileResult(
   if (result.parseResult.type === 'PARSE_SUCCESS') {
     // non blocking cache write
     const cacheKey = getCacheKey(filename, content, versionNumber)
+    console.info('Caching', filename)
     void localforage.setItem(cacheKey, result)
   }
 

--- a/editor/src/core/workers/parser-printer/parser-printer-worker.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-worker.ts
@@ -1,4 +1,4 @@
-import type { ParseSuccess } from '../../shared/project-file-types'
+import type { ParseSuccess, ParsedTextFile } from '../../shared/project-file-types'
 import type { SteganographyMode } from './parser-printer'
 import { printCodeOptions, printCode, lintAndParse } from './parser-printer'
 import type {
@@ -13,40 +13,43 @@ import {
   createParsePrintFilesResult,
   createPrintAndReparseResult,
 } from '../common/worker-types'
+import localforage from 'localforage'
 
-export function handleMessage(
+export async function handleMessage(
   workerMessage: ParsePrintFilesRequest,
   sendMessage: (content: ParsePrintResultMessage) => void,
-): void {
+): Promise<void> {
   switch (workerMessage.type) {
     case 'parseprintfiles': {
       try {
         const alreadyExistingUIDs_MUTABLE: Set<string> = new Set(workerMessage.alreadyExistingUIDs)
-        const results = workerMessage.files.map((file) => {
-          switch (file.type) {
-            case 'parsefile':
-              return getParseFileResult(
-                file.filename,
-                file.content,
-                file.previousParsed,
-                file.versionNumber,
-                alreadyExistingUIDs_MUTABLE,
-                workerMessage.applySteganography,
-              )
-            case 'printandreparsefile':
-              return getPrintAndReparseCodeResult(
-                file.filename,
-                file.parseSuccess,
-                file.stripUIDs,
-                file.versionNumber,
-                alreadyExistingUIDs_MUTABLE,
-                workerMessage.applySteganography,
-              )
-            default:
-              const _exhaustiveCheck: never = file
-              throw new Error(`Unhandled file type ${JSON.stringify(file)}`)
-          }
-        })
+        const results = await Promise.all(
+          workerMessage.files.map(async (file) => {
+            switch (file.type) {
+              case 'parsefile':
+                return getParseFileResultWithCache(
+                  file.filename,
+                  file.content,
+                  file.previousParsed,
+                  file.versionNumber,
+                  alreadyExistingUIDs_MUTABLE,
+                  workerMessage.applySteganography,
+                )
+              case 'printandreparsefile':
+                return getPrintAndReparseCodeResult(
+                  file.filename,
+                  file.parseSuccess,
+                  file.stripUIDs,
+                  file.versionNumber,
+                  alreadyExistingUIDs_MUTABLE,
+                  workerMessage.applySteganography,
+                )
+              default:
+                const _exhaustiveCheck: never = file
+                throw new Error(`Unhandled file type ${JSON.stringify(file)}`)
+            }
+          }),
+        )
         sendMessage(createParsePrintFilesResult(results, workerMessage.messageID))
       } catch (e) {
         sendMessage(createParsePrintFailedMessage(workerMessage.messageID))
@@ -55,6 +58,40 @@ export function handleMessage(
       break
     }
   }
+}
+
+function getCacheKey(filename: string, content: string, versionNumber: number): string {
+  return `${filename}::${content}::${versionNumber}`
+}
+
+async function getParseFileResultWithCache(
+  filename: string,
+  content: string,
+  oldParseResultForUIDComparison: ParseSuccess | null,
+  versionNumber: number,
+  alreadyExistingUIDs_MUTABLE: Set<string>,
+  applySteganography: SteganographyMode,
+  checkCacheFirst: boolean = true,
+): Promise<ParseFileResult> {
+  const cacheKey = getCacheKey(filename, content, versionNumber)
+  if (checkCacheFirst) {
+    //check localforage for cache
+    const cachedResult = await localforage.getItem<ParseFileResult>(cacheKey)
+    if (cachedResult?.parseResult?.type === 'PARSE_SUCCESS') {
+      return cachedResult
+    }
+  }
+
+  const parseResult = getParseFileResult(
+    filename,
+    content,
+    oldParseResultForUIDComparison,
+    versionNumber,
+    alreadyExistingUIDs_MUTABLE,
+    applySteganography,
+  )
+
+  return parseResult
 }
 
 function getParseFileResult(
@@ -73,7 +110,14 @@ function getParseFileResult(
     'trim-bounds',
     applySteganography,
   )
-  return createParseFileResult(filename, parseResult, versionNumber)
+  const result = createParseFileResult(filename, parseResult, versionNumber)
+  if (result.parseResult.type === 'PARSE_SUCCESS') {
+    // non blocking cache write
+    const cacheKey = getCacheKey(filename, content, versionNumber)
+    void localforage.setItem(cacheKey, result)
+  }
+
+  return result
 }
 
 export function getPrintAndReparseCodeResult(


### PR DESCRIPTION
This is a work in progress to cache `parseResult` to reduce editor load time with large projects.

**TODO:**
- Make UIDs longer/related to filename to avoid collision (since some of the results come from cache now and that might cause a collision)