### PR TITLE
VariablesInScope Fix: for component arbitrary blocks, change insertionCeiling to rootElementPath

### DIFF
--- a/editor/src/components/canvas/scoped-variables.spec.tsx
+++ b/editor/src/components/canvas/scoped-variables.spec.tsx
@@ -230,6 +230,9 @@ describe('scoped variables', () => {
                   "scene-1-entity",
                   "app-entity",
                 ],
+                Array [
+                  "8ba",
+                ],
               ],
               "type": "elementpath",
             },
@@ -246,6 +249,9 @@ describe('scoped variables', () => {
                   "storyboard-entity",
                   "scene-1-entity",
                   "app-entity",
+                ],
+                Array [
+                  "8ba",
                 ],
               ],
               "type": "elementpath",
@@ -282,6 +288,9 @@ describe('scoped variables', () => {
                   "storyboard-entity",
                   "scene-1-entity",
                   "app-entity",
+                ],
+                Array [
+                  "8ba",
                 ],
               ],
               "type": "elementpath",
@@ -334,6 +343,9 @@ describe('scoped variables', () => {
                   "scene-1-entity",
                   "app-entity",
                 ],
+                Array [
+                  "af0",
+                ],
               ],
               "type": "elementpath",
             },
@@ -351,6 +363,9 @@ describe('scoped variables', () => {
                   "scene-1-entity",
                   "app-entity",
                 ],
+                Array [
+                  "af0",
+                ],
               ],
               "type": "elementpath",
             },
