### PR TITLE
fixing some "Warning: flushSync was called from inside a lifecycle method"

### DIFF
--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -807,6 +807,8 @@ const useClearSelectionOnNavigation = () => {
     .join('-')
 
   React.useEffect(() => {
-    dispatch([EditorActions.clearSelection()])
+    queueMicrotask(() => {
+      dispatch([EditorActions.clearSelection()])
+    })
   }, [dispatch, paths])
 }

--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -936,7 +936,9 @@ export function useGithubPolling() {
 
     switch (authState) {
       case 'not-authenticated':
-        dispatch([updateGithubData(emptyGithubData())])
+        queueMicrotask(() => {
+          dispatch([updateGithubData(emptyGithubData())])
+        })
         break
       case 'missing-user-details':
         void GithubHelpers.getUserDetailsFromServer().then((userDetails) => {
@@ -971,7 +973,9 @@ export function useGithubPolling() {
     //   })
     // }
 
-    void refreshAndScheduleGithubData()
+    queueMicrotask(() => {
+      void refreshAndScheduleGithubData()
+    })
   }, [authState, refreshAndScheduleGithubData])
 }
 


### PR DESCRIPTION
**Problem:**
It's illegal to call our dispatch function from inside useEffect.

**Fix:**
I fix some of the offending places by wrapping the dispatch in a `queueMicrotask()`

**Commit Details:** (< vv pls delete this section if's not relevant)

- Fixing `useClearSelectionOnNavigation`
- Fixing `useGithubPolling`

**Note**
In the long term, we should break the jest / karma tests when the string "Warning: flushSync was called from inside a lifecycle method" is detected on the console. 

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
