### PR TITLE
update elements in render props on the canvas

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -359,7 +359,8 @@ function isElementInChildrenOrPropsTree(elementPath: string, props: any): boolea
   }
 
   const elementsInProps = Object.values(props).filter(isRenderProp)
-  const isElementInProps = elementsInProps.some((p) => p[UTOPIA_PATH_KEY] === elementPath)
+  const isElementInProps = elementsInProps.some((p) => p.props[UTOPIA_PATH_KEY] === elementPath)
+
   if (isElementInProps) {
     return true
   }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -341,7 +341,7 @@ export function createComponentRendererComponent(params: {
   return Component
 }
 
-function isRenderProp(prop: any): prop is { [UTOPIA_PATH_KEY]: string; props: MapLike<any> } {
+function isRenderProp(prop: any): prop is { props: { [UTOPIA_PATH_KEY]: string } } {
   return (
     prop != null &&
     typeof prop === 'object' &&
@@ -360,7 +360,6 @@ function isElementInChildrenOrPropsTree(elementPath: string, props: any): boolea
 
   const elementsInProps = Object.values(props).filter(isRenderProp)
   const isElementInProps = elementsInProps.some((p) => p.props[UTOPIA_PATH_KEY] === elementPath)
-
   if (isElementInProps) {
     return true
   }


### PR DESCRIPTION
# [Try it here](https://utopia.fish/p/b9aafe7c-mammoth-scribe/?branch_name=fix-render-prop-canvas-updates)

## Problem
https://github.com/concrete-utopia/utopia/issues/5604

Most canvas controls don't work for elements that are root elements of render props (setting the border radius, absolute move, setting the padding, etc)

## Root cause / Fix
The fix/improvement introduced by https://github.com/concrete-utopia/utopia/pull/5559 wasn't 100% correct, the 

```ts
p[UTOPIA_PATH_KEY] === elementPath
```

line should have been 

```ts
p.props[UTOPIA_PATH_KEY] === elementPath
```
(the same check that's made for child elements a few lines above)

This PR fixes the problem and updates `isRenderProp` so that the `[UTOPIA_PATH_KEY]` property access is property type-checked

### Caveats
As of this PR we can't write tests for this feature, because in `asyncTestDispatch` `ElementsToRerenderGLOBAL.current` is always `'rerender-all-elements'`, which means `isElementInChildrenOrPropsTree` (the function with the bug) is never called.

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
