### PR TITLE
Chore: unified cartouche component

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-picker-utils.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-utils.tsx
@@ -24,6 +24,7 @@ interface VariableOptionBase {
   valuePath: Array<string | number>
   disabled: boolean
   insertionCeiling: ElementPath | FileRootPath
+  isChildOfArray: boolean
 }
 
 export interface PrimitiveOption extends VariableOptionBase {

--- a/editor/src/components/inspector/sections/component-section/data-selector-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-cartouche.tsx
@@ -13,7 +13,7 @@ import type { DataPickerOption } from './data-picker-utils'
 export const DataPickerCartouche = React.memo(
   (props: {
     data: DataPickerOption
-    forcedDataSource?: CartoucheSource // if the DataPickerOption is actually a child (of a child) of a variable, we need to provide the CartoucheSource that belongs to the original variable
+    forcedDataSource?: CartoucheSource | null // if the DataPickerOption is actually a child (of a child) of a variable, we need to provide the CartoucheSource that belongs to the original variable
     selected: boolean
   }) => {
     const { data, forcedDataSource, selected } = props

--- a/editor/src/components/inspector/sections/component-section/data-selector-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-cartouche.tsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import {
+  dataPathSuccess,
+  traceDataFromVariableName,
+} from '../../../../core/data-tracing/data-tracing'
+import { assertNever } from '../../../../core/shared/utils'
+import { Substores, useEditorState } from '../../../editor/store/store-hook'
+import { MapCounterUi } from '../../../navigator/navigator-item/map-counter'
+import type { CartoucheSource, CartoucheUIProps } from './cartouche-ui'
+import { CartoucheUI } from './cartouche-ui'
+import type { DataPickerOption } from './data-picker-utils'
+
+export const DataPickerCartouche = React.memo(
+  (props: {
+    data: DataPickerOption
+    forcedDataSource: CartoucheSource | null
+    selected: boolean
+  }) => {
+    const { data, forcedDataSource, selected } = props
+    const dataSource = useVariableDataSource(data)
+    return (
+      <CartoucheUI
+        key={data.valuePath.toString()}
+        source={forcedDataSource ?? dataSource ?? 'internal'}
+        datatype={childTypeToCartoucheDataType(data.type)}
+        selected={!data.disabled && selected}
+        highlight={data.disabled ? 'disabled' : null}
+        role={data.disabled ? 'information' : 'selection'}
+        testId={`data-selector-option-${data.variableInfo.expression}`}
+        badge={
+          data.type === 'array' ? (
+            <MapCounterUi
+              counterValue={data.variableInfo.elements.length}
+              overrideStatus='no-override'
+              selectedStatus={selected}
+            />
+          ) : undefined
+        }
+      >
+        {data.isChildOfArray ? (
+          <>
+            <span style={{ fontStyle: 'italic' }}>item </span>
+            {data.variableInfo.expressionPathPart}
+          </>
+        ) : (
+          data.variableInfo.expressionPathPart
+        )}
+      </CartoucheUI>
+    )
+  },
+)
+
+export function useVariableDataSource(variable: DataPickerOption | null) {
+  return useEditorState(
+    Substores.projectContentsAndMetadata,
+    (store) => {
+      if (variable == null) {
+        return null
+      }
+      const container = variable.variableInfo.insertionCeiling
+      const trace = traceDataFromVariableName(
+        container,
+        variable.variableInfo.expression,
+        store.editor.jsxMetadata,
+        store.editor.projectContents,
+        dataPathSuccess([]),
+      )
+
+      switch (trace.type) {
+        case 'hook-result':
+          return 'external'
+        case 'literal-attribute':
+        case 'literal-assignment':
+          return 'literal'
+        case 'component-prop':
+        case 'element-at-scope':
+        case 'failed':
+          return 'internal'
+          break
+        default:
+          assertNever(trace)
+      }
+    },
+    'useVariableDataSource',
+  )
+}
+
+function childTypeToCartoucheDataType(
+  childType: DataPickerOption['type'],
+): CartoucheUIProps['datatype'] {
+  switch (childType) {
+    case 'array':
+      return 'array'
+    case 'object':
+      return 'object'
+    case 'jsx':
+    case 'primitive':
+      return 'renderable'
+    default:
+      assertNever(childType)
+  }
+}

--- a/editor/src/components/inspector/sections/component-section/data-selector-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-cartouche.tsx
@@ -13,7 +13,7 @@ import type { DataPickerOption } from './data-picker-utils'
 export const DataPickerCartouche = React.memo(
   (props: {
     data: DataPickerOption
-    forcedDataSource: CartoucheSource | null
+    forcedDataSource?: CartoucheSource // if the DataPickerOption is actually a child (of a child) of a variable, we need to provide the CartoucheSource that belongs to the original variable
     selected: boolean
   }) => {
     const { data, forcedDataSource, selected } = props

--- a/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
@@ -1,18 +1,11 @@
 import styled from '@emotion/styled'
 import React from 'react'
-import {
-  dataPathSuccess,
-  traceDataFromVariableName,
-} from '../../../../core/data-tracing/data-tracing'
 import { isPrefixOf } from '../../../../core/shared/array-utils'
 import { arrayEqualsByReference, assertNever } from '../../../../core/shared/utils'
-import { unless, when } from '../../../../utils/react-conditionals'
 import { FlexColumn, FlexRow, colorTheme } from '../../../../uuiui'
-import { Substores, useEditorState } from '../../../editor/store/store-hook'
-import type { CartoucheSource, CartoucheUIProps } from './cartouche-ui'
-import { CartoucheUI } from './cartouche-ui'
+import type { CartoucheSource } from './cartouche-ui'
 import type { ArrayOption, DataPickerOption, ObjectOption, ObjectPath } from './data-picker-utils'
-import { MapCounterUi } from '../../../navigator/navigator-item/map-counter'
+import { DataPickerCartouche, useVariableDataSource } from './data-selector-cartouche'
 
 interface DataSelectorColumnsProps {
   activeScope: Array<DataPickerOption>
@@ -185,8 +178,6 @@ const RowWithCartouche = React.memo((props: RowWithCartoucheProps) => {
   } = props
   const targetPath = data.valuePath
 
-  const dataSource = useVariableDataSource(data)
-
   const onClick: React.MouseEventHandler<HTMLDivElement> = React.useCallback(
     (e) => {
       e.stopPropagation()
@@ -213,33 +204,7 @@ const RowWithCartouche = React.memo((props: RowWithCartoucheProps) => {
       }}
     >
       <span>
-        <CartoucheUI
-          key={data.valuePath.toString()}
-          source={forcedDataSource ?? dataSource ?? 'internal'}
-          datatype={childTypeToCartoucheDataType(data.type)}
-          selected={!data.disabled && selected}
-          highlight={data.disabled ? 'disabled' : null}
-          role={data.disabled ? 'information' : 'selection'}
-          testId={`data-selector-option-${data.variableInfo.expression}`}
-          badge={
-            data.type === 'array' ? (
-              <MapCounterUi
-                counterValue={data.variableInfo.elements.length}
-                overrideStatus='no-override'
-                selectedStatus={selected}
-              />
-            ) : undefined
-          }
-        >
-          {data.isChildOfArray ? (
-            <>
-              <span style={{ fontStyle: 'italic' }}>item </span>
-              {data.variableInfo.expressionPathPart}
-            </>
-          ) : (
-            data.variableInfo.expressionPathPart
-          )}
-        </CartoucheUI>
+        <DataPickerCartouche data={data} forcedDataSource={forcedDataSource} selected={selected} />
       </span>
       <span
         style={{
@@ -252,57 +217,6 @@ const RowWithCartouche = React.memo((props: RowWithCartoucheProps) => {
     </FlexRow>
   )
 })
-
-function useVariableDataSource(variable: DataPickerOption | null) {
-  return useEditorState(
-    Substores.projectContentsAndMetadata,
-    (store) => {
-      if (variable == null) {
-        return null
-      }
-      const container = variable.variableInfo.insertionCeiling
-      const trace = traceDataFromVariableName(
-        container,
-        variable.variableInfo.expression,
-        store.editor.jsxMetadata,
-        store.editor.projectContents,
-        dataPathSuccess([]),
-      )
-
-      switch (trace.type) {
-        case 'hook-result':
-          return 'external'
-        case 'literal-attribute':
-        case 'literal-assignment':
-          return 'literal'
-        case 'component-prop':
-        case 'element-at-scope':
-        case 'failed':
-          return 'internal'
-          break
-        default:
-          assertNever(trace)
-      }
-    },
-    'useVariableDataSource',
-  )
-}
-
-function childTypeToCartoucheDataType(
-  childType: DataPickerOption['type'],
-): CartoucheUIProps['datatype'] {
-  switch (childType) {
-    case 'array':
-      return 'array'
-    case 'object':
-      return 'object'
-    case 'jsx':
-    case 'primitive':
-      return 'renderable'
-    default:
-      assertNever(childType)
-  }
-}
 
 const DataSelectorFlexColumn = styled(FlexColumn)({
   minWidth: 200,

--- a/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
@@ -94,7 +94,6 @@ const DataSelectorColumn = React.memo((props: DataSelectorColumnProps) => {
             <RowWithCartouche
               key={option.variableInfo.expression}
               data={option}
-              currentlyShowingScopeForArray={currentlyShowingScopeForArray}
               isLeaf={nextColumnScope == null}
               selected={selected}
               onActivePath={onActivePath}
@@ -167,7 +166,6 @@ function variableTypeForInfo(info: DataPickerOption): string {
 
 interface RowWithCartoucheProps {
   data: DataPickerOption
-  currentlyShowingScopeForArray: boolean
   selected: boolean
   onActivePath: boolean
   forceShowArrow: boolean
@@ -179,7 +177,6 @@ const RowWithCartouche = React.memo((props: RowWithCartoucheProps) => {
   const {
     onTargetPathChange,
     data,
-    currentlyShowingScopeForArray,
     forcedDataSource,
     isLeaf,
     selected,
@@ -234,7 +231,7 @@ const RowWithCartouche = React.memo((props: RowWithCartoucheProps) => {
             ) : undefined
           }
         >
-          {currentlyShowingScopeForArray ? (
+          {data.isChildOfArray ? (
             <>
               <span style={{ fontStyle: 'italic' }}>item </span>
               {data.variableInfo.expressionPathPart}


### PR DESCRIPTION
This PR creates a data-picker specific cartouche component which means everywhere in the data picker we can show a unified cartouche that uses the same data source etc