### PR TITLE
safe indexing in useFilterVariablesInScope

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -655,18 +655,20 @@ function useFilterVariablesInScope(
 ): {
   filteredVariablesInScope: Array<DataPickerOption>
 } {
-  const filteredOptions = React.useMemo(() => {
+  return React.useMemo(() => {
     if (scopeToShow === 'do-not-filter') {
-      return options
+      return {
+        filteredVariablesInScope: options,
+      }
     }
 
     const matchingScope = findClosestMatchingScope(scopeToShow, scopeBuckets)
-    return scopeBuckets[insertionCeilingToString(matchingScope)]
+    const filteredOptions: Array<DataPickerOption> =
+      scopeBuckets[insertionCeilingToString(matchingScope)] ?? []
+    return {
+      filteredVariablesInScope: filteredOptions,
+    }
   }, [scopeBuckets, options, scopeToShow])
-
-  return {
-    filteredVariablesInScope: filteredOptions,
-  }
 }
 
 function useProcessVariablesInScope(options: DataPickerOption[]): ProcessedVariablesInScope {


### PR DESCRIPTION
## Problem
There an uncheck object indexing that can throw an uncaught error in `useFilterVariablesInScope` (and thus crash the editor)

## Fix
Check the indexing. Also return the object from the `useMemo` call so that the memo isn't broken

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
