### PR TITLE
Trace variable to a literal-valued declaration in the arbitrary js block.

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -301,6 +301,7 @@ export const DataSelectorModal = React.memo(
               result[variable.valuePath.toString()] = 'external'
               break
             case 'literal-attribute':
+            case 'literal-assignment':
               result[variable.valuePath.toString()] = 'literal'
               break
             case 'component-prop':

--- a/editor/src/core/data-tracing/data-tracing.spec.ts
+++ b/editor/src/core/data-tracing/data-tracing.spec.ts
@@ -49,7 +49,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          PP.create('title'),
+          { type: 'property', propertyPath: PP.create('title') },
           dataPathSuccess([]),
         ),
       )
@@ -81,7 +81,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component/inner-child'),
-          PP.create('title'),
+          { type: 'property', propertyPath: PP.create('title') },
           dataPathSuccess([]),
         ),
       )
@@ -113,7 +113,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          PP.create('title'),
+          { type: 'property', propertyPath: PP.create('title') },
           dataPathSuccess([]),
         ),
       )
@@ -152,7 +152,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          PP.create('title'),
+          { type: 'property', propertyPath: PP.create('title') },
           dataPathSuccess([]),
         ),
       )
@@ -184,7 +184,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          PP.create('title'),
+          { type: 'property', propertyPath: PP.create('title') },
           dataPathSuccess([]),
         ),
       )
@@ -216,7 +216,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          PP.create('title'),
+          { type: 'property', propertyPath: PP.create('title') },
           dataPathSuccess([]),
         ),
       )
@@ -255,7 +255,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          PP.create('title'),
+          { type: 'property', propertyPath: PP.create('title') },
           dataPathSuccess([]),
         ),
       )
@@ -287,7 +287,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          PP.create('doc'),
+          { type: 'property', propertyPath: PP.create('doc') },
           dataPathSuccess(['title']),
         ),
       )
@@ -319,7 +319,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          PP.create('doc'),
+          { type: 'property', propertyPath: PP.create('doc') },
           dataPathSuccess(['very', 'deep', 'title']),
         ),
       )
@@ -358,7 +358,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          PP.create('doc'),
+          { type: 'property', propertyPath: PP.create('doc') },
           dataPathSuccess(['very', 'deep', 'title', 'value']),
         ),
       )
@@ -794,7 +794,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          PP.create('title'),
+          { type: 'property', propertyPath: PP.create('title') },
           dataPathSuccess([]),
         ),
       )
@@ -827,7 +827,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          PP.create('title'),
+          { type: 'property', propertyPath: PP.create('title') },
           dataPathSuccess([]),
         ),
       )
@@ -860,7 +860,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          PP.create('title'),
+          { type: 'property', propertyPath: PP.create('title') },
           dataPathSuccess([]),
         ),
       )
@@ -906,7 +906,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          PP.create('titles'),
+          { type: 'property', propertyPath: PP.create('titles') },
           dataPathSuccess(['1']),
         ),
       )
