### PR TITLE
Add label prop to ComponentToRegister

### DIFF
--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -139,6 +139,7 @@ export interface ComponentDescriptor {
   inspector: InspectorSpec
   emphasis: Emphasis
   icon: Icon
+  label: string | null
 }
 
 export const ComponentDescriptorDefaults: Pick<
@@ -161,6 +162,7 @@ export function componentDescriptor(
   inspector: InspectorSpec,
   emphasis: Emphasis,
   icon: Icon,
+  label: string | null,
 ): ComponentDescriptor {
   return {
     properties: properties,
@@ -172,6 +174,7 @@ export function componentDescriptor(
     inspector: inspector,
     emphasis: emphasis,
     icon: icon,
+    label: label,
   }
 }
 

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -144,12 +144,13 @@ export interface ComponentDescriptor {
 
 export const ComponentDescriptorDefaults: Pick<
   ComponentDescriptor,
-  'focus' | 'inspector' | 'emphasis' | 'icon'
+  'focus' | 'inspector' | 'emphasis' | 'icon' | 'label'
 > = {
   focus: 'default',
   inspector: [],
   emphasis: 'regular',
   icon: 'component',
+  label: null,
 }
 
 export function componentDescriptor(

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3430,7 +3430,7 @@ const InspectorSpecKeepDeepEquality: KeepDeepEqualityCall<InspectorSpec> = (oldV
 }
 
 export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<ComponentDescriptor> =
-  combine9EqualityCalls(
+  combine10EqualityCalls(
     (descriptor) => descriptor.properties,
     PropertyControlsKeepDeepEquality,
     (descriptor) => descriptor.supportsChildren,
@@ -3449,6 +3449,8 @@ export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<Component
     createCallWithTripleEquals<Emphasis>(),
     (descriptor) => descriptor.icon,
     createCallWithTripleEquals<Icon>(),
+    (descriptor) => descriptor.label,
+    nullableDeepEquality(StringKeepDeepEquality),
     componentDescriptor,
   )
 

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -259,6 +259,7 @@ describe('registered property controls', () => {
           "focus": "default",
           "icon": "component",
           "inspector": Array [],
+          "label": null,
           "preferredChildComponents": Array [],
           "properties": Object {
             "background": Object {

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -69,6 +69,7 @@ describe('registered property controls', () => {
       '/src/card': {
         Card: {
           component: Card,
+          label: "Labeled Card",
           properties: {
             label: {
               control: 'string-input',
@@ -121,6 +122,7 @@ describe('registered property controls', () => {
             "visual",
             "typography",
           ],
+          "label": "Labeled Card",
           "preferredChildComponents": Array [],
           "properties": Object {
             "background": Object {
@@ -224,6 +226,7 @@ describe('registered property controls', () => {
           "focus": "default",
           "icon": "component",
           "inspector": "all",
+          "label": null,
           "preferredChildComponents": Array [],
           "properties": Object {
             "label": Object {
@@ -837,6 +840,7 @@ describe('registered property controls', () => {
           "focus": "default",
           "icon": "component",
           "inspector": Array [],
+          "label": null,
           "preferredChildComponents": Array [],
           "properties": Object {
             "background": Object {
@@ -1661,6 +1665,7 @@ describe('registered property controls', () => {
             "focus": "default",
             "icon": "component",
             "inspector": Array [],
+            "label": null,
             "preferredChildComponents": Array [],
             "properties": Object {
               "label": Object {

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -559,6 +559,7 @@ export function updatePropertyControlsOnDescriptorFileUpdate(
         inspector: descriptor.inspector,
         emphasis: descriptor.emphasis,
         icon: descriptor.icon,
+        label: descriptor.label,
       }
     })
   })
@@ -946,6 +947,7 @@ export async function componentDescriptorForComponentToRegister(
     inspector: componentToRegister.inspector ?? ComponentDescriptorDefaults.inspector,
     emphasis: componentToRegister.emphasis ?? ComponentDescriptorDefaults.emphasis,
     icon: componentToRegister.icon ?? ComponentDescriptorDefaults.icon,
+    label: componentToRegister.label ?? null,
   })
 }
 
@@ -1009,6 +1011,7 @@ export const parseChildrenSpec = (value: unknown): ParseResult<ChildrenSpec> => 
 
 const parseComponentToRegister = objectParser<ComponentToRegister>({
   component: parseAny,
+  label: optionalProp(parseString),
   properties: fullyParsePropertyControls,
   variants: optionalProp(
     parseAlternative<ComponentExample | Array<ComponentExample>>(

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -95,6 +95,7 @@ export interface ComponentToRegister {
   inspector?: InspectorSpec
   emphasis?: Emphasis
   icon?: Icon
+  label?: string
   variants?: ComponentExample | Array<ComponentExample>
 }
 


### PR DESCRIPTION
## Problem
https://github.com/concrete-utopia/utopia/issues/5647

## Fix
Add a `label?: string` prop to `ComponentToRegister`

### Scope
This PR doesn't implement anything UI-related (even though the issue mentions that), those features are going to be implemented in a follow-up PR

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
