### PR TITLE
Icons and actions for condensed navigator rows

### DIFF
--- a/editor/src/components/navigator/navigator-item/layout-icon.tsx
+++ b/editor/src/components/navigator/navigator-item/layout-icon.tsx
@@ -21,6 +21,7 @@ import type { MetadataSubstate } from '../../editor/store/store-hook-substore-ty
 import * as EP from '../../../core/shared/element-path'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
 import type { Icon } from 'utopia-api'
+import { when } from '../../../utils/react-conditionals'
 
 interface LayoutIconProps {
   navigatorEntry: NavigatorEntry
@@ -265,19 +266,22 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
           position: 'relative',
         }}
       >
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            position: 'absolute',
-            left: -9,
-            height: 18,
-            width: 8,
-          }}
-        >
-          {marker}
-        </div>
+        {when(
+          marker != null,
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              position: 'absolute',
+              left: -9,
+              height: 18,
+              width: 8,
+            }}
+          >
+            {marker}
+          </div>,
+        )}
         {icon}
       </div>
     )

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -371,6 +371,34 @@ const CondensedEntryItem = React.memo(
       'CondensedEntry elementWarningsSelector',
     )
 
+    const isCollapsed = useEditorState(
+      Substores.navigator,
+      (store) =>
+        store.editor.navigator.collapsedViews.some((path) =>
+          EP.pathsEqual(path, props.entry.elementPath),
+        ),
+      'CondensedEntryItemWrapper isCollapsed',
+    )
+
+    const showLabel = useEditorState(
+      Substores.metadata,
+      (store) => {
+        return (
+          MetadataUtils.isProbablyScene(store.editor.jsxMetadata, props.entry.elementPath) ||
+          MetadataUtils.isProbablyRemixScene(store.editor.jsxMetadata, props.entry.elementPath)
+        )
+      },
+      'CondensedEntryItemWrapper isScene',
+    )
+
+    const isChildOfSelected = React.useMemo(() => {
+      return selectedViews.some(
+        (path) =>
+          EP.isDescendantOf(props.entry.elementPath, path) &&
+          !EP.pathsEqual(path, props.entry.elementPath),
+      )
+    }, [props.entry, selectedViews])
+
     const isSelected = React.useMemo(() => {
       return selectedViews.some((path) => EP.pathsEqual(path, props.entry.elementPath))
     }, [selectedViews, props.entry])
@@ -396,40 +424,12 @@ const CondensedEntryItem = React.memo(
       ])
     }, [props.entry, dispatch, highlightedViews])
 
