### PR TITLE
Collapse scenes from the action sheet

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -542,8 +542,9 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
             selected={props.selected}
             instanceOriginalComponentName={props.instanceOriginalComponentName}
           />
-          {(navigatorEntry.type === 'REGULAR' || navigatorEntry.type === 'RENDER_PROP_VALUE') &&
-          (props.highlighted || props.selected) ? (
+          {when(
+            (navigatorEntry.type === 'REGULAR' || navigatorEntry.type === 'RENDER_PROP_VALUE') &&
+              (props.highlighted || props.selected),
             <>
               <AddChildButton target={navigatorEntry.elementPath} iconColor={props.iconColor} />
               <ReplaceElementButton
@@ -552,8 +553,8 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
                 prop={navigatorEntry.type === 'RENDER_PROP_VALUE' ? navigatorEntry.prop : null}
                 conditionalCase={conditionalCase}
               />
-            </>
-          ) : null}
+            </>,
+          )}
           <SelectionLockedIndicator
             key={`selection-locked-indicator-${varSafeNavigatorEntryToKey(navigatorEntry)}`}
             shouldShow={

--- a/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-components.tsx
@@ -6,14 +6,14 @@ import * as EP from '../../../core/shared/element-path'
 import type { IcnProps } from '../../../uuiui'
 import { useColorTheme, Button, FlexRow, Icn } from '../../../uuiui'
 import { stopPropagation } from '../../inspector/common/inspector-utils'
-import { when } from '../../../utils/react-conditionals'
-import { Substores, useEditorState, useRefEditorState } from '../../editor/store/store-hook'
+import { unless, when } from '../../../utils/react-conditionals'
+import { Substores, useEditorState } from '../../editor/store/store-hook'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import type { NavigatorEntry } from '../../editor/store/editor-state'
 import {
-  getMetadata,
   isConditionalClauseNavigatorEntry,
   isRegularNavigatorEntry,
+  navigatorEntryToKey,
   varSafeNavigatorEntryToKey,
 } from '../../editor/store/editor-state'
 import type { SelectionLocked } from '../../canvas/canvas-types'
@@ -27,11 +27,11 @@ import type { ConditionalCase } from '../../../core/model/conditionals'
 import { useConditionalCaseCorrespondingToBranchPath } from '../../../core/model/conditionals'
 import {
   getJSXElementNameAsString,
-  isIntrinsicElement,
   isIntrinsicHTMLElement,
 } from '../../../core/shared/element-template'
 import { getRegisteredComponent } from '../../../core/property-controls/property-controls-utils'
 import { intrinsicHTMLElementNamesThatSupportChildren } from '../../../core/shared/dom-utils'
+import { ExpandableIndicator } from './expandable-indicator'
 
 export const NavigatorHintCircleDiameter = 8
 
@@ -443,6 +443,8 @@ interface NavigatorItemActionSheetProps {
   isVisibleOnCanvas: boolean // TODO FIXME bad name, also, use state
   instanceOriginalComponentName: string | null
   isSlot: boolean
+  isScene: boolean
+  collapsed: boolean
   iconColor: IcnProps['color']
   background?: string | any
   dispatch: EditorDispatch
@@ -489,14 +491,6 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
     'NavigatorItemActionSheet isLockedHierarchy',
   )
 
-  const jsxMetadataRef = useRefEditorState((store) => getMetadata(store.editor))
-  const isSceneElement = React.useMemo(() => {
-    return (
-      isRegularNavigatorEntry(navigatorEntry) &&
-      MetadataUtils.isProbablyScene(jsxMetadataRef.current, navigatorEntry.elementPath)
-    )
-  }, [navigatorEntry, jsxMetadataRef])
-
   const isDescendantOfLocked = useEditorState(
     Substores.restOfEditor,
     (store) => {
@@ -512,6 +506,14 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
 
   const conditionalCase = useConditionalCaseCorrespondingToBranchPath(
     props.navigatorEntry.elementPath,
+  )
+
+  const collapse = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+      event.stopPropagation()
+      dispatch([EditorActions.toggleCollapse(navigatorEntry.elementPath)])
+    },
+    [dispatch, navigatorEntry.elementPath],
   )
 
   return (
@@ -533,50 +535,74 @@ export const NavigatorItemActionSheet: React.FunctionComponent<
             : 'transparent',
       }}
     >