@@ -1251,6 +1251,135 @@ describe('Data Tracing', () => {
             EP.fromString('sb/app:my-component'),
             'useLoaderData',
             dataPathSuccess(['very', 'a', '0', 'helloFromDestructuredArray']),
+          ),
+        )
+      }
+    })
+
+    it('can to a literal-valued variable in the arbitrary js block', async () => {
+      const editor = await renderTestEditorWithCode(
+        makeTestProjectCodeWithStoryboard(`
+        function MyComponent({ doc }) {
+
+          const valueFromTheDeep = doc.title.value
+
+          return <h1 data-uid='component-root'>{doc.title.value}</h1>
+        }
+  
+        function App() {
+          const label = 'yes'
+          const loaded = true
+          const words = ['hello', 'cheese']
+          const deeplyNestedObject = { very: { deep: { title: {value: ['hello', 'world'] } }, a: [1, 2] } }
+          const { very } = deeplyNestedObject
+
+          return <MyComponent data-uid='my-component' doc={very.deep} />
+        }
+        `),
+        'await-first-dom-report',
+      )
+
+      await focusOnComponentForTest(editor, EP.fromString('sb/app:my-component'))
+
+      {
+        const trace = traceDataFromVariableName(
+          EP.fromString('sb/app:my-component'),
+          'label',
+          editor.getEditorState().editor.jsxMetadata,
+          editor.getEditorState().editor.projectContents,
+          dataPathSuccess([]),
+        )
+
+        expect(trace).toEqual(
+          dataTracingToLiteralAttribute(
+            EP.fromString('sb/app:my-component'),
+            { type: 'arbitrary-js-block' },
+            dataPathSuccess([]),
+          ),
+        )
+      }
+      {
+        const trace = traceDataFromVariableName(
+          EP.fromString('sb/app:my-component'),
+          'loaded',
+          editor.getEditorState().editor.jsxMetadata,
+          editor.getEditorState().editor.projectContents,
+          dataPathSuccess([]),
+        )
+
+        expect(trace).toEqual(
+          dataTracingToLiteralAttribute(
+            EP.fromString('sb/app:my-component'),
+            { type: 'arbitrary-js-block' },
+            dataPathSuccess([]),
+          ),
+        )
+      }
+      {
+        const trace = traceDataFromVariableName(
+          EP.fromString('sb/app:my-component'),
+          'words',
+          editor.getEditorState().editor.jsxMetadata,
+          editor.getEditorState().editor.projectContents,
+          dataPathSuccess([]),
+        )
+
+        expect(trace).toEqual(
+          dataTracingToLiteralAttribute(
+            EP.fromString('sb/app:my-component'),
+            { type: 'arbitrary-js-block' },
+            dataPathSuccess([]),
+          ),
+        )
+      }
+      {
+        const trace = traceDataFromVariableName(
+          EP.fromString('sb/app:my-component'),
+          'deeplyNestedObject',
+          editor.getEditorState().editor.jsxMetadata,
+          editor.getEditorState().editor.projectContents,
+          dataPathSuccess([]),
+        )
+
+        expect(trace).toEqual(
+          dataTracingToLiteralAttribute(
+            EP.fromString('sb/app:my-component'),
+            { type: 'arbitrary-js-block' },
+            dataPathSuccess([]),
+          ),
+        )
+      }
+      {
+        const trace = traceDataFromVariableName(
+          EP.fromString('sb/app:my-component'),
+          'very',
+          editor.getEditorState().editor.jsxMetadata,
+          editor.getEditorState().editor.projectContents,
+          dataPathSuccess([]),
+        )
+
+        expect(trace).toEqual(
+          dataTracingToLiteralAttribute(
+            EP.fromString('sb/app:my-component'),
+            { type: 'arbitrary-js-block' },
+            dataPathSuccess(['very']),
+          ),
+        )
+      }
+      {
+        const trace = traceDataFromVariableName(
+          EP.fromString('sb/app:my-component:component-root'),
+          'valueFromTheDeep',
+          editor.getEditorState().editor.jsxMetadata,
+          editor.getEditorState().editor.projectContents,
+          dataPathSuccess([]),
+        )
+
+        expect(trace).toEqual(
+          dataTracingToLiteralAttribute(
+            EP.fromString('sb/app:my-component'),
+            { type: 'arbitrary-js-block' },
+            dataPathSuccess(['very', 'deep', 'title', 'value']),
           ),
         )
       }

--- a/editor/src/core/data-tracing/data-tracing.spec.ts
+++ b/editor/src/core/data-tracing/data-tracing.spec.ts
@@ -19,6 +19,7 @@ import {
   dataTracingFailed,
   dataTracingToAHookCall,
   dataTracingToElementAtScope,
+  dataTracingToLiteralAssignment,
   dataTracingToLiteralAttribute,
   traceDataFromElement,
   traceDataFromProp,
@@ -49,7 +50,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          { type: 'property', propertyPath: PP.create('title') },
+          PP.create('title'),
           dataPathSuccess([]),
         ),
       )
@@ -81,7 +82,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component/inner-child'),
-          { type: 'property', propertyPath: PP.create('title') },
+          PP.create('title'),
           dataPathSuccess([]),
         ),
       )
