### PR TITLE
Fixing annotation of Typography.Text

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -14,6 +14,8 @@ import {
   jsxAttributesFromMap,
   jsxElement,
   jsxElementFromJSXElementWithoutUID,
+  jsxElementNameFromString,
+  getJSXElementNameLastPart,
 } from '../../../core/shared/element-template'
 import type { ElementPath, Imports } from '../../../core/shared/project-file-types'
 import { useDispatch } from '../../editor/store/dispatch-context'
@@ -590,19 +592,13 @@ const ComponentPickerContextMenuSimple = React.memo<ComponentPickerContextMenuPr
 
         const defaultVariantImports = defaultImportsForComponentModule(data.name, data.moduleName)
 
+        const jsxName = jsxElementNameFromString(data.name)
+        const name = getJSXElementNameLastPart(jsxName)
         if (data.variants == null || data.variants.length === 0) {
-          return [
-            defaultVariantItem(data.name, submenuLabel, defaultVariantImports, null, onItemClick),
-          ]
+          return [defaultVariantItem(name, submenuLabel, defaultVariantImports, null, onItemClick)]
         } else {
           return [
-            defaultVariantItem(
-              data.name,
-              '(empty)',
-              defaultVariantImports,
-              submenuLabel,
-              onItemClick,
-            ),
+            defaultVariantItem(name, '(empty)', defaultVariantImports, submenuLabel, onItemClick),
             ...data.variants.map((variant) => {
               return variantItem(variant, submenuLabel, onItemClick)
             }),

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -187,6 +187,114 @@ describe('registered property controls', () => {
       }
     `)
   })
+  it('can register controls for components with property path in their names', async () => {
+    const renderResult = await renderTestEditorWithModel(
+      createModifiedProject({
+        ['/src/card.js']: `import React from 'react'
+
+        export const ExportedObj = {
+          Card: ({ label }) => {
+            return <div>{label}</div>
+          },
+        }        
+        `,
+        [StoryboardFilePath]: `import * as React from 'react'
+      import { Scene, Storyboard, View } from 'utopia-api'
+    
+      export var App = (props) => {
+        return (
+          <div>hello</div>
+        )
+      }
+    
+      export var storyboard = (props) => {
+        return (
+          <Storyboard data-uid='${BakedInStoryboardUID}'>
+            <Scene
+              style={{ position: 'absolute', left: 0, top: 0, width: 400, height: 400 }}
+              data-uid='${TestScene0UID}'
+            >
+              <App data-uid='${TestAppUID}' />
+            </Scene>
+          </Storyboard>
+        )
+      }`,
+        ['/utopia/components.utopia.js']: `import { ExportedObj } from '../src/card'
+        
+        const Components = {
+      '/src/card': {
+        'ExportedObj.Card': {
+          component: ExportedObj.Card,
+          properties: {
+            label: {
+              control: 'string-input',
+            },
+            background: {
+              control: 'color',
+            },
+            visible: {
+              control: 'checkbox',
+              defaultValue: true,
+            },
+          },
+        },
+      },
+    }
+    
+    export default Components
+  `,
+      }),
+      'await-first-dom-report',
+    )
+    const editorState = renderResult.getEditorState().editor
+
+    expect(editorState.propertyControlsInfo['/src/card']).toMatchInlineSnapshot(`
+      Object {
+        "ExportedObj.Card": Object {
+          "emphasis": "regular",
+          "focus": "default",
+          "icon": "component",
+          "inspector": Array [],
+          "preferredChildComponents": Array [],
+          "properties": Object {
+            "background": Object {
+              "control": "color",
+            },
+            "label": Object {
+              "control": "string-input",
+            },
+            "visible": Object {
+              "control": "checkbox",
+              "defaultValue": true,
+            },
+          },
+          "source": Object {
+            "sourceDescriptorFile": "/utopia/components.utopia.js",
+            "type": "DESCRIPTOR_FILE",
+          },
+          "supportsChildren": true,
+          "variants": Array [
+            Object {
+              "elementToInsert": [Function],
+              "importsToAdd": Object {
+                "/src/card": Object {
+                  "importedAs": null,
+                  "importedFromWithin": Array [
+                    Object {
+                      "alias": "ExportedObj",
+                      "name": "ExportedObj",
+                    },
+                  ],
+                  "importedWithName": null,
+                },
+              },
+              "insertMenuLabel": "ExportedObj.Card",
+            },
+          ],
+        },
+      }
+    `)
+  })
   it('Can set property control options using the control factory functions', async () => {
     const renderResult = await renderTestEditorWithModel(
       project({

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -192,11 +192,13 @@ describe('registered property controls', () => {
       createModifiedProject({
         ['/src/card.js']: `import React from 'react'
 
+        const Card = ({ label }) => {
+          return <div>{label}</div>
+        }
+        
         export const ExportedObj = {
-          Card: ({ label }) => {
-            return <div>{label}</div>
-          },
-        }        
+          Card: Card,
+        }
         `,
         [StoryboardFilePath]: `import * as React from 'react'
       import { Scene, Storyboard, View } from 'utopia-api'

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -94,7 +94,12 @@ import {
 } from '../../components/editor/actions/action-creators'
 import type { ProjectContentTreeRoot } from '../../components/assets'
 import type { JSXElementChildWithoutUID } from '../shared/element-template'
-import { jsxAttributesFromMap, jsxElement, jsxTextBlock } from '../shared/element-template'
+import {
+  jsxAttributesFromMap,
+  jsxElement,
+  jsxElementNameFromString,
+  jsxTextBlock,
+} from '../shared/element-template'
 import type { ErrorMessage } from '../shared/error-messages'
 import { errorMessage } from '../shared/error-messages'
 import { dropFileExtension } from '../shared/file-utils'
@@ -615,9 +620,10 @@ function componentInsertOptionFromExample(
           code: `<${typed.name} />`,
         }
       }
+      const jsxName = jsxElementNameFromString(typed.name)
       return {
         label: typed.name,
-        imports: `import {${typed.name}} from '${moduleName}'`,
+        imports: `import {${jsxName.baseVariable}} from '${moduleName}'`,
         code: `<${typed.name} />`,
       }
     case 'component-reference':
@@ -839,10 +845,11 @@ export function defaultImportsForComponentModule(
   componentName: string,
   moduleName: string | null,
 ): Imports {
+  const jsxName = jsxElementNameFromString(componentName)
   return moduleName == null
     ? {}
     : {
-        [moduleName]: importDetails(null, [importAlias(componentName)], null),
+        [moduleName]: importDetails(null, [importAlias(jsxName.baseVariable)], null),
       }
 }
 
@@ -880,10 +887,11 @@ async function parseComponentVariants(
     componentToRegister.variants == null ||
     (Array.isArray(componentToRegister.variants) && componentToRegister.variants.length === 0)
   ) {
+    const jsxName = jsxElementNameFromString(componentName)
     const parsed = await parseCodeFromInsertOption(
       {
         label: componentName,
-        imports: `import { ${componentName} } from '${moduleName}'`,
+        imports: `import { ${jsxName.baseVariable} } from '${moduleName}'`,
         code: `<${componentName} />`,
       },
       workers,

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -298,6 +298,7 @@ function isComponentRegistrationValid(
   }
 
   // check validity of external component
+  // TODO this doesn't work yet for components which are not directly imported, e.g. Typography.Text (where Typography is the imported object)
   const { name, moduleName } = getRequireInfoFromComponent(component)
   if (name != null && name !== registrationKey) {
     return {

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -311,7 +311,7 @@ function isComponentRegistrationValid(
   const { name, moduleName } = getRequireInfoFromComponent(component)
   if (name != null) {
     // TODO: this doesn't work yet for components which are not directly imported, e.g. Typography.Text (where Typography is the imported object)
-    // The code is here to check the last part of the name, but since we don't require the component itself, the data will not be available.
+    // The code is here to check the last part of the name, but since we don't require the component itself in these cases, the name and the moduleName will not be available.
     const nameLastPart = getJSXElementNameLastPart(jsxElementNameFromString(name))
     const registrationKeyLastPart = getJSXElementNameLastPart(
       jsxElementNameFromString(registrationKey),

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -8,6 +8,7 @@ import {
   isIntrinsicHTMLElement,
   isIntrinsicElement,
   isJSXElement,
+  jsxElementName,
 } from '../shared/element-template'
 import type { ParseSuccess, StaticElementPath, ElementPath } from '../shared/project-file-types'
 import type { EditorState } from '../../components/editor/store/editor-state'
@@ -94,7 +95,11 @@ export function getPropertyControlsForTarget(
         } else {
           const originalName =
             importedFrom?.type === 'IMPORTED_ORIGIN' ? importedFrom.exportedName : null
-          const nameAsString = originalName ?? getJSXElementNameAsString(element.name)
+          const jsxName =
+            originalName != null
+              ? jsxElementName(originalName, element.name.propertyPath.propertyElements)
+              : element.name
+          const nameAsString = getJSXElementNameAsString(jsxName)
 
           const props = propertyControlsInfo[filenameForLookup]?.[nameAsString]?.properties
 
@@ -163,7 +168,11 @@ export function getComponentDescriptorForTarget(
         } else {
           const originalName =
             importedFrom?.type === 'IMPORTED_ORIGIN' ? importedFrom.exportedName : null
-          const nameAsString = originalName ?? getJSXElementNameAsString(element.name)
+          const jsxName =
+            originalName != null
+              ? jsxElementName(originalName, element.name.propertyPath.propertyElements)
+              : element.name
+          const nameAsString = getJSXElementNameAsString(jsxName)
 
           const componentDescriptor = propertyControlsInfo[filenameForLookup]?.[nameAsString]
 

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -1577,6 +1577,11 @@ export function jsxElementName(
   }
 }
 
+export function jsxElementNameFromString(name: string): JSXElementName {
+  const [baseVariable, ...properties] = name.split('.')
+  return jsxElementName(baseVariable, properties)
+}
+
 export function jsxElementNameEquals(first: JSXElementName, second: JSXElementName): boolean {
   return (
     first.baseVariable === second.baseVariable &&


### PR DESCRIPTION
**Problem:**
Components which are not directly imported (e.g. `Tyopgraphy.Text` in `antd`) can not be annotated in Utopia.

**Fix:**
We need to make sure names with `.` in them are parsed as JSXElementName, and their baseVariable is imported, but their last part is used as component name.

**Missing:**
Validation does not fully work for these cases:
[ ] For internal components, we only check whether the last part of the name is the component name in ComponentRendererComponent
[ ] For external components the require annotation method doesn't work, because we don't require directly the component itself.
Fortunately, validation is just a best effort, worst case is that we will not find some of the component annotation errors, but valid component annotation files will work.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5552
