### PR TITLE
targetSupportsChildren is false when component annotation says so

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -187,6 +187,7 @@ export function pickCanvasStateFromEditorState(
     startingMetadata: editorState.jsxMetadata,
     startingElementPathTree: editorState.elementPathTree,
     startingAllElementProps: editorState.allElementProps,
+    propertyControlsInfo: editorState.propertyControlsInfo,
   }
 }
 
@@ -207,6 +208,7 @@ export function pickCanvasStateFromEditorStateWithMetadata(
     startingMetadata: metadata,
     startingElementPathTree: editorState.elementPathTree, // IMPORTANT! This isn't based on the passed in metadata
     startingAllElementProps: allElementProps ?? editorState.allElementProps,
+    propertyControlsInfo: editorState.propertyControlsInfo,
   }
 }
 

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -9,8 +9,8 @@ import type { InsertionSubject } from '../../editor/editor-modes'
 import type { CanvasCommand } from '../commands/commands'
 import type { StrategyApplicationStatus } from './interaction-state'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
-import type { RemixRoutingTable } from '../../editor/store/remix-derived-data'
 import type { ActiveFrameAction } from '../commands/set-active-frames-command'
+import type { PropertyControlsInfo } from '../../custom-code/code-file'
 
 // TODO: fill this in, maybe make it an ADT for different strategies
 export interface CustomStrategyState {
@@ -100,6 +100,7 @@ export interface InteractionCanvasState {
   startingMetadata: ElementInstanceMetadataMap
   startingElementPathTree: ElementPathTrees
   startingAllElementProps: AllElementProps
+  propertyControlsInfo: PropertyControlsInfo
 }
 
 export type InteractionTarget = TargetPaths | InsertionSubjects

--- a/editor/src/components/canvas/canvas-strategies/post-action-options/navigator-reparent.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/navigator-reparent.ts
@@ -58,6 +58,7 @@ function getNavigatorReparentCommands(
     editor.elementPathTree,
     wrapperUID,
     data.dragSources.length,
+    editor.propertyControlsInfo,
   )
 
   if (newParentPath == null) {

--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
@@ -601,6 +601,7 @@ function getTargetParentForPasteHere(
       originalContextElementPathTrees: originalPathTree,
     },
     editor.elementPathTree,
+    editor.propertyControlsInfo,
   )
 
   if (isLeft(target)) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-helpers.ts
@@ -16,6 +16,7 @@ import type { AllElementProps } from '../../../../editor/store/editor-state'
 import type { InsertionPath } from '../../../../editor/store/insertion-path'
 import type { ElementPathTrees } from '../../../../../core/shared/element-path-tree'
 import { assertNever } from '../../../../../core/shared/utils'
+import { PropertyControlsInfo } from '../../../../custom-code/code-file'
 
 export type ReparentAsAbsolute = 'REPARENT_AS_ABSOLUTE'
 export type ReparentAsStatic = 'REPARENT_AS_STATIC'
@@ -68,6 +69,7 @@ export function findReparentStrategies(
     canvasState.startingAllElementProps,
     allowSmallerParent,
     elementSupportsChildren,
+    canvasState.propertyControlsInfo,
   )
 
   if (targetParent == null) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-helpers/reparent-strategy-parent-lookup.ts
@@ -35,6 +35,7 @@ import type { ElementPathTrees } from '../../../../../core/shared/element-path-t
 import { isConditionalWithEmptyOrTextEditableActiveBranch } from '../../../../../core/model/conditionals'
 import { getInsertionPathForReparentTarget } from './reparent-helpers'
 import { treatElementAsGroupLike } from '../group-helpers'
+import type { PropertyControlsInfo } from '../../../../custom-code/code-file'
 
 export type FindReparentStrategyResult = {
   strategy: ReparentStrategy
@@ -52,6 +53,7 @@ export function getReparentTargetUnified(
   allElementProps: AllElementProps,
   allowSmallerParent: AllowSmallerParent,
   elementSupportsChildren: Array<ElementSupportsChildren> = ['supportsChildren'],
+  propertyControlsInfo: PropertyControlsInfo,
 ): ReparentTarget | null {
   const canvasScale = canvasState.scale
 
@@ -65,6 +67,7 @@ export function getReparentTargetUnified(
     allElementProps,
     allowSmallerParent,
     elementSupportsChildren,
+    propertyControlsInfo,
   )
 
   // For Flex parents, we want to be able to insert between two children that don't have a gap between them.
@@ -151,6 +154,7 @@ function findValidTargetsUnderPoint(
   allElementProps: AllElementProps,
   allowSmallerParent: AllowSmallerParent,
   elementSupportsChildren: Array<ElementSupportsChildren> = ['supportsChildren'],
+  propertyControlsInfo: PropertyControlsInfo,
 ): Array<ElementPath> {
   const projectContents = canvasState.projectContents
   const openFile = canvasState.openFile ?? null
@@ -222,6 +226,7 @@ function findValidTargetsUnderPoint(
           metadata,
           target,
           elementPathTree,
+          propertyControlsInfo,
         ),
       )
     ) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-metastrategy.tsx
@@ -32,6 +32,7 @@ import { flattenSelection } from './shared-move-strategies-helpers'
 import type { InsertionPath } from '../../../editor/store/insertion-path'
 import { childInsertionPath } from '../../../editor/store/insertion-path'
 import { treatElementAsGroupLike } from './group-helpers'
+import { PropertyControlsInfo } from '../../../custom-code/code-file'
 
 interface ReparentFactoryAndDetails {
   targetParent: InsertionPath
@@ -158,6 +159,7 @@ function getStartingTargetParentsToFilterOutInner(
     canvasState.startingAllElementProps,
     allowSmallerParent,
     elementSupportsChildren,
+    canvasState.propertyControlsInfo,
   )
   if (regularReparentTarget != null) {
     result.push(regularReparentTarget)

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -105,6 +105,7 @@ export const setBorderRadiusStrategy: CanvasStrategyFactory = (
     canvasState.scale,
     canvasState.startingMetadata,
     canvasState.startingElementPathTree,
+    canvasState.propertyControlsInfo,
   ).has('borderRadius')
   if (!canShowBorderRadiusControls) {
     return null

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -106,6 +106,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
     canvasState.scale,
     canvasState.startingMetadata,
     canvasState.startingElementPathTree,
+    canvasState.propertyControlsInfo,
   ).has('padding')
   if (!canShowPadding) {
     return null

--- a/editor/src/components/canvas/commands/add-contain-layout-if-needed-command.ts
+++ b/editor/src/components/canvas/commands/add-contain-layout-if-needed-command.ts
@@ -40,6 +40,7 @@ export const runAddContainLayoutIfNeeded: CommandFunction<AddContainLayoutIfNeed
       command.element,
       editorState.jsxMetadata,
       editorState.elementPathTree,
+      editorState.propertyControlsInfo,
     ) !== 'supportsChildren'
 
   if (isNotNeeded) {

--- a/editor/src/components/canvas/commands/wrap-in-container-command.ts
+++ b/editor/src/components/canvas/commands/wrap-in-container-command.ts
@@ -99,6 +99,7 @@ export const runWrapInContainerCommand: CommandFunction<WrapInContainerCommand> 
         editor.elementPathTree,
         wrapperUID,
         1,
+        editor.propertyControlsInfo,
       )
       if (insertionPath == null) {
         return // maybe this should throw instead?

--- a/editor/src/components/canvas/controls/insert-mode/insert-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/insert-mode/insert-mode-hooks.tsx
@@ -6,6 +6,7 @@ import { isInsertMode } from '../../../editor/editor-modes'
 import { useRefEditorState } from '../../../editor/store/store-hook'
 import type { MouseCallbacks } from '../select-mode/select-mode-hooks'
 import { useHighlightCallbacks } from '../select-mode/select-mode-hooks'
+import { property } from 'css-tree'
 
 function useGetHighlightableViewsForInsertMode() {
   const storeRef = useRefEditorState((store) => {
@@ -19,10 +20,12 @@ function useGetHighlightableViewsForInsertMode() {
       nodeModules: store.editor.nodeModules.files,
       remixRoutingTable: store.derived.remixData?.routingTable ?? null,
       resolve: resolveFn,
+      propertyControlsInfo: store.editor.propertyControlsInfo,
     }
   })
   return React.useCallback(() => {
-    const { componentMetadata, elementPathTree, mode, projectContents } = storeRef.current
+    const { componentMetadata, elementPathTree, mode, projectContents, propertyControlsInfo } =
+      storeRef.current
     if (isInsertMode(mode)) {
       const allPaths = MetadataUtils.getAllPaths(componentMetadata, elementPathTree)
       const insertTargets = allPaths.filter((path) => {
@@ -31,6 +34,7 @@ function useGetHighlightableViewsForInsertMode() {
           componentMetadata,
           path,
           elementPathTree,
+          propertyControlsInfo,
         )
       })
       return insertTargets

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -489,6 +489,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
               EP.fromString(p),
               componentMetadata,
               pathTrees,
+              propertyControlsInfo,
             ),
           )
         )

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -14,6 +14,7 @@ import type { ElementPath } from '../../../../core/shared/project-file-types'
 import { treatElementAsGroupLikeFromMetadata } from '../../canvas-strategies/strategies/group-helpers'
 import { assertNever } from '../../../../core/shared/utils'
 import { mapDropNulls } from '../../../../core/shared/array-utils'
+import type { PropertyControlsInfo } from '../../../custom-code/code-file'
 
 export const Emdash: string = '\u2014'
 
@@ -202,6 +203,7 @@ export function canShowCanvasPropControl(
   scale: number,
   metadata: ElementInstanceMetadataMap,
   elementPathTree: ElementPathTrees,
+  propertyControlsInfo: PropertyControlsInfo,
 ): Set<CanvasPropControl> {
   function getControls(element: ElementInstanceMetadata): CanvasPropControl[] {
     const frame = zeroRectIfNullOrInfinity(element.globalFrame)
@@ -225,6 +227,7 @@ export function canShowCanvasPropControl(
         element.elementPath,
         metadata,
         elementPathTree,
+        propertyControlsInfo,
       )
     ) {
       return ['borderRadius', 'gap']

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -83,7 +83,7 @@ export const ZeroSizedElementControls = controlForStrategyMemoized(
     )
 
     const zeroSizeElements = useEditorState(
-      Substores.metadata,
+      Substores.fullStore,
       (store) => {
         if (showAllPossibleElements) {
           return Object.values(store.editor.jsxMetadata).filter((element) => {
@@ -96,6 +96,7 @@ export const ZeroSizedElementControls = controlForStrategyMemoized(
                 element.elementPath,
                 store.editor.jsxMetadata,
                 store.editor.elementPathTree,
+                store.editor.propertyControlsInfo,
               )
             )
           })
@@ -118,6 +119,7 @@ export const ZeroSizedElementControls = controlForStrategyMemoized(
                     child.elementPath,
                     store.editor.jsxMetadata,
                     store.editor.elementPathTree,
+                    store.editor.propertyControlsInfo,
                   )
                 )
               }
@@ -341,7 +343,7 @@ export const ZeroSizeResizeControlWrapper = controlForStrategyMemoized(
         {zeroSizeElements.map((element) => {
           if (element.globalFrame != null && isFiniteRectangle(element.globalFrame)) {
             return (
-              <React.Fragment>
+              <React.Fragment key={EP.toString(element.elementPath)}>
                 <ZeroSizeOutlineControl frame={element.globalFrame} scale={scale} color={null} />
                 <ZeroSizeResizeControl
                   element={element}

--- a/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
+++ b/editor/src/components/canvas/controls/zero-sized-element-controls.tsx
@@ -83,7 +83,7 @@ export const ZeroSizedElementControls = controlForStrategyMemoized(
     )
 
     const zeroSizeElements = useEditorState(
-      Substores.fullStore,
+      Substores.metadataAndPropertyControlsInfo,
       (store) => {
         if (showAllPossibleElements) {
           return Object.values(store.editor.jsxMetadata).filter((element) => {

--- a/editor/src/components/context-menu-items.ts
+++ b/editor/src/components/context-menu-items.ts
@@ -457,6 +457,7 @@ export const unwrap: ContextMenuItem<CanvasData> = {
           data.jsxMetadata,
           path,
           data.pathTrees,
+          data.propertyControlsInfo,
         ) ||
         treatElementAsFragmentLike(data.jsxMetadata, data.allElementProps, data.pathTrees, path),
     )

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -2591,6 +2591,7 @@ export const UPDATE_FNS = {
         workingEditor.jsxMetadata,
         target,
         workingEditor.elementPathTree,
+        workingEditor.propertyControlsInfo,
       )
 
       const elementIsFragmentLike = treatElementAsFragmentLike(

--- a/editor/src/components/editor/actions/wrap-unwrap-helpers.tsx
+++ b/editor/src/components/editor/actions/wrap-unwrap-helpers.tsx
@@ -180,6 +180,7 @@ export function unwrapTextContainingConditional(
         editor.elementPathTree,
         wrapperUID,
         1,
+        editor.propertyControlsInfo,
       )
       if (insertionPath == null) {
         throw new Error('Invalid unwrap insertion path')

--- a/editor/src/components/editor/convert-callbacks.ts
+++ b/editor/src/components/editor/convert-callbacks.ts
@@ -36,6 +36,7 @@ import type { ElementPathTrees } from '../../core/shared/element-path-tree'
 import type { InsertMenuItem, InsertMenuItemValue } from '../canvas/ui/floating-insert-menu'
 import { wrapInDivStrategy } from './wrap-in-callbacks'
 import { commandsForFirstApplicableStrategy } from '../inspector/inspector-strategies/inspector-strategy'
+import type { PropertyControlsInfo } from '../custom-code/code-file'
 
 export function changeConditionalOrFragment(
   projectContents: ProjectContentTreeRoot,
@@ -45,6 +46,7 @@ export function changeConditionalOrFragment(
   floatingMenuState: FloatingInsertMenuState,
   fixedSizeForInsertion: boolean,
   element: JSXConditionalExpressionWithoutUID | JSXFragmentWithoutUID,
+  propertyControlsInfo: PropertyControlsInfo,
 ): Array<EditorAction> {
   let actionsToDispatch: Array<EditorAction> = []
   const importsToAdd: Imports =
@@ -82,6 +84,7 @@ export function changeConditionalOrFragment(
         elementPathTree,
         wrapperUID,
         selectedViews.length,
+        propertyControlsInfo,
       )
       actionsToDispatch = [
         insertInsertable(
@@ -120,6 +123,7 @@ export function changeElement(
   addContentForInsertion: boolean,
   pickedInsertableComponent: InsertMenuItemValue,
   source: InsertableComponentGroupType | null,
+  propertyControlsInfo: PropertyControlsInfo,
 ): Array<EditorAction> {
   const element = pickedInsertableComponent.element()
   if (element.type !== 'JSX_ELEMENT') {
@@ -136,6 +140,7 @@ export function changeElement(
             elementPathTree,
             allElementProps,
             projectContents,
+            propertyControlsInfo,
           ),
         ])
 
@@ -189,6 +194,7 @@ export function changeElement(
           elementPathTree,
           wrapperUID,
           selectedViews.length,
+          propertyControlsInfo,
         )
         // TODO multiselect?
         actionsToDispatch = [
@@ -231,6 +237,7 @@ export function getActionsToApplyChange(
   fixedSizeForInsertion: boolean,
   addContentForInsertion: boolean,
   insertMenuItemValue: InsertMenuItemValue,
+  propertyControlsInfo: PropertyControlsInfo,
 ): Array<EditorAction> {
   const element = insertMenuItemValue.element()
   switch (element.type) {
@@ -244,6 +251,7 @@ export function getActionsToApplyChange(
         floatingMenuState,
         fixedSizeForInsertion,
         element,
+        propertyControlsInfo,
       )
     case 'JSX_ELEMENT':
       return changeElement(
@@ -257,6 +265,7 @@ export function getActionsToApplyChange(
         addContentForInsertion,
         insertMenuItemValue,
         insertMenuItemValue.source,
+        propertyControlsInfo,
       )
     case 'JSX_MAP_EXPRESSION':
       return [] // we don't support converting to maps
@@ -273,6 +282,7 @@ export function useConvertTo(): (convertTo: InsertMenuItem | null) => void {
   const projectContentsRef = useRefEditorState((store) => store.editor.projectContents)
   const allElementPropsRef = useRefEditorState((store) => store.editor.projectContents)
   const floatingMenuStateRef = useRefEditorState((store) => store.editor.floatingInsertMenu)
+  const propertyControlsInfoRef = useRefEditorState((store) => store.editor.propertyControlsInfo)
 
   return React.useCallback(
     (convertToMenuItem: InsertMenuItem | null) => {
@@ -288,6 +298,7 @@ export function useConvertTo(): (convertTo: InsertMenuItem | null) => void {
           false,
           false,
           convertTo,
+          propertyControlsInfoRef.current,
         )
         dispatch(actions, 'everyone')
       }
@@ -300,6 +311,7 @@ export function useConvertTo(): (convertTo: InsertMenuItem | null) => void {
       jsxMetadataRef,
       projectContentsRef,
       selectedViewsRef,
+      propertyControlsInfoRef,
     ],
   )
 }

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -977,6 +977,7 @@ export function handleKeyDown(
             editor.elementPathTree,
             editor.allElementProps,
             editor.projectContents,
+            editor.propertyControlsInfo,
           ),
         ])
         if (commands == null) {

--- a/editor/src/components/editor/insert-callbacks.ts
+++ b/editor/src/components/editor/insert-callbacks.ts
@@ -167,6 +167,7 @@ export function useToInsert(): (elementToInsert: InsertMenuItem | null) => void 
   const projectContentsRef = useRefEditorState((store) => store.editor.projectContents)
   const openFileRef = useRefEditorState((store) => store.editor.canvas.openFile?.filename ?? null)
   const nodeModulesRef = useRefEditorState((store) => store.editor.nodeModules)
+  const propertyControlsInfoRef = useRefEditorState((store) => store.editor.propertyControlsInfo)
 
   return React.useCallback(
     (elementToInsert: InsertMenuItem | null) => {
@@ -211,6 +212,7 @@ export function useToInsert(): (elementToInsert: InsertMenuItem | null) => void 
         [element.element],
         elementPathTreeRef.current,
         elementToInsert.value.insertionCeiling,
+        propertyControlsInfoRef.current,
       )
 
       if (isLeft(targetParent)) {
@@ -255,6 +257,7 @@ export function useToInsert(): (elementToInsert: InsertMenuItem | null) => void 
       openFileRef,
       projectContentsRef,
       selectedViewsRef,
+      propertyControlsInfoRef,
     ],
   )
 }

--- a/editor/src/components/editor/store/insertion-path.ts
+++ b/editor/src/components/editor/store/insertion-path.ts
@@ -14,6 +14,7 @@ import { isJSXConditionalExpression } from '../../../core/shared/element-templat
 import { isRight } from '../../../core/shared/either'
 import type { ProjectContentTreeRoot } from '../../assets'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
+import type { PropertyControlsInfo } from '../../custom-code/code-file'
 
 export type InsertionPath = ChildInsertionPath | ConditionalClauseInsertionPath
 
@@ -211,12 +212,14 @@ export function getInsertionPath(
   elementPathTree: ElementPathTrees,
   fragmentWrapperUID: string,
   numberOfElementsToInsert: number,
+  propertyControlsInfo: PropertyControlsInfo,
 ): InsertionPath | null {
   const targetSupportsChildren = MetadataUtils.targetSupportsChildren(
     projectContents,
     metadata,
     target,
     elementPathTree,
+    propertyControlsInfo,
   )
 
   if (targetSupportsChildren) {

--- a/editor/src/components/editor/store/store-hook-substore-types.ts
+++ b/editor/src/components/editor/store/store-hook-substore-types.ts
@@ -30,6 +30,7 @@ export type Substates = {
   projectServerState: ProjectServerStateSubstate
   variablesInScope: VariablesInScopeSubstate
   propertyControlsInfo: PropertyControlsInfoSubstate
+  metadataAndPropertyControlsInfo: MetadataAndPropertyControlsInfoSubstate
 }
 
 export type StoreKey = keyof Substates
@@ -142,6 +143,9 @@ const propertyControlsInfoSubstate = {
   editor: pick(propertyControlsInfoSubstateKeys, EmptyEditorStateForKeysOnly),
 } as const
 export type PropertyControlsInfoSubstate = typeof propertyControlsInfoSubstate
+
+export type MetadataAndPropertyControlsInfoSubstate = MetadataSubstate &
+  PropertyControlsInfoSubstate
 
 export interface DerivedSubstate {
   derived: DerivedState

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -25,6 +25,7 @@ import type {
   FocusedElementPathSubstate,
   GithubSubstate,
   HighlightedHoveredViewsSubstate,
+  MetadataAndPropertyControlsInfoSubstate,
   MetadataSubstate,
   MultiplayerSubstate,
   NavigatorSubstate,
@@ -57,6 +58,7 @@ import {
   variablesInScopeSubstateKeys,
 } from './store-hook-substore-types'
 import { Getter } from '../hook-utils'
+import { uniq } from '../../../core/shared/array-utils'
 
 // This is how to officially type the store with a subscribeWithSelector middleware as of Zustand 4.1.5 https://github.com/pmndrs/zustand#using-subscribe-with-selector
 type Store<S> = UseBoundStore<Mutate<StoreApi<S>, [['zustand/subscribeWithSelector', never]]>>
@@ -324,6 +326,16 @@ export const Substores = {
   },
   propertyControlsInfo: (a: PropertyControlsInfoSubstate, b: PropertyControlsInfoSubstate) => {
     return keysEquality(propertyControlsInfoSubstateKeys, a.editor, b.editor)
+  },
+  metadataAndPropertyControlsInfo: (
+    a: MetadataAndPropertyControlsInfoSubstate,
+    b: MetadataAndPropertyControlsInfoSubstate,
+  ) => {
+    return keysEquality(
+      uniq([...propertyControlsInfoSubstateKeys, ...metadataSubstateKeys]),
+      a.editor,
+      b.editor,
+    )
   },
 } as const
 

--- a/editor/src/components/editor/wrap-in-callbacks.ts
+++ b/editor/src/components/editor/wrap-in-callbacks.ts
@@ -43,6 +43,7 @@ import { absolute } from '../../utils/utils'
 import { setProperty } from '../canvas/commands/set-property-command'
 import * as PP from '../../core/shared/property-path'
 import type { InspectorStrategy } from '../inspector/inspector-strategies/inspector-strategy'
+import type { PropertyControlsInfo } from '../custom-code/code-file'
 
 type WrapInDivError =
   | 'No elements selected'
@@ -55,6 +56,7 @@ export const wrapInDivStrategy = (
   elementPathTrees: ElementPathTrees,
   allElementProps: AllElementProps,
   projectContents: ProjectContentTreeRoot,
+  propertyControlsInfo: PropertyControlsInfo,
 ): InspectorStrategy => ({
   name: 'Wrap in div',
   strategy: () => {
@@ -64,6 +66,7 @@ export const wrapInDivStrategy = (
       allElementProps,
       projectContents,
       selectedViews,
+      propertyControlsInfo,
     )
     if (isLeft(result)) {
       return null
@@ -78,6 +81,7 @@ function wrapInDivCommands(
   allElementProps: AllElementProps,
   projectContents: ProjectContentTreeRoot,
   selectedViews: ElementPath[],
+  propertyControlsInfo: PropertyControlsInfo,
 ): Either<WrapInDivError, CanvasCommand[]> {
   if (!isNonEmptyArray(selectedViews)) {
     return left('No elements selected')
@@ -108,6 +112,7 @@ function wrapInDivCommands(
     elementPathTrees,
     fragmentWrapperUid,
     1,
+    propertyControlsInfo,
   )
   if (insertionPath == null) {
     return left('Cannot insert into parent of selected elements')
@@ -238,6 +243,7 @@ export function useWrapInDiv(): () => void {
       editorRef.current.allElementProps,
       editorRef.current.projectContents,
       editorRef.current.selectedViews,
+      editorRef.current.propertyControlsInfo,
     )
 
     if (isLeft(result)) {

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -273,6 +273,7 @@ function canDropInto(editorState: EditorState, moveToEntry: ElementPath): boolea
     editorState.jsxMetadata,
     moveToEntry,
     editorState.elementPathTree,
+    editorState.propertyControlsInfo,
   )
 
   return (

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -32,6 +32,7 @@ import type {
   DerivedSubstate,
   MetadataSubstate,
   ProjectContentAndMetadataSubstate,
+  PropertyControlsInfoSubstate,
 } from '../../editor/store/store-hook-substore-types'
 import type {
   ConditionalClauseNavigatorItemContainerProps,
@@ -88,7 +89,15 @@ const elementSupportsChildrenSelector = createCachedSelector(
   targetElementMetadataSelector,
   (store: MetadataSubstate) => store.editor.elementPathTree,
   targetInNavigatorItemsSelector,
-  (projectContents, metadata, elementMetadata, pathTrees, elementInNavigatorTargets) => {
+  (store: PropertyControlsInfoSubstate) => store.editor.propertyControlsInfo,
+  (
+    projectContents,
+    metadata,
+    elementMetadata,
+    pathTrees,
+    elementInNavigatorTargets,
+    propertyControlsInfo,
+  ) => {
     if (!elementInNavigatorTargets || elementMetadata == null) {
       return false
     }
@@ -97,6 +106,7 @@ const elementSupportsChildrenSelector = createCachedSelector(
       elementMetadata.elementPath,
       metadata,
       pathTrees,
+      propertyControlsInfo,
     )
   },
 )((_, navigatorEntry) => navigatorEntryToKey(navigatorEntry))

--- a/editor/src/core/model/element-metadata-utils.spec.tsx
+++ b/editor/src/core/model/element-metadata-utils.spec.tsx
@@ -426,6 +426,7 @@ describe('targetElementSupportsChildren', () => {
       path,
       { [EP.toString(path)]: element },
       {},
+      {},
     )
     expect(actualResult).toEqual(true)
   })
@@ -439,6 +440,7 @@ describe('targetElementSupportsChildren', () => {
       {},
       path,
       { [EP.toString(path)]: element },
+      {},
       {},
     )
     expect(actualResult).toEqual(true)
@@ -454,6 +456,7 @@ describe('targetElementSupportsChildren', () => {
       path,
       { [EP.toString(path)]: element },
       {},
+      {},
     )
     expect(actualResult).toEqual(true)
   })
@@ -468,6 +471,7 @@ describe('targetElementSupportsChildren', () => {
       path,
       { [EP.toString(path)]: element },
       {},
+      {},
     )
     expect(actualResult).toEqual(true)
   })
@@ -481,6 +485,7 @@ describe('targetElementSupportsChildren', () => {
       {},
       path,
       { [EP.toString(path)]: element },
+      {},
       {},
     )
     expect(actualResult).toEqual(true)
@@ -511,6 +516,7 @@ describe('targetElementSupportsChildren', () => {
       path,
       { [EP.toString(path)]: element },
       {},
+      {},
     )
     expect(actualResult).toEqual(true)
   })
@@ -526,6 +532,7 @@ describe('targetElementSupportsChildren', () => {
       {},
       path,
       { [EP.toString(path)]: element },
+      {},
       {},
     )
     expect(actualResult).toEqual(true)
@@ -543,6 +550,7 @@ describe('targetElementSupportsChildren', () => {
       path,
       { [EP.toString(path)]: element },
       {},
+      {},
     )
     expect(actualResult).toEqual(true)
   })
@@ -558,6 +566,7 @@ describe('targetElementSupportsChildren', () => {
       {},
       path,
       { [EP.toString(path)]: element },
+      {},
       {},
     )
     expect(actualResult).toEqual(true)
@@ -596,6 +605,7 @@ describe('targetElementSupportsChildren', () => {
       path,
       { [EP.toString(path)]: element },
       {},
+      {},
     )
     expect(actualResult).toEqual(true)
   })
@@ -609,6 +619,7 @@ describe('targetElementSupportsChildren', () => {
       {},
       path,
       { [EP.toString(path)]: element },
+      {},
       {},
     )
     expect(actualResult).toEqual(true)
@@ -624,6 +635,7 @@ describe('targetElementSupportsChildren', () => {
       path,
       { [EP.toString(path)]: element },
       {},
+      {},
     )
     expect(actualResult).toEqual(true)
   })
@@ -637,6 +649,7 @@ describe('targetElementSupportsChildren', () => {
       {},
       path,
       { [EP.toString(path)]: element },
+      {},
       {},
     )
     expect(actualResult).toEqual(true)
@@ -652,6 +665,7 @@ describe('targetElementSupportsChildren', () => {
       path,
       { [EP.toString(path)]: element },
       {},
+      {},
     )
     expect(actualResult).toEqual(false)
   })
@@ -665,6 +679,7 @@ describe('targetElementSupportsChildren', () => {
       {},
       path,
       { [EP.toString(path)]: element },
+      {},
       {},
     )
     expect(actualResult).toEqual(false)
@@ -710,6 +725,7 @@ export const App = (props) => {
       projectContents,
       path,
       { [EP.toString(path)]: element },
+      {},
       {},
     )
     expect(actualResult).toEqual(true)
@@ -772,6 +788,7 @@ export const App = (props) => {
         [EP.toString(path)]: element,
       },
       {},
+      {},
     )
     expect(actualResult).toEqual(false)
   })
@@ -824,6 +841,7 @@ export const App = (props) => {
       {
         [EP.toString(path)]: element,
       },
+      {},
       {},
     )
     expect(actualResult).toEqual(false)

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -16,11 +16,9 @@ import type {
   JSXArrayElement,
   JSXProperty,
   ElementInstanceMetadataMap,
-  JSExpressionMapOrOtherJavascript,
   JSXElementChildWithoutUID,
   JSIdentifier,
   JSPropertyAccess,
-  JSElementAccess,
   JSExpressionOtherJavaScript,
 } from '../shared/element-template'
 import {
@@ -42,7 +40,6 @@ import {
   hasElementsWithin,
   isUtopiaJSXComponent,
   isJSPropertyAccessForProperty,
-  isJSIdentifier,
   isJSIdentifierForName,
   isJSExpressionOtherJavaScript,
   isJSXMapExpression,
@@ -86,6 +83,8 @@ import { getAllUniqueUids } from './get-unique-ids'
 import type { ElementPathTrees } from '../shared/element-path-tree'
 import { MetadataUtils } from './element-metadata-utils'
 import { mapValues } from '../shared/object-utils'
+import type { PropertyControlsInfo } from '../../components/custom-code/code-file'
+import { getComponentDescriptorForTarget } from '../property-controls/property-controls-utils'
 
 export function generateUidWithExistingComponents(projectContents: ProjectContentTreeRoot): string {
   const mockUID = generateMockNextGeneratedUID()
@@ -1410,7 +1409,18 @@ export function elementChildSupportsChildrenAlsoText(
   path: ElementPath,
   metadata: ElementInstanceMetadataMap,
   elementPathTree: ElementPathTrees,
+  projectContents: ProjectContentTreeRoot,
+  propertyControlsInfo: PropertyControlsInfo,
 ): ElementSupportsChildren | null {
+  const componentDescriptor = getComponentDescriptorForTarget(
+    path,
+    propertyControlsInfo,
+    projectContents,
+  )
+  if (componentDescriptor != null && !componentDescriptor.supportsChildren) {
+    return 'doesNotSupportChildren'
+  }
+
   if (isJSXConditionalExpression(element)) {
     if (isTextEditableConditional(path, metadata, elementPathTree)) {
       return 'conditionalWithText'

--- a/editor/src/utils/clipboard.ts
+++ b/editor/src/utils/clipboard.ts
@@ -26,6 +26,7 @@ import { fastForEach } from '../core/shared/utils'
 import urljoin from 'url-join'
 import type { ProjectContentTreeRoot } from '../components/assets'
 import { getProjectFileByFilePath } from '../components/assets'
+import type { PropertyControlsInfo } from '../components/custom-code/code-file'
 import {
   normalisePathSuccessOrThrowError,
   normalisePathToUnderlyingTarget,
@@ -142,6 +143,7 @@ function getJSXElementPasteActions(
       originalContextElementPathTrees: clipboardFirstEntry.targetOriginalContextElementPathTrees,
     },
     editor.elementPathTree,
+    editor.propertyControlsInfo,
   )
 
   if (isLeft(target)) {
@@ -195,6 +197,7 @@ function getFilePasteActions(
   componentMetadata: ElementInstanceMetadataMap,
   canvasScale: number,
   elementPathTree: ElementPathTrees,
+  propertyControlsInfo: PropertyControlsInfo,
 ): Array<EditorAction> {
   if (pastedFiles.length == 0) {
     return []
@@ -213,6 +216,7 @@ function getFilePasteActions(
     componentMetadata,
     { elementPaste: [], originalContextMetadata: {}, originalContextElementPathTrees: {} }, // TODO: get rid of this when refactoring pasting images
     elementPathTree,
+    propertyControlsInfo,
   )
 
   if (isLeft(target)) {
@@ -271,6 +275,7 @@ export function getActionsForClipboardItems(
       editor.jsxMetadata,
       canvasScale,
       editor.elementPathTree,
+      editor.propertyControlsInfo,
     ),
   ]
 }


### PR DESCRIPTION
**Problem:**
Insertion on canvas and navigator should respect the API "supports children" annotation.

**Fix:**
We have a few targetSupportsChildren related functions in MetadataUtils. Most of the PR is about passing down propertyControlsInfo to these functions, so they can check the annotation, and return false when `supportsChildren` is false (regardless of any other circumstances).

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5491
