### PR TITLE
Fix: out of order data cartouches

### DIFF
--- a/editor/src/core/shared/element-path-tree.ts
+++ b/editor/src/core/shared/element-path-tree.ts
@@ -98,15 +98,18 @@ function getChildrenPaths(
   ) {
     childrenFromElement = element.element.value.children
       .filter((child) => {
-        return (
-          (!isJSXTextBlock(child) ||
-            // if Data Entries are enabled, we don't want to filter out the text blocks
-            isFeatureEnabled('Data Entries in the Navigator')) &&
-          !isJSExpressionMapOrOtherJavaScript(child) &&
-          !isJSIdentifier(child) &&
-          !isJSPropertyAccess(child) &&
-          !isJSElementAccess(child)
-        )
+        if (isFeatureEnabled('Data Entries in the Navigator')) {
+          // if Data Entries are enabled, we should always show them in the Navigator
+          return true
+        } else {
+          return (
+            !isJSXTextBlock(child) &&
+            !isJSExpressionMapOrOtherJavaScript(child) &&
+            !isJSIdentifier(child) &&
+            !isJSPropertyAccess(child) &&
+            !isJSElementAccess(child)
+          )
+        }
       })
       .map((child) => EP.appendToPath(rootPath, child.uid))
   }


### PR DESCRIPTION
**Problem:**
The code
```
<div>Hello, {"Balazs"}! How are you</div>
```

Would show up out of order in the navigator:
<img width="255" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/3b4b8d14-d19e-4b59-b0d8-d92ccbed2d81">

**Fix:**
The fix was to make `element-path-tree@buildTree` even more inclusive when the 'Data Entries in the Navigator' feature switch is enabled, and include all types of possible child elements, including arbitrary js expressions and property access.
<img width="266" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/20be9491-fb65-48b8-b4f1-92fdee4d1e9a">

