### PR TITLE
Design: data selector rearrange

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-picker-utils.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-picker-utils.tsx
@@ -108,7 +108,7 @@ export function getEnclosingScopes(
       MetadataUtils.isJSXMapExpression(parentOfCurrent, metadata) ||
       EP.isRootElementOfInstance(current)
     ) {
-      result.unshift({
+      result.push({
         insertionCeiling: current,
         label: outletNameHack(metadata, allElementProps, elementPathTree, projectContents, current),
         hasContent: buckets.includes(insertionCeilingToString(current)),
@@ -118,7 +118,7 @@ export function getEnclosingScopes(
 
     // we also add anything that has content in scope even if it's not a component or map
     if (buckets.includes(insertionCeilingToString(current))) {
-      result.unshift({
+      result.push({
         insertionCeiling: current,
         label: outletNameHack(metadata, allElementProps, elementPathTree, projectContents, current),
         hasContent: true,
@@ -128,7 +128,7 @@ export function getEnclosingScopes(
   }
 
   // Add file root
-  result.unshift({
+  result.push({
     insertionCeiling: { type: 'file-root' },
     label: 'File',
     hasContent: buckets.includes(insertionCeilingToString({ type: 'file-root' })),

--- a/editor/src/components/inspector/sections/component-section/data-selector-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-cartouche.tsx
@@ -13,12 +13,13 @@ import type { DataPickerOption } from './data-picker-utils'
 interface DataPickerCartoucheProps {
   data: DataPickerOption
   selected: boolean
+  forceRole?: CartoucheUIProps['role']
   onClick?: CartoucheUIProps['onClick']
 }
 
 export const DataPickerCartouche = React.memo(
   (props: React.PropsWithChildren<DataPickerCartoucheProps>) => {
-    const { data, selected } = props
+    const { data, selected, forceRole } = props
     const dataSource = useVariableDataSource(data)
     const children = props.children ?? data.variableInfo.expressionPathPart
     return (
@@ -28,7 +29,7 @@ export const DataPickerCartouche = React.memo(
         datatype={childTypeToCartoucheDataType(data.type)}
         selected={!data.disabled && selected}
         highlight={data.disabled ? 'disabled' : null}
-        role={data.disabled ? 'information' : 'selection'}
+        role={forceRole ?? (data.disabled ? 'information' : 'selection')}
         testId={`data-selector-option-${data.variableInfo.expression}`}
         badge={
           data.type === 'array' ? (

--- a/editor/src/components/inspector/sections/component-section/data-selector-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-cartouche.tsx
@@ -13,13 +13,13 @@ import type { DataPickerOption } from './data-picker-utils'
 interface DataPickerCartoucheProps {
   data: DataPickerOption
   selected: boolean
-  forceRole?: CartoucheUIProps['role']
+  forcedRole?: CartoucheUIProps['role']
   onClick?: CartoucheUIProps['onClick']
 }
 
 export const DataPickerCartouche = React.memo(
   (props: React.PropsWithChildren<DataPickerCartoucheProps>) => {
-    const { data, selected, forceRole } = props
+    const { data, selected, forcedRole: forceRole } = props
     const dataSource = useVariableDataSource(data)
     const children = props.children ?? data.variableInfo.expressionPathPart
     return (

--- a/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
@@ -9,7 +9,7 @@ import { DataPickerCartouche } from './data-selector-cartouche'
 interface DataSelectorColumnsProps {
   activeScope: Array<DataPickerOption>
   targetPathInsideScope: ObjectPath
-  onTargetPathChange: (newTargetPath: ObjectPath) => void
+  onTargetPathChange: (newTargetVariable: DataPickerOption) => void
 }
 
 export const DataSelectorColumns = React.memo((props: DataSelectorColumnsProps) => {
@@ -38,7 +38,7 @@ interface DataSelectorColumnProps {
   activeScope: Array<DataPickerOption>
   currentlyShowingScopeForArray: boolean
   targetPathInsideScope: ObjectPath
-  onTargetPathChange: (newTargetPath: ObjectPath) => void
+  onTargetPathChange: (newTargetVariable: DataPickerOption) => void
 }
 
 const DataSelectorColumn = React.memo((props: DataSelectorColumnProps) => {
@@ -156,18 +156,17 @@ interface RowWithCartoucheProps {
   onActivePath: boolean
   forceShowArrow: boolean
   isLeaf: boolean
-  onTargetPathChange: (newTargetPath: ObjectPath) => void
+  onTargetPathChange: (newTargetVariable: DataPickerOption) => void
 }
 const RowWithCartouche = React.memo((props: RowWithCartoucheProps) => {
   const { onTargetPathChange, data, isLeaf, selected, onActivePath, forceShowArrow } = props
-  const targetPath = data.valuePath
 
   const onClick: React.MouseEventHandler<HTMLDivElement> = React.useCallback(
     (e) => {
       e.stopPropagation()
-      onTargetPathChange(targetPath)
+      onTargetPathChange(data)
     },
-    [targetPath, onTargetPathChange],
+    [data, onTargetPathChange],
   )
 
   const ref = useScrollIntoView(selected)

--- a/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
@@ -204,6 +204,7 @@ const DataSelectorFlexColumn = styled(FlexColumn)({
   overflowY: 'scroll',
   scrollbarWidth: 'auto',
   scrollbarColor: 'gray transparent',
+  paddingTop: 8,
   paddingRight: 10, // to account for scrollbar
   paddingLeft: 6,
   paddingBottom: 10,

--- a/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
@@ -211,7 +211,7 @@ const DataSelectorFlexColumn = styled(FlexColumn)({
   borderRight: `1px solid ${colorTheme.subduedBorder.cssValue}`,
 })
 
-export const DataPickerRow = styled(FlexRow)((props: { disabled: boolean }) => ({
+const DataPickerRow = styled(FlexRow)((props: { disabled: boolean }) => ({
   alignSelf: 'stretch',
   justifyContent: 'space-between',
   fontSize: 10,

--- a/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { ElementPath } from 'utopia-shared/src/types'
-import { FlexColumn, FlexRow, LargerIcons, colorTheme } from '../../../../uuiui'
+import { CheckboxInput, FlexColumn, FlexRow, LargerIcons, colorTheme } from '../../../../uuiui'
 import {
   insertionCeilingToString,
   insertionCeilingsEqual,
@@ -65,14 +65,24 @@ const ScopeRow = React.memo(
     return (
       <DataPickerRow
         style={{
+          justifyContent: 'flex-start',
+          gap: 8,
           fontSize: 11,
-          fontWeight: 500,
+          fontWeight: 400,
           backgroundColor: selected ? colorTheme.bg4.value : undefined,
           color: disabled ? colorTheme.fg6.value : colorTheme.fg2.value,
         }}
         onClick={onClick}
         disabled={disabled}
       >
+        <CheckboxInput
+          style={{
+            backgroundColor: colorTheme.bg0.value,
+            border: `1px solid ${colorTheme.fg4.cssValue}`,
+          }}
+          checked={selected}
+          onChange={stopPropagation}
+        />
         {scope.label}
       </DataPickerRow>
     )

--- a/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
@@ -7,7 +7,7 @@ import {
   type FileRootPath,
 } from '../../../canvas/ui-jsx-canvas'
 import { stopPropagation } from '../../common/inspector-utils'
-import { DataPickerRow } from './data-selector-columns'
+import { NO_OP } from '../../../../core/shared/utils'
 
 interface SelectableScope {
   label: string
@@ -24,7 +24,18 @@ interface DataSelectorLeftSidebarProps {
 export const DataSelectorLeftSidebar = React.memo((props: DataSelectorLeftSidebarProps) => {
   const { scopes, setSelectedScope, activeScope } = props
   return (
-    <>
+    <FlexColumn
+      onClick={stopPropagation}
+      style={{
+        alignSelf: 'stretch',
+        minWidth: 150,
+        paddingLeft: 16,
+        paddingTop: 8,
+        paddingRight: 8,
+        borderRight: `1px solid ${colorTheme.subduedBorder.cssValue}`,
+        contain: 'layout',
+      }}
+    >
       <span style={{ fontSize: 10, fontWeight: 500, color: colorTheme.fg5.cssValue }}>Sources</span>
       <FlexColumn>
         {scopes.map((scope) => {
@@ -39,7 +50,33 @@ export const DataSelectorLeftSidebar = React.memo((props: DataSelectorLeftSideba
           )
         })}
       </FlexColumn>
-    </>
+      <span
+        style={{
+          marginTop: 32,
+          fontSize: 10,
+          fontWeight: 500,
+          color: colorTheme.fg5.cssValue,
+        }}
+      >
+        Origin
+      </span>
+      <FlexColumn>
+        <RowWithCheckbox
+          label={'Local Data'}
+          color={colorTheme.selectionBlue.value}
+          selected={true}
+          disabled={false}
+          onClick={NO_OP}
+        />
+        <RowWithCheckbox
+          label={'Loader Data'}
+          color={colorTheme.green.value}
+          selected={true}
+          disabled={false}
+          onClick={NO_OP}
+        />
+      </FlexColumn>
+    </FlexColumn>
   )
 })
 
@@ -63,28 +100,46 @@ const ScopeRow = React.memo(
     )
 
     return (
-      <DataPickerRow
-        style={{
-          justifyContent: 'flex-start',
-          gap: 8,
-          fontSize: 11,
-          fontWeight: 400,
-          backgroundColor: selected ? colorTheme.bg4.value : undefined,
-          color: disabled ? colorTheme.fg6.value : colorTheme.fg2.value,
-        }}
-        onClick={onClick}
+      <RowWithCheckbox
+        label={scope.label}
+        selected={selected}
         disabled={disabled}
-      >
-        <CheckboxInput
-          style={{
-            backgroundColor: colorTheme.bg0.value,
-            border: `1px solid ${colorTheme.fg4.cssValue}`,
-          }}
-          checked={selected}
-          onChange={stopPropagation}
-        />
-        {scope.label}
-      </DataPickerRow>
+        onClick={onClick}
+      />
     )
   },
 )
+
+interface RowWithCheckboxProps {
+  label: string
+  color?: string
+  selected: boolean
+  disabled: boolean
+  onClick: (e: React.MouseEvent<HTMLDivElement>) => void
+}
+
+const RowWithCheckbox = React.memo((props: RowWithCheckboxProps) => {
+  const { label, color, selected, disabled, onClick } = props
+  return (
+    <FlexRow
+      style={{
+        justifyContent: 'flex-start',
+        gap: 8,
+        fontSize: 11,
+        fontWeight: 400,
+        color: color ?? (disabled ? colorTheme.fg6.value : colorTheme.fg2.value),
+      }}
+      onClick={onClick}
+    >
+      <CheckboxInput
+        style={{
+          backgroundColor: colorTheme.bg0.value,
+          border: `1px solid ${colorTheme.fg4.cssValue}`,
+        }}
+        checked={selected}
+        onChange={stopPropagation}
+      />
+      {label}
+    </FlexRow>
+  )
+})

--- a/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
@@ -25,9 +25,7 @@ export const DataSelectorLeftSidebar = React.memo((props: DataSelectorLeftSideba
   const { scopes, setSelectedScope, activeScope } = props
   return (
     <>
-      <span style={{ fontSize: 10, fontWeight: 'bold', color: colorTheme.fg4.cssValue }}>
-        Sources
-      </span>
+      <span style={{ fontSize: 10, fontWeight: 500, color: colorTheme.fg5.cssValue }}>Sources</span>
       <FlexColumn>
         {scopes.map((scope) => {
           return (
@@ -67,8 +65,10 @@ const ScopeRow = React.memo(
     return (
       <DataPickerRow
         style={{
+          fontSize: 11,
+          fontWeight: 500,
           backgroundColor: selected ? colorTheme.bg4.value : undefined,
-          color: disabled ? colorTheme.fg6.value : colorTheme.neutralForeground.value,
+          color: disabled ? colorTheme.fg6.value : colorTheme.fg2.value,
         }}
         onClick={onClick}
         disabled={disabled}

--- a/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-left-sidebar.tsx
@@ -62,14 +62,14 @@ export const DataSelectorLeftSidebar = React.memo((props: DataSelectorLeftSideba
       </span>
       <FlexColumn>
         <RowWithCheckbox
-          label={'Local Data'}
+          label={'Local'}
           color={colorTheme.selectionBlue.value}
           selected={true}
           disabled={false}
           onClick={NO_OP}
         />
         <RowWithCheckbox
-          label={'Loader Data'}
+          label={'Loader'}
           color={colorTheme.green.value}
           selected={true}
           disabled={false}

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.spec.browser2.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.spec.browser2.tsx
@@ -13,7 +13,7 @@ describe('data selector modal', () => {
 
     expect(editor.renderedDOM.getByText('Apply')).not.toBeNull()
     expect(editor.renderedDOM.getByTestId(DataSelectorPopupBreadCrumbsTestId).innerText).toEqual(
-      ['header', '.title'].join('\n'),
+      expect.stringContaining('Selection:'),
     )
   })
 })

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -261,6 +261,7 @@ export const DataSelectorModal = React.memo(
           >
             <FlexRow
               ref={forwardedRef}
+              onClick={catchClick}
               style={{
                 minWidth: 850,
                 height: 300,
@@ -279,7 +280,6 @@ export const DataSelectorModal = React.memo(
                 setSelectedScope={setSelectedScopeAndResetSelection}
               />
               <FlexColumn
-                onClick={catchClick}
                 style={{
                   alignSelf: 'stretch',
                   flexGrow: 1,

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -319,7 +319,7 @@ export const DataSelectorModal = React.memo(
                               <DataPickerCartouche
                                 data={selectedVariableOption}
                                 selected={false}
-                                forceRole='information'
+                                forcedRole='information'
                               />
                             ) : null}
                           </FlexRow>

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -273,23 +273,11 @@ export const DataSelectorModal = React.memo(
                 ...style,
               }}
             >
-              <FlexColumn
-                onClick={stopPropagation}
-                style={{
-                  alignSelf: 'stretch',
-                  minWidth: 150,
-                  padding: 8,
-                  paddingTop: 16,
-                  borderRight: `1px solid ${colorTheme.subduedBorder.cssValue}`,
-                  contain: 'layout',
-                }}
-              >
-                <DataSelectorLeftSidebar
-                  scopes={elementLabelsWithScopes}
-                  activeScope={selectedScope}
-                  setSelectedScope={setSelectedScopeAndResetSelection}
-                />
-              </FlexColumn>
+              <DataSelectorLeftSidebar
+                scopes={elementLabelsWithScopes}
+                activeScope={selectedScope}
+                setSelectedScope={setSelectedScopeAndResetSelection}
+              />
               <FlexColumn
                 onClick={catchClick}
                 style={{

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -33,6 +33,7 @@ import { DataSelectorColumns } from './data-selector-columns'
 import { DataSelectorLeftSidebar } from './data-selector-left-sidebar'
 import { DataSelectorSearch } from './data-selector-search'
 import { stopPropagation } from '../../common/inspector-utils'
+import { DataPickerCartouche } from './data-selector-cartouche'
 
 export const DataSelectorPopupBreadCrumbsTestId = 'data-selector-modal-top-bar'
 
@@ -220,14 +221,6 @@ export const DataSelectorModal = React.memo(
         [applyVariable, activeTargetPath],
       )
 
-      const valuePreviewText = (() => {
-        const variable = processedVariablesInScope[pathInTopBarIncludingHover.toString()]
-        if (variable == null) {
-          return null
-        }
-        return JSON.stringify(variable.variableInfo.value, undefined, 2)
-      })()
-
       const navigateToSearchResult = React.useCallback(
         (path: ObjectPath) => {
           setSearchTerm(null)
@@ -237,6 +230,10 @@ export const DataSelectorModal = React.memo(
       )
 
       const searchNullOrEmpty = searchTerm == null || searchTerm.length < 1
+
+      const pickedVariable = processedVariablesInScope[
+        selectedPath.toString()
+      ] as DataPickerOption | null
 
       return (
         <InspectorModal
@@ -287,39 +284,6 @@ export const DataSelectorModal = React.memo(
                   contain: 'layout',
                 }}
               >
-                <FlexRow
-                  style={{
-                    height: 24,
-                    marginBottom: 16,
-                    padding: '6px 8px',
-                    borderRadius: 16,
-                    gap: 8,
-                    border: `1px solid ${colorTheme.fg7.value}`,
-                  }}
-                >
-                  <LargerIcons.MagnifyingGlass style={{ zoom: 0.6 }} />
-                  <input
-                    onClick={onStartSearch}
-                    onFocus={onStartSearch}
-                    onChange={onSearchFieldValueChange}
-                    ref={searchBoxRef}
-                    value={searchTerm ?? ''}
-                    data-testId='data-selector-modal-search-input'
-                    placeholder='Search'
-                    style={{
-                      outline: 'none',
-                      border: 'none',
-                      paddingRight: 14,
-                    }}
-                  />
-                  {when(
-                    searchTerm != null,
-                    <Icons.CrossInTranslucentCircle
-                      style={{ cursor: 'pointer', position: 'fixed', right: 0, marginRight: 14 }}
-                      onClick={cancelSearch}
-                    />,
-                  )}
-                </FlexRow>
                 <DataSelectorLeftSidebar
                   scopes={elementLabelsWithScopes}
                   activeScope={selectedScope}
@@ -331,92 +295,53 @@ export const DataSelectorModal = React.memo(
                 style={{
                   alignSelf: 'stretch',
                   flexGrow: 1,
-                  paddingLeft: 8,
-                  paddingTop: 16,
-                  paddingRight: 16,
                   overflow: 'hidden',
                   width: 700,
                 }}
               >
-                {when(
-                  searchNullOrEmpty,
-                  <>
-                    {/* top bar */}
-                    <FlexRow
-                      style={{ justifyContent: 'space-between', alignItems: 'center', gap: 8 }}
-                    >
-                      <FlexRow style={{ gap: 8, flexWrap: 'wrap', flexGrow: 1 }}>
-                        <FlexRow
-                          style={{
-                            flexGrow: 1,
-                            borderStyle: 'solid',
-                            borderWidth: 1,
-                            borderColor: colorTheme.fg7.value,
-                            borderRadius: 4,
-                            fontSize: 11,
-                            fontWeight: 400,
-                            height: 33,
-                            padding: '0px 6px',
-                          }}
-                        >
-                          <FlexRow
-                            data-testid={DataSelectorPopupBreadCrumbsTestId}
-                            style={{ flexWrap: 'wrap', flexGrow: 1 }}
-                          >
-                            {pathBreadcrumbs(
-                              pathInTopBarIncludingHover,
-                              processedVariablesInScope,
-                            ).map(({ segment, path }, idx) => (
-                              <span key={path.toString()}>
-                                {idx === 0 ? segment : pathSegmentToString(segment)}
-                              </span>
-                            ))}
-                          </FlexRow>
-                          <div
-                            style={{
-                              ...disabledButtonStyles(activeTargetPath.length === 0),
-                              fontWeight: 400,
-                              fontSize: 12,
-                            }}
-                            onClick={onHomeClick}
-                          >
-                            <Icons.Cross />
-                          </div>
-                        </FlexRow>
-                      </FlexRow>
-                      <div
-                        style={{
-                          borderRadius: 4,
-                          backgroundColor: colorTheme.primary.value,
-                          color: 'white',
-                          padding: '8px 12px',
-                          fontSize: 14,
-                          fontWeight: 500,
-                          ...disabledButtonStyles(activeTargetPath.length === 0),
-                        }}
-                        onClick={onApplyClick}
-                      >
-                        Apply
-                      </div>
-                    </FlexRow>
-                    {/* Value preview */}
-                    <FlexRow
+                <FlexRow style={{ padding: '8px 8px 5px' }}>
+                  <FlexRow
+                    style={{
+                      flexGrow: 1,
+                      height: 24,
+                      padding: '6px 8px',
+                      borderRadius: 4,
+                      gap: 8,
+                      border: `1px solid ${colorTheme.subduedBorder.value}`,
+                    }}
+                  >
+                    <LargerIcons.MagnifyingGlass style={{ zoom: 0.6 }} />
+                    <input
+                      onClick={onStartSearch}
+                      onFocus={onStartSearch}
+                      onChange={onSearchFieldValueChange}
+                      ref={searchBoxRef}
+                      value={searchTerm ?? ''}
+                      data-testId='data-selector-modal-search-input'
+                      placeholder='Search data'
                       style={{
-                        flexShrink: 0,
-                        gridColumn: '3',
-                        flexWrap: 'wrap',
-                        gap: 4,
-                        overflowX: 'scroll',
-                        opacity: 0.8,
-                        fontSize: 10,
-                        height: 20,
+                        outline: 'none',
+                        border: 'none',
+                        paddingRight: 14,
                       }}
-                    >
-                      {valuePreviewText}
-                    </FlexRow>
-                  </>,
-                )}
-                <FlexColumn style={{ flexGrow: 1, overflow: 'hidden', contain: 'content' }}>
+                    />
+                    {when(
+                      searchTerm != null,
+                      <Icons.CrossInTranslucentCircle
+                        style={{ cursor: 'pointer', position: 'fixed', right: 0, marginRight: 14 }}
+                        onClick={cancelSearch}
+                      />,
+                    )}
+                  </FlexRow>
+                </FlexRow>
+                <FlexColumn
+                  style={{
+                    flexGrow: 1,
+                    overflow: 'hidden',
+                    contain: 'content',
+                    borderTop: `1px solid ${colorTheme.subduedBorder.cssValue}`,
+                  }}
+                >
                   {searchNullOrEmpty ? (
                     <DataSelectorColumns
                       activeScope={filteredVariablesInScope}
@@ -431,6 +356,84 @@ export const DataSelectorModal = React.memo(
                     />
                   )}
                 </FlexColumn>
+                {when(
+                  searchNullOrEmpty,
+                  <>
+                    {/* bottom bar */}
+                    <FlexRow
+                      style={{
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        gap: 8,
+                        borderTop: `1px solid ${colorTheme.subduedBorder.cssValue}`,
+                        paddingTop: 10,
+                        paddingBottom: 10,
+                        paddingRight: 16,
+                      }}
+                    >
+                      <FlexRow style={{ gap: 8, paddingRight: 8, flexWrap: 'wrap', flexGrow: 1 }}>
+                        <FlexRow
+                          style={{
+                            flexGrow: 1,
+                            fontSize: 11,
+                            fontWeight: 500,
+                            padding: '0px 6px',
+                            alignItems: 'center',
+                          }}
+                        >
+                          <FlexRow
+                            data-testid={DataSelectorPopupBreadCrumbsTestId}
+                            style={{ flexWrap: 'wrap', flexGrow: 1 }}
+                          >
+                            <span>Selection:</span>
+                            {pickedVariable != null ? (
+                              <DataPickerCartouche
+                                data={pickedVariable}
+                                selected={false}
+                                forceRole='information'
+                              />
+                            ) : null}
+                          </FlexRow>
+                        </FlexRow>
+                      </FlexRow>
+                      <div
+                        style={{
+                          borderRadius: 4,
+                          backgroundColor: colorTheme.white.value,
+                          color: colorTheme.fg0.value,
+                          border: `1px solid ${colorTheme.subduedBorder.value}`,
+                          padding: 3,
+                          fontSize: 11,
+                          fontWeight: 400,
+                          height: 24,
+                          width: 81,
+                          textAlign: 'center',
+                          ...disabledButtonStyles(false),
+                        }}
+                        onClick={closePopup}
+                      >
+                        Cancel
+                      </div>
+                      <div
+                        style={{
+                          borderRadius: 4,
+                          backgroundColor: colorTheme.black.value,
+                          color: 'white',
+                          padding: 3,
+                          fontSize: 11,
+                          fontWeight: 400,
+                          height: 24,
+                          width: 81,
+                          textAlign: 'center',
+                          ...disabledButtonStyles(pickedVariable?.disabled ?? true),
+                        }}
+                        onClick={onApplyClick}
+                      >
+                        Apply
+                      </div>
+                    </FlexRow>
+                  </>,
+                )}
               </FlexColumn>
             </FlexRow>
           </div>
@@ -512,31 +515,6 @@ function useProcessVariablesInScope(options: DataPickerOption[]): ProcessedVaria
     options.forEach((o) => walk(o))
     return lookup
   }, [options])
-}
-
-function pathBreadcrumbs(
-  valuePath: DataPickerOption['valuePath'],
-  processedVariablesInScope: ProcessedVariablesInScope,
-): Array<{
-  segment: string | number
-  path: (string | number)[]
-}> {
-  let accumulator = []
-  let current: (string | number)[] = []
-  for (const segment of valuePath) {
-    current.push(segment)
-    const optionFromLookup = processedVariablesInScope[current.toString()]
-
-    if (optionFromLookup == null) {
-      continue
-    }
-
-    accumulator.push({
-      segment: segment,
-      path: [...current],
-    })
-  }
-  return accumulator
 }
 
 function disabledButtonStyles(disabled: boolean): React.CSSProperties {

--- a/editor/src/components/inspector/sections/component-section/data-selector-search.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-search.tsx
@@ -32,6 +32,7 @@ export const DataSelectorSearch = React.memo(
           flexGrow: 1,
           gap: 8,
           paddingTop: 8,
+          paddingLeft: 8,
           display: 'grid',
           gridTemplateColumns: 'auto 1fr',
           gridAutoRows: 'min-content',

--- a/editor/src/components/inspector/sections/component-section/data-selector-search.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-search.tsx
@@ -7,7 +7,7 @@ import { type DataPickerOption, type ObjectPath } from './data-picker-utils'
 import { DataPickerCartouche } from './data-selector-cartouche'
 
 export interface DataSelectorSearchProps {
-  setNavigatedToPath: (_: ObjectPath) => void
+  setNavigatedToPath: (_: DataPickerOption) => void
   allVariablesInScope: DataPickerOption[]
   searchTerm: string
 }
@@ -15,10 +15,10 @@ export interface DataSelectorSearchProps {
 export const DataSelectorSearch = React.memo(
   ({ setNavigatedToPath, searchTerm, allVariablesInScope }: DataSelectorSearchProps) => {
     const setNavigatedToPathCurried = React.useCallback(
-      (path: ObjectPath) => (e: React.MouseEvent) => {
+      (data: DataPickerOption) => (e: React.MouseEvent) => {
         e.stopPropagation()
         e.preventDefault()
-        setNavigatedToPath(path)
+        setNavigatedToPath(data)
       },
       [setNavigatedToPath],
     )
@@ -46,7 +46,7 @@ export const DataSelectorSearch = React.memo(
                   data={searchResult.option}
                   key={`${searchResult.option.variableInfo.expression}-${idx}`}
                   selected={false}
-                  onClick={setNavigatedToPathCurried(searchResult.option.valuePath)}
+                  onClick={setNavigatedToPathCurried(searchResult.option)}
                 >
                   {searchResult.valuePath.map((v, i) => (
                     <React.Fragment key={`${v.value}-${i}`}>


### PR DESCRIPTION
Target design:
<img width="846" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/19167ba2-3fff-4137-8e37-20d103868e39">

Result on branch:
<img width="865" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/3c4979d1-dc77-47b9-bda6-ecee4a49abcd">

**Commit Details:**

- Rearranged the basic layout: search bar lives at the top, apply button moved to the bottom. the "output input field" has been replaced by a "Selection: [cartouche]" row.
- Left sidebar options are now checkboxes (BUT they still behave like radio buttons / tabs)
- Added fake source filtering options to the left sidebar
- minor tweaks to paddings etc
- MASSIVE cleanup of code in data-selector-modal
- instead of storing `selectedPath`, we store `selectedVariableOption` which allowed further simplification of code
- useProcessVariablesInScope no longer necessary

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [ ] I could navigate to various routes in Preview mode