@@ -113,7 +114,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          { type: 'property', propertyPath: PP.create('title') },
+          PP.create('title'),
           dataPathSuccess([]),
         ),
       )
@@ -152,7 +153,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          { type: 'property', propertyPath: PP.create('title') },
+          PP.create('title'),
           dataPathSuccess([]),
         ),
       )
@@ -184,7 +185,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          { type: 'property', propertyPath: PP.create('title') },
+          PP.create('title'),
           dataPathSuccess([]),
         ),
       )
@@ -216,7 +217,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          { type: 'property', propertyPath: PP.create('title') },
+          PP.create('title'),
           dataPathSuccess([]),
         ),
       )
@@ -255,7 +256,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          { type: 'property', propertyPath: PP.create('title') },
+          PP.create('title'),
           dataPathSuccess([]),
         ),
       )
@@ -287,7 +288,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          { type: 'property', propertyPath: PP.create('doc') },
+          PP.create('doc'),
           dataPathSuccess(['title']),
         ),
       )
@@ -319,7 +320,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          { type: 'property', propertyPath: PP.create('doc') },
+          PP.create('doc'),
           dataPathSuccess(['very', 'deep', 'title']),
         ),
       )
@@ -358,7 +359,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          { type: 'property', propertyPath: PP.create('doc') },
+          PP.create('doc'),
           dataPathSuccess(['very', 'deep', 'title', 'value']),
         ),
       )
@@ -794,7 +795,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          { type: 'property', propertyPath: PP.create('title') },
+          PP.create('title'),
           dataPathSuccess([]),
         ),
       )
@@ -827,7 +828,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          { type: 'property', propertyPath: PP.create('title') },
+          PP.create('title'),
           dataPathSuccess([]),
         ),
       )
@@ -860,7 +861,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          { type: 'property', propertyPath: PP.create('title') },
+          PP.create('title'),
           dataPathSuccess([]),
         ),
       )
