### PR TITLE
Data Picker: Left Sidebar displaying Sources

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-picker-utils.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-utils.tsx
@@ -89,12 +89,12 @@ export function getEnclosingScopes(
   buckets: Array<string>,
   lowestInsertionCeiling: ElementPath,
 ): Array<{
-  insertionCeiling: ElementPath
+  insertionCeiling: ElementPath | FileRootPath
   label: string
   hasContent: boolean
 }> {
   let result: Array<{
-    insertionCeiling: ElementPath
+    insertionCeiling: ElementPath | FileRootPath
     label: string
     hasContent: boolean
   }> = []
@@ -128,7 +128,7 @@ export function getEnclosingScopes(
 
   // Add file root
   result.unshift({
-    insertionCeiling: EP.emptyElementPath,
+    insertionCeiling: { type: 'file-root' },
     label: 'File',
     hasContent: buckets.includes(insertionCeilingToString({ type: 'file-root' })),
   })

--- a/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
@@ -195,6 +195,7 @@ const RowWithCartouche = React.memo((props: RowWithCartoucheProps) => {
       style={{
         backgroundColor: onActivePath ? colorTheme.bg4.value : undefined,
       }}
+      disabled={false}
     >
       <span>
         <DataPickerCartouche data={data} forcedDataSource={forcedDataSource} selected={selected} />
@@ -225,15 +226,15 @@ const DataSelectorFlexColumn = styled(FlexColumn)({
   borderRight: `1px solid ${colorTheme.subduedBorder.cssValue}`,
 })
 
-export const DataPickerRow = styled(FlexRow)({
+export const DataPickerRow = styled(FlexRow)((props: { disabled: boolean }) => ({
   alignSelf: 'stretch',
   justifyContent: 'space-between',
   fontSize: 10,
   borderRadius: 4,
   height: 24,
   padding: 5,
-  cursor: 'pointer',
-})
+  cursor: !props.disabled ? 'pointer' : 'initial',
+}))
 
 function useScrollIntoView(shouldScroll: boolean) {
   const elementRef = React.useRef<HTMLDivElement>(null)

--- a/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
@@ -189,18 +189,11 @@ const RowWithCartouche = React.memo((props: RowWithCartoucheProps) => {
   const ref = useScrollIntoView(selected)
 
   return (
-    <FlexRow
+    <DataPickerRow
       onClick={onClick}
       ref={ref}
       style={{
-        alignSelf: 'stretch',
-        justifyContent: 'space-between',
-        fontSize: 10,
-        borderRadius: 4,
-        height: 24,
         backgroundColor: onActivePath ? colorTheme.bg4.value : undefined,
-        padding: 5,
-        cursor: 'pointer',
       }}
     >
       <span>
@@ -214,7 +207,7 @@ const RowWithCartouche = React.memo((props: RowWithCartoucheProps) => {
       >
         {'>'}
       </span>
-    </FlexRow>
+    </DataPickerRow>
   )
 })
 
@@ -230,6 +223,16 @@ const DataSelectorFlexColumn = styled(FlexColumn)({
   paddingLeft: 6,
   paddingBottom: 10,
   borderRight: `1px solid ${colorTheme.subduedBorder.cssValue}`,
+})
+
+export const DataPickerRow = styled(FlexRow)({
+  alignSelf: 'stretch',
+  justifyContent: 'space-between',
+  fontSize: 10,
+  borderRadius: 4,
+  height: 24,
+  padding: 5,
+  cursor: 'pointer',
 })
 
 function useScrollIntoView(shouldScroll: boolean) {

--- a/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
@@ -92,6 +92,7 @@ const ScopeRow = React.memo(
           color: disabled ? colorTheme.fg6.value : colorTheme.neutralForeground.value,
         }}
         onClick={onClick}
+        disabled={disabled}
       >
         {scope.label}
       </DataPickerRow>

--- a/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import type { ElementPath } from 'utopia-shared/src/types'
+import * as EP from '../../../../core/shared/element-path'
+import { FlexColumn, colorTheme } from '../../../../uuiui'
+import {
+  insertionCeilingToString,
+  insertionCeilingsEqual,
+  type FileRootPath,
+} from '../../../canvas/ui-jsx-canvas'
+import { DataPickerRow } from './data-selector-columns'
+
+interface SelectableScope {
+  label: string
+  scope: ElementPath | FileRootPath
+  hasContent: boolean
+}
+
+interface DataSelectorLeftSidebarProps {
+  scopes: Array<SelectableScope>
+  activeScope: ElementPath | FileRootPath
+  setSelectedScope: (scope: ElementPath | FileRootPath) => void
+}
+
+export const DataSelectorLeftSidebar = React.memo((props: DataSelectorLeftSidebarProps) => {
+  const { scopes, setSelectedScope, activeScope } = props
+  return (
+    <FlexColumn
+      style={{
+        alignSelf: 'stretch',
+        minWidth: 150,
+        paddingRight: 8,
+        borderRight: `1px solid ${colorTheme.subduedBorder.cssValue}`,
+      }}
+    >
+      {scopes.map((scope) => {
+        return (
+          <ScopeRow
+            key={insertionCeilingToString(scope.scope)}
+            scope={scope}
+            selected={insertionCeilingsEqual(scope.scope, activeScope)}
+            setSelectedScope={setSelectedScope}
+          />
+        )
+      })}
+    </FlexColumn>
+  )
+})
+
+const ScopeRow = React.memo(
+  (props: {
+    scope: SelectableScope
+    selected: boolean
+    setSelectedScope: (scope: ElementPath | FileRootPath) => void
+  }) => {
+    const { scope, selected, setSelectedScope } = props
+
+    const onClick = React.useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        e.stopPropagation()
+        setSelectedScope(scope.scope)
+      },
+      [setSelectedScope, scope.scope],
+    )
+
+    return (
+      <DataPickerRow
+        style={{
+          backgroundColor: selected ? colorTheme.bg4.value : undefined,
+        }}
+        onClick={onClick}
+      >
+        {scope.label}
+      </DataPickerRow>
+    )
+  },
+)

--- a/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
@@ -47,7 +47,7 @@ export const DataSelectorLeftSidebar = React.memo((props: DataSelectorLeftSideba
         <LargerIcons.MagnifyingGlass style={{ zoom: 0.6 }} />
       </FlexRow>
       <span style={{ fontSize: 10, fontWeight: 'bold', color: colorTheme.fg4.cssValue }}>
-        Scopes
+        Sources
       </span>
       <FlexColumn>
         {scopes.map((scope) => {

--- a/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import type { ElementPath } from 'utopia-shared/src/types'
-import * as EP from '../../../../core/shared/element-path'
-import { FlexColumn, colorTheme } from '../../../../uuiui'
+import { FlexColumn, FlexRow, LargerIcons, colorTheme } from '../../../../uuiui'
 import {
   insertionCeilingToString,
   insertionCeilingsEqual,
   type FileRootPath,
 } from '../../../canvas/ui-jsx-canvas'
+import { stopPropagation } from '../../common/inspector-utils'
 import { DataPickerRow } from './data-selector-columns'
 
 interface SelectableScope {
@@ -25,23 +25,43 @@ export const DataSelectorLeftSidebar = React.memo((props: DataSelectorLeftSideba
   const { scopes, setSelectedScope, activeScope } = props
   return (
     <FlexColumn
+      onClick={stopPropagation}
       style={{
         alignSelf: 'stretch',
         minWidth: 150,
-        paddingRight: 8,
+        padding: 8,
+        paddingTop: 16,
         borderRight: `1px solid ${colorTheme.subduedBorder.cssValue}`,
       }}
     >
-      {scopes.map((scope) => {
-        return (
-          <ScopeRow
-            key={insertionCeilingToString(scope.scope)}
-            scope={scope}
-            selected={insertionCeilingsEqual(scope.scope, activeScope)}
-            setSelectedScope={setSelectedScope}
-          />
-        )
-      })}
+      <FlexRow
+        style={{
+          height: 24,
+          marginBottom: 16,
+          padding: '6px 8px',
+          borderRadius: 16,
+          gap: 8,
+          border: `1px solid ${colorTheme.fg7.value}`,
+        }}
+      >
+        <LargerIcons.MagnifyingGlass style={{ zoom: 0.6 }} />
+      </FlexRow>
+      <span style={{ fontSize: 10, fontWeight: 'bold', color: colorTheme.fg4.cssValue }}>
+        Scopes
+      </span>
+      <FlexColumn>
+        {scopes.map((scope) => {
+          return (
+            <ScopeRow
+              key={insertionCeilingToString(scope.scope)}
+              scope={scope}
+              selected={insertionCeilingsEqual(scope.scope, activeScope)}
+              disabled={!scope.hasContent}
+              setSelectedScope={setSelectedScope}
+            />
+          )
+        })}
+      </FlexColumn>
     </FlexColumn>
   )
 })
@@ -50,22 +70,26 @@ const ScopeRow = React.memo(
   (props: {
     scope: SelectableScope
     selected: boolean
+    disabled: boolean
     setSelectedScope: (scope: ElementPath | FileRootPath) => void
   }) => {
-    const { scope, selected, setSelectedScope } = props
+    const { scope, selected, disabled, setSelectedScope } = props
 
     const onClick = React.useCallback(
       (e: React.MouseEvent<HTMLDivElement>) => {
         e.stopPropagation()
-        setSelectedScope(scope.scope)
+        if (!disabled) {
+          setSelectedScope(scope.scope)
+        }
       },
-      [setSelectedScope, scope.scope],
+      [setSelectedScope, disabled, scope.scope],
     )
 
     return (
       <DataPickerRow
         style={{
           backgroundColor: selected ? colorTheme.bg4.value : undefined,
+          color: disabled ? colorTheme.fg6.value : colorTheme.neutralForeground.value,
         }}
         onClick={onClick}
       >

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -402,7 +402,7 @@ export const DataSelectorModal = React.memo(
           >
             <FlexRow
               style={{
-                width: 700,
+                minWidth: 850,
                 height: 300,
                 backgroundColor: colorTheme.inspectorBackground.value,
                 color: colorTheme.fg1.value,
@@ -428,6 +428,7 @@ export const DataSelectorModal = React.memo(
                   paddingTop: 16,
                   paddingRight: 16,
                   overflow: 'hidden',
+                  width: 700,
                 }}
               >
                 {/* top bar */}

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -401,6 +401,7 @@ export const DataSelectorModal = React.memo(
             onClick={closePopup}
           >
             <FlexRow
+              ref={forwardedRef}
               style={{
                 minWidth: 850,
                 height: 300,
@@ -419,7 +420,6 @@ export const DataSelectorModal = React.memo(
                 setSelectedScope={setSelectedScopeAndResetSelection}
               />
               <FlexColumn
-                ref={forwardedRef}
                 onClick={catchClick}
                 style={{
                   alignSelf: 'stretch',

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -44,6 +44,7 @@ import type { FileRootPath } from '../../../canvas/ui-jsx-canvas'
 import { insertionCeilingToString, insertionCeilingsEqual } from '../../../canvas/ui-jsx-canvas'
 import { set } from 'objectPath'
 import { DataSelectorColumns } from './data-selector-columns'
+import { DataSelectorLeftSidebar } from './data-selector-left-sidebar'
 
 export const DataSelectorPopupBreadCrumbsTestId = 'data-selector-modal-top-bar'
 
@@ -160,14 +161,12 @@ export const DataSelectorModal = React.memo(
       const [selectedScope, setSelectedScope] = React.useState<ElementPath | FileRootPath>(
         lowestMatchingScope,
       )
-      const setSelectedScopeCurried = React.useCallback(
-        (name: ElementPath, hasContent: boolean) => () => {
-          if (hasContent) {
-            setSelectedScope(name)
-            setSelectedPath([])
-            setHoveredPath(null)
-            setNavigatedToPath([])
-          }
+      const setSelectedScopeAndResetSelection = React.useCallback(
+        (scope: ElementPath | FileRootPath) => {
+          setSelectedScope(scope)
+          setSelectedPath([])
+          setHoveredPath(null)
+          setNavigatedToPath([])
         },
         [],
       )
@@ -401,15 +400,10 @@ export const DataSelectorModal = React.memo(
             }}
             onClick={closePopup}
           >
-            <FlexColumn
-              ref={forwardedRef}
-              onClick={catchClick}
+            <FlexRow
               style={{
                 width: 700,
                 height: 300,
-                paddingTop: 16,
-                paddingLeft: 16,
-                paddingRight: 16,
                 backgroundColor: colorTheme.inspectorBackground.value,
                 color: colorTheme.fg1.value,
                 overflow: 'hidden',
@@ -419,118 +413,103 @@ export const DataSelectorModal = React.memo(
                 ...style,
               }}
             >
-              {/* top bar */}
-              <FlexRow style={{ justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
-                <FlexRow style={{ gap: 8, flexWrap: 'wrap', flexGrow: 1 }}>
-                  <FlexRow
-                    style={{
-                      flexGrow: 1,
-                      borderStyle: 'solid',
-                      borderWidth: 1,
-                      borderColor: colorTheme.fg7.value,
-                      borderRadius: 4,
-                      fontSize: 11,
-                      fontWeight: 400,
-                      height: 33,
-                      padding: '0px 6px',
-                    }}
-                  >
+              <DataSelectorLeftSidebar
+                scopes={elementLabelsWithScopes}
+                activeScope={selectedScope}
+                setSelectedScope={setSelectedScopeAndResetSelection}
+              />
+              <FlexColumn
+                ref={forwardedRef}
+                onClick={catchClick}
+                style={{
+                  alignSelf: 'stretch',
+                  flexGrow: 1,
+                  paddingLeft: 8,
+                  paddingTop: 16,
+                  paddingRight: 16,
+                  overflow: 'hidden',
+                }}
+              >
+                {/* top bar */}
+                <FlexRow style={{ justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
+                  <FlexRow style={{ gap: 8, flexWrap: 'wrap', flexGrow: 1 }}>
                     <FlexRow
-                      data-testid={DataSelectorPopupBreadCrumbsTestId}
-                      style={{ flexWrap: 'wrap', flexGrow: 1 }}
-                    >
-                      {pathBreadcrumbs(pathInTopBarIncludingHover, processedVariablesInScope).map(
-                        ({ segment, path }, idx) => (
-                          <span key={path.toString()}>
-                            {idx === 0 ? segment : pathSegmentToString(segment)}
-                          </span>
-                        ),
-                      )}
-                    </FlexRow>
-                    <div
                       style={{
-                        ...disabledButtonStyles(activeTargetPath.length === 0),
-                        fontWeight: 400,
-                        fontSize: 12,
-                      }}
-                      onClick={onHomeClick}
-                    >
-                      <Icons.Cross />
-                    </div>
-                  </FlexRow>
-                </FlexRow>
-                <div
-                  style={{
-                    borderRadius: 4,
-                    backgroundColor: colorTheme.primary.value,
-                    color: 'white',
-                    padding: '8px 12px',
-                    fontSize: 14,
-                    fontWeight: 500,
-                    ...disabledButtonStyles(activeTargetPath.length === 0),
-                  }}
-                  onClick={onApplyClick}
-                >
-                  Apply
-                </div>
-              </FlexRow>
-              {/* Value preview */}
-              <FlexRow
-                style={{
-                  flexShrink: 0,
-                  gridColumn: '3',
-                  flexWrap: 'wrap',
-                  gap: 4,
-                  overflowX: 'scroll',
-                  opacity: 0.8,
-                  fontSize: 10,
-                  height: 20,
-                }}
-              >
-                {valuePreviewText}
-              </FlexRow>
-
-              <FlexColumn style={{ flexGrow: 1, overflow: 'hidden', contain: 'content' }}>
-                <DataSelectorColumns
-                  activeScope={filteredVariablesInScope}
-                  targetPathInsideScope={selectedPath}
-                  onTargetPathChange={setSelectedPathFromColumns}
-                />
-              </FlexColumn>
-              {/* Scope Selector Breadcrumbs */}
-              <FlexRow
-                style={{
-                  gap: 2,
-                  paddingTop: 4,
-                  paddingBottom: 4,
-                  opacity: 0.5,
-                }}
-              >
-                {elementLabelsWithScopes.map(({ label, scope, hasContent }, idx, a) => (
-                  <React.Fragment key={`label-${idx}`}>
-                    <div
-                      onClick={setSelectedScopeCurried(scope, hasContent)}
-                      style={{
-                        width: 'max-content',
-                        padding: '2px 4px',
+                        flexGrow: 1,
+                        borderStyle: 'solid',
+                        borderWidth: 1,
+                        borderColor: colorTheme.fg7.value,
                         borderRadius: 4,
-                        cursor: hasContent ? 'pointer' : undefined,
-                        color: hasContent
-                          ? colorTheme.neutralForeground.value
-                          : colorTheme.subduedForeground.value,
-                        fontSize: 12,
-                        fontWeight: insertionCeilingsEqual(selectedScope, scope) ? 800 : undefined,
+                        fontSize: 11,
+                        fontWeight: 400,
+                        height: 33,
+                        padding: '0px 6px',
                       }}
                     >
-                      {label}
-                    </div>
-                    {idx < a.length - 1 ? (
-                      <span style={{ width: 'max-content', padding: '2px 4px' }}>{'/'}</span>
-                    ) : null}
-                  </React.Fragment>
-                ))}
-              </FlexRow>
-            </FlexColumn>
+                      <FlexRow
+                        data-testid={DataSelectorPopupBreadCrumbsTestId}
+                        style={{ flexWrap: 'wrap', flexGrow: 1 }}
+                      >
+                        {pathBreadcrumbs(pathInTopBarIncludingHover, processedVariablesInScope).map(
+                          ({ segment, path }, idx) => (
+                            <span key={path.toString()}>
+                              {idx === 0 ? segment : pathSegmentToString(segment)}
+                            </span>
+                          ),
+                        )}
+                      </FlexRow>
+                      <div
+                        style={{
+                          ...disabledButtonStyles(activeTargetPath.length === 0),
+                          fontWeight: 400,
+                          fontSize: 12,
+                        }}
+                        onClick={onHomeClick}
+                      >
+                        <Icons.Cross />
+                      </div>
+                    </FlexRow>
+                  </FlexRow>
+                  <div
+                    style={{
+                      borderRadius: 4,
+                      backgroundColor: colorTheme.primary.value,
+                      color: 'white',
+                      padding: '8px 12px',
+                      fontSize: 14,
+                      fontWeight: 500,
+                      ...disabledButtonStyles(activeTargetPath.length === 0),
+                    }}
+                    onClick={onApplyClick}
+                  >
+                    Apply
+                  </div>
+                </FlexRow>
+                {/* Value preview */}
+                <FlexRow
+                  style={{
+                    flexShrink: 0,
+                    gridColumn: '3',
+                    flexWrap: 'wrap',
+                    gap: 4,
+                    overflowX: 'scroll',
+                    opacity: 0.8,
+                    fontSize: 10,
+                    height: 20,
+                  }}
+                >
+                  {valuePreviewText}
+                </FlexRow>
+
+                <FlexColumn style={{ flexGrow: 1, overflow: 'hidden', contain: 'content' }}>
+                  <DataSelectorColumns
+                    activeScope={filteredVariablesInScope}
+                    targetPathInsideScope={selectedPath}
+                    onTargetPathChange={setSelectedPathFromColumns}
+                  />
+                </FlexColumn>
+              </FlexColumn>
+            </FlexRow>
           </div>
         </InspectorModal>
       )


### PR DESCRIPTION
<img width="877" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/ed28c05c-e47e-4827-a9a1-08e8e1e0c40a">


**Commit Details:**
- The root element of the data picker is now a FlexRow
- New `DataSelectorLeftSidebar` component in its own file
- Removed bottom scope breadcrumbs

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [ ] I could navigate to various routes in Preview mode
