### PR TITLE
Consistent border radii for navigator selection

### DIFF
--- a/editor/src/components/navigator/navigator-item/navigator-condensed-entry.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-condensed-entry.tsx
@@ -18,6 +18,7 @@ import {
   NavigatorRowClickableWrapper,
   useGetNavigatorClickActions,
 } from './navigator-item-clickable-wrapper'
+import { useNavigatorSelectionBoundsForEntry } from './use-navigator-selection-bounds-for-entry'
 
 function useEntryLabel(entry: NavigatorEntry) {
   const labelForTheElement = useEditorState(
@@ -87,6 +88,14 @@ export const CondensedEntryItemWrapper = React.memo(
       )
     }, [selectedViews, props.navigatorRow])
 
+    const { isTopOfSelection, isBottomOfSelection } = useNavigatorSelectionBoundsForEntry(
+      props.navigatorRow.entries[0],
+      rowRootSelected,
+      0,
+    )
+
+    const borderRadius = 5
+
     return (
       <div
         style={{
@@ -98,12 +107,12 @@ export const CondensedEntryItemWrapper = React.memo(
             : hasSelection || wholeRowInsideSelection
             ? colorTheme.childSelectionBlue.value
             : 'transparent',
-          borderTopLeftRadius: rowContainsSelection ? 5 : 0,
-          borderTopRightRadius: rowContainsSelection ? 5 : 0,
+          borderTopLeftRadius: isTopOfSelection ? borderRadius : 0,
+          borderTopRightRadius: isTopOfSelection ? borderRadius : 0,
           borderBottomLeftRadius:
-            rowContainsSelection && (isCollapsed || isDataReferenceRow) ? 5 : 0,
+            isBottomOfSelection && (isCollapsed || isDataReferenceRow) ? borderRadius : 0,
           borderBottomRightRadius:
-            rowContainsSelection && (isCollapsed || isDataReferenceRow) ? 5 : 0,
+            isBottomOfSelection && (isCollapsed || isDataReferenceRow) ? borderRadius : 0,
           overflowX: 'auto',
         }}
       >

--- a/editor/src/components/navigator/navigator-item/navigator-condensed-entry.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-condensed-entry.tsx
@@ -7,7 +7,11 @@ import { Substores, useEditorState } from '../../editor/store/store-hook'
 import { condensedNavigatorRow, type CondensedNavigatorRow } from '../navigator-row'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { getNavigatorEntryLabel, labelSelector } from './navigator-item-wrapper'
-import { BasePaddingUnit, elementWarningsSelector } from './navigator-item'
+import {
+  BasePaddingUnit,
+  NavigatorRowBorderRadius,
+  elementWarningsSelector,
+} from './navigator-item'
 import { setHighlightedViews, toggleCollapse } from '../../editor/actions/action-creators'
 import type { ElementPath } from 'utopia-shared/src/types'
 import { unless, when } from '../../../utils/react-conditionals'
@@ -94,8 +98,6 @@ export const CondensedEntryItemWrapper = React.memo(
       0,
     )
 
-    const borderRadius = 5
-
     return (
       <div
         style={{
@@ -107,12 +109,16 @@ export const CondensedEntryItemWrapper = React.memo(
             : hasSelection || wholeRowInsideSelection
             ? colorTheme.childSelectionBlue.value
             : 'transparent',
-          borderTopLeftRadius: isTopOfSelection ? borderRadius : 0,
-          borderTopRightRadius: isTopOfSelection ? borderRadius : 0,
+          borderTopLeftRadius: isTopOfSelection ? NavigatorRowBorderRadius : 0,
+          borderTopRightRadius: isTopOfSelection ? NavigatorRowBorderRadius : 0,
           borderBottomLeftRadius:
-            isBottomOfSelection && (isCollapsed || isDataReferenceRow) ? borderRadius : 0,
+            isBottomOfSelection && (isCollapsed || isDataReferenceRow)
+              ? NavigatorRowBorderRadius
+              : 0,
           borderBottomRightRadius:
-            isBottomOfSelection && (isCollapsed || isDataReferenceRow) ? borderRadius : 0,
+            isBottomOfSelection && (isCollapsed || isDataReferenceRow)
+              ? NavigatorRowBorderRadius
+              : 0,
           overflowX: 'auto',
         }}
       >

--- a/editor/src/components/navigator/navigator-item/navigator-item.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item.tsx
@@ -169,6 +169,8 @@ const getColors = (
   }
 }
 
+export const NavigatorRowBorderRadius = 5
+
 const computeResultingStyle = (params: {
   selected: boolean
   isTopOfSelection: boolean
@@ -239,8 +241,8 @@ const computeResultingStyle = (params: {
 
   let result = getColors(styleType, selectedType, colorTheme)
 
-  const borderRadiusTop = isTopOfSelection ? 5 : 0
-  const borderRadiusBottom = isBottomOfSelection ? 5 : 0
+  const borderRadiusTop = isTopOfSelection ? NavigatorRowBorderRadius : 0
+  const borderRadiusBottom = isBottomOfSelection ? NavigatorRowBorderRadius : 0
 
   result.style = {
     ...result.style,

--- a/editor/src/components/navigator/navigator-item/use-navigator-selection-bounds-for-entry.tsx
+++ b/editor/src/components/navigator/navigator-item/use-navigator-selection-bounds-for-entry.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import * as EP from '../../../core/shared/element-path'
+import type { NavigatorEntry } from '../../editor/store/editor-state'
+import { Substores, useEditorState } from '../../editor/store/store-hook'
+import { isRegulaNavigatorRow } from '../navigator-row'
+
+export function useNavigatorSelectionBoundsForEntry(
+  navigatorEntry: NavigatorEntry,
+  selected: boolean,
+  childComponentCount: number,
+): {
+  isTopOfSelection: boolean
+  isBottomOfSelection: boolean
+} {
+  const selectedViews = useEditorState(
+    Substores.selectedViews,
+    (store) => store.editor.selectedViews,
+    'useNavigatorSelectionBoundsCheck selectedViews',
+  )
+
+  const navigatorRowsPaths = useEditorState(
+    Substores.derived,
+    (store) => {
+      return store.derived.navigatorRows.map((row) =>
+        isRegulaNavigatorRow(row) ? row.entry.elementPath : row.entries[0].elementPath,
+      )
+    },
+    'useNavigatorSelectionBoundsCheck navigatorRowsPaths',
+  )
+
+  const collapsedViews = useEditorState(
+    Substores.navigator,
+    (store) => {
+      return store.editor.navigator.collapsedViews
+    },
+    'useNavigatorSelectionBoundsCheck collapsedViews',
+  )
+
+  return React.useMemo(() => {
+    const index = navigatorRowsPaths.findIndex((view) =>
+      EP.pathsEqual(view, navigatorEntry.elementPath),
+    )
+
+    const previous = index > 0 ? navigatorRowsPaths.at(index - 1) : null
+    const next = index < navigatorRowsPaths.length - 1 ? navigatorRowsPaths.at(index + 1) : null
+
+    const isDangling =
+      childComponentCount === 0 || collapsedViews.includes(navigatorEntry.elementPath)
+
+    const isTopOfSelection =
+      previous == null ||
+      (!selectedViews.some(
+        (view) =>
+          EP.pathsEqual(view, previous) ||
+          EP.isDescendantOf(EP.parentPath(navigatorEntry.elementPath), view) ||
+          EP.isDescendantOf(previous, view),
+      ) &&
+        selected)
+
+    const isBottomOfSelection =
+      next == null ||
+      ((!selected || isDangling) &&
+        !selectedViews.some((view) => EP.pathsEqual(view, next) || EP.isDescendantOf(next, view)))
+
+    return {
+      isTopOfSelection: isTopOfSelection,
+      isBottomOfSelection: isBottomOfSelection,
+    }
+  }, [
+    navigatorRowsPaths,
+    navigatorEntry,
+    selectedViews,
+    selected,
+    childComponentCount,
+    collapsedViews,
+  ])
+}


### PR DESCRIPTION
**Problem:**

Selected rows in the navigator have inconsistent / potato border radii applied to pretty much any selected row. Moreover, the children selection also does not have any border radius.

**Fix:**

Contiguous regions of selection now share just 4 rounded corners. This is done with a hook which is used on both the regular and the condensed navigator rows, so they share all the underlying logic to figure out which element should have `borderRadius` applied or not.

Note: there's a reasonable chance there will be corner (pun intended) cases here and there, but it feels decently solid.

<img width="926" alt="Screenshot 2024-06-13 at 4 08 41 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/eee83821-3302-46e5-a98d-9d1f4bd9e6bc">

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5927
