### PR TITLE
List Source Checks Data Source.

### DIFF
--- a/editor/src/components/inspector/sections/layout-section/list-source-cartouche.tsx
+++ b/editor/src/components/inspector/sections/layout-section/list-source-cartouche.tsx
@@ -10,6 +10,7 @@ import {
   getTextContentOfElement,
 } from '../component-section/data-reference-cartouche'
 import { mapExpressionValueToMapSelector, useDataPickerButtonListSource } from './list-section'
+import { traceDataFromElement } from '../../../../core/data-tracing/data-tracing'
 
 interface MapListSourceCartoucheProps {
   target: ElementPath
@@ -48,6 +49,28 @@ export const MapListSourceCartouche = React.memo((props: MapListSourceCartoucheP
     }
   }, [openOn, openPopup])
 
+  const isDataComingFromHookResult = useEditorState(
+    Substores.projectContentsAndMetadata,
+    (store) => {
+      if (
+        originalMapExpression === 'multiselect' ||
+        originalMapExpression === 'not-a-mapexpression'
+      ) {
+        return false
+      } else {
+        const traceDataResult = traceDataFromElement(
+          originalMapExpression.valueToMap,
+          target,
+          store.editor.jsxMetadata,
+          store.editor.projectContents,
+          [],
+        )
+        return traceDataResult.type === 'hook-result'
+      }
+    },
+    'ListSection isDataComingFromHookResult',
+  )
+
   if (originalMapExpression === 'multiselect' || originalMapExpression === 'not-a-mapexpression') {
     return null
   }
@@ -77,7 +100,7 @@ export const MapListSourceCartouche = React.memo((props: MapListSourceCartoucheP
         inverted={props.inverted}
         safeToDelete={false}
         testId='list-source-cartouche'
-        contentIsComingFromServer={false}
+        contentIsComingFromServer={isDataComingFromHookResult}
       />
     </div>
   )


### PR DESCRIPTION
**Problem:**
The cartouche for lists (mapped values) should indicate if the mapped value originates from a server similar to how other property cartouches do.

**Fix:**
This pretty much copies 1 for 1 the code that calls `traceDataFromElement` into `MapListSourceCartouche`.

**Commit Details:**
- `MapListSourceCartouche` now invokes `traceDataFromElement` from which
  the property `contentIsComingFromServer` is then calculated.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5693