### PR TITLE
Consistent width for background layers pickers

### DIFF
--- a/editor/src/components/inspector/controls/background-solid-or-gradient-thumbnail-control.tsx
+++ b/editor/src/components/inspector/controls/background-solid-or-gradient-thumbnail-control.tsx
@@ -183,7 +183,11 @@ export const BackgroundSolidOrGradientThumbnailControl = React.memo(
           ['controlClassName'],
           props,
         )} ignore-react-onclickoutside-${props.id}`}
-        style={props.style}
+        style={{
+          width: 30,
+          height: 24,
+          ...props.style,
+        }}
       >
         {picker}
         <div className={`widget-color-control relative`} key={`${props.id}-surround`}>


### PR DESCRIPTION
**Problem:**

The color pickers for the background resize with the inspector.

**Fix:**

Make the different background layers' swatches sizes consistent.

<img width="352" alt="Screenshot 2024-06-10 at 5 57 33 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/8534f55a-780f-497d-9c88-16df8834a9d4">

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5870

