### PR TITLE
Icon for radio control options.

### DIFF
--- a/editor/src/components/custom-code/internal-property-controls.ts
+++ b/editor/src/components/custom-code/internal-property-controls.ts
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'react'
 import type { ComponentInfo } from './code-file'
+import type { PropertyControlIcon } from 'utopia-api/core'
 
 interface GenericControlProps<T> {
   label?: string
@@ -46,7 +47,14 @@ export interface BasicControlOption<T> {
   label: string
 }
 
+export interface BasicControlOptionWithIcon<T> {
+  value: T
+  label: string
+  icon: PropertyControlIcon | null
+}
+
 export type BasicControlOptions<T> = AllowedEnumType[] | BasicControlOption<T>[]
+export type BasicControlOptionsWithIcon<T> = AllowedEnumType[] | BasicControlOptionWithIcon<T>[]
 
 export interface PopUpListControlDescription
   extends GenericControlProps<AllowedEnumType | BasicControlOption<unknown>> {
@@ -121,7 +129,7 @@ export interface NumberInputControlDescription extends GenericControlProps<unkno
 export interface RadioControlDescription
   extends GenericControlProps<AllowedEnumType | BasicControlOption<unknown>> {
   control: 'radio'
-  options: BasicControlOptions<unknown>
+  options: BasicControlOptionsWithIcon<unknown>
 }
 
 export interface ExpressionInputControlDescription extends GenericControlProps<unknown> {

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -392,7 +392,7 @@ export const RadioPropertyControl = React.memo(
     const value = propMetadata.propertyStatus.set ? propMetadata.value : undefined
 
     // TS baulks at the map below for some reason if we don't first do this
-    const controlOptions: Array<IndividualOption> = controlDescription.options
+    const controlOptions: RadioControlDescription['options'] = controlDescription.options
 
     const options: Array<OptionChainOption<unknown>> = useKeepReferenceEqualityIfPossible(
       controlOptions.map((option) => {

--- a/editor/src/core/property-controls/property-control-values.spec.ts
+++ b/editor/src/core/property-controls/property-control-values.spec.ts
@@ -179,6 +179,7 @@ describe('RadioControlDescription', () => {
       {
         value: validValue,
         label: 'Label',
+        icon: null,
       },
     ],
   }

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -2,6 +2,9 @@ import type {
   RegularControlDescription as RegularControlDescriptionFromUtopia,
   JSXControlDescription as JSXControlDescriptionFromUtopia,
   PropertyControls as PropertyControlsFromUtopiaAPI,
+  RadioControlDescription as RadioControlDescriptionFromUtopia,
+  AllowedEnumType as AllowedEnumTypeFromUtopia,
+  BasicControlOptionWithIcon as BasicControlOptionWithIconFromUtopia,
   ComponentToRegister,
   ComponentInsertOption,
   ComponentExample,
@@ -26,6 +29,9 @@ import type {
   RegularControlDescription,
   JSXControlDescription,
   PreferredChildComponentDescriptor,
+  RadioControlDescription,
+  AllowedEnumType,
+  BasicControlOptionWithIcon,
 } from '../../components/custom-code/internal-property-controls'
 import { packageJsonFileFromProjectContents, walkContentsTree } from '../../components/assets'
 import {
@@ -65,6 +71,7 @@ import {
   foldEither,
   forEachRight,
   isLeft,
+  isRight,
   left,
   mapEither,
   right,
@@ -743,6 +750,83 @@ async function parseJSXControlDescription(
   })
 }
 
+function parseAllowedEnumType(option: AllowedEnumTypeFromUtopia): AllowedEnumType {
+  return option
+}
+
+function parseBasicControlOptionWithIcon(
+  option: BasicControlOptionWithIconFromUtopia<unknown>,
+): BasicControlOptionWithIcon<unknown> {
+  return {
+    label: option.label,
+    value: option.value,
+    icon: option.icon ?? null,
+  }
+}
+
+function isAllowedEnumType(
+  option: AllowedEnumTypeFromUtopia | BasicControlOptionWithIconFromUtopia<unknown>,
+): option is AllowedEnumTypeFromUtopia {
+  return (
+    typeof option === 'string' ||
+    typeof option === 'boolean' ||
+    typeof option === 'number' ||
+    typeof option === 'undefined' ||
+    (typeof option === 'object' && option === null)
+  )
+}
+
+function parseRadioControlOptions(
+  options: AllowedEnumTypeFromUtopia[] | BasicControlOptionWithIconFromUtopia<unknown>[],
+): Either<string, AllowedEnumType[] | BasicControlOptionWithIcon<unknown>[]> {
+  const allowedEnumTypes = sequenceEither(
+    options.map(
+      (o): Either<string, AllowedEnumType> =>
+        isAllowedEnumType(o) ? right(parseAllowedEnumType(o)) : left('Not an allowed enum type'),
+    ),
+  )
+
+  if (isRight(allowedEnumTypes)) {
+    return allowedEnumTypes
+  }
+
+  const basicControlOptions = sequenceEither(
+    options.map(
+      (o): Either<string, BasicControlOptionWithIcon<unknown>> =>
+        isAllowedEnumType(o)
+          ? left('Not a BasicControlOptionWithIcon<unknown>>')
+          : right(parseBasicControlOptionWithIcon(o)),
+    ),
+  )
+
+  if (isRight(basicControlOptions)) {
+    return basicControlOptions
+  }
+
+  return left('Cannot mix AllowedEnumType and BasicControlOptionWithIcon')
+}
+
+async function parseRadioControlDescription(
+  descriptor: RadioControlDescriptionFromUtopia,
+): Promise<PropertyDescriptorResult<RadioControlDescription>> {
+  const options = parseRadioControlOptions(descriptor.options)
+  if (isLeft(options)) {
+    return options
+  }
+
+  return right({
+    control: descriptor.control,
+    label: descriptor.label,
+    visibleByDefault: descriptor.visibleByDefault,
+    options: options.value,
+    required: descriptor.required,
+    defaultValue: isAllowedEnumType(descriptor.defaultValue)
+      ? parseAllowedEnumType(descriptor.defaultValue)
+      : parseBasicControlOptionWithIcon(descriptor.defaultValue),
+    folder: descriptor.folder,
+  })
+}
+
 async function makeRegularControlDescription(
   descriptor: RegularControlDescriptionFromUtopia,
   context: { moduleName: string; workers: UtopiaTsWorkers },
@@ -751,6 +835,9 @@ async function makeRegularControlDescription(
     if (descriptor.control === 'jsx') {
       const parsedJSXControlDescription = parseJSXControlDescription(descriptor, context)
       return parsedJSXControlDescription
+    }
+    if (descriptor.control === 'radio') {
+      return parseRadioControlDescription(descriptor)
     }
     return right(descriptor)
   }

--- a/utopia-api/src/property-controls/property-controls.ts
+++ b/utopia-api/src/property-controls/property-controls.ts
@@ -12,6 +12,9 @@ interface ControlBaseFields {
   folder?: string
 }
 
+export const PropertyControlIcons = ['arrow-left', 'arrow-right', 'text'] as const
+export type PropertyControlIcon = (typeof PropertyControlIcons)[number]
+
 // Base Level Controls
 
 export type BaseControlType =
@@ -58,6 +61,12 @@ export type AllowedEnumType = string | boolean | number | undefined | null
 export interface BasicControlOption<T> {
   value: T
   label: string
+}
+
+export interface BasicControlOptionWithIcon<T> {
+  value: T
+  label: string
+  icon?: PropertyControlIcon
 }
 
 export type BasicControlOptions<T> = AllowedEnumType[] | BasicControlOption<T>[]
@@ -164,9 +173,9 @@ export interface RadioControlDescription {
   control: 'radio'
   label?: string
   visibleByDefault?: boolean
-  options: BasicControlOptions<unknown>
+  options: AllowedEnumType[] | BasicControlOptionWithIcon<unknown>[]
   required?: boolean
-  defaultValue?: AllowedEnumType | BasicControlOption<unknown>
+  defaultValue?: AllowedEnumType | BasicControlOptionWithIcon<unknown>
   folder?: string
 }
 


### PR DESCRIPTION
## Problem
https://github.com/concrete-utopia/utopia/issues/5782

## Fix
Extend the API. The actual icons are TBD, check before merging

### Manual Tests
I hereby swear that:

- [ ] I opened a hydrogen project and it loaded
- [ ] I could navigate to various routes in Preview mode
