### PR TITLE
Cartouche selection color in navigator

### DIFF
--- a/editor/src/components/inspector/sections/component-section/cartouche-ui.tsx
+++ b/editor/src/components/inspector/sections/component-section/cartouche-ui.tsx
@@ -15,6 +15,7 @@ export interface HoverHandlers {
 export type CartoucheDataType = 'renderable' | 'boolean' | 'array' | 'object' | 'unknown'
 
 type CartoucheSource = 'internal' | 'external' | 'literal'
+export type CartoucheHighlight = 'strong' | 'subtle'
 
 export type CartoucheUIProps = React.PropsWithChildren<{
   tooltip?: string | null
@@ -22,6 +23,7 @@ export type CartoucheUIProps = React.PropsWithChildren<{
   role: 'selection' | 'information' | 'folder'
   datatype: CartoucheDataType
   selected: boolean
+  highlight?: CartoucheHighlight | null
   testId: string
   preview?: boolean
   onDelete?: (e: React.MouseEvent) => void
@@ -40,13 +42,14 @@ export const CartoucheUI = React.forwardRef(
       children,
       source,
       selected,
+      highlight,
       role,
       datatype,
       onHover,
       preview = false,
     } = props
 
-    const colors = useCartoucheColors(source)
+    const colors = useCartoucheColors(source, highlight ?? null)
 
     const wrappedOnClick = useStopPropagation(onClick)
     const wrappedOnDoubleClick = useStopPropagation(onDoubleClick)
@@ -78,10 +81,10 @@ export const CartoucheUI = React.forwardRef(
               opacity: preview ? 0.5 : 1,
             }}
             css={{
-              color: selected ? colors.fg.selected : colors.fg.default,
+              color: selected || highlight === 'strong' ? colors.fg.selected : colors.fg.default,
               backgroundColor: selected ? colors.bg.selected : colors.bg.default,
               ':hover': {
-                color: selected ? undefined : colors.fg.hovered,
+                color: selected || highlight === 'strong' ? undefined : colors.fg.hovered,
                 backgroundColor: selected ? undefined : colors.bg.hovered,
               },
             }}
@@ -90,7 +93,9 @@ export const CartoucheUI = React.forwardRef(
               <Icn
                 category='navigator-element'
                 type={dataTypeToIconType(datatype)}
-                color={selected ? colors.icon.selected : colors.icon.default}
+                color={
+                  selected || highlight === 'strong' ? colors.icon.selected : colors.icon.default
+                }
                 width={12}
                 height={12}
               />
@@ -124,7 +129,9 @@ export const CartoucheUI = React.forwardRef(
               <Icn
                 category='semantic'
                 type='cross'
-                color={selected ? colors.icon.selected : colors.icon.default}
+                color={
+                  selected || highlight === 'strong' ? colors.icon.selected : colors.icon.default
+                }
                 width={12}
                 height={12}
                 data-testid={`delete-${props.testId}`}
@@ -172,7 +179,7 @@ type CartoucheStateColor<T> = {
   selected: T
 }
 
-function useCartoucheColors(source: CartoucheSource) {
+function useCartoucheColors(source: CartoucheSource, highlight: CartoucheHighlight | null) {
   const colorTheme = useColorTheme()
 
   const colors: {
@@ -189,8 +196,10 @@ function useCartoucheColors(source: CartoucheSource) {
             selected: colorTheme.white.value,
           },
           bg: {
-            default: colorTheme.green10.value,
-            hovered: colorTheme.green20.value,
+            default:
+              highlight === 'strong' ? colorTheme.whiteOpacity20.value : colorTheme.green10.value,
+            hovered:
+              highlight === 'strong' ? colorTheme.whiteOpacity30.value : colorTheme.green20.value,
             selected: colorTheme.green.value,
           },
           icon: { default: 'green', hovered: 'green', selected: 'on-highlight-main' },
@@ -203,8 +212,14 @@ function useCartoucheColors(source: CartoucheSource) {
             selected: colorTheme.white.value,
           },
           bg: {
-            default: colorTheme.selectionBlue10.value,
-            hovered: colorTheme.selectionBlue20.value,
+            default:
+              highlight === 'strong'
+                ? colorTheme.whiteOpacity20.value
+                : colorTheme.selectionBlue10.value,
+            hovered:
+              highlight === 'strong'
+                ? colorTheme.whiteOpacity30.value
+                : colorTheme.selectionBlue20.value,
             selected: colorTheme.selectionBlue.value,
           },
           icon: { default: 'dynamic', hovered: 'dynamic', selected: 'on-highlight-main' },
@@ -217,16 +232,29 @@ function useCartoucheColors(source: CartoucheSource) {
             selected: colorTheme.white.value,
           },
           bg: {
-            default: colorTheme.bg5.value,
-            hovered: colorTheme.fg8.value,
-            selected: colorTheme.fg6.value,
+            default:
+              highlight === 'strong'
+                ? colorTheme.whiteOpacity20.value
+                : highlight === 'subtle'
+                ? colorTheme.cartoucheLiteralHighlightDefault.value
+                : colorTheme.bg5.value,
+            hovered:
+              highlight === 'strong'
+                ? colorTheme.whiteOpacity30.value
+                : highlight === 'subtle'
+                ? colorTheme.cartoucheLiteralHighlightHovered.value
+                : colorTheme.fg8.value,
+            selected:
+              highlight === 'subtle'
+                ? colorTheme.cartoucheLiteralHighlightSelected.value
+                : colorTheme.fg6.value,
           },
           icon: { default: 'secondary', hovered: 'secondary', selected: 'on-highlight-main' },
         }
       default:
         assertNever(source)
     }
-  }, [source, colorTheme])
+  }, [source, colorTheme, highlight])
 
   return colors
 }