-    const isChildOfSelected = React.useMemo(() => {
-      return selectedViews.some(
-        (path) =>
-          EP.isDescendantOf(props.entry.elementPath, path) &&
-          !EP.pathsEqual(path, props.entry.elementPath),
-      )
-    }, [props.entry, selectedViews])
-
     const collapse = React.useCallback(
       (elementPath: ElementPath) => (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
         e.stopPropagation()
         dispatch([toggleCollapse(elementPath)], 'leftpane')
       },
       [dispatch],
-    )
-
-    const isCollapsed = useEditorState(
-      Substores.navigator,
-      (store) =>
-        store.editor.navigator.collapsedViews.some((path) =>
-          EP.pathsEqual(path, props.entry.elementPath),
-        ),
-      'CondensedEntryItemWrapper isCollapsed',
-    )
-
-    const showLabel = useEditorState(
-      Substores.metadata,
-      (store) => {
-        return (
-          MetadataUtils.isProbablyScene(store.editor.jsxMetadata, props.entry.elementPath) ||
-          MetadataUtils.isProbablyRemixScene(store.editor.jsxMetadata, props.entry.elementPath)
-        )
-      },
-      'CondensedEntryItemWrapper isScene',
     )
 
     return (

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -405,8 +405,8 @@ const CondensedEntryItem = React.memo(
     }, [props.entry, selectedViews])
 
     const collapse = React.useCallback(
-      (elementPath: ElementPath) => (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-        event.stopPropagation()
+      (elementPath: ElementPath) => (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+        e.stopPropagation()
         dispatch([toggleCollapse(elementPath)], 'leftpane')
       },
       [dispatch],
@@ -466,13 +466,24 @@ const CondensedEntryItem = React.memo(
             >
               {when(
                 props.showExpandableIndicator,
-                <ExpandableIndicator
+                <div
+                  style={{
+                    width: 12,
+                    height: 29,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    cursor: 'pointer',
+                  }}
                   onClick={collapse(props.entry.elementPath)}
-                  visible={true}
-                  collapsed={isCollapsed}
-                  selected={false}
-                  iconColor={isSelected ? 'white' : 'main'}
-                />,
+                >
+                  <ExpandableIndicator
+                    visible={true}
+                    collapsed={isCollapsed}
+                    selected={false}
+                    iconColor={isSelected ? 'white' : 'main'}
+                  />
+                </div>,
               )}
               <LayoutIcon
                 navigatorEntry={props.entry}

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -1,9 +1,9 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/react'
-import React from 'react'
-import { assertNever } from '../../../core/shared/utils'
 import { createCachedSelector } from 're-reselect'
+import React from 'react'
+import { maybeConditionalExpression } from '../../../core/model/conditionals'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import * as EP from '../../../core/shared/element-path'
 import type {
@@ -15,6 +15,10 @@ import {
   isNullJSXAttributeValue,
 } from '../../../core/shared/element-template'
 import type { ElementPath } from '../../../core/shared/project-file-types'
+import { assertNever } from '../../../core/shared/utils'
+import { Icons, Tooltip, useColorTheme } from '../../../uuiui'
+import { getRouteComponentNameForOutlet } from '../../canvas/remix/remix-utils'
+import { selectComponents, setHighlightedViews } from '../../editor/actions/action-creators'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import type {
   DropTargetHint,
@@ -34,6 +38,11 @@ import type {
   ProjectContentAndMetadataSubstate,
   PropertyControlsInfoSubstate,
 } from '../../editor/store/store-hook-substore-types'
+import type { CondensedNavigatorRow, CondensedNavigatorRowVariant } from '../navigator-row'
+import { isRegulaNavigatorRow, type NavigatorRow } from '../navigator-row'
+import { navigatorDepth } from '../navigator-utils'
+import { LayoutIcon } from './layout-icon'
+import { BasePaddingUnit, elementWarningsSelector } from './navigator-item'
 import type {
   ConditionalClauseNavigatorItemContainerProps,
   ErrorNavigatorItemContainerProps,
@@ -52,11 +61,6 @@ import {
   SlotNavigatorItemContainer,
   SyntheticNavigatorItemContainer,
 } from './navigator-item-dnd-container'
-import { navigatorDepth } from '../navigator-utils'
-import { maybeConditionalExpression } from '../../../core/model/conditionals'
-import { getRouteComponentNameForOutlet } from '../../canvas/remix/remix-utils'
-import { CondensedNavigatorRow, isRegulaNavigatorRow, type NavigatorRow } from '../navigator-row'
-import { BasePaddingUnit } from './navigator-item'
 
 interface NavigatorItemWrapperProps {
   index: number
@@ -238,31 +242,167 @@ export const NavigatorItemWrapper: React.FunctionComponent<NavigatorItemWrapperP
       )
     }
     return (
+      <CondensedEntryItemWrapper
+        windowStyle={props.windowStyle}
+        navigatorRow={props.navigatorRow}
+      />
+    )
+  },
+)
+
+const CondensedEntryItemWrapper = React.memo(
+  (props: { windowStyle: React.CSSProperties; navigatorRow: CondensedNavigatorRow }) => {
+    return (
       <div
         style={{
           ...props.windowStyle,
-          left: 5 + 12 + 6 + BasePaddingUnit * props.navigatorRow.indentation,
+          left: 5 + 6 + BasePaddingUnit * props.navigatorRow.indentation,
+          display: 'flex',
         }}
       >
-        {props.navigatorRow.variant === 'trunk' ? (
-          <React.Fragment>
-            {props.navigatorRow.entries.map((entry) => (
-              <span key={EP.toString(entry.elementPath)}>{EP.toUid(entry.elementPath)} / </span>
-            ))}
-          </React.Fragment>
-        ) : (
-          <React.Fragment>
-            [
-            {props.navigatorRow.entries.map((entry) => (
-              <span key={EP.toString(entry.elementPath)}>{EP.toUid(entry.elementPath)}, </span>
-            ))}
-            ]
-          </React.Fragment>
-        )}
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          {props.navigatorRow.entries.map((entry, idx) => {
+            const showSeparator = idx < props.navigatorRow.entries.length - 1
+            const separator = showSeparator ? (
+              <CondensedEntryItemSeparator variant={props.navigatorRow.variant} />
+            ) : null
+
+            return (
+              <CondensedEntryItem
+                key={EP.toString(entry.elementPath)}
+                entry={entry}
+                separator={separator}
+              />
+            )
+          })}
+        </div>
       </div>
     )
   },
 )
+CondensedEntryItemWrapper.displayName = 'CondensedEntryItemWrapper'
+
+const CondensedEntryItemSeparator = React.memo(
+  (props: { variant: CondensedNavigatorRowVariant }) => {
+    const colorTheme = useColorTheme()
+    return (
+      <div
+        style={{
+          width: 12,
+          height: 12,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: colorTheme.fg6.value,
+        }}
+      >
+        {props.variant === 'leaf' ? <span>,</span> : <Icons.NarrowExpansionArrowRight />}
+      </div>
+    )
+  },
+)
+CondensedEntryItemSeparator.displayName = 'CondensedEntryItemSeparator'
+
+const CondensedEntryItem = React.memo(
+  (props: { entry: NavigatorEntry; separator: React.ReactNode }) => {
+    const colorTheme = useColorTheme()
+    const dispatch = useDispatch()
+
+    const selectedViews = useEditorState(
+      Substores.selectedViews,
+      (store) => store.editor.selectedViews,
+      'CondensedEntry selectedViews',
+    )
+
+    const highlightedViews = useEditorState(
+      Substores.highlightedHoveredViews,
+      (store) => store.editor.highlightedViews,
+      'CondensedEntry highlightedViews',
+    )
+
+    const iconOverride = useEditorState(
+      Substores.propertyControlsInfo,
+      (store) =>
+        MetadataUtils.getIconOfComponent(
+          props.entry.elementPath,
+          store.editor.propertyControlsInfo,
+          store.editor.projectContents,
+        ),
+      'CondensedEntry iconOverride',
+    )
+
+    const labelForTheElement = useEditorState(
+      Substores.projectContentsAndMetadata,
+      (store) => labelSelector(store, props.entry),
+      'CondensedEntry labelSelector',
+    )
+
+    const elementWarnings = useEditorState(
+      Substores.derived,
+      (store) => elementWarningsSelector(store, props.entry),
+      'CondensedEntry elementWarningsSelector',
+    )
+
+    const isSelected = React.useMemo(() => {
+      return selectedViews.some((path) => EP.pathsEqual(path, props.entry.elementPath))
+    }, [selectedViews, props.entry])
+
+    const onClick = React.useCallback(
+      (e: React.MouseEvent) => {
+        e.preventDefault()
+        e.stopPropagation()
+        dispatch([selectComponents([props.entry.elementPath], false)])
+      },
+      [dispatch, props.entry],
+    )
+
+    const onMouseOver = React.useCallback(() => {
+      dispatch([setHighlightedViews([props.entry.elementPath])])
+    }, [props.entry, dispatch])
+
+    const onMouseOut = React.useCallback(() => {
+      dispatch([
+        setHighlightedViews(
+          highlightedViews.filter((path) => !EP.pathsEqual(path, props.entry.elementPath)),
+        ),
+      ])
+    }, [props.entry, dispatch, highlightedViews])
+
+    return (
+      <React.Fragment>
+        <Tooltip title={getNavigatorEntryLabel(props.entry, labelForTheElement)}>
+          <div
+            style={{
+              padding: 4,
+              borderRadius: 2,
+              cursor: 'pointer',
+            }}
+            css={{
+              backgroundColor: isSelected ? colorTheme.selectionBlue.value : 'transparent',
+              ':hover': {
+                backgroundColor: !isSelected
+                  ? colorTheme.selectionBlue10.value
+                  : colorTheme.selectionBlue.value,
+              },
+            }}
+            onClick={onClick}
+            onMouseOver={onMouseOver}
+            onMouseOut={onMouseOut}
+          >
+            <LayoutIcon
+              navigatorEntry={props.entry}
+              override={iconOverride}
+              color={isSelected ? 'white' : 'main'}
+              elementWarnings={elementWarnings}
+            />
+          </div>
+        </Tooltip>
+        {props.separator}
+      </React.Fragment>
+    )
+  },
+)
+CondensedEntryItem.displayName = 'CondensedEntryItem'
 
 type SingleEntryNavigatorItemWrapperProps = NavigatorItemWrapperProps & {
   indentation: number

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -466,7 +466,7 @@ const isHiddenConditionalBranchSelector = createCachedSelector(
   },
 )((_, elementPath, parentPath) => `${EP.toString(elementPath)}_${EP.toString(parentPath)}`)
 
-const elementWarningsSelector = createCachedSelector(
+export const elementWarningsSelector = createCachedSelector(
   (store: DerivedSubstate) => store.derived.elementWarnings,
   (_: DerivedSubstate, navigatorEntry: NavigatorEntry) => navigatorEntry,
   (elementWarnings, navigatorEntry) => {

--- a/editor/src/components/navigator/navigator-row.tsx
+++ b/editor/src/components/navigator/navigator-row.tsx
@@ -26,9 +26,11 @@ export function isRegulaNavigatorRow(row: NavigatorRow): row is RegularNavigator
 export interface CondensedNavigatorRow {
   type: 'condensed-row'
   indentation: number
-  variant: 'trunk' | 'leaf'
+  variant: CondensedNavigatorRowVariant
   entries: Array<NavigatorEntry>
 }
+
+export type CondensedNavigatorRowVariant = 'trunk' | 'leaf'
 
 export function condensedNavigatorRow(
   entries: Array<NavigatorEntry>,


### PR DESCRIPTION
**Problem:**

https://github.com/concrete-utopia/utopia/pull/5716 introduced the condensed rows, they now need to be actionable.

**Fix:**

1. Show icons on breadcrumbs
2. Select on click
3. Highlight on hover
4. Show the label on the first element, if it's a scene
5. Show tooltips on hover, containing the label
6. Add the collapse button like any other navigator row
7. Make the row able to scroll horizontally

Additionally this PR does two additional things:
1. Fix the collapsing of condensed rows, which was not working (https://github.com/concrete-utopia/utopia/pull/5724/commits/db3de730be4180c241c03a2ec497cd2ff96e5c38)
2. Fix the placement of the warning overlay which would result in the expansion arrow being hard to click (https://github.com/concrete-utopia/utopia/pull/5724/commits/984b3fad31cc6f6282d8c6d705cb8da41814ae00)

**Note**: most of the code doing actual navigator things is cannibalized from the previous code for regular navigator items.

<img width="312" alt="Screenshot 2024-05-23 at 11 29 51 AM" src="https://github.com/concrete-utopia/utopia/assets/1081051/03581a08-6008-4c76-b16c-67bb228ea8f5">

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5726 
