### PR TITLE
Prevent invalid props being passed to fragments.

### DIFF
--- a/editor/src/utils/canvas-react-utils.spec.tsx
+++ b/editor/src/utils/canvas-react-utils.spec.tsx
@@ -358,6 +358,20 @@ describe('Monkey Function', () => {
     `)
   })
 
+  it('Props get pushed down off of a fragment onto the children', () => {
+    const ElementThatIsReallyAFragment: any = React.Fragment as any
+    expect(
+      renderToFormattedString(
+        <ElementThatIsReallyAFragment style={{ backgroundColor: 'red' }}>
+          <div>Hello!</div>
+        </ElementThatIsReallyAFragment>,
+      ),
+    ).toMatchInlineSnapshot(`
+      "<div style=\\"background-color: red\\">Hello!</div>
+      "
+    `)
+  })
+
   it('Fragments work if theres a uid 2', () => {
     const Component = () => {
       return (


### PR DESCRIPTION
**Problem:**
With a particular set of components in the sample store, we experienced an issue which resulted in properties being passed to fragments.

**Cause:**
The headlessui library does some introspection to detect fragments, which was being tripped up by our special React `createElement` implementation as a result of it wrapping the underlying component. As a result of that, the headlessui library then assigned properties onto the fragments, which React complained about but that otherwise would be assigned to the children of the fragment.

**Fix:**
This adds protection in our patched `createElement` implementation to not assign invalid properties to fragments, as well as slightly extending our logic that pushes our special properties down off of a fragment onto its children.

**Commit Details:**
- Exclude properties other than `key` and `children` from fragments.
- Pass properties assigned to fragments down to their children.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5709
