### PR TITLE
Data picker css tweaks

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -479,128 +479,119 @@ export const DataSelectorModal = React.memo(
                   </React.Fragment>
                 ))}
               </FlexRow>
-              <Separator color={colorTheme.seperator.value} margin={12} />
               {/* detail view */}
-              <FlexColumn
+              <div
                 style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'auto 40px 1fr',
+                  gap: 8,
+                  overflowX: 'hidden',
                   overflowY: 'scroll',
                   scrollbarWidth: 'auto',
                   scrollbarColor: 'gray transparent',
+                  paddingTop: 8,
+                  paddingBottom: 16,
                 }}
               >
-                <div
-                  style={{
-                    display: 'grid',
-                    gridTemplateColumns: 'auto 40px 1fr',
-                    gap: 8,
-                    overflowY: 'scroll',
-                    overflowX: 'hidden',
-                    paddingBottom: 16,
-                  }}
-                >
-                  {when(
-                    primitiveVars.length > 0,
-                    <>
-                      <FlexRow
-                        style={{
-                          flexWrap: 'wrap',
-                          height: 'max-content',
-                          gap: 4,
-                        }}
-                      >
-                        {primitiveVars.map((variable) => (
-                          <CartoucheUI
-                            key={variable.valuePath.toString()}
-                            tooltip={variableNameFromPath(variable)}
-                            source={variableSources[variable.valuePath.toString()] ?? 'internal'}
-                            datatype={childTypeToCartoucheDataType(variable.type)}
-                            inverted={false}
-                            selected={
-                              selectedPath == null
-                                ? false
-                                : arrayEqualsByReference(selectedPath, variable.valuePath)
-                            }
-                            role={cartoucheFolderOrInfo(variable, 'no-folder')}
-                            testId={`data-selector-primitive-values-${variableNameFromPath(
-                              variable,
-                            )}`}
-                            onHover={onHover(variable.valuePath)}
-                            onClick={setCurrentSelectedPathCurried(variable.valuePath)}
-                          >
-                            {variableNameFromPath(variable)}
-                          </CartoucheUI>
-                        ))}
-                      </FlexRow>
+                <Separator color={colorTheme.seperator.value} spanGridColumns={3} margin={4} />
+                {when(
+                  primitiveVars.length > 0,
+                  <>
+                    <FlexRow
+                      style={{
+                        flexWrap: 'wrap',
+                        height: 'max-content',
+                        gap: 4,
+                      }}
+                    >
+                      {primitiveVars.map((variable) => (
+                        <CartoucheUI
+                          key={variable.valuePath.toString()}
+                          tooltip={variableNameFromPath(variable)}
+                          source={variableSources[variable.valuePath.toString()] ?? 'internal'}
+                          datatype={childTypeToCartoucheDataType(variable.type)}
+                          inverted={false}
+                          selected={
+                            selectedPath == null
+                              ? false
+                              : arrayEqualsByReference(selectedPath, variable.valuePath)
+                          }
+                          role={cartoucheFolderOrInfo(variable, 'no-folder')}
+                          testId={`data-selector-primitive-values-${variableNameFromPath(
+                            variable,
+                          )}`}
+                          onHover={onHover(variable.valuePath)}
+                          onClick={setCurrentSelectedPathCurried(variable.valuePath)}
+                        >
+                          {variableNameFromPath(variable)}
+                        </CartoucheUI>
+                      ))}
+                    </FlexRow>
+                    <Separator color={colorTheme.seperator.value} spanGridColumns={3} margin={4} />
+                  </>,
+                )}
+                {folderVars.map((variable, idx) => (
+                  <React.Fragment key={variable.valuePath.toString()}>
+                    <CartoucheUI
+                      tooltip={variableNameFromPath(variable)}
+                      datatype={childTypeToCartoucheDataType(variable.type)}
+                      source={variableSources[variable.valuePath.toString()] ?? 'internal'}
+                      inverted={false}
+                      selected={
+                        selectedPath == null
+                          ? false
+                          : arrayEqualsByReference(selectedPath, variable.valuePath)
+                      }
+                      role={cartoucheFolderOrInfo(variable, 'no-folder')}
+                      testId={`data-selector-left-section-${variableNameFromPath(variable)}`}
+                      onClick={setCurrentSelectedPathCurried(variable.valuePath)}
+                      onHover={onHover(variable.valuePath)}
+                    >
+                      {variableNameFromPath(variable)}
+                    </CartoucheUI>
+                    {variable.type === 'array' ? (
+                      <ArrayIndexSelector
+                        total={variable.children.length}
+                        selected={indexLookup[variable.valuePath.toString()] ?? 0}
+                        onSelect={updateIndexInLookup(variable.valuePath.toString())}
+                      />
+                    ) : (
+                      <div />
+                    )}
+                    {/* properties in scope */}
+                    <FlexRow style={{ flexWrap: 'wrap', height: 'max-content', gap: 4 }}>
+                      {childVars(variable, indexLookup).map((child) => (
+                        <CartoucheUI
+                          key={child.valuePath.toString()}
+                          tooltip={variableNameFromPath(child)}
+                          source={variableSources[variable.valuePath.toString()] ?? 'internal'}
+                          inverted={false}
+                          datatype={childTypeToCartoucheDataType(child.type)}
+                          selected={
+                            selectedPath == null
+                              ? false
+                              : arrayEqualsByReference(selectedPath, child.valuePath)
+                          }
+                          role={cartoucheFolderOrInfo(child, 'can-be-folder')}
+                          testId={`data-selector-right-section-${variableNameFromPath(child)}`}
+                          onClick={setCurrentSelectedPathCurried(child.valuePath)}
+                          onDoubleClick={setNavigatedToPathCurried(child.valuePath)}
+                          onHover={onHover(child.valuePath)}
+                        >
+                          {variableNameFromPath(child)}
+                        </CartoucheUI>
+                      ))}
+                    </FlexRow>
+                    {idx < focusedVariableChildren.length - 1 ? (
                       <Separator
                         color={colorTheme.seperator.value}
                         spanGridColumns={3}
                         margin={4}
                       />
-                    </>,
-                  )}
-                  {folderVars.map((variable, idx) => (
-                    <React.Fragment key={variable.valuePath.toString()}>
-                      <CartoucheUI
-                        tooltip={variableNameFromPath(variable)}
-                        datatype={childTypeToCartoucheDataType(variable.type)}
-                        source={variableSources[variable.valuePath.toString()] ?? 'internal'}
-                        inverted={false}
-                        selected={
-                          selectedPath == null
-                            ? false
-                            : arrayEqualsByReference(selectedPath, variable.valuePath)
-                        }
-                        role={cartoucheFolderOrInfo(variable, 'no-folder')}
-                        testId={`data-selector-left-section-${variableNameFromPath(variable)}`}
-                        onClick={setCurrentSelectedPathCurried(variable.valuePath)}
-                        onHover={onHover(variable.valuePath)}
-                      >
-                        {variableNameFromPath(variable)}
-                      </CartoucheUI>
-                      {variable.type === 'array' ? (
-                        <ArrayIndexSelector
-                          total={variable.children.length}
-                          selected={indexLookup[variable.valuePath.toString()] ?? 0}
-                          onSelect={updateIndexInLookup(variable.valuePath.toString())}
-                        />
-                      ) : (
-                        <div />
-                      )}
-                      {/* properties in scope */}
-                      <FlexRow style={{ flexWrap: 'wrap', height: 'max-content', gap: 4 }}>
-                        {childVars(variable, indexLookup).map((child) => (
-                          <CartoucheUI
-                            key={child.valuePath.toString()}
-                            tooltip={variableNameFromPath(child)}
-                            source={variableSources[variable.valuePath.toString()] ?? 'internal'}
-                            inverted={false}
-                            datatype={childTypeToCartoucheDataType(child.type)}
-                            selected={
-                              selectedPath == null
-                                ? false
-                                : arrayEqualsByReference(selectedPath, child.valuePath)
-                            }
-                            role={cartoucheFolderOrInfo(child, 'can-be-folder')}
-                            testId={`data-selector-right-section-${variableNameFromPath(child)}`}
-                            onClick={setCurrentSelectedPathCurried(child.valuePath)}
-                            onDoubleClick={setNavigatedToPathCurried(child.valuePath)}
-                            onHover={onHover(child.valuePath)}
-                          >
-                            {variableNameFromPath(child)}
-                          </CartoucheUI>
-                        ))}
-                      </FlexRow>
-                      {idx < focusedVariableChildren.length - 1 ? (
-                        <Separator
-                          color={colorTheme.seperator.value}
-                          spanGridColumns={3}
-                          margin={4}
-                        />
-                      ) : null}
-                    </React.Fragment>
-                  ))}
-                </div>
-              </FlexColumn>
+                    ) : null}
+                  </React.Fragment>
+                ))}
+              </div>
             </FlexColumn>
           </div>
         </InspectorModal>

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -481,114 +481,126 @@ export const DataSelectorModal = React.memo(
               </FlexRow>
               <Separator color={colorTheme.seperator.value} margin={12} />
               {/* detail view */}
-              <div
+              <FlexColumn
                 style={{
-                  display: 'grid',
-                  gridTemplateColumns: 'auto 40px 1fr',
-                  gap: 8,
                   overflowY: 'scroll',
-                  overflowX: 'hidden',
-                  paddingBottom: 16,
+                  scrollbarWidth: 'auto',
+                  scrollbarColor: 'gray transparent',
                 }}
               >
-                {when(
-                  primitiveVars.length > 0,
-                  <>
-                    <FlexRow
-                      style={{
-                        flexWrap: 'wrap',
-                        height: 'max-content',
-                        gap: 4,
-                      }}
-                    >
-                      {primitiveVars.map((variable) => (
-                        <CartoucheUI
-                          key={variable.valuePath.toString()}
-                          tooltip={variableNameFromPath(variable)}
-                          source={variableSources[variable.valuePath.toString()] ?? 'internal'}
-                          datatype={childTypeToCartoucheDataType(variable.type)}
-                          inverted={false}
-                          selected={
-                            selectedPath == null
-                              ? false
-                              : arrayEqualsByReference(selectedPath, variable.valuePath)
-                          }
-                          role={cartoucheFolderOrInfo(variable, 'no-folder')}
-                          testId={`data-selector-primitive-values-${variableNameFromPath(
-                            variable,
-                          )}`}
-                          onHover={onHover(variable.valuePath)}
-                          onClick={setCurrentSelectedPathCurried(variable.valuePath)}
-                        >
-                          {variableNameFromPath(variable)}
-                        </CartoucheUI>
-                      ))}
-                    </FlexRow>
-                    <Separator color={colorTheme.seperator.value} spanGridColumns={3} margin={4} />
-                  </>,
-                )}
-                {folderVars.map((variable, idx) => (
-                  <React.Fragment key={variable.valuePath.toString()}>
-                    <CartoucheUI
-                      tooltip={variableNameFromPath(variable)}
-                      datatype={childTypeToCartoucheDataType(variable.type)}
-                      source={variableSources[variable.valuePath.toString()] ?? 'internal'}
-                      inverted={false}
-                      selected={
-                        selectedPath == null
-                          ? false
-                          : arrayEqualsByReference(selectedPath, variable.valuePath)
-                      }
-                      role={cartoucheFolderOrInfo(variable, 'no-folder')}
-                      testId={`data-selector-left-section-${variableNameFromPath(variable)}`}
-                      onClick={setCurrentSelectedPathCurried(variable.valuePath)}
-                      onHover={onHover(variable.valuePath)}
-                    >
-                      {variableNameFromPath(variable)}
-                    </CartoucheUI>
-                    {variable.type === 'array' ? (
-                      <ArrayIndexSelector
-                        total={variable.children.length}
-                        selected={indexLookup[variable.valuePath.toString()] ?? 0}
-                        onSelect={updateIndexInLookup(variable.valuePath.toString())}
-                      />
-                    ) : (
-                      <div />
-                    )}
-                    {/* properties in scope */}
-                    <FlexRow style={{ flexWrap: 'wrap', height: 'max-content', gap: 4 }}>
-                      {childVars(variable, indexLookup).map((child) => (
-                        <CartoucheUI
-                          key={child.valuePath.toString()}
-                          tooltip={variableNameFromPath(child)}
-                          source={variableSources[variable.valuePath.toString()] ?? 'internal'}
-                          inverted={false}
-                          datatype={childTypeToCartoucheDataType(child.type)}
-                          selected={
-                            selectedPath == null
-                              ? false
-                              : arrayEqualsByReference(selectedPath, child.valuePath)
-                          }
-                          role={cartoucheFolderOrInfo(child, 'can-be-folder')}
-                          testId={`data-selector-right-section-${variableNameFromPath(child)}`}
-                          onClick={setCurrentSelectedPathCurried(child.valuePath)}
-                          onDoubleClick={setNavigatedToPathCurried(child.valuePath)}
-                          onHover={onHover(child.valuePath)}
-                        >
-                          {variableNameFromPath(child)}
-                        </CartoucheUI>
-                      ))}
-                    </FlexRow>
-                    {idx < focusedVariableChildren.length - 1 ? (
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'auto 40px 1fr',
+                    gap: 8,
+                    overflowY: 'scroll',
+                    overflowX: 'hidden',
+                    paddingBottom: 16,
+                  }}
+                >
+                  {when(
+                    primitiveVars.length > 0,
+                    <>
+                      <FlexRow
+                        style={{
+                          flexWrap: 'wrap',
+                          height: 'max-content',
+                          gap: 4,
+                        }}
+                      >
+                        {primitiveVars.map((variable) => (
+                          <CartoucheUI
+                            key={variable.valuePath.toString()}
+                            tooltip={variableNameFromPath(variable)}
+                            source={variableSources[variable.valuePath.toString()] ?? 'internal'}
+                            datatype={childTypeToCartoucheDataType(variable.type)}
+                            inverted={false}
+                            selected={
+                              selectedPath == null
+                                ? false
+                                : arrayEqualsByReference(selectedPath, variable.valuePath)
+                            }
+                            role={cartoucheFolderOrInfo(variable, 'no-folder')}
+                            testId={`data-selector-primitive-values-${variableNameFromPath(
+                              variable,
+                            )}`}
+                            onHover={onHover(variable.valuePath)}
+                            onClick={setCurrentSelectedPathCurried(variable.valuePath)}
+                          >
+                            {variableNameFromPath(variable)}
+                          </CartoucheUI>
+                        ))}
+                      </FlexRow>
                       <Separator
                         color={colorTheme.seperator.value}
                         spanGridColumns={3}
                         margin={4}
                       />
-                    ) : null}
-                  </React.Fragment>
-                ))}
-              </div>
+                    </>,
+                  )}
+                  {folderVars.map((variable, idx) => (
+                    <React.Fragment key={variable.valuePath.toString()}>
+                      <CartoucheUI
+                        tooltip={variableNameFromPath(variable)}
+                        datatype={childTypeToCartoucheDataType(variable.type)}
+                        source={variableSources[variable.valuePath.toString()] ?? 'internal'}
+                        inverted={false}
+                        selected={
+                          selectedPath == null
+                            ? false
+                            : arrayEqualsByReference(selectedPath, variable.valuePath)
+                        }
+                        role={cartoucheFolderOrInfo(variable, 'no-folder')}
+                        testId={`data-selector-left-section-${variableNameFromPath(variable)}`}
+                        onClick={setCurrentSelectedPathCurried(variable.valuePath)}
+                        onHover={onHover(variable.valuePath)}
+                      >
+                        {variableNameFromPath(variable)}
+                      </CartoucheUI>
+                      {variable.type === 'array' ? (
+                        <ArrayIndexSelector
+                          total={variable.children.length}
+                          selected={indexLookup[variable.valuePath.toString()] ?? 0}
+                          onSelect={updateIndexInLookup(variable.valuePath.toString())}
+                        />
+                      ) : (
+                        <div />
+                      )}
+                      {/* properties in scope */}
+                      <FlexRow style={{ flexWrap: 'wrap', height: 'max-content', gap: 4 }}>
+                        {childVars(variable, indexLookup).map((child) => (
+                          <CartoucheUI
+                            key={child.valuePath.toString()}
+                            tooltip={variableNameFromPath(child)}
+                            source={variableSources[variable.valuePath.toString()] ?? 'internal'}
+                            inverted={false}
+                            datatype={childTypeToCartoucheDataType(child.type)}
+                            selected={
+                              selectedPath == null
+                                ? false
+                                : arrayEqualsByReference(selectedPath, child.valuePath)
+                            }
+                            role={cartoucheFolderOrInfo(child, 'can-be-folder')}
+                            testId={`data-selector-right-section-${variableNameFromPath(child)}`}
+                            onClick={setCurrentSelectedPathCurried(child.valuePath)}
+                            onDoubleClick={setNavigatedToPathCurried(child.valuePath)}
+                            onHover={onHover(child.valuePath)}
+                          >
+                            {variableNameFromPath(child)}
+                          </CartoucheUI>
+                        ))}
+                      </FlexRow>
+                      {idx < focusedVariableChildren.length - 1 ? (
+                        <Separator
+                          color={colorTheme.seperator.value}
+                          spanGridColumns={3}
+                          margin={4}
+                        />
+                      ) : null}
+                    </React.Fragment>
+                  ))}
+                </div>
+              </FlexColumn>
             </FlexColumn>
           </div>
         </InspectorModal>

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -106,13 +106,6 @@ function ArrayIndexSelector({
   )
 }
 
