### PR TITLE
Decode HTML entities in cartouche labels

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
@@ -25,6 +25,9 @@ import { useAtom } from 'jotai'
 import type { CartoucheDataType, CartoucheHighlight, CartoucheUIProps } from './cartouche-ui'
 import { CartoucheUI } from './cartouche-ui'
 import * as PP from '../../../../core/shared/property-path'
+import { AllHtmlEntities } from 'html-entities'
+
+const htmlEntities = new AllHtmlEntities()
 
 interface DataReferenceCartoucheControlProps {
   elementPath: ElementPath
@@ -44,11 +47,16 @@ export const DataReferenceCartoucheControl = React.memo(
 
     const contentsToDisplay = useEditorState(
       Substores.metadata,
-      (store) =>
-        getTextContentOfElement(
+      (store) => {
+        const content = getTextContentOfElement(
           childOrAttribute,
           MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, elementPath),
-        ),
+        )
+        if (content.label != null) {
+          return { ...content, label: htmlEntities.decode(content.label) }
+        }
+        return content
+      },
       'DataReferenceCartoucheControl contentsToDisplay',
     )
 


### PR DESCRIPTION
**Problem:**

HTML entities are displayed raw in the cartouche labels.

**Fix:**

Parse the entities when building the content to display.

<img width="547" alt="Screenshot 2024-06-13 at 5 29 45 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/8b4caeca-72d2-48d3-97c7-2e5ef5df3953">


**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5916 