@@ -367,6 +382,9 @@ describe('scoped variables', () => {
                   "storyboard-entity",
                   "scene-1-entity",
                   "app-entity",
+                ],
+                Array [
+                  "af0",
                 ],
               ],
               "type": "elementpath",

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -173,7 +173,7 @@ export function createComponentRendererComponent(params: {
     }
 
     let spiedVariablesInScope: VariableData = {}
-    if (utopiaJsxComponent.param != null) {
+    if (rootElementPath != null && utopiaJsxComponent.param != null) {
       spiedVariablesInScope = mapArrayToDictionary(
         propertiesExposedByParam(utopiaJsxComponent.param),
         (paramName) => {
@@ -267,15 +267,17 @@ export function createComponentRendererComponent(params: {
 
       switch (arbitraryBlockResult.type) {
         case 'ARBITRARY_BLOCK_RAN_TO_END':
-          spiedVariablesInScope = {
-            ...spiedVariablesInScope,
-            ...objectMap(
-              (spiedValue) => ({
-                spiedValue: spiedValue,
-                insertionCeiling: rootElementPath,
-              }),
-              arbitraryBlockResult.scope,
-            ),
+          if (rootElementPath != null) {
+            spiedVariablesInScope = {
+              ...spiedVariablesInScope,
+              ...objectMap(
+                (spiedValue) => ({
+                  spiedValue: spiedValue,
+                  insertionCeiling: rootElementPath,
+                }),
+                arbitraryBlockResult.scope,
+              ),
+            }
           }
           break
         case 'EARLY_RETURN_VOID':

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -182,7 +182,7 @@ export function createComponentRendererComponent(params: {
         (paramName) => {
           return {
             spiedValue: scope[paramName],
-            insertionCeiling: instancePath,
+            insertionCeiling: rootElementPath,
           }
         },
       )
@@ -272,7 +272,7 @@ export function createComponentRendererComponent(params: {
             ...objectMap(
               (spiedValue) => ({
                 spiedValue: spiedValue,
-                insertionCeiling: instancePath,
+                insertionCeiling: rootElementPath,
               }),
               arbitraryBlockResult.scope,
             ),

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -137,10 +137,12 @@ export function createLookupRender(
     let innerVariablesInScope: VariableData = {
       ...context.variablesInScope,
     }
-    for (const valueInScope of valuesInScopeFromParameters) {
-      innerVariablesInScope[valueInScope] = {
-        spiedValue: scope[valueInScope],
-        insertionCeiling: innerPath,
+    if (innerPath != null) {
+      for (const valueInScope of valuesInScopeFromParameters) {
+        innerVariablesInScope[valueInScope] = {
+          spiedValue: scope[valueInScope],
+          insertionCeiling: innerPath,
+        }
       }
     }
 

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -103,7 +103,7 @@ export const ElementsToRerenderGLOBAL: { current: ElementsToRerender } = {
 
 export interface VariableMetadata {
   spiedValue: unknown
-  insertionCeiling: ElementPath | null
+  insertionCeiling: ElementPath
 }
 
 export interface VariableData {

--- a/editor/src/core/model/element-metadata.spec.browser2.tsx
+++ b/editor/src/core/model/element-metadata.spec.browser2.tsx
@@ -1400,52 +1400,64 @@ describe('record variable values', () => {
     const editor = await renderTestEditorWithCode(ProjectWithVariables, 'await-first-dom-report')
     const { variablesInScope } = editor.getEditorState().editor
     expect(variablesInScope['sb/scene/pg:root']).toEqual<VariableData>({
-      definedInsideNumber: { spiedValue: 12, insertionCeiling: EP.fromString('sb/scene/pg') },
+      definedInsideNumber: { spiedValue: 12, insertionCeiling: EP.fromString('sb/scene/pg:root') },
       definedInsideObject: {
         spiedValue: {
           prop: [33],
         },
-        insertionCeiling: EP.fromString('sb/scene/pg'),
+        insertionCeiling: EP.fromString('sb/scene/pg:root'),
       },
-      definedInsideString: { spiedValue: 'hello', insertionCeiling: EP.fromString('sb/scene/pg') },
-      functionResult: { spiedValue: 35, insertionCeiling: EP.fromString('sb/scene/pg') },
-      style: { spiedValue: {}, insertionCeiling: EP.fromString('sb/scene/pg') },
+      definedInsideString: {
+        spiedValue: 'hello',
+        insertionCeiling: EP.fromString('sb/scene/pg:root'),
+      },
+      functionResult: { spiedValue: 35, insertionCeiling: EP.fromString('sb/scene/pg:root') },
+      style: { spiedValue: {}, insertionCeiling: EP.fromString('sb/scene/pg:root') },
     })
     expect(variablesInScope['sb/scene/pg:root/111']).toEqual<VariableData>({
-      definedInsideNumber: { spiedValue: 12, insertionCeiling: EP.fromString('sb/scene/pg') },
+      definedInsideNumber: { spiedValue: 12, insertionCeiling: EP.fromString('sb/scene/pg:root') },
       definedInsideObject: {
         spiedValue: {
           prop: [33],
         },
-        insertionCeiling: EP.fromString('sb/scene/pg'),
+        insertionCeiling: EP.fromString('sb/scene/pg:root'),
       },
-      definedInsideString: { spiedValue: 'hello', insertionCeiling: EP.fromString('sb/scene/pg') },
-      functionResult: { spiedValue: 35, insertionCeiling: EP.fromString('sb/scene/pg') },
-      style: { spiedValue: {}, insertionCeiling: EP.fromString('sb/scene/pg') },
+      definedInsideString: {
+        spiedValue: 'hello',
+        insertionCeiling: EP.fromString('sb/scene/pg:root'),
+      },
+      functionResult: { spiedValue: 35, insertionCeiling: EP.fromString('sb/scene/pg:root') },
+      style: { spiedValue: {}, insertionCeiling: EP.fromString('sb/scene/pg:root') },
     })
     expect(variablesInScope['sb/scene/pg:root/222']).toEqual<VariableData>({
-      definedInsideNumber: { spiedValue: 12, insertionCeiling: EP.fromString('sb/scene/pg') },
+      definedInsideNumber: { spiedValue: 12, insertionCeiling: EP.fromString('sb/scene/pg:root') },
       definedInsideObject: {
         spiedValue: {
           prop: [33],
         },
-        insertionCeiling: EP.fromString('sb/scene/pg'),
+        insertionCeiling: EP.fromString('sb/scene/pg:root'),
       },
-      definedInsideString: { spiedValue: 'hello', insertionCeiling: EP.fromString('sb/scene/pg') },
-      functionResult: { spiedValue: 35, insertionCeiling: EP.fromString('sb/scene/pg') },
-      style: { spiedValue: {}, insertionCeiling: EP.fromString('sb/scene/pg') },
+      definedInsideString: {
+        spiedValue: 'hello',
+        insertionCeiling: EP.fromString('sb/scene/pg:root'),
+      },
+      functionResult: { spiedValue: 35, insertionCeiling: EP.fromString('sb/scene/pg:root') },
+      style: { spiedValue: {}, insertionCeiling: EP.fromString('sb/scene/pg:root') },
     })
     expect(variablesInScope['sb/scene/pg:root/333']).toEqual<VariableData>({
-      definedInsideNumber: { spiedValue: 12, insertionCeiling: EP.fromString('sb/scene/pg') },
+      definedInsideNumber: { spiedValue: 12, insertionCeiling: EP.fromString('sb/scene/pg:root') },
       definedInsideObject: {
         spiedValue: {
           prop: [33],
         },
-        insertionCeiling: EP.fromString('sb/scene/pg'),
+        insertionCeiling: EP.fromString('sb/scene/pg:root'),
       },
-      definedInsideString: { spiedValue: 'hello', insertionCeiling: EP.fromString('sb/scene/pg') },
-      functionResult: { spiedValue: 35, insertionCeiling: EP.fromString('sb/scene/pg') },
-      style: { spiedValue: {}, insertionCeiling: EP.fromString('sb/scene/pg') },
+      definedInsideString: {
+        spiedValue: 'hello',
+        insertionCeiling: EP.fromString('sb/scene/pg:root'),
+      },
+      functionResult: { spiedValue: 35, insertionCeiling: EP.fromString('sb/scene/pg:root') },
+      style: { spiedValue: {}, insertionCeiling: EP.fromString('sb/scene/pg:root') },
     })
   })
 })


### PR DESCRIPTION
This is a preparation PR for #5815

**Problem:**
The ComponentRendererComponent saves variables declared in its arbitrary block into `VariablesInScope`. However, the `insertionCeiling` is:
1. not guaranteed to be non-null, even though a null value would not be sensible here
2. points to the _element instance_ of the component instead of the component's root element. since the insertionCeiling is a ceiling above which insertion is not allowed, it must be the component's root element.

**Commit Details:** (< vv pls delete this section if's not relevant)

- Adding null check before pushing to VariablesInScope
- Use `insertionCeiling: rootElementPath`
- As @bkrmendy pointed out, it actually makes more sense to make insertionCeiling non-nullable, so I did that and fixed the fallout

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

