### PR TITLE
Fix Comment Notification

### DIFF
--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -237,8 +237,8 @@ const UnreadThreadsIndicator = React.memo(() => {
             ? `1.5px solid ${colorTheme.primary.value}`
             : `1.5px solid ${colorTheme.bg1.value}`,
         position: 'relative',
-        top: 8,
-        left: -15,
+        top: 5,
+        left: -9,
         opacity: unreadThreads.length > 0 ? 1 : 0,
       }}
     />


### PR DESCRIPTION
Moving this dot back to where it belongs, since it got moved after the latest toolbar design updates.

Before:
![image](https://github.com/concrete-utopia/utopia/assets/47405698/8f044056-0ab4-432b-9749-03a0ed093d2f)


After:
![Screenshot 2024-05-30 at 6 21 00 PM](https://github.com/concrete-utopia/utopia/assets/47405698/24bf94f9-cabc-40bb-aa86-2f0d3de2cf21)
