### PR TITLE
Use editor url for origin check

### DIFF
--- a/utopia-remix/app/util/assets.server.ts
+++ b/utopia-remix/app/util/assets.server.ts
@@ -1,5 +1,5 @@
 import urlJoin from 'url-join'
-import { ServerEnvironment } from '../env.server'
+import { BrowserEnvironment } from '../env.server'
 import { allowedAssetExtensions } from '../handlers/splatLoad'
 import { canAccessProject } from '../handlers/validators'
 import { UserProjectPermission } from '../types'
@@ -39,7 +39,7 @@ export function getProjectIdFromReferer(req: Request): string | null {
 
   const refererURL = new URL(referer)
   const isMaybeProjectReferer =
-    refererURL.origin === ServerEnvironment.CORS_ORIGIN &&
+    refererURL.origin === BrowserEnvironment.EDITOR_URL &&
     (refererURL.pathname.startsWith('/p/') || refererURL.pathname.startsWith('/project/'))
   if (!isMaybeProjectReferer) {
     return null


### PR DESCRIPTION
Use `EDITOR_URL` for the referer check since the `CORS_ORIGIN` is not meant for that as it can be a comma-separated string.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
