### PR TITLE
Trim children string inspector inputs

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section-children.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section-children.tsx
@@ -82,7 +82,7 @@ export function useChildrenPropOverride(
               ? props.controlDescription
               : {
                   control: 'string-input',
-                  label: 'hey',
+                  label: 'children',
                 }
           }
         />

--- a/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
+++ b/editor/src/components/inspector/sections/component-section/property-control-controls.tsx
@@ -551,11 +551,19 @@ export const StringInputPropertyControl = React.memo(
             element.element.value.children.length > 0
           ) {
             const child = element.element.value.children[0]
-            switch (child.type) {
-              case 'ATTRIBUTE_OTHER_JAVASCRIPT':
-                return child.originalJavascript
-              case 'JSX_TEXT_BLOCK':
-                return child.text
+            function getChildText(): string | null {
+              switch (child.type) {
+                case 'ATTRIBUTE_OTHER_JAVASCRIPT':
+                  return child.originalJavascript
+                case 'JSX_TEXT_BLOCK':
+                  return child.text
+                default:
+                  return null
+              }
+            }
+            const maybeText = getChildText()
+            if (maybeText != null) {
+              return maybeText.trim()
             }
           }
           return undefined


### PR DESCRIPTION
**Problem:**

Children text string inputs in the inspector can contain non-trimmed strings.

**Fix:**

Trim them if defined.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5871 
