### PR TITLE
Update child nodes from cartouches

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -165,6 +165,18 @@ export interface ReplaceMappedElement {
   importsToAdd: Imports
 }
 
+export type ElementReplacementPath = {
+  type: 'replace-child-with-uid'
+  uid: string
+  replaceWith: JSXElementChild
+}
+
+export interface ReplaceElementInScope {
+  action: 'REPLACE_ELEMENT_IN_SCOPE'
+  target: ElementPath
+  replacementPath: ElementReplacementPath
+}
+
 export interface InsertAttributeOtherJavascriptIntoElement {
   action: 'INSERT_ATTRIBUTE_OTHER_JAVASCRIPT_INTO_ELEMENT'
   expression: JSExpressionOtherJavaScript
@@ -1175,6 +1187,7 @@ export type EditorAction =
   | ClearSelection
   | InsertJSXElement
   | ReplaceMappedElement
+  | ReplaceElementInScope
   | InsertAttributeOtherJavascriptIntoElement
   | DeleteSelected
   | DeleteView

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -236,6 +236,8 @@ import type {
   ReplaceTarget,
   InsertAsChildTarget,
   ReplaceKeepChildrenAndStyleTarget,
+  ReplaceElementInScope,
+  ElementReplacementPath,
 } from '../action-types'
 import type { InsertionSubjectWrapper, Mode } from '../editor-modes'
 import { EditorModes, insertionSubject } from '../editor-modes'
@@ -305,6 +307,17 @@ export function replaceMappedElement(
     jsxElement: element,
     target: target,
     importsToAdd: importsToAdd,
+  }
+}
+
+export function replaceElementInScope(
+  target: ElementPath,
+  replacementPath: ElementReplacementPath,
+): ReplaceElementInScope {
+  return {
+    action: 'REPLACE_ELEMENT_IN_SCOPE',
+    target: target,
+    replacementPath: replacementPath,
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -215,6 +215,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_IMPORTS_FROM_COLLABORATION_UPDATE':
     case 'UPDATE_CODE_FROM_COLLABORATION_UPDATE':
     case 'REPLACE_MAPPED_ELEMENT':
+    case 'REPLACE_ELEMENT_IN_SCOPE':
       return false
     case 'SAVE_ASSET':
       return (

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -343,6 +343,7 @@ import type {
   AddCollapsedViews,
   ReplaceMappedElement,
   UpdateMapExpression,
+  ReplaceElementInScope,
 } from '../action-types'
 import { isLoggedIn } from '../action-types'
 import type { Mode } from '../editor-modes'
@@ -2416,6 +2417,20 @@ export const UPDATE_FNS = {
       leftMenu: { visible: editor.leftMenu.visible, selectedTab: LeftMenuTab.Navigator },
       selectedViews: newSelectedViews,
     }
+  },
+  REPLACE_ELEMENT_IN_SCOPE: (action: ReplaceElementInScope, editor: EditorModel): EditorModel => {
+    return modifyUnderlyingTarget(action.target, editor, (element) => {
+      if (element.type !== 'JSX_ELEMENT' && element.type !== 'JSX_FRAGMENT') {
+        return element
+      }
+
+      return {
+        ...element,
+        children: element.children.map((c) =>
+          c.uid !== action.replacementPath.uid ? c : action.replacementPath.replaceWith,
+        ),
+      }
+    })
   },
   INSERT_ATTRIBUTE_OTHER_JAVASCRIPT_INTO_ELEMENT: (
     action: InsertAttributeOtherJavascriptIntoElement,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -191,7 +191,6 @@ import { emptyImports } from '../../../core/workers/common/project-file-utils'
 import type { CommentFilterMode } from '../../inspector/sections/comment-section'
 import type { Collaborator } from '../../../core/shared/multiplayer'
 import type { OnlineState } from '../online-status'
-import type { RenderedAt } from '../../inspector/sections/component-section/data-reference-cartouche'
 
 const ObjectPathImmutable: any = OPI
 
@@ -2172,6 +2171,29 @@ export function syntheticNavigatorEntry(
     elementPath: elementPath,
     childOrAttribute: childOrAttribute,
   }
+}
+
+interface RenderedAtPropertyPath {
+  type: 'element-property-path'
+  elementPropertyPath: ElementPropertyPath
+}
+
+interface RenderedAtChildNode {
+  type: 'child-node'
+  parentPath: ElementPath
+  nodeUid: string
+}
+
+export type RenderedAt = RenderedAtPropertyPath | RenderedAtChildNode
+
+export function renderedAtPropertyPath(
+  elementPropertyPath: ElementPropertyPath,
+): RenderedAtPropertyPath {
+  return { type: 'element-property-path', elementPropertyPath: elementPropertyPath }
+}
+
+export function renderedAtChildNode(parentPath: ElementPath, nodeUid: string): RenderedAtChildNode {
+  return { type: 'child-node', parentPath: parentPath, nodeUid: nodeUid }
 }
 
 export interface DataReferenceNavigatorEntry {

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -191,6 +191,7 @@ import { emptyImports } from '../../../core/workers/common/project-file-utils'
 import type { CommentFilterMode } from '../../inspector/sections/comment-section'
 import type { Collaborator } from '../../../core/shared/multiplayer'
 import type { OnlineState } from '../online-status'
+import type { RenderedAt } from '../../inspector/sections/component-section/data-reference-cartouche'
 
 const ObjectPathImmutable: any = OPI
 
@@ -2176,14 +2177,14 @@ export function syntheticNavigatorEntry(
 export interface DataReferenceNavigatorEntry {
   type: 'DATA_REFERENCE'
   elementPath: ElementPath
-  renderedAt: ElementPropertyPath | null
+  renderedAt: RenderedAt
   surroundingScope: ElementPath
   childOrAttribute: JSXElementChild
 }
 
 export function dataReferenceNavigatorEntry(
   elementPath: ElementPath,
-  renderedAt: ElementPropertyPath | null,
+  renderedAt: RenderedAt,
   surroundingScope: ElementPath,
   childOrAttribute: JSXElementChild,
 ): DataReferenceNavigatorEntry {

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -491,6 +491,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.SET_SHARING_DIALOG_OPEN(action, state)
     case 'REPLACE_MAPPED_ELEMENT':
       return UPDATE_FNS.REPLACE_MAPPED_ELEMENT(action, state)
+    case 'REPLACE_ELEMENT_IN_SCOPE':
+      return UPDATE_FNS.REPLACE_ELEMENT_IN_SCOPE(action, state)
     default:
       return state
   }

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -605,6 +605,11 @@ import type {
 } from '../../custom-code/internal-property-controls'
 import type { OnlineState } from '../online-status'
 import { onlineState } from '../online-status'
+import type { RenderedAt } from '../../inspector/sections/component-section/data-reference-cartouche'
+import {
+  renderedAtChildNode,
+  renderedAtPropertyPath,
+} from '../../inspector/sections/component-section/data-reference-cartouche'
 
 export function ElementPropertyPathKeepDeepEquality(): KeepDeepEqualityCall<ElementPropertyPath> {
   return combine2EqualityCalls(
@@ -705,7 +710,7 @@ export const DataReferenceNavigatorEntryKeepDeepEquality: KeepDeepEqualityCall<D
     (entry) => entry.elementPath,
     ElementPathKeepDeepEquality,
     (entry) => entry.renderedAt,
-    nullableDeepEquality(ElementPropertyPathKeepDeepEquality()),
+    createCallWithTripleEquals(), // TODO
     (entry) => entry.surroundingScope,
     ElementPathKeepDeepEquality,
     (entry) => entry.childOrAttribute,
@@ -750,6 +755,37 @@ export const SlotNavigatorEntryKeepDeepEquality: KeepDeepEqualityCall<SlotNaviga
     StringKeepDeepEquality,
     (elementPath, prop) => ({ type: 'SLOT', elementPath: elementPath, prop: prop }),
   )
+
+export const RenderedAtKeepDeepEquality: KeepDeepEqualityCall<RenderedAt> = (
+  oldValue,
+  newValue,
+) => {
+  switch (oldValue.type) {
+    case 'element-property-path':
+      if (oldValue.type === newValue.type) {
+        return combine1EqualityCall(
+          (r) => r.elementPropertyPath,
+          ElementPropertyPathKeepDeepEquality(),
+          renderedAtPropertyPath,
+        )(oldValue, newValue)
+      }
+      break
+    case 'child-node':
+      if (oldValue.type === newValue.type) {
+        return combine2EqualityCalls(
+          (r) => r.parentPath,
+          ElementPathKeepDeepEquality,
+          (r) => r.nodeUid,
+          StringKeepDeepEquality,
+          renderedAtChildNode,
+        )(oldValue, newValue)
+      }
+      break
+    default:
+      assertNever(oldValue)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
 
 export const NavigatorEntryKeepDeepEquality: KeepDeepEqualityCall<NavigatorEntry> = (
   oldValue,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -358,6 +358,7 @@ import type {
   DataReferenceNavigatorEntry,
   GithubUser,
   PullRequest,
+  RenderedAt,
 } from './editor-state'
 import {
   trueUpGroupElementChanged,
@@ -368,6 +369,8 @@ import {
   renderPropValueNavigatorEntry,
   dataReferenceNavigatorEntry,
   newGithubData,
+  renderedAtPropertyPath,
+  renderedAtChildNode,
 } from './editor-state'
 import {
   editorStateNodeModules,
@@ -605,11 +608,6 @@ import type {
 } from '../../custom-code/internal-property-controls'
 import type { OnlineState } from '../online-status'
 import { onlineState } from '../online-status'
-import type { RenderedAt } from '../../inspector/sections/component-section/data-reference-cartouche'
-import {
-  renderedAtChildNode,
-  renderedAtPropertyPath,
-} from '../../inspector/sections/component-section/data-reference-cartouche'
 
 export function ElementPropertyPathKeepDeepEquality(): KeepDeepEqualityCall<ElementPropertyPath> {
   return combine2EqualityCalls(
@@ -705,12 +703,43 @@ export const SyntheticNavigatorEntryKeepDeepEquality: KeepDeepEqualityCall<Synth
     syntheticNavigatorEntry,
   )
 
+export const RenderedAtKeepDeepEquality: KeepDeepEqualityCall<RenderedAt> = (
+  oldValue,
+  newValue,
+) => {
+  switch (oldValue.type) {
+    case 'element-property-path':
+      if (oldValue.type === newValue.type) {
+        return combine1EqualityCall(
+          (r) => r.elementPropertyPath,
+          ElementPropertyPathKeepDeepEquality(),
+          renderedAtPropertyPath,
+        )(oldValue, newValue)
+      }
+      break
+    case 'child-node':
+      if (oldValue.type === newValue.type) {
+        return combine2EqualityCalls(
+          (r) => r.parentPath,
+          ElementPathKeepDeepEquality,
+          (r) => r.nodeUid,
+          StringKeepDeepEquality,
+          renderedAtChildNode,
+        )(oldValue, newValue)
+      }
+      break
+    default:
+      assertNever(oldValue)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
 export const DataReferenceNavigatorEntryKeepDeepEquality: KeepDeepEqualityCall<DataReferenceNavigatorEntry> =
   combine4EqualityCalls(
     (entry) => entry.elementPath,
     ElementPathKeepDeepEquality,
     (entry) => entry.renderedAt,
-    createCallWithTripleEquals(), // TODO
+    RenderedAtKeepDeepEquality,
     (entry) => entry.surroundingScope,
     ElementPathKeepDeepEquality,
     (entry) => entry.childOrAttribute,
@@ -755,37 +784,6 @@ export const SlotNavigatorEntryKeepDeepEquality: KeepDeepEqualityCall<SlotNaviga
     StringKeepDeepEquality,
     (elementPath, prop) => ({ type: 'SLOT', elementPath: elementPath, prop: prop }),
   )
-
-export const RenderedAtKeepDeepEquality: KeepDeepEqualityCall<RenderedAt> = (
-  oldValue,
-  newValue,
-) => {
-  switch (oldValue.type) {
-    case 'element-property-path':
-      if (oldValue.type === newValue.type) {
-        return combine1EqualityCall(
-          (r) => r.elementPropertyPath,
-          ElementPropertyPathKeepDeepEquality(),
-          renderedAtPropertyPath,
-        )(oldValue, newValue)
-      }
-      break
-    case 'child-node':
-      if (oldValue.type === newValue.type) {
-        return combine2EqualityCalls(
-          (r) => r.parentPath,
-          ElementPathKeepDeepEquality,
-          (r) => r.nodeUid,
-          StringKeepDeepEquality,
-          renderedAtChildNode,
-        )(oldValue, newValue)
-      }
-      break
-    default:
-      assertNever(oldValue)
-  }
-  return keepDeepEqualityResult(newValue, false)
-}
 
 export const NavigatorEntryKeepDeepEquality: KeepDeepEqualityCall<NavigatorEntry> = (
   oldValue,

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -97,6 +97,7 @@ import { optionalMap } from '../../../../core/shared/optional-utils'
 import type { VariableData } from '../../../canvas/ui-jsx-canvas'
 import { array } from 'prop-types'
 import { useVariablesInScopeForSelectedElement } from './variables-in-scope-utils'
+import type { DataPickerType } from './data-picker-popup'
 import { DataPickerPopup, dataPickerForAProperty } from './data-picker-popup'
 import { jsxElementChildToText } from '../../../canvas/ui-jsx-canvas-renderer/jsx-element-child-to-text'
 import { foldEither } from '../../../../core/shared/either'
@@ -347,6 +348,7 @@ export function useDataPickerButton(
   propPath: PropertyPath,
   isScene: boolean,
   controlDescription: RegularControlDescription,
+  dataPickerType?: DataPickerType,
 ) {
   const [referenceElement, setReferenceElement] = React.useState<HTMLDivElement | null>(null)
   const [popperElement, setPopperElement] = React.useState<HTMLDivElement | null>(null)
@@ -384,8 +386,8 @@ export function useDataPickerButton(
   }, [propMetadata.attributeExpression])
 
   const pickerType = React.useMemo(() => {
-    return dataPickerForAProperty(selectedElement, propPath, propExpressionPath)
-  }, [propExpressionPath, propPath, selectedElement])
+    return dataPickerType ?? dataPickerForAProperty(selectedElement, propPath, propExpressionPath)
+  }, [dataPickerType, propExpressionPath, propPath, selectedElement])
 
   const DataPickerComponent = React.useMemo(
     () => (

--- a/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-popup.tsx
@@ -9,6 +9,7 @@ import type { ElementPath, PropertyPath } from '../../../../core/shared/project-
 import { useColorTheme, Button, FlexColumn, UtopiaStyles } from '../../../../uuiui'
 import {
   insertJSXElement,
+  replaceElementInScope,
   setProp_UNSAFE,
   updateMapExpression,
 } from '../../../editor/actions/action-creators'
@@ -152,13 +153,23 @@ export function dataPickerForAnElement(elementPath: ElementPath): DataPickerForA
   }
 }
 
-export type DataPickerType = DataPickerForAProperty | DataPickerForAMapExpressionValue
+export interface DataPickerForChildNode {
+  type: 'FOR_CHILD_NODE'
+  elementPath: ElementPath
+  childNodeUid: string
+}
+
+export type DataPickerType =
+  | DataPickerForAProperty
+  | DataPickerForAMapExpressionValue
+  | DataPickerForChildNode
 
 export function dataPickerIgnoreClass(pickerType: DataPickerType): string {
   switch (pickerType.type) {
     case 'FOR_A_PROPERTY':
       return `ignore-react-onclickoutside-data-picker-${PP.toString(pickerType.propPath)}`
     case 'FOR_A_MAP_EXPRESSION_VALUE':
+    case 'FOR_CHILD_NODE':
       return `ignore-react-onclickoutside-data-picker-${EP.toString(pickerType.elementPath)}`
     default:
       assertNever(pickerType)
@@ -253,6 +264,15 @@ export const DataPickerPopup = React.memo(
             break
           case 'FOR_A_MAP_EXPRESSION_VALUE':
             dispatch([updateMapExpression(props.pickerType.elementPath, expression)])
+            break
+          case 'FOR_CHILD_NODE':
+            dispatch([
+              replaceElementInScope(pickerType.elementPath, {
+                type: 'replace-child-with-uid',
+                uid: pickerType.childNodeUid,
+                replaceWith: expression,
+              }),
+            ])
             break
           default:
             assertNever(pickerType)

--- a/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
@@ -18,29 +18,7 @@ import { selectComponents } from '../../../editor/actions/meta-actions'
 import { when } from '../../../../utils/react-conditionals'
 import { traceDataFromElement } from '../../../../core/data-tracing/data-tracing'
 import type { DataPickerType } from './data-picker-popup'
-
-interface RenderedAtPropertyPath {
-  type: 'element-property-path'
-  elementPropertyPath: ElementPropertyPath
-}
-
-interface RenderedAtChildNode {
-  type: 'child-node'
-  parentPath: ElementPath
-  nodeUid: string
-}
-
-export type RenderedAt = RenderedAtPropertyPath | RenderedAtChildNode
-
-export function renderedAtPropertyPath(
-  elementPropertyPath: ElementPropertyPath,
-): RenderedAtPropertyPath {
-  return { type: 'element-property-path', elementPropertyPath: elementPropertyPath }
-}
-
-export function renderedAtChildNode(parentPath: ElementPath, nodeUid: string): RenderedAtChildNode {
-  return { type: 'child-node', parentPath: parentPath, nodeUid: nodeUid }
-}
+import type { RenderedAt } from '../../../editor/store/editor-state'
 
 interface DataReferenceCartoucheControlProps {
   elementPath: ElementPath

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -7,15 +7,12 @@ import type {
   JSXConditionalExpression,
 } from '../../core/shared/element-template'
 import {
-  emptyComments,
   getJSXAttribute,
   hasElementsWithin,
   isJSExpressionValue,
   isJSXConditionalExpression,
   isJSXElement,
   isJSXMapExpression,
-  jsExpressionOtherJavaScriptSimple,
-  jsExpressionValue,
 } from '../../core/shared/element-template'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { foldEither, isLeft, isRight } from '../../core/shared/either'
@@ -29,6 +26,8 @@ import {
   regularNavigatorEntry,
   renderPropNavigatorEntry,
   renderPropValueNavigatorEntry,
+  renderedAtChildNode,
+  renderedAtPropertyPath,
   slotNavigatorEntry,
   syntheticNavigatorEntry,
 } from '../editor/store/editor-state'
@@ -45,10 +44,6 @@ import type { PropertyControls } from '../custom-code/internal-property-controls
 import { isFeatureEnabled } from '../../utils/feature-switches'
 import * as PP from '../../core/shared/property-path'
 import * as EPP from '../template-property-path'
-import {
-  renderedAtChildNode,
-  renderedAtPropertyPath,
-} from '../inspector/sections/component-section/data-reference-cartouche'
 
 export function baseNavigatorDepth(path: ElementPath): number {
   // The storyboard means that this starts at -1,

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -45,6 +45,10 @@ import type { PropertyControls } from '../custom-code/internal-property-controls
 import { isFeatureEnabled } from '../../utils/feature-switches'
 import * as PP from '../../core/shared/property-path'
 import * as EPP from '../template-property-path'
+import {
+  renderedAtChildNode,
+  renderedAtPropertyPath,
+} from '../inspector/sections/component-section/data-reference-cartouche'
 
 export function baseNavigatorDepth(path: ElementPath): number {
   // The storyboard means that this starts at -1,
@@ -136,8 +140,8 @@ export function getNavigatorTargets(
           // add synthetic entry
           const dataRefEntry = dataReferenceNavigatorEntry(
             path,
-            null,
-            path, // TODO this should be pointing at the enclosing scope, but EP.parentPath(path) breaks if `path` is the root of a component
+            renderedAtChildNode(EP.parentPath(path), EP.toUid(path)),
+            EP.parentPath(path),
             elementFromProjectContents,
           )
           addNavigatorTargetsUnlessCollapsed(dataRefEntry)
@@ -216,7 +220,7 @@ export function getNavigatorTargets(
             const synthEntry = isFeatureEnabled('Data Entries in the Navigator')
               ? dataReferenceNavigatorEntry(
                   childPath,
-                  EPP.create(path, PP.create(prop)),
+                  renderedAtPropertyPath(EPP.create(path, PP.create(prop))),
                   path,
                   propValue,
                 )
@@ -352,7 +356,12 @@ export function getNavigatorTargets(
           const children = jsxElement.children
           children.forEach((child) => {
             const childPath = EP.appendToPath(path, child.uid)
-            const dataRefEntry = dataReferenceNavigatorEntry(childPath, null, path, child)
+            const dataRefEntry = dataReferenceNavigatorEntry(
+              childPath,
+              renderedAtChildNode(path, child.uid),
+              path,
+              child,
+            )
             addNavigatorTargetsUnlessCollapsed(dataRefEntry)
           })
         }


### PR DESCRIPTION
# [Try it here](https://utopia.fish/p/a0e7a39b-cookie-nova/?branch_name=feature-replace-child-node-only)

## Problem
https://github.com/concrete-utopia/utopia/issues/5690

## Fix
Create an action that makes it possible to update child nodes on a node-by-node basis.

https://screenshot.click/16-30-dnbig-i1h8a.mp4

### Commit Details

- Added the `ReplaceElementInScope` action. This action takes a "replacement path" and uses that to actually perform the replace operation. Additional replacement paths will be added for setting the variables in properties or setting the left hand side of map expressions (see https://github.com/concrete-utopia/utopia/issues/5684 for details)
- A new data picker type (`DataPickerForChildNode`) is added as a stopgap measure until `ReplaceElementInScope` isn't powerful enough to handle to express all the data picker modes
- `RenderedAt` in `DataReferenceCartoucheControl` and `DataReferenceNavigatorEntry` is added as an explicit type, to specify where the cartouche is rendered. This might not be 100% correct when referring to the left hand sides of map expressions, dealing with that case is deferred to a follow-up PR

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
