### PR TITLE
Property for a Remix starting route.

### DIFF
--- a/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
+++ b/editor/src/components/canvas/remix/utopia-remix-root-component.tsx
@@ -286,6 +286,7 @@ function traverseRoutesAndGetIDs(routes: RouteLike[]): Set<string> {
 export interface UtopiaRemixRootComponentProps {
   [UTOPIA_PATH_KEY]: ElementPath
   getLoadContext?: (request: Request) => Promise<AppLoadContext> | AppLoadContext
+  startingRoute?: string
 }
 
 export const UtopiaRemixRootComponent = (props: UtopiaRemixRootComponentProps) => {
@@ -313,6 +314,12 @@ export const UtopiaRemixRootComponent = (props: UtopiaRemixRootComponentProps) =
     const initialEntries = currentEntriesRef.current == null ? undefined : currentEntriesRef.current
     return createMemoryRouter(routes, { initialEntries: initialEntries })
   }, [routes])
+
+  React.useEffect(() => {
+    if (props.startingRoute != null && router != null) {
+      void router.navigate(props.startingRoute)
+    }
+  }, [router, props.startingRoute])
 
   const setNavigationDataForRouter = React.useCallback(
     (

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/remix-scene-component.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/remix-scene-component.tsx
@@ -15,13 +15,13 @@ export interface RemixSceneProps {
   style?: React.CSSProperties
   [UTOPIA_PATH_KEY]?: string
   getLoadContext?: (request: Request) => Promise<AppLoadContext> | AppLoadContext
+  startingRoute?: string
 }
 
 export const RemixSceneComponent = React.memo((props: React.PropsWithChildren<RemixSceneProps>) => {
   const colorTheme = useColorTheme()
-  const canvasIsLive = false
 
-  const { style, getLoadContext, ...remainingProps } = props
+  const { style, getLoadContext, startingRoute, ...remainingProps } = props
 
   const sceneStyle: React.CSSProperties = {
     position: 'relative',
@@ -51,7 +51,11 @@ export const RemixSceneComponent = React.memo((props: React.PropsWithChildren<Re
       style={sceneStyle}
       onMouseDown={onMouseDown}
     >
-      <UtopiaRemixRootComponent data-path={path} getLoadContext={getLoadContext} />
+      <UtopiaRemixRootComponent
+        data-path={path}
+        getLoadContext={getLoadContext}
+        startingRoute={startingRoute}
+      />
     </div>
   )
 })


### PR DESCRIPTION
**Problem:**
For convenience, we want to have a property on `RemixScene` which on a reload of the editor changes the route to whatever that is.

**Fix:**
A new property of `startingRoute` has been added to `RemixScene`, if that is set the editor navigates to that route.

**Commit Details:**
- Added `startingRoute` to `UtopiaRemixComponentProps`.
- `UtopiaRemixComponentProps` triggers a navigation against the starting route.
- Added `startingRoute` to `RemixSceneProps`.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5827
