### PR TITLE
Generate folder controls from folder labels

### DIFF
--- a/editor/src/components/inspector/sections/component-section/folder-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/folder-section.tsx
@@ -16,7 +16,10 @@ import { RowOrFolderWrapper } from './row-or-folder-wrapper'
 import { RowForControl } from './component-section'
 import { InspectorWidthAtom } from '../../common/inspector-atoms'
 import { useAtom } from 'jotai'
-import { specialPropertiesToIgnore } from '../../../../core/property-controls/property-controls-utils'
+import {
+  isAdvancedFolderLabel,
+  specialPropertiesToIgnore,
+} from '../../../../core/property-controls/property-controls-utils'
 
 interface FolderSectionProps {
   isRoot: boolean
@@ -32,7 +35,7 @@ interface FolderSectionProps {
 
 export const FolderSection = React.memo((props: FolderSectionProps) => {
   const showIndentation = useAtom(InspectorWidthAtom)[0] === 'wide'
-  const [open, setOpen] = React.useState(true)
+  const [open, setOpen] = React.useState(!isAdvancedFolderLabel(props.title))
   const colorTheme = useColorTheme()
   const hiddenPropsList = React.useMemo(
     () =>

--- a/editor/src/components/inspector/sections/component-section/folder-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/folder-section.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 import React from 'react'
-import { css, jsx } from '@emotion/react'
+import { jsx } from '@emotion/react'
 import { unless, when } from '../../../../utils/react-conditionals'
 import type { CSSCursor } from '../../../canvas/canvas-types'
 import type {
@@ -14,8 +14,6 @@ import * as PP from '../../../../core/shared/property-path'
 import { useColorTheme } from '../../../../uuiui'
 import { RowOrFolderWrapper } from './row-or-folder-wrapper'
 import { RowForControl } from './component-section'
-import { InspectorWidthAtom } from '../../common/inspector-atoms'
-import { useAtom } from 'jotai'
 import {
   isAdvancedFolderLabel,
   specialPropertiesToIgnore,
@@ -34,7 +32,6 @@ interface FolderSectionProps {
 }
 
 export const FolderSection = React.memo((props: FolderSectionProps) => {
-  const showIndentation = useAtom(InspectorWidthAtom)[0] === 'wide'
   const [open, setOpen] = React.useState(!isAdvancedFolderLabel(props.title))
   const colorTheme = useColorTheme()
   const hiddenPropsList = React.useMemo(
@@ -110,8 +107,8 @@ export const FolderSection = React.memo((props: FolderSectionProps) => {
       {unless(
         props.isRoot,
         <FolderLabel
-          indentationLevel={props.indentationLevel}
-          showIndentation={showIndentation}
+          indentationLevel={1}
+          showIndentation={true}
           open={open}
           toggleOpen={toggleOpen}
           title={props.title ?? ''}

--- a/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-controls-section.tsx
@@ -68,7 +68,7 @@ export const PropertyControlsSection = React.memo((props: PropertyControlsSectio
         <FolderSection
           key={name}
           isRoot={false}
-          indentationLevel={0}
+          indentationLevel={2}
           propertyControls={controls}
           setGlobalCursor={setGlobalCursor}
           visibleEmptyControls={visibleEmptyControls}
@@ -81,7 +81,7 @@ export const PropertyControlsSection = React.memo((props: PropertyControlsSectio
       {Object.keys(propertiesWithFolders.advanced).length === 0 ? null : (
         <FolderSection
           isRoot={false}
-          indentationLevel={0}
+          indentationLevel={2}
           propertyControls={propertiesWithFolders.advanced}
           setGlobalCursor={setGlobalCursor}
           visibleEmptyControls={visibleEmptyControls}

--- a/editor/src/core/performance/__snapshots__/performance-regression-tests.spec.tsx.snap
+++ b/editor/src/core/performance/__snapshots__/performance-regression-tests.spec.tsx.snap
@@ -624,10 +624,6 @@ Array [
   "/UtopiaSpiedExoticType(Symbol(react.fragment))/PropertyLabel/Symbol(react.forward_ref)(EmotionCssPropInternal)/div",
   "/Symbol(react.provider)///Symbol(react.memo)(Inspector)",
   "/Symbol(react.provider)///Symbol(react.memo)()",
-  "//UtopiaSpiedExoticType(Symbol(react.fragment))//Symbol(react.memo)()",
-  "//UtopiaSpiedExoticType(Symbol(react.fragment))//Symbol(react.memo)()",
-  "//UtopiaSpiedExoticType(Symbol(react.fragment))//Symbol(react.memo)()",
-  "//UtopiaSpiedExoticType(Symbol(react.fragment))//Symbol(react.forward_ref)(EmotionCssPropInternal)",
   "/Symbol(react.forward_ref)(Styled(div))/div/IndicatorArrow/div:data-testid='indicator-elements-outside-visible-area'",
 ]
 `;
@@ -1153,9 +1149,6 @@ Array [
   "/UtopiaSpiedExoticType(Symbol(react.fragment))/UtopiaSpiedExoticType(Symbol(react.fragment))/TextShadowSubsection/UtopiaSpiedClass(InspectorContextMenuWrapper)",
   "/Symbol(react.provider)///Symbol(react.memo)(Inspector)",
   "/Symbol(react.provider)///Symbol(react.memo)()",
-  "//UtopiaSpiedExoticType(Symbol(react.fragment))//Symbol(react.memo)()",
-  "//UtopiaSpiedExoticType(Symbol(react.fragment))//Symbol(react.memo)()",
-  "//UtopiaSpiedExoticType(Symbol(react.fragment))//Symbol(react.forward_ref)(EmotionCssPropInternal)",
   "/Symbol(react.forward_ref)(Styled(div))/div/IndicatorArrow/div:data-testid='indicator-elements-outside-visible-area'",
 ]
 `;

--- a/editor/src/core/performance/performance-regression-tests.spec.tsx
+++ b/editor/src/core/performance/performance-regression-tests.spec.tsx
@@ -183,7 +183,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`523`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`520`)
     expect(renderResult.getRenderInfo()).toMatchSnapshot()
   })
 
@@ -249,7 +249,7 @@ describe('React Render Count Tests -', () => {
 
     const renderCountAfter = renderResult.getNumberOfRenders()
     // if this breaks, GREAT NEWS but update the test please :)
-    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`627`)
+    expect(renderCountAfter - renderCountBefore).toMatchInlineSnapshot(`623`)
     expect(renderResult.getRenderInfo()).toMatchSnapshot()
   })
 })

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -241,3 +241,9 @@ export function getInspectorPreferencesForTargets(
 
   return [...sectionsToShow]
 }
+
+export const AdvancedFolderLabel = 'Advanced'
+
+const advancedFolderLabel = AdvancedFolderLabel.toLowerCase()
+export const isAdvancedFolderLabel = (title: string | undefined) =>
+  title != null && title.toLowerCase() === advancedFolderLabel


### PR DESCRIPTION
# [Try it here](https://utopia.fish/p/65e36c8e-ring-air/?branch_name=feature-automatic-property-folders)
Select `Row` in the navigator and tweak the `components.utopia.js` file to see folders at work

## Description
This PR adds the capability to group properties into folders. The folder for a property can be set via the `folder` prop in the property description. The inspector then is populated with the properties (the following is taken from the issue https://github.com/concrete-utopia/utopia/issues/5649):
- the inspector is populated first by folder-less components, then by foldered ones, in order of appearance ('first time the particular folder label shows up when iterating over the props').
- folders are open by default, except if label matches exactly 'Advanced' (that is closed by default)

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
