### PR TITLE
disabling "updates property controls after cloning the branch"

### DIFF
--- a/editor/src/core/shared/github/github.spec.browser2.ts
+++ b/editor/src/core/shared/github/github.spec.browser2.ts
@@ -210,7 +210,7 @@ describe('Github integration', () => {
     expect(renderResult.renderedDOM.getByText('Editor from Github')).toBeDefined()
   })
 
-  it('updates property controls after cloning the branch', async () => {
+  xit('updates property controls after cloning the branch', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippet(`
           <h1>Starting Editor</h1>


### PR DESCRIPTION
The test unfortunately became flaky, I am making a github TODO to investigate and fix, but I'm disabling it now