-      <OriginalComponentNameLabel
-        selected={props.selected}
-        instanceOriginalComponentName={props.instanceOriginalComponentName}
-      />
-      {(navigatorEntry.type === 'REGULAR' || navigatorEntry.type === 'RENDER_PROP_VALUE') &&
-      (props.highlighted || props.selected) ? (
+      {unless(
+        props.isScene,
         <>
-          <AddChildButton target={navigatorEntry.elementPath} iconColor={props.iconColor} />
-          <ReplaceElementButton
-            target={navigatorEntry.elementPath}
-            iconColor={props.iconColor}
-            prop={navigatorEntry.type === 'RENDER_PROP_VALUE' ? navigatorEntry.prop : null}
-            conditionalCase={conditionalCase}
+          <OriginalComponentNameLabel
+            selected={props.selected}
+            instanceOriginalComponentName={props.instanceOriginalComponentName}
           />
-        </>
-      ) : null}
-      <SelectionLockedIndicator
-        key={`selection-locked-indicator-${varSafeNavigatorEntryToKey(navigatorEntry)}`}
-        shouldShow={
-          !isSceneElement &&
-          (props.highlighted ||
-            props.selected ||
-            isLockedElement ||
-            isLockedHierarchy ||
-            isDescendantOfLocked) &&
-          !props.isSlot &&
-          !isConditionalClauseTitle
-        }
-        value={isLockedElement ? 'locked' : isLockedHierarchy ? 'locked-hierarchy' : 'selectable'}
-        isDescendantOfLocked={isDescendantOfLocked}
-        selected={props.selected}
-        iconColor={props.iconColor}
-        onClick={toggleSelectable}
-      />
-      <VisibilityIndicator
-        key={`visibility-indicator-${varSafeNavigatorEntryToKey(navigatorEntry)}`}
-        shouldShow={
-          !props.isSlot && (props.highlighted || props.selected || !props.isVisibleOnCanvas)
-        }
-        visibilityEnabled={props.isVisibleOnCanvas}
-        selected={props.selected}
-        iconColor={props.iconColor}
-        onClick={toggleHidden}
-      />
+          {(navigatorEntry.type === 'REGULAR' || navigatorEntry.type === 'RENDER_PROP_VALUE') &&
+          (props.highlighted || props.selected) ? (
+            <>
+              <AddChildButton target={navigatorEntry.elementPath} iconColor={props.iconColor} />
+              <ReplaceElementButton
+                target={navigatorEntry.elementPath}
+                iconColor={props.iconColor}
+                prop={navigatorEntry.type === 'RENDER_PROP_VALUE' ? navigatorEntry.prop : null}
+                conditionalCase={conditionalCase}
+              />
+            </>
+          ) : null}
+          <SelectionLockedIndicator
+            key={`selection-locked-indicator-${varSafeNavigatorEntryToKey(navigatorEntry)}`}
+            shouldShow={
+              !props.isScene &&
+              (props.highlighted ||
+                props.selected ||
+                isLockedElement ||
+                isLockedHierarchy ||
+                isDescendantOfLocked) &&
+              !props.isSlot &&
+              !isConditionalClauseTitle
+            }
+            value={
+              isLockedElement ? 'locked' : isLockedHierarchy ? 'locked-hierarchy' : 'selectable'
+            }
+            isDescendantOfLocked={isDescendantOfLocked}
+            selected={props.selected}
+            iconColor={props.iconColor}
+            onClick={toggleSelectable}
+          />
+          <VisibilityIndicator
+            key={`visibility-indicator-${varSafeNavigatorEntryToKey(navigatorEntry)}`}
+            shouldShow={
+              !props.isSlot && (props.highlighted || props.selected || !props.isVisibleOnCanvas)
+            }
+            visibilityEnabled={props.isVisibleOnCanvas}
+            selected={props.selected}
+            iconColor={props.iconColor}
+            onClick={toggleHidden}
+          />
+        </>,
+      )}
+      {when(
+        props.isScene,
+        <ExpandableIndicator
+          key='expandable-indicator'
+          visible={true}
+          collapsed={props.collapsed}
+          selected={props.selected}
+          onMouseDown={collapse}
+          style={{
+            opacity: 'var(--paneHoverOpacity)',
+          }}
+          testId={`navigator-item-action-sheet-collapse-${navigatorEntryToKey(
+            props.navigatorEntry,
+          )}`}
+          iconColor={props.selected ? 'white' : 'main'}
+        />,
+      )}
     </FlexRow>
   )
 })

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -1076,6 +1076,8 @@ export const NavigatorItem: React.FunctionComponent<
                 isSlot={isPlaceholder}
                 iconColor={iconColor}
                 background={rowStyle.background}
+                isScene={isScene}
+                collapsed={collapsed}
               />,
             )}
           </FlexRow>


### PR DESCRIPTION
**Problem:**

1. It's not possible to collapse scenes anymore
2. The action sheet usual buttons are shown for scenes, even though they shouldn't

**Fix:**

If the navigator entry is a scene, replace the action sheet buttons with a single expandable indicator to collapse the scene from there.


https://github.com/concrete-utopia/utopia/assets/1081051/9dff4ac0-7f0e-439f-94d4-9b52c8eed2b4



**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5795 
