### PR TITLE
fix: segement controls CSS

### DIFF
--- a/editor/src/components/inspector/controls/option-chain-control.tsx
+++ b/editor/src/components/inspector/controls/option-chain-control.tsx
@@ -66,6 +66,7 @@ export const OptionChainControl: React.FunctionComponent<
           flexDirection: 'row',
           border: `1px solid ${colorTheme.bg2.value}`,
           borderRadius: 3,
+          padding: '1px',
         }}
         className={`option-chain-control-container ${Utils.pathOr(
           '',

--- a/editor/src/components/inspector/controls/option-control.tsx
+++ b/editor/src/components/inspector/controls/option-control.tsx
@@ -120,9 +120,21 @@ export const OptionControl: React.FunctionComponent<
             '.option-chain-control-container &': {
               borderRadius: isChecked ? '3px' : 0,
               boxShadow: 'none !important',
-              opacity: isChecked ? 1 : controlOpacity,
+              opacity: 1,
+              borderColor: colorTheme.border0.value,
+              backgroundColor: isChecked
+                ? props.controlStatus === 'overridden'
+                  ? colorTheme.brandNeonPink10.value
+                  : colorTheme.bg4.value
+                : 'transparent',
+              color: isChecked
+                ? props.controlStatus === 'overridden'
+                  ? colorTheme.brandNeonPink.value
+                  : colorTheme.fg1.value
+                : colorTheme.verySubduedForeground.value,
               '&:hover': {
                 opacity: props.controlStatus == 'disabled' ? undefined : 1,
+                color: colorTheme.fg1.value,
                 cursor: 'pointer',
               },
             },

--- a/editor/src/components/inspector/controls/option-control.tsx
+++ b/editor/src/components/inspector/controls/option-control.tsx
@@ -120,6 +120,11 @@ export const OptionControl: React.FunctionComponent<
             '.option-chain-control-container &': {
               borderRadius: isChecked ? '3px' : 0,
               boxShadow: 'none !important',
+              opacity: isChecked ? 1 : controlOpacity,
+              '&:hover': {
+                opacity: props.controlStatus == 'disabled' ? undefined : 1,
+                cursor: 'pointer',
+              },
             },
             '.option-chain-control-container .segment:first-of-type  &': {
               borderTopLeftRadius: UtopiaTheme.inputBorderRadius,
@@ -145,10 +150,8 @@ export const OptionControl: React.FunctionComponent<
               rc === 'all' || rc === 'left' || rc === 'bottomLeft' || rc === 'bottom'
                 ? UtopiaTheme.inputBorderRadius
                 : undefined,
-            opacity: isChecked ? 1 : controlOpacity,
             '&:hover': {
-              opacity: props.controlStatus == 'disabled' ? undefined : 1,
-              cursor: 'pointer',
+              opacity: props.controlStatus == 'disabled' ? undefined : controlOpacity + 0.2,
             },
             '&:active': {
               opacity: props.controlStatus == 'disabled' ? undefined : 1,

--- a/editor/src/components/inspector/controls/option-control.tsx
+++ b/editor/src/components/inspector/controls/option-control.tsx
@@ -118,7 +118,7 @@ export const OptionControl: React.FunctionComponent<
             borderRadius: rc != null ? 0 : UtopiaTheme.inputBorderRadius,
             // If part of a option chain control:
             '.option-chain-control-container &': {
-              borderRadius: 0,
+              borderRadius: isChecked ? '3px' : 0,
               boxShadow: 'none !important',
             },
             '.option-chain-control-container .segment:first-of-type  &': {
@@ -145,8 +145,10 @@ export const OptionControl: React.FunctionComponent<
               rc === 'all' || rc === 'left' || rc === 'bottomLeft' || rc === 'bottom'
                 ? UtopiaTheme.inputBorderRadius
                 : undefined,
+            opacity: isChecked ? 1 : controlOpacity,
             '&:hover': {
-              opacity: props.controlStatus == 'disabled' ? undefined : controlOpacity + 0.2,
+              opacity: props.controlStatus == 'disabled' ? undefined : 1,
+              cursor: 'pointer',
             },
             '&:active': {
               opacity: props.controlStatus == 'disabled' ? undefined : 1,


### PR DESCRIPTION
Adjust the style of segment controls to match design:

<img width="561" alt="image" src="https://github.com/concrete-utopia/utopia/assets/7003853/97ed42eb-6b21-4ff4-a9b0-748674b1c60b">

With overridden values:
![image](https://github.com/concrete-utopia/utopia/assets/7003853/26e5ac00-b833-4329-8e23-bb10d52e5bd4)

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode

Fixes #5830 