### PR TITLE
Assign min width to code pane

### DIFF
--- a/editor/src/components/canvas/grid-panels-state.tsx
+++ b/editor/src/components/canvas/grid-panels-state.tsx
@@ -18,6 +18,7 @@ import type {
 import {
   GridMenuMaxWidth,
   GridMenuMinWidth,
+  GridPaneMinWidth,
   GridPanelsNumberOfRows,
   IndexOfCanvas,
   NumberOfColumns,
@@ -340,7 +341,9 @@ export function useColumnWidths(): [
           })
         } else {
           // pane resize!
-          return immutableUpdate(current, { [columnIndex]: { paneWidth: { $set: newWidth } } })
+          return immutableUpdate(current, {
+            [columnIndex]: { paneWidth: { $set: Math.max(newWidth, GridPaneMinWidth) } },
+          })
         }
       })
     },

--- a/editor/src/components/canvas/stored-layout.ts
+++ b/editor/src/components/canvas/stored-layout.ts
@@ -5,6 +5,7 @@ export const GridMenuMinWidth = 200
 export const GridMenuMaxWidth = 500
 
 export const GridPaneWidth = 500
+export const GridPaneMinWidth = 100
 
 export const NumberOfColumns = 4
 export const IndexOfCanvas = 2


### PR DESCRIPTION
**Problem:**
Currently we can resize the code pane to be width 0, which makes it harder to restore

**Fix:**
Define min width for `Pane`, similar to `GridMenu`

<video src="https://github.com/concrete-utopia/utopia/assets/7003853/a6148498-92df-4285-a950-699e939ae2a9"></video>

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode

Fixes #5876 (this was the chosen fix for it)
