### PR TITLE
oops: fix data picker missing values

### DIFF
--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -215,7 +215,7 @@ export function variableInfoFromValue(
   insertionCeiling: ElementPath | FileRootPath,
   valueStackSoFar: Set<any>,
 ): VariableInfo | null {
-  if (valueStackSoFar.has(value)) {
+  if ((typeof value === 'object' || typeof value === 'function') && valueStackSoFar.has(value)) {
     // prevent circular dependencies
     return null
   }


### PR DESCRIPTION
**Problem:**
```
const myTestData = {
  keyA: 5,
  keyB: 5,
  keyC: 5,
  keyD: 5,
}
```
would only show keyA in the data picker:
<img width="880" alt="image" src="https://github.com/concrete-utopia/utopia/assets/2226774/f21e19ab-1309-450b-b010-08b98246d4ef">


**Fix:**
Turns out I botched a circular reference checker, and prevented traversal if we encountered repeated simple values. but simple values are value-compared, so in the above example keyB would be considered equal to keyA and omitted.


**Commit Details:** (< vv pls delete this section if's not relevant)

- Only bail out if we encounter a known reference to an object or function.
