### PR TITLE
Component validation error is a warning

### DIFF
--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -409,7 +409,7 @@ describe('registered property controls', () => {
             fileName: '/utopia/components.utopia.js',
             message: "Validation failed: Component registered for key 'Card' is undefined",
             passTime: null,
-            severity: 'fatal',
+            severity: 'warning',
             source: 'component-descriptor',
             startColumn: null,
             startLine: null,
@@ -625,7 +625,7 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Component name (Card) does not match the registration key (Cart)',
             passTime: null,
-            severity: 'fatal',
+            severity: 'warning',
             source: 'component-descriptor',
             startColumn: null,
             startLine: null,
@@ -677,7 +677,7 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Module name (/src/card) does not match the module key (/src/cardd)',
             passTime: null,
-            severity: 'fatal',
+            severity: 'warning',
             source: 'component-descriptor',
             startColumn: null,
             startLine: null,
@@ -729,7 +729,7 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Component name (View) does not match the registration key (Vieww)',
             passTime: null,
-            severity: 'fatal',
+            severity: 'warning',
             source: 'component-descriptor',
             startColumn: null,
             startLine: null,
@@ -781,7 +781,7 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Module name (utopia-api) does not match the module key (utopia-apii)',
             passTime: null,
-            severity: 'fatal',
+            severity: 'warning',
             source: 'component-descriptor',
             startColumn: null,
             startLine: null,
@@ -832,7 +832,7 @@ describe('registered property controls', () => {
             message:
               'Validation failed: Component name (Card) does not match the registration key (Cart)',
             passTime: null,
-            severity: 'fatal',
+            severity: 'warning',
             source: 'component-descriptor',
             startColumn: null,
             startLine: null,
@@ -2069,7 +2069,7 @@ describe('Lifecycle management of registering components', () => {
         fileName: '/utopia/components.utopia.js',
         message: "Validation failed: Component registered for key 'Card' is undefined",
         passTime: null,
-        severity: 'fatal',
+        severity: 'warning',
         source: 'component-descriptor',
         startColumn: null,
         startLine: null,

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -99,7 +99,7 @@ import {
   jsxElementNameFromString,
   jsxTextBlock,
 } from '../shared/element-template'
-import type { ErrorMessage } from '../shared/error-messages'
+import type { ErrorMessage, ErrorMessageSeverity } from '../shared/error-messages'
 import { errorMessage } from '../shared/error-messages'
 import { dropFileExtension } from '../shared/file-utils'
 import type { FancyError } from '../shared/code-exec-utils'
@@ -418,7 +418,11 @@ async function getComponentDescriptorPromisesFromParseResult(
   }
 }
 
-function simpleErrorMessage(fileName: string, error: string): ErrorMessage {
+function simpleErrorMessage(
+  fileName: string,
+  error: string,
+  severity: ErrorMessageSeverity = 'fatal',
+): ErrorMessage {
   return errorMessage(
     fileName,
     null,
@@ -426,7 +430,7 @@ function simpleErrorMessage(fileName: string, error: string): ErrorMessage {
     null,
     null,
     '',
-    'fatal',
+    severity,
     '',
     error,
     '',
@@ -490,6 +494,7 @@ function errorsFromComponentRegistration(
             `Validation failed: ${messageForComponentRegistrationValidationError(
               error.validationError,
             )}`,
+            'warning',
           ),
         ]
       default:


### PR DESCRIPTION
**Problem:**
Component name and modulename validation (for component annotations) is broken in some cases:
1) if you wrap a component into a React.forwardRef, then getting the name and the module of the component is broken, because it is not rendered by a ComponentRendererComponent
2) if you use an import alias defined in jsconfig.json (e.g. in te sample store @h2 is /app/components/hydrogen), then when you use the component, it is not going to find in the property controls (only if you register it to with aliased module name, but that is not allowed by the annotation validation) 

**Fix:**
Because these errors block the annotation of these components, as a quick fix I decreased the severity of validation errors to warnings, so we can at least work on these annotations.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

