### PR TITLE
Data Picker Data Tracing fixes and improvements

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-selector-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-cartouche.tsx
@@ -6,26 +6,25 @@ import {
 import { assertNever } from '../../../../core/shared/utils'
 import { Substores, useEditorState } from '../../../editor/store/store-hook'
 import { MapCounterUi } from '../../../navigator/navigator-item/map-counter'
-import type { CartoucheSource, CartoucheUIProps } from './cartouche-ui'
+import type { CartoucheUIProps } from './cartouche-ui'
 import { CartoucheUI } from './cartouche-ui'
 import type { DataPickerOption } from './data-picker-utils'
 
+interface DataPickerCartoucheProps {
+  data: DataPickerOption
+  selected: boolean
+  onClick?: CartoucheUIProps['onClick']
+}
+
 export const DataPickerCartouche = React.memo(
-  (
-    props: React.PropsWithChildren<{
-      data: DataPickerOption
-      forcedDataSource?: CartoucheSource | null // if the DataPickerOption is actually a child (of a child) of a variable, we need to provide the CartoucheSource that belongs to the original variable
-      selected: boolean
-      onClick?: CartoucheUIProps['onClick']
-    }>,
-  ) => {
-    const { data, forcedDataSource, selected } = props
+  (props: React.PropsWithChildren<DataPickerCartoucheProps>) => {
+    const { data, selected } = props
     const dataSource = useVariableDataSource(data)
     const children = props.children ?? data.variableInfo.expressionPathPart
     return (
       <CartoucheUI
         key={data.valuePath.toString()}
-        source={forcedDataSource ?? dataSource ?? 'internal'}
+        source={dataSource ?? 'internal'}
         datatype={childTypeToCartoucheDataType(data.type)}
         selected={!data.disabled && selected}
         highlight={data.disabled ? 'disabled' : null}
@@ -65,10 +64,10 @@ export function useVariableDataSource(variable: DataPickerOption | null) {
       const container = variable.variableInfo.insertionCeiling
       const trace = traceDataFromVariableName(
         container,
-        variable.variableInfo.expression,
+        variable.valuePath[0].toString(),
         store.editor.jsxMetadata,
         store.editor.projectContents,
-        dataPathSuccess([]),
+        dataPathSuccess(variable.valuePath.slice(1).map((x) => x.toString())),
       )
 
       switch (trace.type) {

--- a/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
@@ -3,9 +3,8 @@ import React from 'react'
 import { isPrefixOf } from '../../../../core/shared/array-utils'
 import { arrayEqualsByReference, assertNever } from '../../../../core/shared/utils'
 import { FlexColumn, FlexRow, colorTheme } from '../../../../uuiui'
-import type { CartoucheSource } from './cartouche-ui'
 import type { ArrayOption, DataPickerOption, ObjectOption, ObjectPath } from './data-picker-utils'
-import { DataPickerCartouche, useVariableDataSource } from './data-selector-cartouche'
+import { DataPickerCartouche } from './data-selector-cartouche'
 
 interface DataSelectorColumnsProps {
   activeScope: Array<DataPickerOption>
@@ -30,7 +29,6 @@ export const DataSelectorColumns = React.memo((props: DataSelectorColumnsProps) 
         targetPathInsideScope={props.targetPathInsideScope}
         onTargetPathChange={props.onTargetPathChange}
         currentlyShowingScopeForArray={false}
-        originalDataForScope={null}
       />
     </FlexRow>
   )
@@ -38,7 +36,6 @@ export const DataSelectorColumns = React.memo((props: DataSelectorColumnsProps) 
 
 interface DataSelectorColumnProps {
   activeScope: Array<DataPickerOption>
-  originalDataForScope: DataPickerOption | null
   currentlyShowingScopeForArray: boolean
   targetPathInsideScope: ObjectPath
   onTargetPathChange: (newTargetPath: ObjectPath) => void
@@ -72,8 +69,6 @@ const DataSelectorColumn = React.memo((props: DataSelectorColumnProps) => {
 
   const nextColumnScopeValue = nextColumnScope == null ? elementOnSelectedPath : null
 
-  const dataSource = useVariableDataSource(props.originalDataForScope)
-
   const isLastColumn = nextColumnScope == null && nextColumnScopeValue == null
   const columnRef = useScrollIntoView(isLastColumn)
 
@@ -92,7 +87,6 @@ const DataSelectorColumn = React.memo((props: DataSelectorColumnProps) => {
               onActivePath={onActivePath}
               forceShowArrow={pseudoSelectedElementForArray != null && index === 0}
               onTargetPathChange={props.onTargetPathChange}
-              forcedDataSource={dataSource}
             />
           )
         })}
@@ -103,7 +97,6 @@ const DataSelectorColumn = React.memo((props: DataSelectorColumnProps) => {
           targetPathInsideScope={targetPathInsideScope}
           onTargetPathChange={props.onTargetPathChange}
           currentlyShowingScopeForArray={nextColumnScope.type === 'array'}
-          originalDataForScope={props.originalDataForScope ?? elementOnSelectedPath}
         />
       ) : null}
       {nextColumnScopeValue != null ? <ValuePreviewColumn data={nextColumnScopeValue} /> : null}
@@ -163,19 +156,10 @@ interface RowWithCartoucheProps {
   onActivePath: boolean
   forceShowArrow: boolean
   isLeaf: boolean
-  forcedDataSource: CartoucheSource | null
   onTargetPathChange: (newTargetPath: ObjectPath) => void
 }
 const RowWithCartouche = React.memo((props: RowWithCartoucheProps) => {
-  const {
-    onTargetPathChange,
-    data,
-    forcedDataSource,
-    isLeaf,
-    selected,
-    onActivePath,
-    forceShowArrow,
-  } = props
+  const { onTargetPathChange, data, isLeaf, selected, onActivePath, forceShowArrow } = props
   const targetPath = data.valuePath
 
   const onClick: React.MouseEventHandler<HTMLDivElement> = React.useCallback(
@@ -198,7 +182,7 @@ const RowWithCartouche = React.memo((props: RowWithCartoucheProps) => {
       disabled={false}
     >
       <span>
-        <DataPickerCartouche data={data} forcedDataSource={forcedDataSource} selected={selected} />
+        <DataPickerCartouche data={data} selected={selected} />
       </span>
       <span
         style={{

--- a/editor/src/core/data-tracing/data-tracing.spec.ts
+++ b/editor/src/core/data-tracing/data-tracing.spec.ts
@@ -943,6 +943,12 @@ describe('Data Tracing', () => {
 
       await focusOnComponentForTest(editor, EP.fromString('sb/app:my-component:component-root'))
 
+      const expectedResult = dataTracingToAHookCall(
+        EP.fromString('sb/app:my-component:component-root'),
+        'useLoaderData',
+        dataPathSuccess(['reviews', '1', 'title']),
+      )
+
       const traceResult = traceDataFromProp(
         EPP.create(
           EP.fromString('sb/app:my-component:component-root/map/mapped~~~2/mapped-child'),
@@ -953,13 +959,17 @@ describe('Data Tracing', () => {
         dataPathSuccess([]),
       )
 
-      expect(traceResult).toEqual(
-        dataTracingToAHookCall(
-          EP.fromString('sb/app:my-component:component-root'),
-          'useLoaderData',
-          dataPathSuccess(['reviews', '1', 'title']),
-        ),
+      expect(traceResult).toEqual(expectedResult)
+
+      const variableNameTraceResult = traceDataFromVariableName(
+        EP.fromString('sb/app:my-component:component-root/map/mapped~~~2/mapped-child'),
+        'review',
+        editor.getEditorState().editor.jsxMetadata,
+        editor.getEditorState().editor.projectContents,
+        dataPathSuccess(['title']),
       )
+
+      expect(variableNameTraceResult).toEqual(expectedResult)
     })
 
     it('Works with a destructure in the map function', async () => {

--- a/editor/src/core/data-tracing/data-tracing.ts
+++ b/editor/src/core/data-tracing/data-tracing.ts
@@ -428,6 +428,7 @@ export function traceDataFromVariableName(
   if (enclosingScope.type === 'file-root') {
     return dataTracingFailed('Cannot trace data from variable name in file root')
   }
+  const containingComponentPath = EP.getPathOfComponentRoot(enclosingScope)
   const componentHoldingElement = findContainingComponentForPathInProjectContents(
     enclosingScope,
     projectContents,
@@ -442,7 +443,7 @@ export function traceDataFromVariableName(
     projectContents,
     enclosingScope,
     enclosingScope,
-    enclosingScope,
+    containingComponentPath,
     componentHoldingElement,
     jsIdentifier(variableName, '', null, emptyComments),
     pathDrillSoFar,

--- a/editor/src/core/data-tracing/data-tracing.ts
+++ b/editor/src/core/data-tracing/data-tracing.ts
@@ -434,7 +434,7 @@ export function traceDataFromVariableName(
     projectContents,
   )
 
-  if (componentHoldingElement == null || componentHoldingElement.arbitraryJSBlock == null) {
+  if (componentHoldingElement == null) {
     return dataTracingFailed('Could not find containing component')
   }
 


### PR DESCRIPTION
**Problem:**
![image](https://github.com/concrete-utopia/utopia/assets/2226774/85a27535-4f0c-4c63-8aa8-094252133b7e)
The data picker sometimes would show data in blue (local variable) even though the variable traces back to a hook, and the correct color should be green (as seen in the navigator's cartouche).

Turns out the problem boiled down to a few bugs in `traceDataFromVariableName`.

**Commit Details:** 
- Added a test which calls `traceDataFromVariableName` from inside a map inside a component
- Added a test which calls `traceDataFromVariableName` for a `props.title` tracing all the way back to a hook
- `traceDataFromVariableName` now correctly passes in `containingComponentPath` to `walkUpInnerScopesUntilReachingComponent` 
- `useVariableDataSource` now correctly fills out `pathDrillSoFar` to support cases like `props.title`
- Fixing the `pathDrillSoFar` fixed an issue I originally worked around by providing a `forcedDataSource` prop, this is no longer needed!
- With `forcedDataSource` gone, I could delete `props.originalDataForScope` from `DataSelectorColumn`

**Fixed behavior:**
<img width="909" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/56fdc1f5-781a-4fa4-bed3-b047b0d1609a">

This is pretty interesting, props is of course local data, but props.cica comes from a hook!
<img width="917" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/fd16f61b-ff3f-418b-b43e-a0283c92ce16">

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [ ] I could navigate to various routes in Preview mode