### PR TITLE
Open inspector cartouches on double click

### DIFF
--- a/editor/src/components/inspector/sections/component-section/cartouche-control.tsx
+++ b/editor/src/components/inspector/sections/component-section/cartouche-control.tsx
@@ -1,7 +1,4 @@
 import React from 'react'
-import { when } from '../../../../utils/react-conditionals'
-import { FlexRow, Icn, Tooltip, colorTheme } from '../../../../uuiui'
-import { stopPropagation } from '../../common/inspector-utils'
 import { DataCartoucheInner } from './data-reference-cartouche'
 import { NO_OP } from '../../../../core/shared/utils'
 import type { ElementPath, PropertyPath } from '../../../../core/shared/project-file-types'
@@ -41,9 +38,9 @@ export const IdentifierExpressionCartoucheControl = React.memo(
     return (
       <DataCartoucheInner
         contentsToDisplay={{ label: props.contents, type: 'reference' }}
-        onClick={onOpenDataPicker}
+        onClick={NO_OP}
         selected={false}
-        onDoubleClick={NO_OP}
+        onDoubleClick={onOpenDataPicker}
         safeToDelete={safeToDelete}
         onDelete={onDeleteCartouche}
         testId={testId}

--- a/editor/src/components/inspector/sections/data-reference-section.tsx
+++ b/editor/src/components/inspector/sections/data-reference-section.tsx
@@ -167,8 +167,8 @@ export const DataReferenceSection = React.memo(({ paths }: { paths: ElementPath[
             <span>Value</span>
 
             <DataCartoucheInner
-              onClick={openPicker(element.path)}
-              onDoubleClick={NO_OP}
+              onClick={NO_OP}
+              onDoubleClick={openPicker(element.path)}
               selected={false}
               contentsToDisplay={element.textContent}
               safeToDelete={false}

--- a/editor/src/components/inspector/sections/layout-section/list-section.tsx
+++ b/editor/src/components/inspector/sections/layout-section/list-section.tsx
@@ -141,7 +141,7 @@ export const ListSection = React.memo(({ paths }: { paths: ElementPath[] }) => {
       </FlexRow>
       <UIGridRow padded variant='<--1fr--><--1fr-->'>
         List Source
-        <MapListSourceCartouche target={target} openOn='single-click' selected={false} />
+        <MapListSourceCartouche target={target} openOn='double-click' selected={false} />
       </UIGridRow>
       <UIGridRow padded variant='<--1fr--><--1fr-->'>
         Contents


### PR DESCRIPTION
Part of #5840 

**Problem:**

Cartouches in the inspector should be openable on double-click like in the navigator, not on single clicks.

**Fix:**

Do that.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