@@ -906,7 +907,7 @@ describe('Data Tracing', () => {
       expect(traceResult).toEqual(
         dataTracingToLiteralAttribute(
           EP.fromString('sb/app:my-component'),
-          { type: 'property', propertyPath: PP.create('titles') },
+          PP.create('titles'),
           dataPathSuccess(['1']),
         ),
       )
@@ -1291,11 +1292,7 @@ describe('Data Tracing', () => {
         )
 
         expect(trace).toEqual(
-          dataTracingToLiteralAttribute(
-            EP.fromString('sb/app:my-component'),
-            { type: 'arbitrary-js-block' },
-            dataPathSuccess([]),
-          ),
+          dataTracingToLiteralAssignment(EP.fromString('sb/app:my-component'), dataPathSuccess([])),
         )
       }
       {
@@ -1308,11 +1305,7 @@ describe('Data Tracing', () => {
         )
 
         expect(trace).toEqual(
-          dataTracingToLiteralAttribute(
-            EP.fromString('sb/app:my-component'),
-            { type: 'arbitrary-js-block' },
-            dataPathSuccess([]),
-          ),
+          dataTracingToLiteralAssignment(EP.fromString('sb/app:my-component'), dataPathSuccess([])),
         )
       }
       {
@@ -1325,11 +1318,7 @@ describe('Data Tracing', () => {
         )
 
         expect(trace).toEqual(
-          dataTracingToLiteralAttribute(
-            EP.fromString('sb/app:my-component'),
-            { type: 'arbitrary-js-block' },
-            dataPathSuccess([]),
-          ),
+          dataTracingToLiteralAssignment(EP.fromString('sb/app:my-component'), dataPathSuccess([])),
         )
       }
       {
@@ -1342,11 +1331,7 @@ describe('Data Tracing', () => {
         )
 
         expect(trace).toEqual(
-          dataTracingToLiteralAttribute(
-            EP.fromString('sb/app:my-component'),
-            { type: 'arbitrary-js-block' },
-            dataPathSuccess([]),
-          ),
+          dataTracingToLiteralAssignment(EP.fromString('sb/app:my-component'), dataPathSuccess([])),
         )
       }
       {
@@ -1359,9 +1344,8 @@ describe('Data Tracing', () => {
         )
 
         expect(trace).toEqual(
-          dataTracingToLiteralAttribute(
+          dataTracingToLiteralAssignment(
             EP.fromString('sb/app:my-component'),
-            { type: 'arbitrary-js-block' },
             dataPathSuccess(['very']),
           ),
         )
@@ -1376,9 +1360,8 @@ describe('Data Tracing', () => {
         )
 
         expect(trace).toEqual(
-          dataTracingToLiteralAttribute(
+          dataTracingToLiteralAssignment(
             EP.fromString('sb/app:my-component'),
-            { type: 'arbitrary-js-block' },
             dataPathSuccess(['very', 'deep', 'title', 'value']),
           ),
         )

--- a/editor/src/core/data-tracing/data-tracing.ts
+++ b/editor/src/core/data-tracing/data-tracing.ts
@@ -806,10 +806,6 @@ function lookupInComponentScope(
     )
 
     if (foundAssignmentOfIdentifier != null) {
-      if (isConsideredLiteralValue(foundAssignmentOfIdentifier.rightHandSide)) {
-        return dataTracingToLiteralAssignment(componentPath, pathDrillSoFar)
-      }
-
       if (
         foundAssignmentOfIdentifier.rightHandSide.type === 'JS_IDENTIFIER' ||
         foundAssignmentOfIdentifier.rightHandSide.type === 'JS_ELEMENT_ACCESS' ||
@@ -842,6 +838,10 @@ function lookupInComponentScope(
           foundAssignmentOfIdentifier.rightHandSide.originalJavascript.split('()')[0],
           pathDrillSoFar,
         )
+      }
+
+      if (isConsideredLiteralValue(foundAssignmentOfIdentifier.rightHandSide)) {
+        return dataTracingToLiteralAssignment(componentPath, pathDrillSoFar)
       }
     }
   }

--- a/editor/src/core/data-tracing/data-tracing.ts
+++ b/editor/src/core/data-tracing/data-tracing.ts
@@ -806,7 +806,7 @@ function lookupInComponentScope(
     )
 
     if (foundAssignmentOfIdentifier != null) {
-      if (isNestedValueLiteral(foundAssignmentOfIdentifier.rightHandSide)) {
+      if (isConsideredLiteralValue(foundAssignmentOfIdentifier.rightHandSide)) {
         return dataTracingToLiteralAssignment(componentPath, pathDrillSoFar)
       }
 
@@ -898,7 +898,7 @@ function substractFromStringNumber(n: string, minus: number): string {
   return `${parseInt(n) - minus}`
 }
 
-function isNestedValueLiteral(value: JSExpression): boolean {
+function isConsideredLiteralValue(value: JSExpression): boolean {
   switch (value.type) {
     case 'ATTRIBUTE_VALUE':
       return true
@@ -920,9 +920,9 @@ function isNestedValueLiteral(value: JSExpression): boolean {
 }
 
 function isArrayLiteral(array: JSExpressionNestedArray): boolean {
-  return array.content.every((c) => isNestedValueLiteral(c.value))
+  return array.content.every((c) => isConsideredLiteralValue(c.value))
 }
 
 function isObjectLiteral(value: JSExpressionNestedObject): boolean {
-  return value.content.every((c) => isNestedValueLiteral(c.value))
+  return value.content.every((c) => isConsideredLiteralValue(c.value))
 }


### PR DESCRIPTION
## Problem
Consider the following code

```tsx
function App() {
  const label = 'yes'
  const loaded = true
  const words = ['hello', 'cheese']
  const deeplyNestedObject = { very: { deep: { title: {value: ['hello', 'world'] } }, a: [1, 2] } }
  const { very } = deeplyNestedObject

  return <MyComponent data-uid='my-component' doc={very.deep} />
}
```

Due to a missing feature, the data tracing code can't recognise `label` (and similar literal-valued declarations) as literals.

## Fix
Detect this situation and return a data tracing result for it

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
