### PR TITLE
Fix/data picker fixes more

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -182,6 +182,7 @@ export const DataSelectorModal = React.memo(
             store.editor.jsxMetadata,
             store.editor.allElementProps,
             store.editor.elementPathTree,
+            store.editor.projectContents,
             Object.keys(scopeBuckets),
             lowestInsertionCeiling ?? EP.emptyElementPath,
           )

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -411,6 +411,32 @@ export const DataSelectorModal = React.memo(
                 ...style,
               }}
             >
+              {/* Scope Selector Breadcrumbs */}
+              <FlexRow style={{ gap: 2, paddingBottom: 8 }}>
+                {elementLabelsWithScopes.map(({ label, scope, hasContent }, idx, a) => (
+                  <React.Fragment key={`label-${idx}`}>
+                    <div
+                      onClick={setSelectedScopeCurried(scope, hasContent)}
+                      style={{
+                        width: 'max-content',
+                        padding: '2px 4px',
+                        borderRadius: 4,
+                        cursor: hasContent ? 'pointer' : undefined,
+                        color: hasContent
+                          ? colorTheme.neutralForeground.value
+                          : colorTheme.subduedForeground.value,
+                        fontSize: 12,
+                        fontWeight: insertionCeilingsEqual(selectedScope, scope) ? 800 : undefined,
+                      }}
+                    >
+                      {label}
+                    </div>
+                    {idx < a.length - 1 ? (
+                      <span style={{ width: 'max-content', padding: '2px 4px' }}>{'/'}</span>
+                    ) : null}
+                  </React.Fragment>
+                ))}
+              </FlexRow>
               {/* top bar */}
               <FlexRow style={{ justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
                 <FlexRow style={{ gap: 8, flexWrap: 'wrap', flexGrow: 1 }}>
@@ -481,32 +507,7 @@ export const DataSelectorModal = React.memo(
               >
                 {valuePreviewText}
               </FlexRow>
-              {/* Scope Selector Breadcrumbs */}
-              <FlexRow style={{ gap: 2, paddingBottom: 4, paddingTop: 4 }}>
-                {elementLabelsWithScopes.map(({ label, scope, hasContent }, idx, a) => (
-                  <React.Fragment key={`label-${idx}`}>
-                    <div
-                      onClick={setSelectedScopeCurried(scope, hasContent)}
-                      style={{
-                        width: 'max-content',
-                        padding: '2px 4px',
-                        borderRadius: 4,
-                        cursor: hasContent ? 'pointer' : undefined,
-                        color: hasContent
-                          ? colorTheme.neutralForeground.value
-                          : colorTheme.subduedForeground.value,
-                        fontSize: 12,
-                        fontWeight: insertionCeilingsEqual(selectedScope, scope) ? 800 : undefined,
-                      }}
-                    >
-                      {label}
-                    </div>
-                    {idx < a.length - 1 ? (
-                      <span style={{ width: 'max-content', padding: '2px 4px' }}>{'/'}</span>
-                    ) : null}
-                  </React.Fragment>
-                ))}
-              </FlexRow>
+
               {/* detail view */}
               <div
                 style={{

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -609,6 +609,21 @@ export const DataSelectorModal = React.memo(
                     ) : null}
                   </React.Fragment>
                 ))}
+                {/* Empty State */}
+                {when(
+                  focusedVariableChildren.length === 0,
+                  <div
+                    style={{
+                      gridColumn: '1 / span 3',
+                      display: 'flex',
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                      height: 100,
+                    }}
+                  >
+                    No variables in scope
+                  </div>,
+                )}
               </div>
             </FlexColumn>
           </div>

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -462,12 +462,13 @@ export const DataSelectorModal = React.memo(
                   overflowX: 'scroll',
                   opacity: 0.8,
                   fontSize: 10,
-                  height: 20,
+                  height: 24,
                 }}
               >
                 {valuePreviewText}
               </FlexRow>
