### PR TITLE
Remove quotes for text cartouches

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
@@ -212,9 +212,9 @@ export function getTextContentOfElement(
     case 'ATTRIBUTE_VALUE':
       return { type: 'literal', label: `${JSON.stringify(element.value)}` }
     case 'JSX_TEXT_BLOCK':
-      return { type: 'literal', label: `'${element.text}'` }
+      return { type: 'literal', label: element.text.trim() }
     case 'JS_IDENTIFIER':
-      return { type: 'reference', label: `${element.name}` }
+      return { type: 'reference', label: element.name.trim() }
     case 'JS_ELEMENT_ACCESS':
       return {
         type: 'reference',


### PR DESCRIPTION
**Problem:**

Text cartouches have quotation marks around them that take a lot of space.

**Fix:**

1. Remove the quotation marks
2. Trim space around the text

| Before | After | 
|-------|-----------|
| <img width="546" alt="Screenshot 2024-05-30 at 5 41 43 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/8fb180bc-96ed-43aa-ab59-5e59f7055cfb"> | <img width="546" alt="Screenshot 2024-05-30 at 5 41 18 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/1fc5dca7-dc82-4870-b01d-743da6faf02e"> |

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5792 
