### PR TITLE
Condensed Row Style Tweaks

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -508,6 +508,7 @@ const RowForBaseControl = React.memo((props: RowForBaseControlProps) => {
       items={contextMenuItems}
       data={null}
     >
+      {dataPickerButtonData.popupIsOpen ? dataPickerButtonData.DataPickerComponent : null}
       <UIGridRow padded={false} style={{ padding: '3px 8px' }} variant='<--1fr--><--1fr-->'>
         {propertyLabel}
         <div
@@ -529,7 +530,6 @@ const RowForBaseControl = React.memo((props: RowForBaseControlProps) => {
           />
         </div>
       </UIGridRow>
-      {dataPickerButtonData.popupIsOpen ? dataPickerButtonData.DataPickerComponent : null}
     </InspectorContextMenuWrapper>
   )
 })

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -508,7 +508,6 @@ const RowForBaseControl = React.memo((props: RowForBaseControlProps) => {
       items={contextMenuItems}
       data={null}
     >
-      {dataPickerButtonData.popupIsOpen ? dataPickerButtonData.DataPickerComponent : null}
       <UIGridRow padded={false} style={{ padding: '3px 8px' }} variant='<--1fr--><--1fr-->'>
         {propertyLabel}
         <div
@@ -530,6 +529,7 @@ const RowForBaseControl = React.memo((props: RowForBaseControlProps) => {
           />
         </div>
       </UIGridRow>
+      {dataPickerButtonData.popupIsOpen ? dataPickerButtonData.DataPickerComponent : null}
     </InspectorContextMenuWrapper>
   )
 })

--- a/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
@@ -191,7 +191,7 @@ export const DataCartoucheInner = React.forwardRef(
     const backgroundColor =
       contentsToDisplay.type === 'reference'
         ? primaryBackgroundColorToUse
-        : colorTheme.fg0Opacity20.value
+        : colorTheme.fg0Opacity10.value
 
     const label = contentsToDisplay.label ?? 'DATA'
 

--- a/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
@@ -112,7 +112,7 @@ export const DataReferenceCartoucheControl = React.memo(
     }, [dispatch, elementPath])
 
     return (
-      <div>
+      <>
         <DataCartoucheInner
           ref={dataPickerButtonData.setReferenceElement}
           onClick={onClick}
@@ -125,8 +125,11 @@ export const DataReferenceCartoucheControl = React.memo(
           testId={`data-reference-cartouche-${EP.toString(elementPath)}`}
           contentIsComingFromServer={isDataComingFromHookResult}
         />
-        {dataPickerButtonData.popupIsOpen ? dataPickerButtonData.DataPickerComponent : null}
-      </div>
+        {/* this div prevents the popup form putting padding into the condensed rows */}
+        <div style={{ width: 0 }}>
+          {dataPickerButtonData.popupIsOpen ? dataPickerButtonData.DataPickerComponent : null}
+        </div>
+      </>
     )
   },
 )

--- a/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
@@ -222,9 +222,7 @@ export const DataCartoucheInner = React.forwardRef(
         >
           {contentsToDisplay.type === 'reference' ? (
             <Icons.NavigatorData color={cartoucheIconColor} />
-          ) : (
-            <Icons.NavigatorText color={cartoucheIconColor} />
-          )}
+          ) : null}
           <Tooltip title={label}>
             <div
               style={{

--- a/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
@@ -112,8 +112,7 @@ export const DataReferenceCartoucheControl = React.memo(
     }, [dispatch, elementPath])
 
     return (
-      <>
-        {dataPickerButtonData.popupIsOpen ? dataPickerButtonData.DataPickerComponent : null}
+      <div>
         <DataCartoucheInner
           ref={dataPickerButtonData.setReferenceElement}
           onClick={onClick}
@@ -126,7 +125,8 @@ export const DataReferenceCartoucheControl = React.memo(
           testId={`data-reference-cartouche-${EP.toString(elementPath)}`}
           contentIsComingFromServer={isDataComingFromHookResult}
         />
-      </>
+        {dataPickerButtonData.popupIsOpen ? dataPickerButtonData.DataPickerComponent : null}
+      </div>
     )
   },
 )
@@ -172,7 +172,11 @@ export const DataCartoucheInner = React.forwardRef(
       ? cartoucheIconColorToUse
       : 'secondary'
 
-    const borderColor = inverted ? colorTheme.white.value : colorTheme.primary.value
+    const borderColor = inverted
+      ? colorTheme.white.value
+      : contentIsComingFromServer
+      ? colorTheme.green.value
+      : colorTheme.primary.value
 
     const primaryForegoundColorToUse = contentIsComingFromServer
       ? colorTheme.green.value

--- a/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
@@ -179,7 +179,7 @@ export const DataCartoucheInner = React.forwardRef(
       ? colorTheme.white.value
       : contentIsComingFromServer
       ? colorTheme.green.value
-      : colorTheme.primary.value
+      : colorTheme.selectionBlue.value
 
     const primaryForegoundColorToUse = contentIsComingFromServer
       ? colorTheme.green.value

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -484,7 +484,7 @@ const CondensedEntryItem = React.memo(
               justifyContent: 'center',
               backgroundColor:
                 !props.wholeRowInsideSelection && !isChildOfSelected
-                  ? colorTheme.bg0.value
+                  ? colorTheme.bg1.value
                   : undefined,
               borderTopRightRadius: isSelected ? 5 : 0,
               borderBottomRightRadius: isSelected ? 5 : 0,
@@ -501,7 +501,7 @@ const CondensedEntryItem = React.memo(
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
-                gap: 3,
+                gap: showLabel ? 5 : 3,
                 borderRadius: 5,
                 backgroundColor:
                   isSelected && !isDataReference ? colorTheme.selectionBlue.value : undefined,
@@ -542,7 +542,9 @@ const CondensedEntryItem = React.memo(
               )}
               {when(
                 showLabel,
-                <span style={{ color: isSelected ? 'white' : undefined }}>{entryLabel}</span>,
+                <span style={{ color: isSelected ? 'white' : undefined, padding: '0 4px' }}>
+                  {entryLabel}
+                </span>,
               )}
               {when(
                 isDataReference,
@@ -559,7 +561,7 @@ const CondensedEntryItem = React.memo(
               ? 'transparent'
               : !selectionIsDataReference && (isSelected || isChildOfSelected)
               ? colorTheme.childSelectionBlue.value
-              : colorTheme.bg0.value,
+              : colorTheme.bg1.value,
             height: '100%',
             display: 'flex',
             alignItems: 'center',

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -292,7 +292,7 @@ const CondensedEntryItemWrapper = React.memo(
               ? colorTheme.childSelectionBlue.value
               : 'transparent',
           borderTopLeftRadius: wholeRowInsideSelection ? 0 : 5,
-          borderTopRightRadius: 5,
+          // borderTopRightRadius: 5,
           overflowX: 'auto',
         }}
       >
@@ -322,6 +322,11 @@ CondensedEntryItemWrapper.displayName = 'CondensedEntryItemWrapper'
 const CondensedEntryItemSeparator = React.memo(
   (props: { variant: CondensedNavigatorRowVariant }) => {
     const colorTheme = useColorTheme()
+
+    if (props.variant === 'leaf') {
+      return <div style={{ width: 5 }} />
+    }
+
     return (
       <div
         style={{
@@ -333,11 +338,12 @@ const CondensedEntryItemSeparator = React.memo(
           color: colorTheme.fg6.value,
         }}
       >
-        {props.variant === 'leaf' ? null : <Icons.NarrowExpansionArrowRight />}
+        <Icons.NarrowExpansionArrowRight />
       </div>
     )
   },
 )
+
 CondensedEntryItemSeparator.displayName = 'CondensedEntryItemSeparator'
 
 const CondensedEntryItem = React.memo(
@@ -561,7 +567,7 @@ const CondensedEntryItem = React.memo(
               ? 'transparent'
               : !selectionIsDataReference && (isSelected || isChildOfSelected)
               ? colorTheme.childSelectionBlue.value
-              : colorTheme.bg1.value,
+              : undefined,
             height: '100%',
             display: 'flex',
             alignItems: 'center',

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -68,11 +68,6 @@ import {
 import { ExpandableIndicator } from './expandable-indicator'
 import { unless, when } from '../../../utils/react-conditionals'
 import { DataReferenceCartoucheControl } from '../../inspector/sections/component-section/data-reference-cartouche'
-import {
-  DataPickerPopupButtonTestId,
-  useDataPickerButton,
-} from 'src/components/inspector/sections/component-section/component-section'
-import { DataPickerPopup } from 'src/components/inspector/sections/component-section/data-picker-popup'
 
 interface NavigatorItemWrapperProps {
   index: number

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -68,6 +68,11 @@ import {
 import { ExpandableIndicator } from './expandable-indicator'
 import { unless, when } from '../../../utils/react-conditionals'
 import { DataReferenceCartoucheControl } from '../../inspector/sections/component-section/data-reference-cartouche'
+import {
+  DataPickerPopupButtonTestId,
+  useDataPickerButton,
+} from 'src/components/inspector/sections/component-section/component-section'
+import { DataPickerPopup } from 'src/components/inspector/sections/component-section/data-picker-popup'
 
 interface NavigatorItemWrapperProps {
   index: number
@@ -292,7 +297,7 @@ const CondensedEntryItemWrapper = React.memo(
               ? colorTheme.childSelectionBlue.value
               : 'transparent',
           borderTopLeftRadius: wholeRowInsideSelection ? 0 : 5,
-          // borderTopRightRadius: 5,
+          borderTopRightRadius: 5,
           overflowX: 'auto',
         }}
       >
@@ -567,7 +572,7 @@ const CondensedEntryItem = React.memo(
               ? 'transparent'
               : !selectionIsDataReference && (isSelected || isChildOfSelected)
               ? colorTheme.childSelectionBlue.value
-              : undefined,
+              : colorTheme.bg1.value,
             height: '100%',
             display: 'flex',
             alignItems: 'center',

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -501,13 +501,13 @@ const CondensedEntryItem = React.memo(
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
-                gap: showLabel ? 5 : 3,
+                gap: 5,
                 borderRadius: 5,
                 backgroundColor:
                   isSelected && !isDataReference ? colorTheme.selectionBlue.value : undefined,
                 width: '100%',
                 height: '100%',
-                padding: props.showExpandableIndicator ? '0px 6px 0px 4px' : 0,
+                padding: props.showExpandableIndicator ? '0px 5px' : 0,
               }}
             >
               {when(


### PR DESCRIPTION
Some small changes to the padding and style in the new condensed navigator rows

| Before | After |
| ------------- | ------------- |
| <img width="443" alt="Screenshot 2024-05-23 at 9 05 04 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/81dddc67-8c6c-4e1c-89a6-9565b4e2f4de"> |  <img width="439" alt="Screenshot 2024-05-23 at 9 04 41 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/14d50d97-2ad9-4c1b-af9b-96ed183b3032"> |
| <img width="444" alt="Screenshot 2024-05-23 at 9 06 16 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/d2be63b9-09ac-48bb-a2af-1649dc530e86"> | <img width="440" alt="Screenshot 2024-05-23 at 9 06 38 PM" src="https://github.com/concrete-utopia/utopia/assets/47405698/5d69f2b9-bc0d-49b2-b88b-e6670ac66840">|
