### PR TITLE
Remove resize-observer polyfill and run observers in select mode

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -259,7 +259,6 @@
     "react-windowed-select": "3.1.2",
     "remix-react": "0.0.2",
     "reselect": "4.1.7",
-    "resize-observer-polyfill": "1.5.0",
     "sanitize-html": "2.11.0",
     "scheduler": "0.17.0",
     "semver": "7.3.2",

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -295,7 +295,6 @@ specifiers:
   react-windowed-select: 3.1.2
   remix-react: 0.0.2
   reselect: 4.1.7
-  resize-observer-polyfill: 1.5.0
   sanitize-html: 2.11.0
   scheduler: 0.17.0
   script-ext-html-webpack-plugin: 2.1.5
@@ -470,7 +469,6 @@ dependencies:
   react-windowed-select: 3.1.2_jxk2kndhaer357t5mrx7cw3eei
   remix-react: 0.0.2_ef5jwxihqo6n7gxfmzogljlgcm
   reselect: 4.1.7_lchp3amipq5ospj3jcph7hcfwu
-  resize-observer-polyfill: 1.5.0
   sanitize-html: 2.11.0
   scheduler: 0.17.0
   semver: 7.3.2
@@ -16653,10 +16651,6 @@ packages:
     resolution: {integrity: sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A==}
     dev: false
     patched: true
-
-  /resize-observer-polyfill/1.5.0:
-    resolution: {integrity: sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg==}
-    dev: false
 
   /resize-observer-polyfill/1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -1,7 +1,5 @@
 import React from 'react'
 import { sides } from 'utopia-api/core'
-import * as ResizeObserverSyntheticDefault from 'resize-observer-polyfill'
-const ResizeObserver = ResizeObserverSyntheticDefault.default ?? ResizeObserverSyntheticDefault
 
 import * as EP from '../../core/shared/element-path'
 import type {
@@ -170,7 +168,7 @@ function isScene(node: Node): node is HTMLElement {
   )
 }
 
-function findParentScene(target: HTMLElement): string | null {
+function findParentScene(target: Element): string | null {
   // First check if the node is a Scene element, which could be nested at any level
   const sceneID = getDOMAttribute(target, UTOPIA_SCENE_ID_KEY)
   if (sceneID != null) {
@@ -538,12 +536,19 @@ export function initDomWalkerObservers(
   editorStore: UtopiaStoreAPI,
   dispatch: EditorDispatch,
 ): { resizeObserver: ResizeObserver; mutationObserver: MutationObserver } {
+  // Warning: I modified this code so it runs in all modes, not just in live mode. We still don't trigger
+  // the DOM walker during canvas interactions, so the performance impact doesn't seem that bad. But it is
+  // necessary, because after remix navigation, and after dynamic changes coming from loaders sometimes the
+  // dom walker was not executed after all the changes.
+  //
+  // This was the original comment here when this only ran in live mode:
+  //
   // Warning: These observers only trigger the DOM walker whilst in live mode to ensure metadata is up to date
   // when interacting with the actual running application / components. There are likely edge cases where we
   // also want these to trigger the DOM walker whilst in select mode, but if we find such a case we need to
   // adequately assess the performance impact of doing so, and ideally find a way to only do so when the observed
   // change was not triggered by a user interaction
-  const resizeObserver = new ResizeObserver((entries: any) => {
+  const resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => {
     const canvasInteractionHappening = selectCanvasInteractionHappening(editorStore.getState())
     const selectedViews = editorStore.getState().editor.selectedViews
     if (canvasInteractionHappening) {
@@ -560,7 +565,7 @@ export function initDomWalkerObservers(
           shouldRunDOMWalker = true
         }
       }
-      if (shouldRunDOMWalker && isLiveMode(editorStore.getState().editor.mode)) {
+      if (shouldRunDOMWalker) {
         dispatch([runDOMWalker()])
       }
     }
@@ -592,7 +597,7 @@ export function initDomWalkerObservers(
           }
         }
       }
-      if (shouldRunDOMWalker && isLiveMode(editorStore.getState().editor.mode)) {
+      if (shouldRunDOMWalker) {
         dispatch([runDOMWalker()])
       }
     }

--- a/editor/src/missing-types/index.d.ts
+++ b/editor/src/missing-types/index.d.ts
@@ -31,8 +31,6 @@ declare module 'lodash.debounce' {
       any
 }
 
-declare module 'resize-observer-polyfill'
-
 declare module 'jest-matcher-deep-close-to'
 
 declare namespace DropboxTypes {

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -101,11 +101,9 @@ import { UtopiaStyles, colorTheme } from '../uuiui'
 import { DropHandlers } from './image-drop'
 import { EditorCommon } from '../components/editor/editor-component-common'
 import { CursorComponent } from '../components/canvas/controls/select-mode/cursor-component'
-import * as ResizeObserverSyntheticDefault from 'resize-observer-polyfill'
 import { isFeatureEnabled } from '../utils/feature-switches'
 import { getCanvasViewportCenter } from './paste-helpers'
 import { DataPasteHandler, isPasteHandler } from '../utils/paste-handler'
-const ResizeObserver = ResizeObserverSyntheticDefault.default ?? ResizeObserverSyntheticDefault
 
 const webFrame = PROBABLY_ELECTRON ? requireElectron().webFrame : null
 


### PR DESCRIPTION
**Problem:**
In the sample store we encountered out-of-date navigator several times, e.g. after initial load or after remix navigation.
Sometimes the problem is automatically fixed after a while, sometimes you need to interact with the editor, and then the navigator is fixed.
See: https://github.com/concrete-utopia/utopia/issues/5824

**Fix:**
When you navigate with Remix, or you wait for asynchronous load of data and for the changes after that, then there is no final dispatch when the content is ready (which would trigger a dom walker run).
We experienced this problem earlier in live mode: when the state of the app changes in live mode, we need to guarantee to run the dom walker, even though no dispatch has happened. To fix this, we rely in resize and mutation observers, see, https://github.com/concrete-utopia/utopia/pull/4167

Even though In the original PR the observers were not turned in select mode due to performance reasons, in my experience the performance impact is acceptable, because we don't listen to the observer during canvas interactions. So we only have extra dom walker runs after one-off interactions, e.g. after changing something in the inspector.

I also removed the resize observer polyfill, because it is widely supported on modern browsers, so that just looked as a potential source of problems (and the native solution should be better regarding performance too)


**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5824