--- a/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
@@ -22,7 +22,7 @@ import {
 } from './variables-in-scope-utils'
 import { DataPickerPreferredAllAtom, jsxElementChildToValuePath } from './data-picker-utils'
 import { useAtom } from 'jotai'
-import type { CartoucheDataType, CartoucheUIProps } from './cartouche-ui'
+import type { CartoucheDataType, CartoucheHighlight, CartoucheUIProps } from './cartouche-ui'
 import { CartoucheUI } from './cartouche-ui'
 
 interface DataReferenceCartoucheControlProps {
@@ -32,6 +32,7 @@ interface DataReferenceCartoucheControlProps {
   renderedAt: RenderedAt
   surroundingScope: ElementPath
   hideTooltip?: boolean
+  highlight?: CartoucheHighlight | null
 }
 
 export const DataReferenceCartoucheControl = React.memo(
@@ -144,6 +145,7 @@ export const DataReferenceCartoucheControl = React.memo(
           contentsToDisplay={contentsToDisplay}
           selected={selected}
           safeToDelete={false}
+          highlight={props.highlight}
           onDelete={NO_OP}
           testId={`data-reference-cartouche-${EP.toString(elementPath)}`}
           contentIsComingFromServer={isDataComingFromHookResult}
@@ -170,6 +172,7 @@ interface DataCartoucheInnerProps {
   contentIsComingFromServer: boolean
   hideTooltip?: boolean
   datatype: CartoucheDataType
+  highlight?: CartoucheHighlight | null
 }
 
 export const DataCartoucheInner = React.forwardRef(
@@ -180,6 +183,7 @@ export const DataCartoucheInner = React.forwardRef(
       safeToDelete,
       onDelete: onDeleteCallback,
       selected,
+      highlight,
       testId,
       contentsToDisplay,
       contentIsComingFromServer,
@@ -210,6 +214,7 @@ export const DataCartoucheInner = React.forwardRef(
         onDoubleClick={onDoubleClick}
         datatype={datatype}
         selected={selected}
+        highlight={highlight}
         testId={testId}
         tooltip={!props.hideTooltip ? contentsToDisplay.label ?? 'DATA' : null}
         role='selection'

--- a/editor/src/components/navigator/navigator-item/navigator-condensed-entry.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-condensed-entry.tsx
@@ -78,20 +78,29 @@ export const CondensedEntryItemWrapper = React.memo(
       )
     }, [selectedViews, props.navigatorRow])
 
+    const rowRootSelected = React.useMemo(() => {
+      return selectedViews.some((view) =>
+        EP.pathsEqual(view, props.navigatorRow.entries[0].elementPath),
+      )
+    }, [selectedViews, props.navigatorRow])
+
     return (
       <div
         style={{
           ...props.windowStyle,
           display: 'flex',
           alignItems: 'center',
-          backgroundColor:
-            hasSelection || wholeRowInsideSelection
-              ? colorTheme.childSelectionBlue.value
-              : 'transparent',
+          backgroundColor: rowRootSelected
+            ? colorTheme.selectionBlue.value
+            : hasSelection || wholeRowInsideSelection
+            ? colorTheme.childSelectionBlue.value
+            : 'transparent',
           borderTopLeftRadius: rowContainsSelection ? 5 : 0,
           borderTopRightRadius: rowContainsSelection ? 5 : 0,
-          borderBottomLeftRadius: isCollapsed || isDataReferenceRow ? 5 : 0,
-          borderBottomRightRadius: isCollapsed || isDataReferenceRow ? 5 : 0,
+          borderBottomLeftRadius:
+            rowContainsSelection && (isCollapsed || isDataReferenceRow) ? 5 : 0,
+          borderBottomRightRadius:
+            rowContainsSelection && (isCollapsed || isDataReferenceRow) ? 5 : 0,
           overflowX: 'auto',
         }}
       >
@@ -109,6 +118,7 @@ export const CondensedEntryItemWrapper = React.memo(
               showSeparator={showSeparator}
               wholeRowInsideSelection={wholeRowInsideSelection}
               rowContainsSelection={rowContainsSelection}
+              rowRootSelected={rowRootSelected}
             />
           )
         })}
@@ -124,6 +134,7 @@ const CondensedEntryItem = React.memo(
     navigatorRow: CondensedNavigatorRow
     isDataReferenceRow: boolean
     rowContainsSelection: boolean
+    rowRootSelected: boolean
     wholeRowInsideSelection: boolean
     showSeparator: boolean
     showExpandableIndicator: boolean
@@ -197,16 +208,11 @@ const CondensedEntryItem = React.memo(
           showExpandableIndicator={props.showExpandableIndicator}
           isDataReferenceRow={props.isDataReferenceRow}
           indentation={indentation}
+          rowRootSelected={props.rowRootSelected}
         />
         {when(
           props.showSeparator,
           <CondensedEntryTrunkSeparator backgroundColor={backgroundColor} />,
-        )}
-        {when(
-          !props.showSeparator &&
-            (!props.showExpandableIndicator ||
-              (props.rowContainsSelection && !selectionIsDataReference)),
-          <div style={{ width: 4, height: '100%' }} />,
         )}
       </React.Fragment>
     )
@@ -220,6 +226,7 @@ const CondensedEntryItemContent = React.memo(
     wholeRowInsideSelection: boolean
     isChildOfSelected: boolean
     selected: boolean
+    rowRootSelected: boolean
     showExpandableIndicator: boolean
     isDataReferenceRow: boolean
     indentation: number
@@ -293,6 +300,7 @@ const CondensedEntryItemContent = React.memo(
               : undefined,
           borderTopRightRadius: props.selected ? 5 : 0,
           borderBottomRightRadius: props.selected ? 5 : 0,
+          marginRight: 4,
         }}
         onClick={onClick}
         onMouseOver={onMouseOver}
@@ -343,6 +351,9 @@ const CondensedEntryItemContent = React.memo(
             <DataReferenceCartoucheControl
               {...(props.entry as DataReferenceNavigatorEntry)}
               selected={props.selected}
+              highlight={
+                props.rowRootSelected ? 'strong' : props.wholeRowInsideSelection ? 'subtle' : null
+              }
               hideTooltip={true}
             />,
           )}

--- a/editor/src/components/navigator/navigator-item/navigator-condensed-entry.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-condensed-entry.tsx
@@ -212,7 +212,10 @@ const CondensedEntryItem = React.memo(
         />
         {when(
           props.showSeparator,
-          <CondensedEntryTrunkSeparator backgroundColor={backgroundColor} />,
+          <CondensedEntryTrunkSeparator
+            backgroundColor={backgroundColor}
+            selected={props.rowRootSelected}
+          />,
         )}
       </React.Fragment>
     )
@@ -300,7 +303,7 @@ const CondensedEntryItemContent = React.memo(
               : undefined,
           borderTopRightRadius: props.selected ? 5 : 0,
           borderBottomRightRadius: props.selected ? 5 : 0,
-          marginRight: 4,
+          marginRight: !props.showExpandableIndicator && props.isDataReferenceRow ? 4 : 0,
         }}
         onClick={onClick}
         onMouseOver={onMouseOver}
@@ -341,7 +344,7 @@ const CondensedEntryItemContent = React.memo(
               <WrappedLayoutIcon
                 entry={props.entry}
                 hideTooltip={isDataReference || showLabel}
-                selected={props.selected}
+                selected={props.selected || props.rowRootSelected}
               />,
             )}
           </div>
