### PR TITLE
Make the canvas plus button respect the insertion index position

### DIFF
--- a/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker-context-menu.tsx
@@ -582,12 +582,26 @@ export function insertComponentPickerItem(
       }
 
       if (!isConditionalTarget(insertionTarget)) {
-        return [insertJSXElement(fixedElement, firstTarget, toInsert.importsToAdd ?? undefined)]
+        return [
+          insertJSXElement(
+            fixedElement,
+            firstTarget,
+            toInsert.importsToAdd ?? undefined,
+            insertionTarget.indexPosition,
+          ),
+        ]
       }
     }
 
     if (isInsertAsChildTarget(insertionTarget)) {
-      return [insertInsertable(childInsertionPath(firstTarget), toInsert, 'do-not-add', null)]
+      return [
+        insertInsertable(
+          childInsertionPath(firstTarget),
+          toInsert,
+          'do-not-add',
+          insertionTarget.indexPosition ?? null,
+        ),
+      ]
     }
 
     if (isConditionalTarget(insertionTarget)) {


### PR DESCRIPTION
## Problem
The on-canvas plus button doesn't respect the insertion index position

## Fix
Pass the index position to the relevant insertion handlers

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode


https://github.com/concrete-utopia/utopia/issues/5923