### PR TITLE
Component API for the upcoming inspector sections

### DIFF
--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -51,7 +51,7 @@ import type {
 import type { ProjectContentTreeRoot } from '../assets'
 import { getProjectFileByFilePath } from '../assets'
 import type { EditorDispatch } from '../editor/action-types'
-import type { Emphasis, Focus, Icon, InspectorSpec } from 'utopia-api'
+import type { Emphasis, Focus, Icon, InspectorSpec, StyleSectionState } from 'utopia-api'
 
 type ModuleExportTypes = { [name: string]: ExportType }
 
@@ -154,17 +154,19 @@ export interface ComponentDescriptor {
   emphasis: Emphasis
   icon: Icon
   label: string | null
+  future_styleSection: StyleSectionState | null
 }
 
 export const ComponentDescriptorDefaults: Pick<
   ComponentDescriptor,
-  'focus' | 'inspector' | 'emphasis' | 'icon' | 'label'
+  'focus' | 'inspector' | 'emphasis' | 'icon' | 'label' | 'future_styleSection'
 > = {
   focus: 'default',
   inspector: [],
   emphasis: 'regular',
   icon: 'component',
   label: null,
+  future_styleSection: null,
 }
 
 export function componentDescriptor(
@@ -178,6 +180,7 @@ export function componentDescriptor(
   emphasis: Emphasis,
   icon: Icon,
   label: string | null,
+  styleSectioState: StyleSectionState | null,
 ): ComponentDescriptor {
   return {
     properties: properties,
@@ -190,6 +193,7 @@ export function componentDescriptor(
     emphasis: emphasis,
     icon: icon,
     label: label,
+    future_styleSection: styleSectioState,
   }
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -79,7 +79,15 @@ import {
   exportType,
   singleFileBuildResult,
 } from '../../../core/workers/common/worker-types'
-import type { Sides, Focus, Styling, Emphasis, Icon, InspectorSpec } from 'utopia-api/core'
+import type {
+  Sides,
+  Focus,
+  Styling,
+  Emphasis,
+  Icon,
+  InspectorSpec,
+  StyleSectionState,
+} from 'utopia-api/core'
 import type {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
@@ -3466,7 +3474,7 @@ const InspectorSpecKeepDeepEquality: KeepDeepEqualityCall<InspectorSpec> = (oldV
 }
 
 export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<ComponentDescriptor> =
-  combine10EqualityCalls(
+  combine11EqualityCalls(
     (descriptor) => descriptor.properties,
     PropertyControlsKeepDeepEquality,
     (descriptor) => descriptor.supportsChildren,
@@ -3487,6 +3495,8 @@ export const ComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<Component
     createCallWithTripleEquals<Icon>(),
     (descriptor) => descriptor.label,
     nullableDeepEquality(StringKeepDeepEquality),
+    (descriptor) => descriptor.future_styleSection,
+    nullableDeepEquality(createCallWithTripleEquals<StyleSectionState>()),
     componentDescriptor,
   )
 

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -117,6 +117,7 @@ describe('registered property controls', () => {
         "Card": Object {
           "emphasis": "regular",
           "focus": "default",
+          "future_styleSection": null,
           "icon": "component",
           "inspector": Array [
             "visual",
@@ -257,6 +258,7 @@ describe('registered property controls', () => {
         "ExportedObj.Card": Object {
           "emphasis": "regular",
           "focus": "default",
+          "future_styleSection": null,
           "icon": "component",
           "inspector": Array [],
           "label": null,
@@ -335,6 +337,7 @@ describe('registered property controls', () => {
         "Card": Object {
           "emphasis": "regular",
           "focus": "default",
+          "future_styleSection": null,
           "icon": "component",
           "inspector": "all",
           "label": null,
@@ -949,6 +952,7 @@ describe('registered property controls', () => {
         "Card": Object {
           "emphasis": "regular",
           "focus": "default",
+          "future_styleSection": null,
           "icon": "component",
           "inspector": Array [],
           "label": null,
@@ -1774,6 +1778,7 @@ describe('registered property controls', () => {
           "Card": Object {
             "emphasis": "regular",
             "focus": "default",
+            "future_styleSection": null,
             "icon": "component",
             "inspector": Array [],
             "label": null,

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -583,6 +583,7 @@ export function updatePropertyControlsOnDescriptorFileUpdate(
         emphasis: descriptor.emphasis,
         icon: descriptor.icon,
         label: descriptor.label,
+        future_styleSection: descriptor.future_styleSection,
       }
     })
   })
@@ -974,6 +975,7 @@ export async function componentDescriptorForComponentToRegister(
     emphasis: componentToRegister.emphasis ?? ComponentDescriptorDefaults.emphasis,
     icon: componentToRegister.icon ?? ComponentDescriptorDefaults.icon,
     label: componentToRegister.label ?? null,
+    future_styleSection: componentToRegister.future_styleSection ?? null,
   })
 }
 

--- a/utopia-api/src/helpers/helper-functions.ts
+++ b/utopia-api/src/helpers/helper-functions.ts
@@ -87,6 +87,9 @@ export const IconOptions = [
 ] as const
 export type Icon = (typeof IconOptions)[number]
 
+export const StyleSectionStates = ['expanded', 'collapsed', 'hidden'] as const
+export type StyleSectionState = (typeof StyleSectionStates)[number]
+
 export interface ComponentToRegister {
   component: any
   properties: PropertyControls
@@ -97,6 +100,7 @@ export interface ComponentToRegister {
   icon?: Icon
   label?: string
   variants?: ComponentExample | Array<ComponentExample>
+  future_styleSection?: StyleSectionState
 }
 
 export type RawSingleBorderWidth = number | string


### PR DESCRIPTION
Part of https://github.com/concrete-utopia/utopia/issues/5635

## Description
In https://github.com/concrete-utopia/utopia/issues/5635, we want to create a new Styles (name TBD) section that groups the visual controls in the inspector. This component API will be able to collapse, expand or hide this section. This PR adds the component API annotation for this.

## Scope & Naming
- `styleSection` is not used anywhere yet, it'll be used by an upcoming PR

## Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

