### PR TITLE
Filtered replace element options to avoid losing children.

### DIFF
--- a/editor/src/components/canvas/ui/floating-insert-menu.tsx
+++ b/editor/src/components/canvas/ui/floating-insert-menu.tsx
@@ -52,7 +52,7 @@ export type InsertableComponentFlatList = Array<InsertMenuItemGroup>
 function convertInsertableComponentsToFlatList(
   insertableComponents: InsertableComponentGroup[],
 ): InsertableComponentFlatList {
-  return insertableComponents.flatMap((componentGroup) => {
+  return insertableComponents.map((componentGroup) => {
     return {
       label: getInsertableGroupLabel(componentGroup.source),
       options: componentGroup.insertableComponents.map(

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -111,6 +111,20 @@ export function clearComponentElementToInsertUniqueIDs(
   }
 }
 
+export function componentElementToInsertHasChildren(toInsert: ComponentElementToInsert): boolean {
+  switch (toInsert.type) {
+    case 'JSX_ELEMENT':
+    case 'JSX_FRAGMENT':
+      return toInsert.children.length > 0
+    case 'JSX_MAP_EXPRESSION':
+    case 'JSX_CONDITIONAL_EXPRESSION':
+      // More in the conceptual sense than actual sense of having a field containing children.
+      return true
+    default:
+      assertNever(toInsert)
+  }
+}
+
 export interface ComponentInfo {
   insertMenuLabel: string
   elementToInsert: () => ComponentElementToInsert

--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -52,7 +52,11 @@ import type {
   ReplaceTarget,
 } from '../../editor/action-types'
 import { type ProjectContentTreeRoot } from '../../assets'
-import type { PropertyControlsInfo, ComponentInfo } from '../../custom-code/code-file'
+import {
+  type PropertyControlsInfo,
+  type ComponentInfo,
+  componentElementToInsertHasChildren,
+} from '../../custom-code/code-file'
 import { type Icon } from 'utopia-api'
 import { getRegisteredComponent } from '../../../core/property-controls/property-controls-utils'
 import { defaultImportsForComponentModule } from '../../../core/property-controls/property-controls-local'
@@ -151,6 +155,7 @@ export function preferredChildrenForTarget(
   targetElement: ElementInstanceMetadata | null,
   insertionTarget: InsertionTarget,
   propertyControlsInfo: PropertyControlsInfo,
+  elementChildren: Array<ElementInstanceMetadata>,
 ): Array<PreferredChildComponentDescriptorWithIcon> {
   const targetJSXElement = MetadataUtils.getJSXElementFromElementInstanceMetadata(targetElement)
   const elementImportInfo = targetElement?.importInfo
@@ -172,10 +177,27 @@ export function preferredChildrenForTarget(
       isReplaceTarget(insertionTarget) ||
       isReplaceKeepChildrenAndStyleTarget(insertionTarget)
     ) {
-      return registeredComponent.preferredChildComponents.map((v) => ({
-        ...v,
-        icon: getIconForComponent(v.name, v.moduleName, propertyControlsInfo),
-      }))
+      // If we want to keep the children of this element when it has some, don't include replacements that have children.
+      const includeComponentsWithChildren =
+        !isReplaceKeepChildrenAndStyleTarget(insertionTarget) || elementChildren.length === 0
+
+      return registeredComponent.preferredChildComponents.map((childComponent) => {
+        return {
+          ...childComponent,
+          variants: childComponent.variants.filter((variant) => {
+            // Includes everything if components with children are permitted, otherwise only includes components without children.
+            return (
+              includeComponentsWithChildren ||
+              !componentElementToInsertHasChildren(variant.elementToInsert())
+            )
+          }),
+          icon: getIconForComponent(
+            childComponent.name,
+            childComponent.moduleName,
+            propertyControlsInfo,
+          ),
+        }
+      })
     } else if (isRenderPropTarget(insertionTarget)) {
       for (const [registeredPropName, registeredPropValue] of Object.entries(
         registeredComponent.properties,
@@ -216,19 +238,30 @@ function augmentPreferredChildren(
   return preferredChildren
 }
 
+function getTargetParentFromInsertionTarget(
+  target: ElementPath,
+  insertionTarget: InsertionTarget,
+): ElementPath {
+  return isReplaceTarget(insertionTarget) || isReplaceKeepChildrenAndStyleTarget(insertionTarget)
+    ? EP.parentPath(target)
+    : target
+}
+
 const usePreferredChildrenForTarget = (
   target: ElementPath,
   insertionTarget: InsertionTarget,
 ): Array<PreferredChildComponentDescriptorWithIcon> => {
-  const targetParent =
-    isReplaceTarget(insertionTarget) || isReplaceKeepChildrenAndStyleTarget(insertionTarget)
-      ? EP.parentPath(target)
-      : target
+  const targetParent = getTargetParentFromInsertionTarget(target, insertionTarget)
 
   const targetElement = useEditorState(
     Substores.metadata,
     (store) => MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, targetParent),
     'usePreferredChildrenForTarget targetElement',
+  )
+  const targetChildren = useEditorState(
+    Substores.metadata,
+    (store) => MetadataUtils.getChildrenUnordered(store.editor.jsxMetadata, target),
+    'usePreferredChildrenForTarget targetChildren',
   )
 
   const preferredChildren = useEditorState(
@@ -238,6 +271,7 @@ const usePreferredChildrenForTarget = (
         targetElement,
         insertionTarget,
         store.editor.propertyControlsInfo,
+        targetChildren,
       )
     },
     'usePreferredChildrenForSelectedElement propertyControlsInfo',
@@ -295,10 +329,15 @@ export const useCreateCallbackToShowComponentPicker =
               editorRef.current.jsxMetadata,
               targetParent,
             )
+            const targetChildren = MetadataUtils.getChildrenUnordered(
+              editorRef.current.jsxMetadata,
+              targetParent,
+            )
             const preferredChildren = preferredChildrenForTarget(
               targetElement,
               insertionTarget,
               editorRef.current.propertyControlsInfo,
+              targetChildren,
             )
 
             pickerType = preferredChildren.length > 0 ? 'preferred' : 'full'
@@ -683,20 +722,34 @@ const ComponentPickerContextMenuSimple = React.memo<ComponentPickerContextMenuPr
 
 const ComponentPickerContextMenuFull = React.memo<ComponentPickerContextMenuProps>(
   ({ target, insertionTarget }) => {
-    const allInsertableComponents = useGetInsertableComponents('insert').flatMap((g) => ({
-      label: g.label,
-      options: g.options.filter((o) => {
-        if (
-          isInsertAsChildTarget(insertionTarget) ||
-          isConditionalTarget(insertionTarget) ||
-          isReplaceTarget(insertionTarget)
-        ) {
-          return true
-        }
-        // Right now we only support inserting JSX elements when we insert into a render prop or when replacing elements
-        return o.value.element().type === 'JSX_ELEMENT'
-      }),
-    }))
+    const targetChildren = useEditorState(
+      Substores.metadata,
+      (store) => MetadataUtils.getChildrenUnordered(store.editor.jsxMetadata, target),
+      'usePreferredChildrenForTarget targetChildren',
+    )
+    const allInsertableComponents = useGetInsertableComponents('insert').flatMap((group) => {
+      return {
+        label: group.label,
+        options: group.options.filter((option) => {
+          if (
+            isInsertAsChildTarget(insertionTarget) ||
+            isConditionalTarget(insertionTarget) ||
+            isReplaceTarget(insertionTarget)
+          ) {
+            return true
+          }
+          if (isReplaceKeepChildrenAndStyleTarget(insertionTarget)) {
+            // If we want to keep the children of this element when it has some, don't include replacements that have children.
+            return (
+              targetChildren.length === 0 ||
+              !componentElementToInsertHasChildren(option.value.element())
+            )
+          }
+          // Right now we only support inserting JSX elements when we insert into a render prop or when replacing elements
+          return option.value.element().type === 'JSX_ELEMENT'
+        }),
+      }
+    })
 
     const dispatch = useDispatch()
 

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -465,6 +465,7 @@ const ComponentPickerComponentSection = React.memo(
                 onClick={onItemClick(component.value)}
                 onMouseOver={onItemHover(component.value)}
                 data-key={component.value.key}
+                data-testid={component.value.key}
               >
                 <FlexRow css={{ gap: 10, height: 28, alignItems: 'center' }}>
                   <Icn


### PR DESCRIPTION
**Problem:**
It's possible to define components which include their own children, but swapping a particular element with those will result in the original children of the element being lost.

**Fix:**
The main crux of this is just a check (in the two most appropriate places they appeared to apply) which checks if the following conditions hold:
- The element is being replaced, instead of fully swapped out.
- The current element has child elements..
- The new element also defines its own child elements.
If all of those conditions hold then the component definition is excluded from the listing.

**Commit Details:**
- Added `componentElementToInsertHasChildren` function.
- Adapted `preferredChildrenForTarget` to perform the filtering which removes components that wont preserve children.
- Added `getTargetParentFromInsertionTarget` function.
- Adapted `ComponentPickerContextMenuFull` component to perform the filtering which removes components that wont preserve children.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5650
