### PR TITLE
Use the starting value path to determine the starting scope

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -147,9 +147,19 @@ export const DataSelectorModal = React.memo(
         if (lowestInsertionCeiling == null) {
           return null
         }
+
+        const scopeFromStartedSelectedValuePath = optionalMap(
+          (s) => getSelectedScopeFromBuckets(s, scopeBuckets),
+          startingSelectedValuePath,
+        )
+
+        if (scopeFromStartedSelectedValuePath != null) {
+          return scopeFromStartedSelectedValuePath
+        }
+
         const matchingScope = findClosestMatchingScope(lowestInsertionCeiling, scopeBuckets)
         return matchingScope ?? lowestInsertionCeiling
-      }, [scopeBuckets, lowestInsertionCeiling])
+      }, [lowestInsertionCeiling, startingSelectedValuePath, scopeBuckets])
 
       const [selectedScope, setSelectedScope] = React.useState<ElementPath | null>(
         lowestMatchingScope,
@@ -768,4 +778,20 @@ function pathSegmentToString(segment: string | number) {
     return `.${segment}`
   }
   return `[${segment}]`
+}
+
+function getSelectedScopeFromBuckets(
+  startingSelectedValuePath: ObjectPath,
+  scopeBuckets: ScopeBuckets,
+): ElementPath | null {
+  for (const [pathString, options] of Object.entries(scopeBuckets)) {
+    const anyOptionHasMatchingValuePath = options.some((o) =>
+      arrayEqualsByReference(o.valuePath, startingSelectedValuePath),
+    )
+    if (anyOptionHasMatchingValuePath) {
+      return EP.fromString(pathString)
+    }
+  }
+
+  return null
 }


### PR DESCRIPTION
## Description
This PR tweaks the logic for determining the initially selected scope in the data picker by looking through the scopes, and using the scope that contains a variable with the starting value path.

### Manual Tests
I hereby swear that:

- [ ] I opened a hydrogen project and it loaded
- [ ] I could navigate to various routes in Preview mode
