### PR TITLE
Layout icon should be blue too

### DIFF
--- a/editor/src/components/navigator/navigator-item/layout-icon.tsx
+++ b/editor/src/components/navigator/navigator-item/layout-icon.tsx
@@ -117,7 +117,11 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
         iconTypeToReturn = props.override
         if (baseColor === 'white') {
           colorToReturn = baseColor
-        } else if (props.override === 'row' || props.override === 'column') {
+        } else if (
+          props.override === 'row' ||
+          props.override === 'column' ||
+          props.override === 'layout'
+        ) {
           colorToReturn = 'primary'
         } else {
           colorToReturn = baseColor

--- a/editor/src/components/navigator/navigator-item/layout-icon.tsx
+++ b/editor/src/components/navigator/navigator-item/layout-icon.tsx
@@ -120,7 +120,8 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
         } else if (
           props.override === 'row' ||
           props.override === 'column' ||
-          props.override === 'layout'
+          props.override === 'layout' ||
+          props.override === 'grid'
         ) {
           colorToReturn = 'primary'
         } else {


### PR DESCRIPTION
**Problem:**
Icon `layout` coming from the component annotation should be blue, just like `row` and `column`

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

