### PR TITLE
Insert React Import For Modules

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -132,6 +132,7 @@
   },
   "dependencies": {
     "@babel/code-frame": "7.14.5",
+    "@babel/parser": "7.24.5",
     "@babel/plugin-external-helpers": "7.14.5",
     "@babel/plugin-proposal-class-properties": "7.16.7",
     "@babel/plugin-proposal-export-namespace-from": "7.14.5",

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -45,6 +45,7 @@ specifiers:
   '@babel/cli': 7.23.4
   '@babel/code-frame': 7.14.5
   '@babel/core': 7.23.6
+  '@babel/parser': 7.24.5
   '@babel/plugin-external-helpers': 7.14.5
   '@babel/plugin-proposal-class-properties': 7.16.7
   '@babel/plugin-proposal-export-namespace-from': 7.14.5
@@ -345,6 +346,7 @@ specifiers:
 
 dependencies:
   '@babel/code-frame': 7.14.5
+  '@babel/parser': 7.24.5
   '@babel/plugin-external-helpers': 7.14.5_@babel+core@7.23.6
   '@babel/plugin-proposal-class-properties': 7.16.7_@babel+core@7.23.6
   '@babel/plugin-proposal-export-namespace-from': 7.14.5_@babel+core@7.23.6
@@ -793,7 +795,7 @@ packages:
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-module-transforms': 7.23.3_@babel+core@7.23.6
       '@babel/helpers': 7.23.6
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.24.5
       '@babel/template': 7.22.15
       '@babel/traverse': 7.23.6
       '@babel/types': 7.23.6
@@ -1013,16 +1015,8 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
-  /@babel/parser/7.15.7:
-    resolution: {integrity: sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.23.6
-    dev: false
-
-  /@babel/parser/7.23.6:
-    resolution: {integrity: sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==}
+  /@babel/parser/7.24.5:
+    resolution: {integrity: sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
@@ -2128,7 +2122,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.23.5
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.24.5
       '@babel/types': 7.23.6
 
   /@babel/traverse/7.23.6:
@@ -2141,7 +2135,7 @@ packages:
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.24.5
       '@babel/types': 7.23.6
       debug: 4.3.4
       globals: 11.12.0
@@ -4526,7 +4520,7 @@ packages:
   /@types/babel__core/7.1.16:
     resolution: {integrity: sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==}
     dependencies:
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.24.5
       '@babel/types': 7.23.6
       '@types/babel__generator': 7.6.3
       '@types/babel__template': 7.4.1
@@ -4542,7 +4536,7 @@ packages:
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.24.5
       '@babel/types': 7.23.6
     dev: true
 
@@ -6263,7 +6257,7 @@ packages:
       eslint: '>= 4.12.1'
     dependencies:
       '@babel/code-frame': 7.23.5
-      '@babel/parser': 7.15.7
+      '@babel/parser': 7.24.5
       '@babel/traverse': 7.23.6
       '@babel/types': 7.23.6
       eslint: 7.32.0
@@ -7559,7 +7553,7 @@ packages:
     dev: true
 
   /component-indexof/0.0.3:
-    resolution: {integrity: sha512-puDQKvx/64HZXb4hBwIcvQLaLgux8o1CbWl39s41hrIIZDl1lJiD5jc22gj3RBeGK0ovxALDYpIbyjqDUUl0rw==}
+    resolution: {integrity: sha1-EdCRMSI5648yyPJa6csAL/6NPCQ=}
     dev: false
 
   /compressible/2.0.18:
@@ -11780,7 +11774,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.23.6
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.24.5
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -12376,7 +12370,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.6
       '@babel/generator': 7.23.6
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.24.5
       '@babel/plugin-syntax-typescript': 7.23.3_@babel+core@7.23.6
       '@babel/traverse': 7.23.6
       '@babel/types': 7.23.6

--- a/editor/src/core/es-modules/evaluator/evaluator.ts
+++ b/editor/src/core/es-modules/evaluator/evaluator.ts
@@ -85,6 +85,9 @@ function evaluateJs(
   requireFn: (toImport: string) => unknown,
 ): any {
   let module = fileEvaluationCache
+  // With a lot of configurations of how to handle JSX, a React import is implicitly added to the code.
+  // As this is a fallback case for code in the project and the code hasn't been transpiled yet, it may not have a React import.
+  // This streamlines in a React import if it's missing, so that the transpiled code can refer to `React.createElement`.
   const moduleCode = addReactImport(filePath, moduleCodeBefore)
 
   function firstErrorHandler(error: Error): void {


### PR DESCRIPTION
**Problem:**
We found that a sample project required a lot of additional React imports to be added into the code when run in the editor. With it failing to a lot of `React is not defined` errors seemingly from `React.createElement` calls.

**Cause:**
In most configurations, an import for React is added when transpiling the JSX markup. Ordinarily when using our component rendering functionality this is not an issue as we effectively control that part anyway. But if the entire file is loaded through our evaluators then it needs to include those.

**Fix:**
If the code appears to be a JSX like file but does not include an import of React, we add one to the top of the file and execute that code instead.

**Notes:**
I spent some time trying to write a unit test that covers this case. However it appears that Babel is doing some kind of introspection of the environment it's running in and the behaviour is quite different where it introduces a function `_interopRequireWildcard` which it applies to the result of the `require` call which somehow breaks the React import.

**Commit Details:**
- `evaluateJs` now streamlines an import for React into the code, if there isn't already one.
- Added `addReactImport`, `includesReactImport` and `isJSXLikeFilePath` utility functions.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5699
