### PR TITLE
unified cartouche datatype

### DIFF
--- a/editor/src/components/editor/store/store-hook-substore-types.ts
+++ b/editor/src/components/editor/store/store-hook-substore-types.ts
@@ -198,6 +198,10 @@ export type CanvasAndMetadataSubstate = {
 
 export type ProjectContentAndMetadataSubstate = ProjectContentSubstate & MetadataSubstate
 
+export type ProjectContentAndMetadataAndVariablesInScopeSubstate = ProjectContentSubstate &
+  MetadataSubstate &
+  VariablesInScopeSubstate
+
 export type NavigatorSubstate = {
   editor: Pick<EditorState, 'navigator'>
 }

--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -31,6 +31,7 @@ import type {
   NavigatorSubstate,
   OnlineStateSubstate,
   PostActionInteractionSessionSubstate,
+  ProjectContentAndMetadataAndVariablesInScopeSubstate,
   ProjectContentAndMetadataSubstate,
   ProjectContentSubstate,
   ProjectServerStateSubstate,
@@ -302,6 +303,16 @@ export const Substores = {
     b: ProjectContentAndMetadataSubstate,
   ) => {
     return keysEquality([...projectContentsKeys, ...metadataSubstateKeys], a.editor, b.editor)
+  },
+  projectContentsAndMetadataAndVariablesInScope: (
+    a: ProjectContentAndMetadataAndVariablesInScopeSubstate,
+    b: ProjectContentAndMetadataAndVariablesInScopeSubstate,
+  ) => {
+    return keysEquality(
+      [...projectContentsKeys, ...metadataSubstateKeys, ...variablesInScopeSubstateKeys],
+      a.editor,
+      b.editor,
+    )
   },
   projectServerState: (a: ProjectServerStateSubstate, b: ProjectServerStateSubstate) => {
     return ProjectServerStateKeepDeepEquality(a.projectServerState, b.projectServerState).areEqual

--- a/editor/src/components/inspector/sections/component-section/cartouche-control.tsx
+++ b/editor/src/components/inspector/sections/component-section/cartouche-control.tsx
@@ -8,6 +8,7 @@ import type { ElementPath, PropertyPath } from '../../../../core/shared/project-
 import * as EPP from '../../../template-property-path'
 import { dataPathSuccess, traceDataFromProp } from '../../../../core/data-tracing/data-tracing'
 import { Substores, useEditorState } from '../../../editor/store/store-hook'
+import type { CartoucheDataType } from './cartouche-ui'
 
 interface IdentifierExpressionCartoucheControlProps {
   contents: string
@@ -19,6 +20,7 @@ interface IdentifierExpressionCartoucheControlProps {
   testId: string
   propertyPath: PropertyPath
   elementPath: ElementPath
+  datatype: CartoucheDataType
 }
 export const IdentifierExpressionCartoucheControl = React.memo(
   (props: IdentifierExpressionCartoucheControlProps) => {
@@ -47,6 +49,7 @@ export const IdentifierExpressionCartoucheControl = React.memo(
         testId={testId}
         inverted={false}
         contentIsComingFromServer={isDataComingFromHookResult}
+        datatype={props.datatype}
       />
     )
   },

--- a/editor/src/components/inspector/sections/component-section/cartouche-ui.tsx
+++ b/editor/src/components/inspector/sections/component-section/cartouche-ui.tsx
@@ -7,11 +7,13 @@ export interface HoverHandlers {
   onMouseLeave: (e: React.MouseEvent) => void
 }
 
+export type CartoucheDataType = 'renderable' | 'boolean' | 'array' | 'object' | 'unknown'
+
 export type CartoucheUIProps = React.PropsWithChildren<{
   tooltip?: string | null
   source: 'internal' | 'external' | 'literal'
   role: 'selection' | 'information' | 'folder'
-  datatype: 'renderable' | 'boolean' | 'array' | 'object'
+  datatype: CartoucheDataType
   inverted: boolean
   selected: boolean
   testId: string
@@ -173,6 +175,8 @@ function dataTypeToIconType(dataType: CartoucheUIProps['datatype']): string {
       return 'array'
     case 'object':
       return 'object'
+    case 'unknown':
+      return '👻'
   }
 }
 

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -205,6 +205,8 @@ const ControlForProp = React.memo((props: ControlForPropProps<RegularControlDesc
     showHiddenControl,
   ])
 
+  const attributeExpression = props.propMetadata.attributeExpression
+
   const datatypeForExpression = useEditorState(
     Substores.projectContentsAndMetadataAndVariablesInScope,
     (store) => {
@@ -223,8 +225,6 @@ const ControlForProp = React.memo((props: ControlForPropProps<RegularControlDesc
   if (controlDescription == null) {
     return null
   }
-
-  const attributeExpression = props.propMetadata.attributeExpression
 
   if (attributeExpression != null) {
     if (

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -96,7 +96,10 @@ import { stopPropagation } from '../../common/inspector-utils'
 import { IdentifierExpressionCartoucheControl } from './cartouche-control'
 import { getRegisteredComponent } from '../../../../core/property-controls/property-controls-utils'
 import type { EditorAction } from '../../../editor/action-types'
-import { useVariablesInScopeForSelectedElement } from './variables-in-scope-utils'
+import {
+  getCartoucheDataTypeForExpression,
+  useVariablesInScopeForSelectedElement,
+} from './variables-in-scope-utils'
 import { useAtom } from 'jotai'
 import { DataSelectorModal } from './data-selector-modal'
 import { getModifiableJSXAttributeAtPath } from '../../../../core/shared/jsx-attribute-utils'
@@ -202,6 +205,21 @@ const ControlForProp = React.memo((props: ControlForPropProps<RegularControlDesc
     showHiddenControl,
   ])
 
+  const datatypeForExpression = useEditorState(
+    Substores.projectContentsAndMetadataAndVariablesInScope,
+    (store) => {
+      if (attributeExpression == null) {
+        return 'unknown'
+      }
+      return getCartoucheDataTypeForExpression(
+        props.elementPath,
+        attributeExpression,
+        store.editor.variablesInScope,
+      )
+    },
+    'ControlForProp datatypeForExpression',
+  )
+
   if (controlDescription == null) {
     return null
   }
@@ -225,6 +243,7 @@ const ControlForProp = React.memo((props: ControlForPropProps<RegularControlDesc
           safeToDelete={safeToDelete}
           propertyPath={props.propPath}
           elementPath={props.elementPath}
+          datatype={datatypeForExpression}
         />
       )
     }
@@ -246,6 +265,7 @@ const ControlForProp = React.memo((props: ControlForPropProps<RegularControlDesc
             propertyPath={props.propPath}
             safeToDelete={safeToDelete}
             elementPath={props.elementPath}
+            datatype={datatypeForExpression}
           />
         )
       }

--- a/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
@@ -16,10 +16,13 @@ import { selectComponents } from '../../../editor/actions/meta-actions'
 import { dataPathSuccess, traceDataFromElement } from '../../../../core/data-tracing/data-tracing'
 import type { RenderedAt } from '../../../editor/store/editor-state'
 import { replaceElementInScope } from '../../../editor/actions/action-creators'
-import { useVariablesInScopeForSelectedElement } from './variables-in-scope-utils'
+import {
+  getCartoucheDataTypeForExpression,
+  useVariablesInScopeForSelectedElement,
+} from './variables-in-scope-utils'
 import { DataPickerPreferredAllAtom, jsxElementChildToValuePath } from './data-picker-utils'
 import { useAtom } from 'jotai'
-import type { CartoucheUIProps } from './cartouche-ui'
+import type { CartoucheDataType, CartoucheUIProps } from './cartouche-ui'
 import { CartoucheUI } from './cartouche-ui'
 
 interface DataReferenceCartoucheControlProps {
@@ -107,6 +110,18 @@ export const DataReferenceCartoucheControl = React.memo(
       [childOrAttribute],
     )
 
+    const currentlySelectedValueDataType = useEditorState(
+      Substores.projectContentsAndMetadataAndVariablesInScope,
+      (store) => {
+        return getCartoucheDataTypeForExpression(
+          elementPath,
+          childOrAttribute,
+          store.editor.variablesInScope,
+        )
+      },
+      'DataReferenceCartoucheControl currentlySelectedValueDataType',
+    )
+
     const dataPickerButtonData = useDataPickerButton(
       variableNamesInScope,
       updateDataWithDataPicker,
@@ -134,6 +149,7 @@ export const DataReferenceCartoucheControl = React.memo(
           testId={`data-reference-cartouche-${EP.toString(elementPath)}`}
           contentIsComingFromServer={isDataComingFromHookResult}
           hideTooltip={props.hideTooltip}
+          datatype={currentlySelectedValueDataType}
         />
         {/* this div prevents the popup form putting padding into the condensed rows */}
         <div style={{ width: 0 }}>
@@ -155,6 +171,7 @@ interface DataCartoucheInnerProps {
   testId: string
   contentIsComingFromServer: boolean
   hideTooltip?: boolean
+  datatype: CartoucheDataType
 }
 
 export const DataCartoucheInner = React.forwardRef(
@@ -169,6 +186,7 @@ export const DataCartoucheInner = React.forwardRef(
       testId,
       contentsToDisplay,
       contentIsComingFromServer,
+      datatype,
     } = props
 
     const onDeleteInner = React.useCallback(
@@ -193,7 +211,7 @@ export const DataCartoucheInner = React.forwardRef(
         onDelete={onDelete}
         onClick={onClick}
         onDoubleClick={onDoubleClick}
-        datatype='renderable' // TODO actually feed the real value here
+        datatype={datatype}
         selected={selected}
         inverted={inverted}
         testId={testId}

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -676,9 +676,9 @@ function getSpiedValueForIdentifierOrAccess(
   if (isLeft(accessorPath)) {
     return accessorPath
   }
-  const spiedValue =
-    variablesInScope[EP.toString(enclosingScope)]?.[accessorPath.value.originalIdentifier.name]
-      ?.spiedValue
+  const spiedValue = findClosestMatchingScope(variablesInScope, enclosingScope)?.[
+    accessorPath.value.originalIdentifier.name
+  ]?.spiedValue
 
   if (spiedValue == null) {
     return left('Variable not found in scope')
@@ -695,4 +695,21 @@ function getSpiedValueForIdentifierOrAccess(
   const value = ObjectPath.get(spiedValue, accessorPath.value.path)
 
   return right(value)
+}
+
+function findClosestMatchingScope(
+  variablesInScope: VariablesInScope,
+  targetScope: ElementPath,
+): VariableData | null {
+  if (targetScope.type === 'elementpath') {
+    const allPaths = EP.allPathsInsideComponent(targetScope)
+    for (const path of allPaths) {
+      const variableData = variablesInScope[EP.toString(path)]
+      if (variableData != null) {
+        return variableData
+      }
+    }
+  }
+
+  return null
 }

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -1,10 +1,11 @@
+import * as ObjectPath from 'object-path'
 import type {
   ControlDescription,
   ArrayControlDescription,
   ObjectControlDescription,
 } from '../../../custom-code/internal-property-controls'
 import type { ElementPath, PropertyPath } from '../../../../core/shared/project-file-types'
-import type { FileRootPath, VariableData } from '../../../canvas/ui-jsx-canvas'
+import type { FileRootPath, VariableData, VariablesInScope } from '../../../canvas/ui-jsx-canvas'
 import { useEditorState, Substores } from '../../../editor/store/store-hook'
 import type { DataPickerFilterOption, DataPickerOption } from './data-picker-utils'
 import * as EP from '../../../../core/shared/element-path'
@@ -16,6 +17,13 @@ import { assertNever, identity } from '../../../../core/shared/utils'
 import { isValidReactNode } from '../../../../utils/react-utils'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { emptySet } from '../../../../core/shared/set-utils'
+import type { JSExpression, JSXElementChild } from '../../../../core/shared/element-template'
+import type { Either } from '../../../../core/shared/either'
+import { foldEither, isLeft, left, right } from '../../../../core/shared/either'
+import { processJSPropertyAccessors } from '../../../../core/data-tracing/data-tracing'
+import type { CartoucheDataType } from './cartouche-ui'
+import { jsxSimpleAttributeToValue } from '../../../../core/shared/jsx-attribute-utils'
+import type { ModifiableAttribute } from '../../../../core/shared/jsx-attributes'
 
 function valuesFromObject(
   variable: ArrayInfo | ObjectInfo,
@@ -482,17 +490,17 @@ export function useVariablesInScopeForSelectedElement(
   return variableNamesInScope
 }
 
-function arrayShapesMatch(left: Array<unknown>, right: Array<unknown>): boolean {
-  if (left.length === 0 || right.length === 0) {
+function arrayShapesMatch(l: Array<unknown>, r: Array<unknown>): boolean {
+  if (l.length === 0 || r.length === 0) {
     return true
   }
 
-  return variableShapesMatch(left[0], right[0])
+  return variableShapesMatch(l[0], r[0])
 }
 
-function objectShapesMatch(left: object, right: object): boolean {
-  const keysFromLeft = Object.keys(left)
-  const keysFromRight = Object.keys(right)
+function objectShapesMatch(l: object, r: object): boolean {
+  const keysFromLeft = Object.keys(l)
+  const keysFromRight = Object.keys(r)
   const keysMatch =
     keysFromLeft.length === keysFromRight.length &&
     keysFromLeft.every((key) => keysFromRight.includes(key))
@@ -501,7 +509,7 @@ function objectShapesMatch(left: object, right: object): boolean {
     return false
   }
 
-  return keysFromLeft.every((key) => variableShapesMatch((left as any)[key], (right as any)[key]))
+  return keysFromLeft.every((key) => variableShapesMatch((l as any)[key], (r as any)[key]))
 }
 
 function variableShapesMatch(current: unknown, other: unknown): boolean {
@@ -607,4 +615,84 @@ function usePropertyValue(
   }
 
   return { type: 'existing', value: prop }
+}
+
+export function getCartoucheDataTypeForExpression(
+  enclosingScope: ElementPath,
+  expression: JSXElementChild | ModifiableAttribute,
+  variablesInScope: VariablesInScope,
+): CartoucheDataType {
+  switch (expression.type) {
+    case 'ATTRIBUTE_FUNCTION_CALL':
+    case 'ATTRIBUTE_NESTED_ARRAY':
+    case 'ATTRIBUTE_NESTED_OBJECT':
+    case 'ATTRIBUTE_OTHER_JAVASCRIPT':
+      return 'unknown'
+    case 'JSX_ELEMENT':
+    case 'JSX_FRAGMENT':
+    case 'JSX_MAP_EXPRESSION':
+    case 'JSX_CONDITIONAL_EXPRESSION':
+    case 'JSX_TEXT_BLOCK':
+      return 'renderable'
+    case 'ATTRIBUTE_VALUE':
+    case 'PART_OF_ATTRIBUTE_VALUE':
+    case 'ATTRIBUTE_NOT_FOUND':
+      return foldEither(
+        () => 'unknown',
+        (value) => getCartoucheDataTypeFromJsValue(value),
+        jsxSimpleAttributeToValue(expression),
+      )
+    case 'JS_IDENTIFIER':
+    case 'JS_ELEMENT_ACCESS':
+    case 'JS_PROPERTY_ACCESS':
+      return foldEither(
+        () => 'unknown',
+        (value) => getCartoucheDataTypeFromJsValue(value),
+        getSpiedValueForIdentifierOrAccess(enclosingScope, expression, variablesInScope),
+      )
+    default:
+      assertNever(expression)
+  }
+}
+
+function getCartoucheDataTypeFromJsValue(value: unknown): CartoucheDataType {
+  if (React.isValidElement(value) || typeof value === 'string' || typeof value === 'number') {
+    return 'renderable'
+  } else if (Array.isArray(value)) {
+    return 'array'
+  } else if (typeof value === 'object' && value != null) {
+    return 'object'
+  } else {
+    return 'unknown'
+  }
+}
+
+function getSpiedValueForIdentifierOrAccess(
+  enclosingScope: ElementPath,
+  expression: JSExpression,
+  variablesInScope: VariablesInScope,
+): Either<string, any> {
+  const accessorPath = processJSPropertyAccessors(expression)
+  if (isLeft(accessorPath)) {
+    return accessorPath
+  }
+  const spiedValue =
+    variablesInScope[EP.toString(enclosingScope)]?.[accessorPath.value.originalIdentifier.name]
+      ?.spiedValue
+
+  if (spiedValue == null) {
+    return left('Variable not found in scope')
+  }
+
+  if (accessorPath.value.path.length === 0) {
+    return right(spiedValue)
+  }
+
+  if (typeof spiedValue !== 'object') {
+    return left('Cannot access properties of a non-object')
+  }
+
+  const value = ObjectPath.get(spiedValue, accessorPath.value.path)
+
+  return right(value)
 }

--- a/editor/src/components/inspector/sections/data-reference-section.tsx
+++ b/editor/src/components/inspector/sections/data-reference-section.tsx
@@ -20,7 +20,10 @@ import { useDispatch } from '../../editor/store/dispatch-context'
 import { replaceElementInScope } from '../../editor/actions/action-creators'
 import { NO_OP } from '../../../core/shared/utils'
 import { dataPathSuccess, traceDataFromElement } from '../../../core/data-tracing/data-tracing'
-import { useVariablesInScopeForSelectedElement } from './component-section/variables-in-scope-utils'
+import {
+  getCartoucheDataTypeForExpression,
+  useVariablesInScopeForSelectedElement,
+} from './component-section/variables-in-scope-utils'
 import { jsxElementChildToValuePath } from './component-section/data-picker-utils'
 
 export const DataReferenceSectionId = 'code-element-section-test-id'
@@ -37,7 +40,7 @@ export const DataReferenceSection = React.memo(({ paths }: { paths: ElementPath[
     React.useState<ElementPath | null>(null)
 
   const elements = useEditorState(
-    Substores.projectContentsAndMetadata,
+    Substores.projectContentsAndMetadataAndVariablesInScope,
     (store) => {
       return mapDropNulls((path) => {
         const element = getElementFromProjectContents(path, store.editor.projectContents)
@@ -63,6 +66,7 @@ export const DataReferenceSection = React.memo(({ paths }: { paths: ElementPath[
           textContent: getTextContentOfElement(element, elementMetadata),
           path: path,
           contentIsComingFromServer: isDataComingFromServer.type === 'hook-result',
+          datatype: getCartoucheDataTypeForExpression(path, element, store.editor.variablesInScope),
         }
       }, paths)
     },
@@ -172,6 +176,7 @@ export const DataReferenceSection = React.memo(({ paths }: { paths: ElementPath[
               onDelete={NO_OP}
               testId={`inspector-data-cartouche-${EP.toString(element.path)}`}
               contentIsComingFromServer={element.contentIsComingFromServer}
+              datatype={element.datatype}
             />
           </UIGridRow>
         )

--- a/editor/src/components/inspector/sections/layout-section/list-source-cartouche.tsx
+++ b/editor/src/components/inspector/sections/layout-section/list-source-cartouche.tsx
@@ -20,9 +20,13 @@ import {
   DataPickerPreferredAllAtom,
   jsxElementChildToValuePath,
 } from '../component-section/data-picker-utils'
-import { useVariablesInScopeForSelectedElement } from '../component-section/variables-in-scope-utils'
+import {
+  getCartoucheDataTypeForExpression,
+  useVariablesInScopeForSelectedElement,
+} from '../component-section/variables-in-scope-utils'
 import { mapDropNulls } from '../../../../core/shared/array-utils'
 import { traceDataFromElement, dataPathSuccess } from '../../../../core/data-tracing/data-tracing'
+import type { CartoucheDataType } from '../component-section/cartouche-ui'
 
 function filterVariableOption(option: DataPickerOption): DataPickerOption | null {
   switch (option.type) {
@@ -153,6 +157,24 @@ export const MapListSourceCartouche = React.memo((props: MapListSourceCartoucheP
     'ListSection isDataComingFromHookResult',
   )
 
+  const cartoucheDataType: CartoucheDataType = useEditorState(
+    Substores.projectContentsAndMetadataAndVariablesInScope,
+    (store) => {
+      if (
+        originalMapExpression === 'multiselect' ||
+        originalMapExpression === 'not-a-mapexpression'
+      ) {
+        return 'unknown'
+      }
+      return getCartoucheDataTypeForExpression(
+        target,
+        originalMapExpression.valueToMap,
+        store.editor.variablesInScope,
+      )
+    },
+    'MapListSourceCartouche cartoucheDataType',
+  )
+
   if (originalMapExpression === 'multiselect' || originalMapExpression === 'not-a-mapexpression') {
     return null
   }
@@ -183,7 +205,7 @@ export const MapListSourceCartouche = React.memo((props: MapListSourceCartoucheP
         safeToDelete={false}
         testId='list-source-cartouche'
         contentIsComingFromServer={isDataComingFromHookResult}
-        datatype='array' // this is by definition an array, otherwise it wouldn't be a map expression
+        datatype={cartoucheDataType}
       />
     </div>
   )

--- a/editor/src/components/inspector/sections/layout-section/list-source-cartouche.tsx
+++ b/editor/src/components/inspector/sections/layout-section/list-source-cartouche.tsx
@@ -183,6 +183,7 @@ export const MapListSourceCartouche = React.memo((props: MapListSourceCartoucheP
         safeToDelete={false}
         testId='list-source-cartouche'
         contentIsComingFromServer={isDataComingFromHookResult}
+        datatype='array' // this is by definition an array, otherwise it wouldn't be a map expression
       />
     </div>
   )


### PR DESCRIPTION
**Problem:**
The cartouche sometimes shows `[ ]` icons, sometimes the `{ }` icon, and other times the 🌺 icon. 
But these icons were not synchronized across the various places rendering cartouches. Despite them sharing the same component they don't share the same data sources, so some more unification was needed.

**Fix:**
Create a new helper function `getCartoucheDataTypeForExpression` which takes a unified approach to coming up with the right icon to show for the cartouche, so it is the same inside the data picker, navigator, and the inspector.

**Commit Details:**
- Created `getCartoucheDataTypeForExpression`
- Created helper `getSpiedValueForIdentifierOrAccess` – I tried to look for code to reuse for this one, but couldn't find much
- Added `datatype: CartoucheDataType` to the various cartouche wrapper component props
- Filling `props.datatype` with data from `getCartoucheDataTypeForExpression`

**Note:**
- The data picker is the last remaining place which uses a separate data source called `childTypeToCartoucheDataType` that is coming from the `VariableInfo` internal type. the reason I'm keeping it separate is because for dozens of cartouches I'm worried it would add extra cost to call out to `getCartoucheDataTypeForExpression`. the results today match up, but if there is a slight divergence we can switch this to getCartoucheDataTypeForExpression too, but it needs some careful performance investigation then.