### PR TITLE
Handle Early Returns In Navigator.

### DIFF
--- a/editor/src/components/navigator/navigator.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator.spec.browser2.tsx
@@ -1025,6 +1025,59 @@ export function Heading({ children }) {
 `,
   })
 
+const projectWithEarlyReturn = createModifiedProject({
+  [StoryboardFilePath]: `import * as React from 'react'
+import * as Utopia from 'utopia-api'
+import {
+  Storyboard,
+  Scene,
+} from 'utopia-api'
+
+var Playground = ({ style }) => {
+  if (true) {
+    return null
+  }
+  return (
+    <div style={style} data-uid='dbc'>Cake</div>
+  )
+}
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <Scene
+      style={{
+        width: 521,
+        height: 266,
+        position: 'absolute',
+        left: 554,
+        top: 247,
+        backgroundColor: 'white',
+      }}
+      data-uid='scene'
+      data-testid='scene'
+      commentId='120'
+    >
+      <Playground
+        style={{
+          width: 454,
+          height: 177,
+          position: 'absolute',
+          left: 34,
+          top: 44,
+          backgroundColor: 'white',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+        className='playground'
+        css={{ color: 'red' }}
+        data-uid='pg'
+      />
+    </Scene>
+  </Storyboard>
+)
+`,
+})
+
 function getProjectCodeForMultipleSelection(): string {
   return `import * as React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
@@ -5708,6 +5761,22 @@ describe('Navigator row order', () => {
       'render-prop-sb/scene/pg:dbc/78c/prop-label-children-children',
       'regular-sb/scene/pg:dbc/78c/891',
     ])
+  })
+
+  it('is correct in the presence of an early return', async () => {
+    const renderResult = await renderTestEditorWithModel(
+      projectWithEarlyReturn,
+      'await-first-dom-report',
+    )
+
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(renderResult.getEditorState().derived.navigatorTargets.map(navigatorEntryToKey)).toEqual(
+      ['regular-sb/scene'],
+    )
+    expect(
+      renderResult.getEditorState().derived.visibleNavigatorTargets.map(navigatorEntryToKey),
+    ).toEqual(['regular-sb/scene'])
   })
 })
 


### PR DESCRIPTION
**Problem:**
When you have an early return in a component, there are `Element was not found in project contents` error items in the navigator for the later returned elements.

**Fix:**
Now when walking the tree to build the navigator representation, if an early return is encountered we stop walking the tree.

**Commit Details:**
- `walkRegularNavigatorEntry` now stops walking the tree if it encounters an early return and itself returns null.
- Some other functions calling `walkRegularNavigatorEntry` now either themselves return null as well or handle the null case.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5896
