### PR TITLE
Feat/condensed row component

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -426,7 +426,6 @@ export const NavigatorItem: React.FunctionComponent<
   const isInFocusedComponentSubtree = useEditorState(
     Substores.focusedElement,
     (store) =>
-      isRegularNavigatorEntry(navigatorEntry) &&
       EP.isInExplicitlyFocusedSubtree(
         store.editor.focusedElementPath,
         autoFocusedPaths,


### PR DESCRIPTION
Part of #5840 

**Problem:**

Condensed rows (and even render prop rows!) don't use the purple colors for component contexts.

**Fix:**

Make them behave like the other navigator rows.

| Before | After |
|--------|--------|
| <img width="397" alt="Screenshot 2024-06-13 at 1 25 32 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/5c1cb40f-3465-4baf-b107-a59010ae1b22"> | <img width="397" alt="Screenshot 2024-06-13 at 1 25 25 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/4a71dd58-e0e4-4ad7-b451-11bbbc423448"> |

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode


