### PR TITLE
More flexible path mappings lookup.

### DIFF
--- a/editor/src/core/model/project-file-utils.spec.ts
+++ b/editor/src/core/model/project-file-utils.spec.ts
@@ -1,0 +1,97 @@
+import { addFileToProjectContents } from '../../components/assets'
+import { codeFile } from '../shared/project-file-types'
+import { getFilePathMappings } from './project-file-utils'
+
+const regularConfigFile = `{
+  "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "module": "ES2022",
+    "target": "ES2022",
+    "strict": true,
+    "allowJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@thing/*": ["app/components/thing/*"],
+      "~/*": ["app/*"]
+    },
+    "noEmit": true
+  },
+  "include": ["./**/*.d.ts", "./**/*.js", "./**/*.jsx"]
+}`
+
+const configFileWithComments = `{
+  // "compilerOptions": {
+  //   "checkJs": false,
+  //   "target": "ES2022",
+  //   "module": "ES2022",
+  //   "moduleResolution": "Bundler",
+  //   "baseUrl": ".",
+  //   "paths": {
+  //     "@thing/*": ["app/components/thing/*"],
+  //     "~/*": ["app/*"]
+  //   }
+  // },
+  "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "module": "ES2022",
+    "target": "ES2022",
+    "strict": true,
+    "allowJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@thing/*": ["app/components/thing/*"],
+      "~/*": ["app/*"]
+    },
+    "noEmit": true
+  },
+  "include": ["./**/*.d.ts", "./**/*.js", "./**/*.jsx"]
+}`
+
+const expectedResult: Array<[RegExp, Array<string>]> = [
+  [/@thing\/([^/]*)/y, [`/app/components/thing/$1`]],
+  [/~\/([^/]*)/y, [`/app/$1`]],
+]
+
+describe('getFilePathMappings', () => {
+  it('loads from jsconfig.json', () => {
+    const projectContents = addFileToProjectContents(
+      {},
+      'jsconfig.json',
+      codeFile(regularConfigFile, null),
+    )
+    const mappings = getFilePathMappings(projectContents)
+    expect(mappings).toEqual(expectedResult)
+  })
+  it('loads from tsconfig.json', () => {
+    const projectContents = addFileToProjectContents(
+      {},
+      'tsconfig.json',
+      codeFile(regularConfigFile, null),
+    )
+    const mappings = getFilePathMappings(projectContents)
+    expect(mappings).toEqual(expectedResult)
+  })
+  it('handles files with comments in them', () => {
+    const projectContents = addFileToProjectContents(
+      {},
+      'jsconfig.json',
+      codeFile(configFileWithComments, null),
+    )
+    const mappings = getFilePathMappings(projectContents)
+    expect(mappings).toEqual(expectedResult)
+  })
+})

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -78,6 +78,7 @@ import { filenameFromParts, getFilenameParts } from '../../components/images'
 import globToRegexp from 'glob-to-regexp'
 import { is } from '../shared/equality-utils'
 import { absolutePathFromRelativePath } from '../../utils/path-utils'
+import json5 from 'json5'
 
 export const sceneMetadata = _sceneMetadata // This is a hotfix for a circular dependency AND a leaking of utopia-api into the workers
 
@@ -952,6 +953,10 @@ function getFilePathMappingsImpl(projectContents: ProjectContentTreeRoot): FileP
   if (jsConfigFile != null && isTextFile(jsConfigFile)) {
     return getFilePathMappingsFromConfigFile(jsConfigFile)
   }
+  const tsConfigFile = getProjectFileByFilePath(projectContents, 'tsconfig.json')
+  if (tsConfigFile != null && isTextFile(tsConfigFile)) {
+    return getFilePathMappingsFromConfigFile(tsConfigFile)
+  }
 
   return []
 }
@@ -963,7 +968,7 @@ const getFilePathMappingsFromConfigFile = memoize(getFilePathMappingsFromConfigF
 
 function getFilePathMappingsFromConfigFileImpl(configFile: TextFile): FilePathMappings {
   try {
-    const parsedJSON = JSON.parse(configFile.fileContents.code)
+    const parsedJSON = json5.parse(configFile.fileContents.code)
     if (typeof parsedJSON === 'object') {
       const compilerOptions = propOrNull('compilerOptions', parsedJSON)
       const paths = propOrNull('paths', compilerOptions)
@@ -996,7 +1001,7 @@ function getFilePathMappingsFromConfigFileImpl(configFile: TextFile): FilePathMa
       }
     }
   } catch (e) {
-    // Do nothing
+    console.error('Error parsing file path mappings.', e)
   }
 
   return []


### PR DESCRIPTION
**Problem:**
From the sample store code mentioned in #5698, some path mappings were not handled it would appear.

**Cause:**
With the project as it was at the point this issue was logged, the two issues were:
- We only load `jsconfig.json`, but the mappings were in `tsconfig.json`.
- The `tsconfig.json` file had comments in it, which ordinarily are not valid in JSON.

**Fix:**
The fixes for the above issues were respectively:
- Fallback to `tsconfig.json` if `jsconfig.json` doesn't exist.
- Use the json5 parser so that comments in the file are ignored (albeit that's not actually valid JSON).

**Commit Details:**
- Use `json5` parse so that the code can still be parsed even if it contains comments.
- Check for the existence of both `tsconfig.json` as well as `jsconfig.json`.
- Log the error to the console if anything is wrong with the lookup.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5698
