### PR TITLE
Make the try me links public by default

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -255,7 +255,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           edit-mode: replace
           body: |
-            ## [Try me](https://${{ secrets.STAGING_SERVER }}/p/?branch_name=${{ steps.extract_branch.outputs.branch }})
+            ## [Try me](https://${{ secrets.STAGING_SERVER }}/p/?accessLevel=public&branch_name=${{ steps.extract_branch.outputs.branch }})
 
   performance-test:
     name: Run Performance Tests


### PR DESCRIPTION
## Description

This PR updates the github workflow definitions to make the `Try me` links public by default so that we don't have to manually set the to public before sharing them