-              <FlexRow style={{ gap: 2, paddingBottom: 4, paddingTop: 8 }}>
+              {/* Scope Selector Breadcrumbs */}
+              <FlexRow style={{ gap: 2, paddingBottom: 4, paddingTop: 4 }}>
                 {elementLabelsWithScopes.map(({ label, scope }, idx, a) => (
                   <React.Fragment key={`label-${idx}`}>
                     <div

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -838,12 +838,15 @@ function findFirstObjectPathToNavigateTo(
 
   let currentPath = selectedValuePath
   while (currentPath.length > 0) {
-    const currentPathString = currentPath.toString()
-    const currentOption = processedVariablesInScope[currentPathString]
-    if (currentOption != null) {
-      if (currentOption.type === 'object') {
-        return currentPath
-      }
+    const parentPath = currentPath.slice(0, -1)
+    const parentOption = processedVariablesInScope[parentPath.toString()]
+    const grandParentPath = currentPath.slice(0, -2)
+    const grandParentOption = processedVariablesInScope[grandParentPath.toString()]
+    if (grandParentOption != null && grandParentOption.type === 'array') {
+      return grandParentPath.slice(0, -1)
+    }
+    if (parentOption != null && parentOption.type === 'object') {
+      return parentPath.slice(0, -1)
     }
     currentPath = currentPath.slice(0, -1)
   }

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -173,6 +173,8 @@ export const DataSelectorModal = React.memo(
         selectedScope,
       )
 
+      const processedVariablesInScope = useProcessVariablesInScope(filteredVariablesInScope)
+
       const elementLabelsWithScopes = useEditorState(
         Substores.fullStore,
         (store) => {
@@ -192,7 +194,9 @@ export const DataSelectorModal = React.memo(
         'DataSelectorModal elementLabelsWithScopes',
       )
 
-      const [navigatedToPath, setNavigatedToPath] = React.useState<ObjectPath>([])
+      const [navigatedToPath, setNavigatedToPath] = React.useState<ObjectPath>(
+        findFirstObjectPathToNavigateTo(processedVariablesInScope, startingSelectedValuePath) ?? [],
+      )
 
       const [selectedPath, setSelectedPath] = React.useState<ObjectPath | null>(
         startingSelectedValuePath,
@@ -242,8 +246,6 @@ export const DataSelectorModal = React.memo(
           setIndexLookup((lookup) => ({ ...lookup, [valuePathString]: option.value })),
         [],
       )
-
-      const processedVariablesInScope = useProcessVariablesInScope(filteredVariablesInScope)
 
       const focusedVariableChildren = React.useMemo(() => {
         if (navigatedToPath.length === 0) {
@@ -816,6 +818,29 @@ function getSelectedScopeFromBuckets(
     if (anyOptionHasMatchingValuePath) {
       return EP.fromString(pathString)
     }
+  }
+
+  return null
+}
+
+function findFirstObjectPathToNavigateTo(
+  processedVariablesInScope: ProcessedVariablesInScope,
+  selectedValuePath: ObjectPath | null,
+): ObjectPath | null {
+  if (selectedValuePath == null) {
+    return null
+  }
+
+  let currentPath = selectedValuePath
+  while (currentPath.length > 0) {
+    const currentPathString = currentPath.toString()
+    const currentOption = processedVariablesInScope[currentPathString]
+    if (currentOption != null) {
+      if (currentOption.type === 'object') {
+        return currentPath
+      }
+    }
+    currentPath = currentPath.slice(0, -1)
   }
 
   return null

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -42,6 +42,7 @@ import { Substores, useEditorState } from '../../../editor/store/store-hook'
 import { optionalMap } from '../../../../core/shared/optional-utils'
 import type { FileRootPath } from '../../../canvas/ui-jsx-canvas'
 import { insertionCeilingToString, insertionCeilingsEqual } from '../../../canvas/ui-jsx-canvas'
+import { set } from 'objectPath'
 
 export const DataSelectorPopupBreadCrumbsTestId = 'data-selector-modal-top-bar'
 
@@ -162,6 +163,9 @@ export const DataSelectorModal = React.memo(
         (name: ElementPath, hasContent: boolean) => () => {
           if (hasContent) {
             setSelectedScope(name)
+            setSelectedPath(null)
+            setHoveredPath(null)
+            setNavigatedToPath([])
           }
         },
         [],

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -621,7 +621,7 @@ export const DataSelectorModal = React.memo(
                       height: 100,
                     }}
                   >
-                    No variables in scope
+                    We did not find any insertable data
                   </div>,
                 )}
               </div>

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -739,7 +739,7 @@ function childVars(option: DataPickerOption, indices: ArrayIndexLookup): DataPic
   }
 }
 
-export function pathBreadcrumbs(
+function pathBreadcrumbs(
   valuePath: DataPickerOption['valuePath'],
   processedVariablesInScope: ProcessedVariablesInScope,
 ): Array<{

--- a/editor/src/core/data-tracing/data-tracing.ts
+++ b/editor/src/core/data-tracing/data-tracing.ts
@@ -4,7 +4,10 @@ import { findUnderlyingTargetComponentImplementationFromImportInfo } from '../..
 import { withUnderlyingTarget } from '../../components/editor/store/editor-state'
 import * as TPP from '../../components/template-property-path'
 import { MetadataUtils } from '../model/element-metadata-utils'
-import { findContainingComponentForPath } from '../model/element-template-utils'
+import {
+  findContainingComponentForPath,
+  findContainingComponentForPathInProjectContents,
+} from '../model/element-template-utils'
 import { mapFirstApplicable } from '../shared/array-utils'
 import type { Either } from '../shared/either'
 import { isLeft, isRight, left, mapEither, maybeEitherToMaybe, right } from '../shared/either'
@@ -213,19 +216,6 @@ export type DataTracingResult =
   | DataTracingToAComponentProp
   | DataTracingToElementAtScope
   | DataTracingFailed
-
-function findContainingComponentForElementPath(
-  elementPath: ElementPath,
-  projectContents: ProjectContentTreeRoot,
-): UtopiaJSXComponent | null {
-  return withUnderlyingTarget(elementPath, projectContents, null, (success) => {
-    const containingComponent = findContainingComponentForPath(
-      success.topLevelElements,
-      elementPath,
-    )
-    return containingComponent
-  })
-}
 
 export function processJSPropertyAccessors(
   expression: JSExpression,
@@ -438,7 +428,7 @@ export function traceDataFromVariableName(
   if (enclosingScope.type === 'file-root') {
     return dataTracingFailed('Cannot trace data from variable name in file root')
   }
-  const componentHoldingElement = findContainingComponentForElementPath(
+  const componentHoldingElement = findContainingComponentForPathInProjectContents(
     enclosingScope,
     projectContents,
   )
@@ -466,10 +456,8 @@ function traceDataFromIdentifierOrAccess(
   projectContents: ProjectContentTreeRoot,
   pathDrillSoFar: DataPathPositiveResult,
 ): DataTracingResult {
-  const componentHoldingElement: UtopiaJSXComponent | null = findContainingComponentForElementPath(
-    enclosingScope,
-    projectContents,
-  )
+  const componentHoldingElement: UtopiaJSXComponent | null =
+    findContainingComponentForPathInProjectContents(enclosingScope, projectContents)
 
   if (componentHoldingElement == null) {
     return dataTracingFailed('Could not find containing component')

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -88,6 +88,7 @@ import { MetadataUtils } from './element-metadata-utils'
 import { mapValues } from '../shared/object-utils'
 import type { PropertyControlsInfo } from '../../components/custom-code/code-file'
 import { getComponentDescriptorForTarget } from '../property-controls/property-controls-utils'
+import { withUnderlyingTarget } from '../../components/editor/store/editor-state'
 
 export function generateUidWithExistingComponents(projectContents: ProjectContentTreeRoot): string {
   const mockUID = generateMockNextGeneratedUID()
@@ -1656,4 +1657,17 @@ export function findContainingComponentForPath(
   }
 
   return null
+}
+
+export function findContainingComponentForPathInProjectContents(
+  elementPath: ElementPath,
+  projectContents: ProjectContentTreeRoot,
+): UtopiaJSXComponent | null {
+  return withUnderlyingTarget(elementPath, projectContents, null, (success) => {
+    const containingComponent = findContainingComponentForPath(
+      success.topLevelElements,
+      elementPath,
+    )
+    return containingComponent
+  })
 }


### PR DESCRIPTION
<img width="718" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/ee46b634-613d-4e83-8021-f01692d529a3">


An assortment of small data picker fixes:

- flipping breadcrumbs and the "data path input field", because the logical scope is breadcrumb -> data path, for example: `Reviews >  data.reviews[0].quote`. How it is on master makes it look like we are inside data.reviews[0].quote and we have options File > Reviews to further narrow the scope, which is backwards.
- adding an empty state
- various minor css tweaks
- not allowing clicking on breadcrumbs that point at an empty scope slice, these breadcrumbs are also subdued
- fixing vite hot reload for tweaking the data modal by unexporting `function pathBreadcrumbs`
- When opening the data picker with an already selected data, navigate into the object hierarchy to be able to show the selected Cartouche
- Outlet Name Hack – if we find that the Scope Breadcrumb would be named Outlet, we try to manually look up the component name from the parsed model