@@ -364,7 +367,12 @@ const CondensedEntryItemContent = React.memo(
 )
 CondensedEntryItemContent.displayName = 'CondensedEntryItemContent'
 
-const CondensedEntryTrunkSeparator = React.memo((props: { backgroundColor: string }) => {
+type CondensedEntryTrunkSeparatorProps = {
+  backgroundColor: string
+  selected: boolean
+}
+
+const CondensedEntryTrunkSeparator = React.memo((props: CondensedEntryTrunkSeparatorProps) => {
   const colorTheme = useColorTheme()
 
   return (
@@ -387,7 +395,7 @@ const CondensedEntryTrunkSeparator = React.memo((props: { backgroundColor: strin
           color: colorTheme.fg6.value,
         }}
       >
-        <Icons.NarrowExpansionArrowRight />
+        <Icons.NarrowExpansionArrowRight color={props.selected ? 'white' : 'main'} />
       </div>
     </div>
   )

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -130,7 +130,9 @@ const colorsWithOpacity = {
   fg0Opacity10: createUtopiColor('hsla(0,100%,100%,0.1)'),
   fg0Opacity20: createUtopiColor('hsla(0,100%,100%,0.2)'),
   fg6Opacity50: createUtopiColor('rgba(111, 119, 139, 0.5)'),
+  whiteOpacity20: createUtopiColor('oklch(100% 0 0 /20%)'),
   whiteOpacity30: createUtopiColor('oklch(100% 0 0 /30%)'),
+  whiteOpacity35: createUtopiColor('oklch(100% 0 0 /35%)'),
   canvasControlsSizeBoxShadowColor20: createUtopiColor('rgba(255,255,255,0.20)'),
   canvasControlsSizeBoxShadowColor50: createUtopiColor('rgba(255,255,255,0.5)'),
   neutralInvertedBackground10: createUtopiColor('rgba(217, 220, 227, 0.1)'),
@@ -141,6 +143,10 @@ const colorsWithOpacity = {
   // TODO vv only used by button, refactor & remove
   errorForeground20: createUtopiColor('rgba(253, 0, 59, 0.2)'),
   subduedBorder80: createUtopiColor('rgba(24, 28, 32, 0.8)'),
+
+  cartoucheLiteralHighlightDefault: createUtopiColor('rgba(255, 255, 255, 0.1)'),
+  cartoucheLiteralHighlightHovered: createUtopiColor('rgba(255, 255, 255, 0.2)'),
+  cartoucheLiteralHighlightSelected: createUtopiColor('rgba(255, 255, 255, 0.4)'),
 }
 
 const darkTheme: typeof light = {

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -131,7 +131,9 @@ const colorsWithOpacity = {
   fg0Opacity10: createUtopiColor('hsla(0,0%,0%,0.1)'),
   fg0Opacity20: createUtopiColor('hsla(0,0%,0%,0.2)'),
   fg6Opacity50: createUtopiColor('hsla(0,0%,0%,0.5)'),
+  whiteOpacity20: createUtopiColor('oklch(100% 0 0 /20%)'),
   whiteOpacity30: createUtopiColor('oklch(100% 0 0 /30%)'),
+  whiteOpacity35: createUtopiColor('oklch(100% 0 0 /35%)'),
   canvasControlsSizeBoxShadowColor20: createUtopiColor('rgba(0,0,0,0.20)'),
   canvasControlsSizeBoxShadowColor50: createUtopiColor('rgba(0,0,0,0.5)'),
   neutralInvertedBackground10: createUtopiColor('hsla(0,0%,0%,0.1)'),
@@ -142,6 +144,10 @@ const colorsWithOpacity = {
   // TODO vv only used by button, refactor & remove
   errorForeground20: createUtopiColor('rgba(253, 0, 59, 0.2)'),
   subduedBorder80: createUtopiColor('hsla(0, 0%, 91%, 0.8)'),
+
+  cartoucheLiteralHighlightDefault: createUtopiColor('rgba(43, 43, 43, 0.1)'),
+  cartoucheLiteralHighlightHovered: createUtopiColor('rgba(43, 43, 43, 0.2)'),
+  cartoucheLiteralHighlightSelected: createUtopiColor('rgba(43, 43, 43, 0.5)'),
 }
 
 const lightTheme = {


### PR DESCRIPTION
Part of #5840 

This PR adjusts the coloring of cartouches when inside a navigator selected row (direct or parent).

https://github.com/concrete-utopia/utopia/assets/1081051/7a3208e5-9fbd-4b3e-a988-78db3f278622

The entire row coloring is also adjusted following the updated designs in the issue ⬆️ 

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
