### PR TITLE
Restore react-router error handling

### DIFF
--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import { usePubSubAtomWriteOnly } from '../../core/shared/atom-with-pub-sub'
-import type { ErrorMessage } from '../../core/shared/error-messages'
 import { useErrorOverlayRecords } from '../../core/shared/runtime-report-logs'
-import { NO_OP, fastForEach } from '../../core/shared/utils'
+import { NO_OP } from '../../core/shared/utils'
 import { EditorCanvas } from '../../templates/editor-canvas'
 import CloseButton from '../../third-party/react-error-overlay/components/CloseButton'
 import ErrorOverlay from '../../third-party/react-error-overlay/components/ErrorOverlay'
@@ -19,29 +18,6 @@ import {
 import { Substores, useEditorState } from '../editor/store/store-hook'
 import { shouldShowErrorOverlay } from './canvas-utils'
 import { FloatingPostActionMenu } from './controls/select-mode/post-action-menu'
-
-export function filterOldPasses(errorMessages: Array<ErrorMessage>): Array<ErrorMessage> {
-  let passTimes: { [key: string]: number } = {}
-  fastForEach(errorMessages, (errorMessage) => {
-    if (errorMessage.passTime != null) {
-      if (errorMessage.source in passTimes) {
-        const existingPassCount = passTimes[errorMessage.source]
-        if (errorMessage.passTime > existingPassCount) {
-          passTimes[errorMessage.source] = errorMessage.passTime
-        }
-      } else {
-        passTimes[errorMessage.source] = errorMessage.passTime
-      }
-    }
-  })
-  return errorMessages.filter((errorMessage) => {
-    if (errorMessage.passTime == null) {
-      return true
-    } else {
-      return passTimes[errorMessage.source] === errorMessage.passTime
-    }
-  })
-}
 
 export const CanvasWrapperComponent = React.memo(() => {
   const dispatch = useDispatch()

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -90,6 +90,7 @@ import { matchRoutes } from 'react-router'
 import { useAtom } from 'jotai'
 import { RemixNavigationAtom } from './remix/utopia-remix-root-component'
 import { IS_TEST_ENVIRONMENT } from '../../common/env-vars'
+import { listenForReactRouterErrors } from '../../core/shared/runtime-report-logs'
 
 applyUIDMonkeyPatch()
 
@@ -290,6 +291,10 @@ export const UiJsxCanvas = React.memo<UiJsxCanvasPropsWithErrorCallback>((props)
   resolvedFileNames.current = [uiFilePath]
   let evaluatedFileNames = React.useRef<Array<string>>([]) // evaluated (i.e. not using a cached evaluation) this render
   evaluatedFileNames.current = [uiFilePath]
+
+  if (!IS_TEST_ENVIRONMENT) {
+    listenForReactRouterErrors(console)
+  }
 
   React.useEffect(() => {
     if (clearErrors != null) {

--- a/editor/src/core/shared/runtime-report-logs.tsx
+++ b/editor/src/core/shared/runtime-report-logs.tsx
@@ -155,7 +155,7 @@ export function useErrorOverlayRecords(): ErrorOverlayRecords {
   return { errorRecords, overlayErrors }
 }
 
-export function filterOldPasses(errorMessages: Array<ErrorMessage>): Array<ErrorMessage> {
+function filterOldPasses(errorMessages: Array<ErrorMessage>): Array<ErrorMessage> {
   let passTimes: { [key: string]: number } = {}
   fastForEach(errorMessages, (errorMessage) => {
     if (errorMessage.passTime != null) {


### PR DESCRIPTION
**Problem:**
#5676 removed some handling we put in place in #5084 specific for a couple of react-router errors that would cause issues with the canvas.

**Fix:**
Rather than resurrecting the console proxying code for the sake of this, I've narrowed the logic down to only operate on the `console.error` method. We then listen for those specific errors (checking the first arg of the function, which is what we were doing previously).

**Note:**
Unlike before, this will no longer immediately restore the canvas. Some form of action is required to restore the canvas, such as a manual save, or even scrolling the canvas (in the following video I wait a bit before scrolling the canvas to demonstrate this): 
https://github.com/concrete-utopia/utopia/assets/1044774/d92e3eba-4d7f-413a-b484-8c34228d0adf
I believe this is because with the previous console proxying we would have re-rendered the canvas after any log line due to the (horrible) way the proxying was wired in.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
