### PR TITLE
Prevent Error On Adding Page From Template

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -587,7 +587,10 @@ import { addHookForProjectChanges } from '../store/collaborative-editing'
 import { arrayDeepEquality, objectDeepEquality } from '../../../utils/deep-equality'
 import type { ProjectServerState } from '../store/project-server-state'
 import { updateFileIfPossible } from './can-update-file'
-import { getPrintAndReparseCodeResult } from '../../../core/workers/parser-printer/parser-printer-worker'
+import {
+  getParseFileResult,
+  getPrintAndReparseCodeResult,
+} from '../../../core/workers/parser-printer/parser-printer-worker'
 import { isSteganographyEnabled } from '../../../core/shared/stegano-text'
 import type { ParsedTextFileWithPath } from '../../../core/property-controls/property-controls-local'
 import {
@@ -4114,15 +4117,35 @@ export const UPDATE_FNS = {
       addNewFeaturedRouteToPackageJson(action.newPageName),
     )
 
-    // 2. write the new text file
+    // 2. Parse the file upfront.
+    const existingUIDs = new Set(getAllUniqueUids(editor.projectContents).uniqueIDs)
+    const parsedResult = getParseFileResult(
+      newFileName,
+      templateFile.fileContents.code,
+      null,
+      1,
+      existingUIDs,
+      isSteganographyEnabled(),
+    )
+
+    // 3. write the new text file
     const withTextFile = addTextFile(
       withPackageJson,
       action.parentPath,
       newFileName,
-      codeFile(templateFile.fileContents.code, null, 1, RevisionsState.CodeAhead),
+      textFile(
+        textFileContents(
+          templateFile.fileContents.code,
+          parsedResult.parseResult,
+          RevisionsState.CodeAhead,
+        ),
+        null,
+        null,
+        1,
+      ),
     )
 
-    // 3. open the text file
+    // 4. open the text file
     return UPDATE_FNS.OPEN_CODE_EDITOR_FILE(
       openCodeEditorFile(withTextFile.newFileKey, false),
       withTextFile.editorState,

--- a/editor/src/core/workers/parser-printer/parser-printer-worker.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-worker.ts
@@ -57,7 +57,7 @@ export function handleMessage(
   }
 }
 
-function getParseFileResult(
+export function getParseFileResult(
   filename: string,
   content: string,
   oldParseResultForUIDComparison: ParseSuccess | null,


### PR DESCRIPTION
**Problem:**
When adding a new page from a template, we have a transient error showing up momentarily.

**Cause:**
The editor attempts to navigate to the newly added page, but the page is added in the unparsed state. This causes some internal logic in `useGetRouteModules` to fail returning a null for the route, which results in `routeModules` lacking an entry for the new page. That causes the Remix logic to fail as we've attempted to navigate to a route that does not exist.

**Fix:**
Now when adding the page from the template, we parse it first and add the result to the project, so that at least on a successful parse there's no error that momentarily displays. 

**Commit Details:**
- `ADD_NEW_PAGE` action parses the template file upfront when adding it to the project.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
