### PR TITLE
Scope editor css to only affect the editor

### DIFF
--- a/editor/resources/editor/css/ReactContexify.css
+++ b/editor/resources/editor/css/ReactContexify.css
@@ -1,200 +1,202 @@
-.react-contexify {
-  z-index: 99999;
-  position: fixed;
-  opacity: 0;
-  user-select: none;
-  border-radius: 10px;
-  background-color: var(--utopitheme-contextMenuBackground);
-  box-sizing: border-box;
-  /* the same as boxShadow: UtopiaStyles.shadowStyles.mid.boxShadow */
-  box-shadow: 0px 3px 6px -2px var(--utopitheme-shadow80),
-    0px 4px 8px -2px var(--utopitheme-shadow40);
-  padding: 8px 0px;
-  font-family: 'utopian-inter';
-}
-.react-contexify .react-contexify__submenu {
-  position: absolute;
-  /* negate padding */
-  top: -4px;
-  pointer-events: none;
-  transition: opacity 0.275s;
-}
-
-.react-contexify__submenu-arrow {
-  font-size: 10px;
-  position: absolute;
-  right: 6px;
-  line-height: 12px;
-}
-
-.react-contexify__separator {
-  width: 100%;
-  height: 1px;
-  cursor: default;
-  padding: 0px;
-  background-color: var(--utopitheme-contextMenuSeparator);
-}
-
-/* this contains dividers, too - so not giving it a height */
-.react-contexify__item {
-  cursor: default;
-  position: relative;
-  margin-left: 8px;
-  margin-right: 8px;
-  color: var(--utopitheme-contextMenuForeground);
-}
-.react-contexify__item:not(.react-contexify__item--disabled):hover {
-  color: var(--utopitheme-contextMenuHighlightForeground);
-  background-color: var(--utopitheme-contextMenuHighlightBackground);
-  border-radius: 2px;
-}
-.react-contexify__item:not(.react-contexify__item--disabled):hover > .react-contexify__submenu {
-  pointer-events: initial;
-  opacity: 1;
-}
-.react-contexify__item--disabled {
-  cursor: default;
-  opacity: 0.67;
-}
-.react-contexify__item__content {
-  min-width: 190px;
-  width: 100%;
-  padding-left: 8px;
-  padding-right: 8px;
-  display: flex;
-  align-items: center;
-  text-align: left;
-  white-space: nowrap;
-}
-
-.react-contexify__item__icon {
-  font-size: inherit;
-  margin-right: 6px;
-}
-
-@keyframes react-contexify__scaleIn {
-  from {
+@scope (:root) to (#canvas-container) {
+  .react-contexify {
+    z-index: 99999;
+    position: fixed;
     opacity: 0;
-    transform: scale3d(0.3, 0.3, 0.3);
+    user-select: none;
+    border-radius: 10px;
+    background-color: var(--utopitheme-contextMenuBackground);
+    box-sizing: border-box;
+    /* the same as boxShadow: UtopiaStyles.shadowStyles.mid.boxShadow */
+    box-shadow: 0px 3px 6px -2px var(--utopitheme-shadow80),
+      0px 4px 8px -2px var(--utopitheme-shadow40);
+    padding: 8px 0px;
+    font-family: 'utopian-inter';
   }
-  to {
+  .react-contexify .react-contexify__submenu {
+    position: absolute;
+    /* negate padding */
+    top: -4px;
+    pointer-events: none;
+    transition: opacity 0.275s;
+  }
+
+  .react-contexify__submenu-arrow {
+    font-size: 10px;
+    position: absolute;
+    right: 6px;
+    line-height: 12px;
+  }
+
+  .react-contexify__separator {
+    width: 100%;
+    height: 1px;
+    cursor: default;
+    padding: 0px;
+    background-color: var(--utopitheme-contextMenuSeparator);
+  }
+
+  /* this contains dividers, too - so not giving it a height */
+  .react-contexify__item {
+    cursor: default;
+    position: relative;
+    margin-left: 8px;
+    margin-right: 8px;
+    color: var(--utopitheme-contextMenuForeground);
+  }
+  .react-contexify__item:not(.react-contexify__item--disabled):hover {
+    color: var(--utopitheme-contextMenuHighlightForeground);
+    background-color: var(--utopitheme-contextMenuHighlightBackground);
+    border-radius: 2px;
+  }
+  .react-contexify__item:not(.react-contexify__item--disabled):hover > .react-contexify__submenu {
+    pointer-events: initial;
     opacity: 1;
   }
-}
-@keyframes react-contexify__scaleOut {
-  from {
-    opacity: 1;
+  .react-contexify__item--disabled {
+    cursor: default;
+    opacity: 0.67;
   }
-  to {
-    opacity: 0;
-    transform: scale3d(0.3, 0.3, 0.3);
+  .react-contexify__item__content {
+    min-width: 190px;
+    width: 100%;
+    padding-left: 8px;
+    padding-right: 8px;
+    display: flex;
+    align-items: center;
+    text-align: left;
+    white-space: nowrap;
   }
-}
-.react-contexify__will-enter--scale {
-  transform-origin: top left;
-  animation: react-contexify__scaleIn 0.3s;
-}
 
-.react-contexify__will-leave--scale {
-  transform-origin: top left;
-  animation: react-contexify__scaleOut 0.3s;
-}
+  .react-contexify__item__icon {
+    font-size: inherit;
+    margin-right: 6px;
+  }
 
-@keyframes react-contexify__fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
+  @keyframes react-contexify__scaleIn {
+    from {
+      opacity: 0;
+      transform: scale3d(0.3, 0.3, 0.3);
+    }
+    to {
+      opacity: 1;
+    }
   }
-  to {
-    opacity: 1;
-    transform: translateY(0);
+  @keyframes react-contexify__scaleOut {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+      transform: scale3d(0.3, 0.3, 0.3);
+    }
   }
-}
-@keyframes react-contexify__fadeOut {
-  from {
-    opacity: 1;
-    transform: translateY(0);
+  .react-contexify__will-enter--scale {
+    transform-origin: top left;
+    animation: react-contexify__scaleIn 0.3s;
   }
-  to {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-}
-.react-contexify__will-enter--fade {
-  animation: react-contexify__fadeIn 0.3s ease;
-}
 
-.react-contexify__will-leave--fade {
-  animation: react-contexify__fadeOut 0.3s ease;
-}
+  .react-contexify__will-leave--scale {
+    transform-origin: top left;
+    animation: react-contexify__scaleOut 0.3s;
+  }
 
-@keyframes react-contexify__flipInX {
-  from {
-    transform: perspective(800px) rotate3d(1, 0, 0, 45deg);
+  @keyframes react-contexify__fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
-  to {
-    transform: perspective(800px);
+  @keyframes react-contexify__fadeOut {
+    from {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    to {
+      opacity: 0;
+      transform: translateY(10px);
+    }
   }
-}
-@keyframes react-contexify__flipOutX {
-  from {
-    transform: perspective(800px);
+  .react-contexify__will-enter--fade {
+    animation: react-contexify__fadeIn 0.3s ease;
   }
-  to {
-    transform: perspective(800px) rotate3d(1, 0, 0, 45deg);
-    opacity: 0;
-  }
-}
-.react-contexify__will-enter--flip {
-  -webkit-backface-visibility: visible !important;
-  backface-visibility: visible !important;
-  transform-origin: top center;
-  animation: react-contexify__flipInX 0.3s;
-}
 
-.react-contexify__will-leave--flip {
-  transform-origin: top center;
-  animation: react-contexify__flipOutX 0.3s;
-  -webkit-backface-visibility: visible !important;
-  backface-visibility: visible !important;
-}
+  .react-contexify__will-leave--fade {
+    animation: react-contexify__fadeOut 0.3s ease;
+  }
 
-@keyframes swing-in-top-fwd {
-  0% {
-    transform: rotateX(-100deg);
-    transform-origin: top;
-    opacity: 0;
+  @keyframes react-contexify__flipInX {
+    from {
+      transform: perspective(800px) rotate3d(1, 0, 0, 45deg);
+    }
+    to {
+      transform: perspective(800px);
+    }
   }
-  100% {
-    transform: rotateX(0deg);
-    transform-origin: top;
-    opacity: 1;
+  @keyframes react-contexify__flipOutX {
+    from {
+      transform: perspective(800px);
+    }
+    to {
+      transform: perspective(800px) rotate3d(1, 0, 0, 45deg);
+      opacity: 0;
+    }
   }
-}
-@keyframes react-contexify__slideIn {
-  from {
-    opacity: 0;
-    transform: scale3d(1, 0.3, 1);
+  .react-contexify__will-enter--flip {
+    -webkit-backface-visibility: visible !important;
+    backface-visibility: visible !important;
+    transform-origin: top center;
+    animation: react-contexify__flipInX 0.3s;
   }
-  to {
-    opacity: 1;
-  }
-}
-@keyframes react-contexify__slideOut {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-    transform: scale3d(1, 0.3, 1);
-  }
-}
-.react-contexify__will-enter--slide {
-  transform-origin: top center;
-  animation: react-contexify__slideIn 0.3s;
-}
 
-.react-contexify__will-leave--slide {
-  transform-origin: top center;
-  animation: react-contexify__slideOut 0.3s;
+  .react-contexify__will-leave--flip {
+    transform-origin: top center;
+    animation: react-contexify__flipOutX 0.3s;
+    -webkit-backface-visibility: visible !important;
+    backface-visibility: visible !important;
+  }
+
+  @keyframes swing-in-top-fwd {
+    0% {
+      transform: rotateX(-100deg);
+      transform-origin: top;
+      opacity: 0;
+    }
+    100% {
+      transform: rotateX(0deg);
+      transform-origin: top;
+      opacity: 1;
+    }
+  }
+  @keyframes react-contexify__slideIn {
+    from {
+      opacity: 0;
+      transform: scale3d(1, 0.3, 1);
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  @keyframes react-contexify__slideOut {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+      transform: scale3d(1, 0.3, 1);
+    }
+  }
+  .react-contexify__will-enter--slide {
+    transform-origin: top center;
+    animation: react-contexify__slideIn 0.3s;
+  }
+
+  .react-contexify__will-leave--slide {
+    transform-origin: top center;
+    animation: react-contexify__slideOut 0.3s;
+  }
 }

--- a/editor/resources/editor/css/canvas.css
+++ b/editor/resources/editor/css/canvas.css
@@ -1,26 +1,28 @@
-.canvas-text.canvas-text-editable,
-.canvas-text.canvas-text-editable * {
-  user-select: text;
-  -webkit-user-select: text !important;
-  cursor: text;
-}
+@scope (:root) to (#canvas-container) {
+  .canvas-text.canvas-text-editable,
+  .canvas-text.canvas-text-editable * {
+    user-select: text;
+    -webkit-user-select: text !important;
+    cursor: text;
+  }
 
-.scene {
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
-  /* please leave this in */
-}
+  .scene {
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
+    /* please leave this in */
+  }
 
-svg {
-  overflow: visible;
-}
+  svg {
+    overflow: visible;
+  }
 
-/* this is the control outline for ALL selection */
-.highlight-outline {
-  fill: none;
-  stroke: var(--emphasis-color-luminous);
-}
+  /* this is the control outline for ALL selection */
+  .highlight-outline {
+    fill: none;
+    stroke: var(--emphasis-color-luminous);
+  }
 
-.highlight-outline-link {
-  fill: none;
-  stroke: #574be2;
+  .highlight-outline-link {
+    fill: none;
+    stroke: #574be2;
+  }
 }

--- a/editor/resources/editor/css/initial-load.css
+++ b/editor/resources/editor/css/initial-load.css
@@ -1,62 +1,5 @@
-@font-face {
-  font-family: 'utopian-inter';
-  src: url('../fonts/Inter-Regular.woff2') format('woff');
-  font-weight: 400;
-}
-
-@font-face {
-  font-family: 'utopian-inter';
-  src: url('../fonts/Inter-Italic.woff2') format('woff');
-  font-weight: 400;
-  font-style: italic;
-}
-
-@font-face {
-  font-family: 'utopian-inter';
-  src: url('../fonts/Inter-Medium.woff2') format('woff');
-  font-weight: 500;
-}
-
-@font-face {
-  font-family: 'utopian-inter';
-  src: url('../fonts/Inter-MediumItalic.woff2') format('woff');
-  font-weight: 500;
-  font-style: italic;
-}
-
-@font-face {
-  font-family: 'utopian-inter';
-  src: url('../fonts/Inter-SemiBold.woff2') format('woff');
-  font-weight: 600;
-}
-
-@font-face {
-  font-family: 'utopian-inter';
-  src: url('../fonts/Inter-SemiBoldItalic.woff2') format('woff');
-  font-weight: 600;
-  font-style: italic;
-}
-
-* {
-  scrollbar-width: none;
-}
-
 body {
   margin: 0;
-  background-color: transparent;
-  font-family: 'utopian-inter', 'sans-serif';
-  font-size: 11px !important;
-  font-feature-settings: 'cv01', 'tnum', 'zero';
-  letter-spacing: 0.2px;
-  line-height: 17px;
-  overflow: hidden;
-  outline: none;
-  overscroll-behavior-x: contain;
-}
-
-a {
-  text-decoration: none;
-  color: #007aff;
 }
 
 div,
@@ -65,39 +8,111 @@ img,
 ul,
 li,
 label {
-  user-select: none;
-  -webkit-user-select: none;
   box-sizing: border-box !important;
 }
 
-.react-error-overlay-allow-text-selection,
-.react-error-overlay-allow-text-selection,
-.react-error-overlay-allow-text-selection span,
-.react-error-overlay-allow-text-selection div,
-.react-error-overlay-allow-text-selection pre {
-  user-select: text;
-  cursor: text;
-}
+@scope (:root) to (#canvas-container) {
+  @font-face {
+    font-family: 'utopian-inter';
+    src: url('../fonts/Inter-Regular.woff2') format('woff');
+    font-weight: 400;
+  }
 
-input {
-  box-sizing: border-box;
-  outline: none;
-  font-family: utopian-inter;
-  font-size: 11px;
-  font-feature-settings: 'cv01', 'tnum', 'salt', 'zero';
-}
+  @font-face {
+    font-family: 'utopian-inter';
+    src: url('../fonts/Inter-Italic.woff2') format('woff');
+    font-weight: 400;
+    font-style: italic;
+  }
 
-span:focus,
-div:focus,
-label:focus,
-button:focus,
-input:focus,
-img:focus,
-svg:focus {
-  outline: none;
-}
+  @font-face {
+    font-family: 'utopian-inter';
+    src: url('../fonts/Inter-Medium.woff2') format('woff');
+    font-weight: 500;
+  }
 
-/* todo put this near the contexify CSS after figuring out where _that_ lives */
-.shortcut {
-  float: right;
+  @font-face {
+    font-family: 'utopian-inter';
+    src: url('../fonts/Inter-MediumItalic.woff2') format('woff');
+    font-weight: 500;
+    font-style: italic;
+  }
+
+  @font-face {
+    font-family: 'utopian-inter';
+    src: url('../fonts/Inter-SemiBold.woff2') format('woff');
+    font-weight: 600;
+  }
+
+  @font-face {
+    font-family: 'utopian-inter';
+    src: url('../fonts/Inter-SemiBoldItalic.woff2') format('woff');
+    font-weight: 600;
+    font-style: italic;
+  }
+
+  * {
+    scrollbar-width: none;
+  }
+
+  body {
+    margin: 0;
+    background-color: transparent;
+    font-family: 'utopian-inter', 'sans-serif';
+    font-size: 11px !important;
+    font-feature-settings: 'cv01', 'tnum', 'zero';
+    letter-spacing: 0.2px;
+    line-height: 17px;
+    overflow: hidden;
+    outline: none;
+    overscroll-behavior-x: contain;
+  }
+
+  a {
+    text-decoration: none;
+    color: #007aff;
+  }
+
+  div,
+  span,
+  img,
+  ul,
+  li,
+  label {
+    user-select: none;
+    -webkit-user-select: none;
+    box-sizing: border-box !important;
+  }
+
+  .react-error-overlay-allow-text-selection,
+  .react-error-overlay-allow-text-selection,
+  .react-error-overlay-allow-text-selection span,
+  .react-error-overlay-allow-text-selection div,
+  .react-error-overlay-allow-text-selection pre {
+    user-select: text;
+    cursor: text;
+  }
+
+  input {
+    box-sizing: border-box;
+    outline: none;
+    font-family: utopian-inter;
+    font-size: 11px;
+    font-feature-settings: 'cv01', 'tnum', 'salt', 'zero';
+  }
+
+  span:focus,
+  div:focus,
+  label:focus,
+  button:focus,
+  input:focus,
+  img:focus,
+  svg:focus {
+    outline: none;
+  }
+
+  /* todo put this near the contexify CSS after figuring out where _that_ lives */
+  .shortcut {
+    float: right;
+  }
 }

--- a/editor/resources/editor/css/vscode-overrides.css
+++ b/editor/resources/editor/css/vscode-overrides.css
@@ -1,4 +1,5 @@
-/* Notes: 
+@scope (:root) to (#canvas-container) {
+  /* Notes: 
   1) this file gets loaded after VSCode's CSS. If you use the same specificity in your 
     selectors, you'll be able to override them
   2) Beware that VSCode also sets a number of styles are set inline - 
@@ -10,69 +11,76 @@
      (vscode-editor-loading-screen.tsx)
 */
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title {
-  background-color: transparent !important;
-}
+  .monaco-workbench .part.editor > .content .editor-group-container > .title {
+    background-color: transparent !important;
+  }
 
-/* Tab styles */
-.tab {
-  font-weight: 500;
-  font-family: sans-serif;
-  border-right: none !important;
-  background-color: transparent !important;
-}
+  /* Tab styles */
+  .tab {
+    font-weight: 500;
+    font-family: sans-serif;
+    border-right: none !important;
+    background-color: transparent !important;
+  }
 
-.tab[aria-selected='true'] {
-  background-color: transparent !important;
-}
+  .tab[aria-selected='true'] {
+    background-color: transparent !important;
+  }
 
-.tab[aria-selected='false'] {
-  opacity: 0.7;
-}
+  .tab[aria-selected='false'] {
+    opacity: 0.7;
+  }
 
-.tab[aria-selected='false']:hover {
-  opacity: 1;
-}
+  .tab[aria-selected='false']:hover {
+    opacity: 1;
+  }
 
-.monaco-workbench
-  .part.editor
-  > .content
-  .editor-group-container
-  > .title
-  .tabs-container
-  > .tab
-  .tab-label
-  a,
-.monaco-workbench .part.editor > .content .editor-group-container > .title .title-label a {
-  font-size: 11px;
-  font-weight: 500;
-}
+  .monaco-workbench
+    .part.editor
+    > .content
+    .editor-group-container
+    > .title
+    .tabs-container
+    > .tab
+    .tab-label
+    a,
+  .monaco-workbench .part.editor > .content .editor-group-container > .title .title-label a {
+    font-size: 11px;
+    font-weight: 500;
+  }
 
-/* smaller 'edited / close'  marker, to match Utopia house style */
-.monaco-menu-container {
-  transform: scale(0.8);
-}
+  /* smaller 'edited / close'  marker, to match Utopia house style */
+  .monaco-menu-container {
+    transform: scale(0.8);
+  }
 
-/* Tab bar heights */
-.monaco-workbench
-  .part.editor
-  > .content
-  .editor-group-container
-  > .title
-  .tabs-container
-  > .tab
-  .tab-label {
-  line-height: 34px;
-}
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab {
-  height: 34px;
-}
+  /* Tab bar heights */
+  .monaco-workbench
+    .part.editor
+    > .content
+    .editor-group-container
+    > .title
+    .tabs-container
+    > .tab
+    .tab-label {
+    line-height: 34px;
+  }
+  .monaco-workbench
+    .part.editor
+    > .content
+    .editor-group-container
+    > .title
+    .tabs-container
+    > .tab {
+    height: 34px;
+  }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions {
-  height: 34px;
-}
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container {
-  background: transparent;
-  gap: 8px;
-  height: 34px;
+  .monaco-workbench .part.editor > .content .editor-group-container > .title .editor-actions {
+    height: 34px;
+  }
+  .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container {
+    background: transparent;
+    gap: 8px;
+    height: 34px;
+  }
 }

--- a/editor/src/templates/index.html
+++ b/editor/src/templates/index.html
@@ -30,80 +30,86 @@
     <style>
       body {
         margin: 0;
-        font-size: 11px !important;
-        overflow: hidden;
-        cursor: default;
-        outline: none;
-        overscroll-behavior-x: contain;
-        --loadscreen-accent: rgba(46, 255, 109, 0.5);
       }
 
-      @keyframes animation-keyframes {
-        from {
-          transform: translateX(-212px);
-        }
-        to {
-          transform: translateX(0px);
-        }
-      }
-
-      @keyframes animate-pyramid {
-        0% {
-          transform: translateY(10px);
-        }
-        100% {
-          transform: translateY(-10px);
-        }
-      }
-
-      .animation-progress {
-        animation-name: animation-keyframes;
-        animation-duration: 10s;
-        animation-iteration-count: infinite;
-        animation-direction: alternate;
-      }
-
-      .utopia-logo-pyramid {
-        animation-name: animate-pyramid;
-        animation-duration: 1.5s;
-        animation-iteration-count: infinite;
-        animation-direction: alternate;
-        animation-timing-function: ease-in-out;
-      }
-
-      .progress-bar-shell {
-        border: 1px solid black;
-      }
-
-      .progress-bar-progress {
-        background-color: black;
-      }
-
-      .utopia-logo-pyramid.light {
-        display: block;
-      }
-      .utopia-logo-pyramid.dark {
-        display: none;
-      }
-
-      @media (prefers-color-scheme: dark) {
+      @scope (:root) to (#canvas-container) {
         body {
-          background-color: #1a1a1a;
+          margin: 0;
+          font-size: 11px !important;
+          overflow: hidden;
+          cursor: default;
+          outline: none;
+          overscroll-behavior-x: contain;
+          --loadscreen-accent: rgba(46, 255, 109, 0.5);
+        }
+
+        @keyframes animation-keyframes {
+          from {
+            transform: translateX(-212px);
+          }
+          to {
+            transform: translateX(0px);
+          }
+        }
+
+        @keyframes animate-pyramid {
+          0% {
+            transform: translateY(10px);
+          }
+          100% {
+            transform: translateY(-10px);
+          }
+        }
+
+        .animation-progress {
+          animation-name: animation-keyframes;
+          animation-duration: 10s;
+          animation-iteration-count: infinite;
+          animation-direction: alternate;
+        }
+
+        .utopia-logo-pyramid {
+          animation-name: animate-pyramid;
+          animation-duration: 1.5s;
+          animation-iteration-count: infinite;
+          animation-direction: alternate;
+          animation-timing-function: ease-in-out;
         }
 
         .progress-bar-shell {
-          border: 1px solid white;
+          border: 1px solid black;
         }
 
         .progress-bar-progress {
-          background-color: white;
+          background-color: black;
         }
 
         .utopia-logo-pyramid.light {
-          display: none;
+          display: block;
         }
         .utopia-logo-pyramid.dark {
-          display: block;
+          display: none;
+        }
+
+        @media (prefers-color-scheme: dark) {
+          body {
+            background-color: #1a1a1a;
+          }
+
+          .progress-bar-shell {
+            border: 1px solid white;
+          }
+
+          .progress-bar-progress {
+            background-color: white;
+          }
+
+          .utopia-logo-pyramid.light {
+            display: none;
+          }
+          .utopia-logo-pyramid.dark {
+            display: block;
+          }
         }
       }
     </style>


### PR DESCRIPTION
**Problem:**
Editor CSS is leaking into the user projects.

**Fix:**
By wrapping all editor CSS in `@scope` rules that define upper and lower bounds, we can create what's referred to as a "donut scope" which can be applied to everything but the Canvas Container (https://developer.mozilla.org/en-US/docs/Web/CSS/@scope#scope_roots_and_scope_limits).

It's best to view this diff with whitespace hidden.

Part of #5697 