### PR TITLE
NarrowExpansionArrowRight component

### DIFF
--- a/editor/src/uuiui/icons.tsx
+++ b/editor/src/uuiui/icons.tsx
@@ -215,6 +215,12 @@ export const Icons = {
   ExpansionArrowDown: makeIcon({ type: 'expansionarrow-down', color: 'main' }),
   ExpansionArrowRight: makeIcon({ type: 'expansionarrow-right', color: 'main' }),
   ExpansionArrowRightWhite: makeIcon({ type: 'expansionarrow-right', color: 'white' }),
+  NarrowExpansionArrowRight: makeIcon({
+    type: 'right-facing-caret',
+    color: 'main',
+    width: 12,
+    height: 12,
+  }),
   ExternalLink: makeIcon({ type: 'externallink', color: 'main' }),
   ExternalLinkSmaller: makeIcon({ type: 'externallink-smaller', color: 'main' }),
   EyeStrikethrough: makeIcon({ type: 'eye-strikethrough', color: 'main' }),

--- a/editor/src/uuiui/icons.tsx
+++ b/editor/src/uuiui/icons.tsx
@@ -216,6 +216,7 @@ export const Icons = {
   ExpansionArrowRight: makeIcon({ type: 'expansionarrow-right', color: 'main' }),
   ExpansionArrowRightWhite: makeIcon({ type: 'expansionarrow-right', color: 'white' }),
   NarrowExpansionArrowRight: makeIcon({
+    category: 'navigator-element',
     type: 'right-facing-caret',
     color: 'main',
     width: 12,


### PR DESCRIPTION
Making an icon component called `NarrowExpansionArrowRight` that uses the new right-facing-caret icon