-const DEFAULT_SIZE: React.CSSProperties = {
-  minWidth: 600,
-  minHeight: 50,
-  maxWidth: 700,
-  maxHeight: 300,
-}
-
 interface ProcessedVariablesInScope {
   [valuePath: string]: DataPickerOption
 }
@@ -381,8 +374,8 @@ export const DataSelectorModal = React.memo(
               onClick={catchClick}
               ref={forwardedRef}
               style={{
-                ...style,
-                ...DEFAULT_SIZE,
+                width: 700,
+                height: 300,
                 paddingTop: 16,
                 paddingLeft: 16,
                 paddingRight: 16,
@@ -392,6 +385,7 @@ export const DataSelectorModal = React.memo(
                 borderRadius: UtopiaTheme.panelStyles.panelBorderRadius,
                 boxShadow: UtopiaStyles.shadowStyles.highest.boxShadow,
                 border: `1px solid ${colorTheme.fg0Opacity10.value}`,
+                ...style,
               }}
             >
               {/* top bar */}


### PR DESCRIPTION
Assorted tweaks:
![image](https://github.com/concrete-utopia/utopia/assets/2226774/8bb0baca-fe51-4022-b2e9-8c90bb659b47)

- the data picker now has a fixed size so it doesn't jump around when switching Scopes
- the scrollbar is now visible when scrolling
- to make the scrollbar position feel visually more natural, I rearranged one spacer line