### PR TITLE
Prevent keystrokes from leaking (fix regression)

### DIFF
--- a/editor/src/components/context-menu-wrapper.tsx
+++ b/editor/src/components/context-menu-wrapper.tsx
@@ -15,7 +15,7 @@ import type { ContextMenuItem } from './context-menu-items'
 import type { EditorDispatch } from './editor/action-types'
 import type { WindowPoint } from '../core/shared/math-utils'
 import { windowPoint } from '../core/shared/math-utils'
-import { BodyMenuOpenClass } from '../core/shared/utils'
+import { addOpenMenuId, removeOpenMenuId } from '../core/shared/menu-state'
 
 interface Submenu<T> {
   items: Item<T>[]
@@ -56,12 +56,18 @@ export interface ContextMenuProps<T> {
   items: ContextMenuItem<T>[]
 }
 
-const onVisibilityChange = (isVisible: boolean) => {
-  if (isVisible) document.body.classList.add(BodyMenuOpenClass)
-  else document.body.classList.remove(BodyMenuOpenClass)
-}
-
 export const ContextMenu = <T,>({ dispatch, getData, id, items }: ContextMenuProps<T>) => {
+  const onVisibilityChange = React.useCallback(
+    (isVisible: boolean) => {
+      if (isVisible) {
+        addOpenMenuId(id)
+      } else {
+        removeOpenMenuId(id)
+      }
+    },
+    [id],
+  )
+
   const splitItems = React.useMemo(() => {
     const tempItems: MenuItem<T>[] = []
 

--- a/editor/src/components/editor/editor-component-common.tsx
+++ b/editor/src/components/editor/editor-component-common.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { EditorAction, EditorDispatch } from './action-types'
 import { useDispatch } from './store/dispatch-context'
-import { BodyMenuOpenClass } from '../../core/shared/utils'
+import { isSomeMenuOpen } from '../../core/shared/menu-state'
 
 type EventHandler<K extends keyof WindowEventMap, R> = (this: Window, event: WindowEventMap[K]) => R
 
@@ -52,10 +52,7 @@ function createHandler<K extends keyof WindowEventMap>(
   } else {
     const windowEventHandler = (event: WindowEventMap[K]) => {
       // check if it's a keyboard event and if react-contexify is open
-      if (
-        ['keydown', 'keyup'].includes(event.type) &&
-        document.body.classList.contains(BodyMenuOpenClass)
-      ) {
+      if (['keydown', 'keyup'].includes(event.type) && isSomeMenuOpen()) {
         return
       }
       const collatedActions = handlers.flatMap((handler) => {

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -3,7 +3,7 @@
 /** @jsxFrag React.Fragment */
 import { css, jsx, keyframes } from '@emotion/react'
 import { chrome as isChrome } from 'platform-detect'
-import React from 'react'
+import React, { useEffect } from 'react'
 import ReactDOM from 'react-dom'
 import { DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
@@ -92,6 +92,7 @@ import {
 } from '../navigator/navigator-item/component-picker-context-menu'
 import { useGithubPolling } from '../../core/shared/github/helpers'
 import { useAtom } from 'jotai'
+import { clearOpenMenuIds } from '../../core/shared/menu-state'
 
 const liveModeToastId = 'play-mode-toast'
 
@@ -232,6 +233,10 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
   )
 
   const showComponentPicker = useCreateCallbackToShowComponentPicker()
+
+  React.useEffect(() => {
+    clearOpenMenuIds()
+  }, [])
 
   const onWindowKeyDown = React.useCallback(
     (event: KeyboardEvent) => {

--- a/editor/src/core/shared/menu-state.ts
+++ b/editor/src/core/shared/menu-state.ts
@@ -1,0 +1,17 @@
+const openMenuIds = new Set<string>()
+
+export const addOpenMenuId = (id: string) => {
+  openMenuIds.add(id)
+}
+
+export const removeOpenMenuId = (id: string) => {
+  openMenuIds.delete(id)
+}
+
+export const isMenuOpen = (id: string) => {
+  return openMenuIds.has(id)
+}
+
+export const isSomeMenuOpen = () => {
+  return openMenuIds.size > 0
+}

--- a/editor/src/core/shared/menu-state.ts
+++ b/editor/src/core/shared/menu-state.ts
@@ -15,3 +15,7 @@ export const isMenuOpen = (id: string) => {
 export const isSomeMenuOpen = () => {
   return openMenuIds.size > 0
 }
+
+export const clearOpenMenuIds = () => {
+  openMenuIds.clear()
+}


### PR DESCRIPTION
**Problem:**
Recent upgrade to `react-contexify` caused a regression where there was a race condition between registering and unregistering open menus - so that the code that ignored editor keystrokes when a menu was open was broken

**Fix:**
Store the open menu ids in a set - to prevent a race condition with overriding the classname on the body
This fixes the keystrokes leak and allow keyboard navigation (arrows)

<video src="https://github.com/concrete-utopia/utopia/assets/7003853/79f630b0-5020-400f-9d4b-c2a21aa24e22"></video>

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode

Related to #5875
