### PR TITLE
Change the zoom level multiplier to 1.5

### DIFF
--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -437,7 +437,7 @@ export const CanvasToolbar = React.memo(() => {
             }}
             onClick={zoom100pct}
           >
-            {zoomLevel * 100}%
+            {Math.floor(zoomLevel * 100)}%
           </SquareButton>
         </Tooltip>
         <Tooltip title='Reset Canvas' placement='bottom'>

--- a/editor/src/utils/utils.ts
+++ b/editor/src/utils/utils.ts
@@ -758,12 +758,14 @@ function stepInArray<T>(
   }
 }
 
+const SCALE = 1.5
+
 function increaseScale(scale: number): number {
-  return scale * 2
+  return scale * SCALE
 }
 
 function decreaseScale(scale: number): number {
-  return scale / 2
+  return scale / SCALE
 }
 
 function createThrottler(


### PR DESCRIPTION
# [Sample store](https://utopia.fish/p/99b0d63e-imaginary-child/?branch_name=feature-zoom-level-one-half)

## Description
see https://github.com/concrete-utopia/utopia/issues/5906

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode