### PR TITLE
Pass last saved contents to codeFile in ADD_NEW_PAGE

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4112,7 +4112,12 @@ export const UPDATE_FNS = {
       withPackageJson,
       action.parentPath,
       newFileName,
-      codeFile(templateFile.fileContents.code, RevisionsState.CodeAhead),
+      codeFile(
+        templateFile.fileContents.code,
+        templateFile.fileContents.code,
+        1,
+        RevisionsState.CodeAhead,
+      ),
     )
 
     // 3. open the text file

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -4112,12 +4112,7 @@ export const UPDATE_FNS = {
       withPackageJson,
       action.parentPath,
       newFileName,
-      codeFile(
-        templateFile.fileContents.code,
-        templateFile.fileContents.code,
-        1,
-        RevisionsState.CodeAhead,
-      ),
+      codeFile(templateFile.fileContents.code, null, 1, RevisionsState.CodeAhead),
     )
 
     // 3. open the text file


### PR DESCRIPTION
## Problem
The `codeFile` constructor function is passed ''CODE_AHEAD'` for `lastSavedContents`

## Fix
Pass the new file contents for `lastSavedContents`, 1 for `versionNumber` and `RevisionsState.CodeAhead` for `revisionsState`

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
