### PR TITLE
Data picker search design touchup

### DIFF
--- a/editor/src/components/inspector/sections/component-section/cartouche-ui.tsx
+++ b/editor/src/components/inspector/sections/component-section/cartouche-ui.tsx
@@ -151,6 +151,7 @@ export const CartoucheUI = React.forwardRef(
                 ...(role !== 'information' ? UtopiaStyles.fontStyles.monospaced : {}),
                 display: 'flex',
                 flexDirection: 'row',
+                alignItems: 'center',
               }}
             >
               {children}

--- a/editor/src/components/inspector/sections/component-section/data-selector-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-cartouche.tsx
@@ -15,6 +15,7 @@ interface DataPickerCartoucheProps {
   data: DataPickerOption
   selected: boolean
   forcedRole?: CartoucheUIProps['role']
+  forcedSource?: CartoucheUIProps['source']
   onClick?: CartoucheUIProps['onClick']
 }
 

--- a/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-modal.tsx
@@ -255,6 +255,7 @@ export const DataSelectorModal = React.memo(
                         outline: 'none',
                         border: 'none',
                         paddingRight: 14,
+                        flex: 1,
                       }}
                     />
                     {when(

--- a/editor/src/components/inspector/sections/component-section/data-selector-search.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-search.tsx
@@ -2,9 +2,9 @@ import throttle from 'lodash.throttle'
 import React from 'react'
 import { memoize } from '../../../../core/shared/memoize'
 import { assertNever } from '../../../../core/shared/utils'
-import { FlexRow, Icons, UtopiaStyles } from '../../../../uuiui'
+import { FlexRow, Icons, SmallerIcons, UtopiaStyles } from '../../../../uuiui'
 import { type DataPickerOption, type ObjectPath } from './data-picker-utils'
-import { DataPickerCartouche } from './data-selector-cartouche'
+import { DataPickerCartouche, useVariableDataSource } from './data-selector-cartouche'
 import { when } from '../../../../utils/react-conditionals'
 
 export interface DataSelectorSearchProps {
@@ -43,27 +43,12 @@ export const DataSelectorSearch = React.memo(
           (searchResult, idx) => (
             <React.Fragment key={[...searchResult.valuePath, idx].toString()}>
               <FlexRow style={{ gap: 2 }}>
-                <DataPickerCartouche
-                  data={searchResult.option}
+                <SearchResultCartouche
                   key={`${searchResult.option.variableInfo.expression}-${idx}`}
-                  selected={false}
-                  onClick={setNavigatedToPathCurried(searchResult.option)}
-                >
-                  {searchResult.valuePath.map((v, i) => (
-                    <React.Fragment key={`${v.value}-${i}`}>
-                      <SearchResultString
-                        isMatch={v.matched}
-                        label={v.value}
-                        searchTerm={searchTerm}
-                        fontWeightForMatch={900}
-                      />
-                      {when(
-                        i < searchResult.valuePath.length - 1,
-                        <Icons.ExpansionArrowRight color='primary' />,
-                      )}
-                    </React.Fragment>
-                  ))}
-                </DataPickerCartouche>
+                  searchResult={searchResult}
+                  setNavigatedToPath={setNavigatedToPathCurried(searchResult.option)}
+                  searchTerm={searchTerm}
+                />
               </FlexRow>
               <FlexRow
                 style={{
@@ -245,5 +230,42 @@ function SearchResultString({
         )
       })}
     </>
+  )
+}
+
+function SearchResultCartouche({
+  searchResult,
+  searchTerm,
+  setNavigatedToPath: setNavigatedToPathCurried,
+}: {
+  searchResult: SearchResult
+  searchTerm: string
+  setNavigatedToPath: (e: React.MouseEvent) => void
+}) {
+  const dataSource = useVariableDataSource(searchResult.option)
+  const iconColor = dataSource === 'external' ? 'green' : 'primary'
+
+  return (
+    <DataPickerCartouche
+      data={searchResult.option}
+      selected={false}
+      forcedSource={dataSource ?? undefined}
+      onClick={setNavigatedToPathCurried}
+    >
+      {searchResult.valuePath.map((v, i) => (
+        <React.Fragment key={`${v.value}-${i}`}>
+          <SearchResultString
+            isMatch={v.matched}
+            label={v.value}
+            searchTerm={searchTerm}
+            fontWeightForMatch={900}
+          />
+          {when(
+            i < searchResult.valuePath.length - 1,
+            <SmallerIcons.ExpansionArrowRight color={iconColor} />,
+          )}
+        </React.Fragment>
+      ))}
+    </DataPickerCartouche>
   )
 }

--- a/editor/src/uuiui/icons.tsx
+++ b/editor/src/uuiui/icons.tsx
@@ -199,6 +199,13 @@ export const SmallerIcons = {
     width: 11,
     height: 11,
   }),
+  ExpansionArrowRight: makeIcon({
+    category: 'semantic',
+    type: 'expansionarrow-small-right',
+    color: 'main',
+    width: 12,
+    height: 12,
+  }),
 }
 
 export const Icons = {


### PR DESCRIPTION
## Description

Improves the design of the data picker:
- make the search field span the whole length of its outline 
- use the right colored arrow icon in the search result cartouche
- turn the search results view into two side-by-side columns that eact scroll horizontally (see https://screenshot.click/14-12-847sp-icx9w.mp4)

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
