### PR TITLE
Don't condense scenes

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -933,6 +933,14 @@ export const NavigatorItem: React.FunctionComponent<
     [navigatorEntry],
   )
 
+  const hideExpandableIndicator = React.useMemo(() => {
+    return (
+      props.navigatorEntry.type === 'CONDITIONAL_CLAUSE' ||
+      MetadataUtils.isProbablyScene(metadata, props.navigatorEntry.elementPath) ||
+      MetadataUtils.isProbablyRemixScene(metadata, props.navigatorEntry.elementPath)
+    )
+  }, [props.navigatorEntry, metadata])
+
   return (
     <div
       onClick={onClick}
@@ -1017,7 +1025,7 @@ export const NavigatorItem: React.FunctionComponent<
           >
             <FlexRow style={{ width: '100%' }}>
               {unless(
-                props.navigatorEntry.type === 'CONDITIONAL_CLAUSE',
+                hideExpandableIndicator,
                 <ExpandableIndicator
                   key='expandable-indicator'
                   visible={canBeExpanded}

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -1039,6 +1039,7 @@ export const NavigatorItem: React.FunctionComponent<
                 />,
               )}
               <NavigatorRowLabel
+                hideExpandableIndicator={hideExpandableIndicator}
                 shouldShowParentOutline={props.parentOutline === 'child'}
                 navigatorEntry={navigatorEntry}
                 label={props.label}
@@ -1193,6 +1194,7 @@ interface NavigatorRowLabelProps {
   childComponentCount: number
   dispatch: EditorDispatch
   insideFocusedComponent: boolean
+  hideExpandableIndicator: boolean
 }
 
 export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
@@ -1208,6 +1210,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
         gap: 5,
         borderRadius: 20,
         height: 22,
+        paddingLeft: props.hideExpandableIndicator ? 0 : 5,
         paddingRight: props.codeItemType === 'map' ? 0 : 5,
       }}
     >

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -56,7 +56,6 @@ import type {
   DerivedSubstate,
   MetadataSubstate,
 } from '../../editor/store/store-hook-substore-types'
-import { navigatorDepth } from '../navigator-utils'
 import { ComponentPreview } from './component-preview'
 import { ExpandableIndicator } from './expandable-indicator'
 import { ItemLabel } from './item-label'
@@ -1209,7 +1208,6 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
         gap: 5,
         borderRadius: 20,
         height: 22,
-        paddingLeft: 5,
         paddingRight: props.codeItemType === 'map' ? 0 : 5,
       }}
     >

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -2,6 +2,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react'
 import createCachedSelector from 're-reselect'
+import type { CSSProperties } from 'react'
 import React from 'react'
 import type { ConditionalCase } from '../../../core/model/conditionals'
 import {
@@ -932,13 +933,16 @@ export const NavigatorItem: React.FunctionComponent<
     [navigatorEntry],
   )
 
-  const hideExpandableIndicator = React.useMemo(() => {
+  const isScene = React.useMemo(() => {
     return (
-      props.navigatorEntry.type === 'CONDITIONAL_CLAUSE' ||
       MetadataUtils.isProbablyScene(metadata, props.navigatorEntry.elementPath) ||
       MetadataUtils.isProbablyRemixScene(metadata, props.navigatorEntry.elementPath)
     )
   }, [props.navigatorEntry, metadata])
+
+  const hideExpandableIndicator = React.useMemo(() => {
+    return props.navigatorEntry.type === 'CONDITIONAL_CLAUSE' || isScene
+  }, [props.navigatorEntry, isScene])
 
   return (
     <div
@@ -1039,7 +1043,6 @@ export const NavigatorItem: React.FunctionComponent<
                 />,
               )}
               <NavigatorRowLabel
-                hideExpandableIndicator={hideExpandableIndicator}
                 shouldShowParentOutline={props.parentOutline === 'child'}
                 navigatorEntry={navigatorEntry}
                 label={props.label}
@@ -1055,6 +1058,10 @@ export const NavigatorItem: React.FunctionComponent<
                 elementWarnings={!isConditional ? elementWarnings : null}
                 childComponentCount={childComponentCount}
                 insideFocusedComponent={isInsideComponent && isDescendantOfSelected}
+                style={{
+                  paddingLeft: isScene ? 0 : 5,
+                  paddingRight: codeItemType === 'map' ? 0 : 5,
+                }}
               />
             </FlexRow>
             {unless(
@@ -1194,7 +1201,7 @@ interface NavigatorRowLabelProps {
   childComponentCount: number
   dispatch: EditorDispatch
   insideFocusedComponent: boolean
-  hideExpandableIndicator: boolean
+  style?: CSSProperties
 }
 
 export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
@@ -1203,6 +1210,7 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
   return (
     <div
       style={{
+        ...props.style,
         display: 'flex',
         flexDirection: 'row',
         alignItems: 'center',
@@ -1210,8 +1218,6 @@ export const NavigatorRowLabel = React.memo((props: NavigatorRowLabelProps) => {
         gap: 5,
         borderRadius: 20,
         height: 22,
-        paddingLeft: props.hideExpandableIndicator ? 0 : 5,
-        paddingRight: props.codeItemType === 'map' ? 0 : 5,
       }}
     >
       {unless(

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -708,18 +708,24 @@ function getNavigatorRowsForTree(
       return []
     }
 
+    const nextIndentation =
+      MetadataUtils.isProbablyScene(metadata, entry.navigatorEntry.elementPath) ||
+      MetadataUtils.isProbablyRemixScene(metadata, entry.navigatorEntry.elementPath)
+        ? indentation // scenes live on a dedicated row, on the same indent as their children
+        : indentation + 1 // for everything else, go one level deeper
+
     switch (entry.type) {
       case 'condensed-trunk': {
         const { singleRow, child } = flattenCondensedTrunk(entry)
         if (singleRow.length === 1) {
           return [
             regularNavigatorRow(singleRow[0], indentation),
-            ...walkIfSubtreeVisible(child, indentation + 1),
+            ...walkIfSubtreeVisible(child, nextIndentation),
           ]
         }
         return [
           condensedNavigatorRow(singleRow, 'trunk', indentation),
-          ...walkIfSubtreeVisible(child, indentation + 1),
+          ...walkIfSubtreeVisible(child, nextIndentation),
         ]
       }
       case 'condensed-leaf':
@@ -748,9 +754,9 @@ function getNavigatorRowsForTree(
                   propName,
                   renderPropChild.navigatorEntry.elementPath,
                 ),
-                indentation + 1,
+                nextIndentation,
               ),
-              ...walkIfSubtreeVisible(renderPropChild, indentation + 2),
+              ...walkIfSubtreeVisible(renderPropChild, nextIndentation + 1),
             ]
           }),
           ...(showChildrenLabel
@@ -762,12 +768,12 @@ function getNavigatorRowsForTree(
                     'children',
                     entry.children[0].navigatorEntry.elementPath, // pick the first child path
                   ),
-                  indentation + 1,
+                  nextIndentation,
                 ),
               ]
             : []),
           ...entry.children.flatMap((t) =>
-            walkIfSubtreeVisible(t, showChildrenLabel ? indentation + 2 : indentation + 1),
+            walkIfSubtreeVisible(t, showChildrenLabel ? nextIndentation + 1 : nextIndentation),
           ),
         ]
       }
@@ -776,7 +782,7 @@ function getNavigatorRowsForTree(
       case 'map-entry':
         return [
           regularNavigatorRow(entry.navigatorEntry, indentation),
-          ...entry.mappedEntries.flatMap((t) => walkIfSubtreeVisible(t, indentation + 1)),
+          ...entry.mappedEntries.flatMap((t) => walkIfSubtreeVisible(t, nextIndentation)),
         ]
       case 'conditional-entry':
         return dropNulls([
@@ -785,16 +791,16 @@ function getNavigatorRowsForTree(
             ? null
             : regularNavigatorRow(
                 conditionalClauseNavigatorEntry(entry.navigatorEntry.elementPath, 'true-case'),
-                indentation + 1,
+                nextIndentation,
               ),
-          ...entry.trueCase.flatMap((t) => walkIfSubtreeVisible(t, indentation + 2)),
+          ...entry.trueCase.flatMap((t) => walkIfSubtreeVisible(t, nextIndentation + 1)),
           entry.subtreeHidden
             ? null
             : regularNavigatorRow(
                 conditionalClauseNavigatorEntry(entry.navigatorEntry.elementPath, 'false-case'),
-                indentation + 1,
+                nextIndentation,
               ),
-          ...entry.falseCase.flatMap((t) => walkIfSubtreeVisible(t, indentation + 2)),
+          ...entry.falseCase.flatMap((t) => walkIfSubtreeVisible(t, nextIndentation + 1)),
         ])
       default:
         assertNever(entry)

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -608,7 +608,9 @@ function condenseNavigatorTree(
     if (
       entry.type === 'regular-entry' &&
       entry.children.length === 1 &&
-      dataCanCondenseFromMetadata(metadata, entry.navigatorEntry.elementPath)
+      dataCanCondenseFromMetadata(metadata, entry.navigatorEntry.elementPath) &&
+      !MetadataUtils.isProbablyScene(metadata, entry.navigatorEntry.elementPath) &&
+      !MetadataUtils.isProbablyRemixScene(metadata, entry.navigatorEntry.elementPath)
     ) {
       return {
         type: 'condensed-trunk',


### PR DESCRIPTION
**Problem:**

Scenes and condensed rows should need some adjusting.

**Fix:**

1. Don't condense scenes, they always live on a dedicated row
2. Don't show the expandable indicator for scene rows
3. Indent scenes on the same level as their children

| Before | After |
|-------|---------|
| <img width="273" alt="Screenshot 2024-05-28 at 2 23 04 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/7060a9f4-cd5a-41ed-b814-d333ee51ee45"> | <img width="273" alt="Screenshot 2024-05-28 at 2 23 00 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/6ffd6c14-637e-4a6d-8d86-bf36bfd176db"> |


**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5767 
