### PR TITLE
Fix navigator hint lines indentation

### DIFF
--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -524,7 +524,7 @@ function navigatorStructure(editorState: EditorState, deriveState: DerivedState)
   const lines = deriveState.visibleNavigatorTargets.map((target) => {
     const targetAsText = navigatorEntryToKey(target)
     let prefix: string = ''
-    const depth = navigatorDepth(target, editorState.jsxMetadata)
+    const depth = navigatorDepth(target, editorState.jsxMetadata, deriveState.navigatorRows)
     for (let index = 0; index < depth; index++) {
       prefix = prefix.concat('  ')
     }

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -65,7 +65,7 @@ import {
   DragItemTestId,
   TopDropTargetLineTestId,
 } from './navigator-item/navigator-item-dnd-container'
-import { isRegulaNavigatorRow } from './navigator-row'
+import { getEntriesForRow } from './navigator-row'
 
 const ASYNC_NOOP = async () => NO_OP()
 
@@ -526,9 +526,7 @@ function navigatorStructure(editorState: EditorState, deriveState: DerivedState)
     let prefix: string = ''
     const depth =
       deriveState.navigatorRows.find((row) =>
-        isRegulaNavigatorRow(row)
-          ? EP.pathsEqual(row.entry.elementPath, target.elementPath)
-          : row.entries.some((entry) => EP.pathsEqual(entry.elementPath, target.elementPath)),
+        EP.pathsEqual(getEntriesForRow(row)[0].elementPath, target.elementPath),
       )?.indentation ?? 0
     for (let index = 0; index < depth; index++) {
       prefix = prefix.concat('  ')

--- a/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-conditionals.spec.browser2.tsx
@@ -65,7 +65,7 @@ import {
   DragItemTestId,
   TopDropTargetLineTestId,
 } from './navigator-item/navigator-item-dnd-container'
-import { navigatorDepth } from './navigator-utils'
+import { isRegulaNavigatorRow } from './navigator-row'
 
 const ASYNC_NOOP = async () => NO_OP()
 
@@ -524,7 +524,12 @@ function navigatorStructure(editorState: EditorState, deriveState: DerivedState)
   const lines = deriveState.visibleNavigatorTargets.map((target) => {
     const targetAsText = navigatorEntryToKey(target)
     let prefix: string = ''
-    const depth = navigatorDepth(target, editorState.jsxMetadata, deriveState.navigatorRows)
+    const depth =
+      deriveState.navigatorRows.find((row) =>
+        isRegulaNavigatorRow(row)
+          ? EP.pathsEqual(row.entry.elementPath, target.elementPath)
+          : row.entries.some((entry) => EP.pathsEqual(entry.elementPath, target.elementPath)),
+      )?.indentation ?? 0
     for (let index = 0; index < depth; index++) {
       prefix = prefix.concat('  ')
     }
@@ -612,36 +617,36 @@ describe('conditionals in the navigator', () => {
       getProjectCodeTree(),
       'await-first-dom-report',
     )
-    const want = `  regular-utopia-storyboard-uid/aaa
-  regular-utopia-storyboard-uid/cond1
-    conditional-clause-utopia-storyboard-uid/cond1-true-case
-      regular-utopia-storyboard-uid/cond1/bbb
-    conditional-clause-utopia-storyboard-uid/cond1-false-case
-      synthetic-utopia-storyboard-uid/cond1/d84-attribute
-  regular-utopia-storyboard-uid/ccc
-    regular-utopia-storyboard-uid/ccc/ddd
-    regular-utopia-storyboard-uid/ccc/cond2
-      conditional-clause-utopia-storyboard-uid/ccc/cond2-true-case
-        regular-utopia-storyboard-uid/ccc/cond2/eee
-          regular-utopia-storyboard-uid/ccc/cond2/eee/cond3
-            conditional-clause-utopia-storyboard-uid/ccc/cond2/eee/cond3-true-case
-              regular-utopia-storyboard-uid/ccc/cond2/eee/cond3/fff
-            conditional-clause-utopia-storyboard-uid/ccc/cond2/eee/cond3-false-case
-              synthetic-utopia-storyboard-uid/ccc/cond2/eee/cond3/019-attribute
-          regular-utopia-storyboard-uid/ccc/cond2/eee/ggg
-      conditional-clause-utopia-storyboard-uid/ccc/cond2-false-case
-        synthetic-utopia-storyboard-uid/ccc/cond2/89b-attribute
-  regular-utopia-storyboard-uid/cond4
-    conditional-clause-utopia-storyboard-uid/cond4-true-case
-      regular-utopia-storyboard-uid/cond4/hhh
-    conditional-clause-utopia-storyboard-uid/cond4-false-case
-      synthetic-utopia-storyboard-uid/cond4/d00-attribute
-  regular-utopia-storyboard-uid/cond5
-    conditional-clause-utopia-storyboard-uid/cond5-true-case
-      regular-utopia-storyboard-uid/cond5/iii
-    conditional-clause-utopia-storyboard-uid/cond5-false-case
-      synthetic-utopia-storyboard-uid/cond5/73a-attribute
-  regular-utopia-storyboard-uid/jjj`
+    const want = `regular-utopia-storyboard-uid/aaa
+regular-utopia-storyboard-uid/cond1
+conditional-clause-utopia-storyboard-uid/cond1-true-case
+    regular-utopia-storyboard-uid/cond1/bbb
+conditional-clause-utopia-storyboard-uid/cond1-false-case
+    synthetic-utopia-storyboard-uid/cond1/d84-attribute
+regular-utopia-storyboard-uid/ccc
+  regular-utopia-storyboard-uid/ccc/ddd
+  regular-utopia-storyboard-uid/ccc/cond2
+  conditional-clause-utopia-storyboard-uid/ccc/cond2-true-case
+      regular-utopia-storyboard-uid/ccc/cond2/eee
+        regular-utopia-storyboard-uid/ccc/cond2/eee/cond3
+        conditional-clause-utopia-storyboard-uid/ccc/cond2/eee/cond3-true-case
+            regular-utopia-storyboard-uid/ccc/cond2/eee/cond3/fff
+        conditional-clause-utopia-storyboard-uid/ccc/cond2/eee/cond3-false-case
+            synthetic-utopia-storyboard-uid/ccc/cond2/eee/cond3/019-attribute
+        regular-utopia-storyboard-uid/ccc/cond2/eee/ggg
+  conditional-clause-utopia-storyboard-uid/ccc/cond2-false-case
+      synthetic-utopia-storyboard-uid/ccc/cond2/89b-attribute
+regular-utopia-storyboard-uid/cond4
+conditional-clause-utopia-storyboard-uid/cond4-true-case
+    regular-utopia-storyboard-uid/cond4/hhh
+conditional-clause-utopia-storyboard-uid/cond4-false-case
+    synthetic-utopia-storyboard-uid/cond4/d00-attribute
+regular-utopia-storyboard-uid/cond5
+conditional-clause-utopia-storyboard-uid/cond5-true-case
+    regular-utopia-storyboard-uid/cond5/iii
+conditional-clause-utopia-storyboard-uid/cond5-false-case
+    synthetic-utopia-storyboard-uid/cond5/73a-attribute
+regular-utopia-storyboard-uid/jjj`
     expect(
       navigatorStructure(
         renderResult.getEditorState().editor,
@@ -652,18 +657,18 @@ describe('conditionals in the navigator', () => {
   it('can not drag into a conditional', async () => {
     const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
 
-    const expectedNavigatorStructure = `  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
-              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`
+    const expectedNavigatorStructure = `regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`
 
     expect(
       navigatorStructure(
@@ -750,18 +755,18 @@ describe('conditionals in the navigator', () => {
         renderResult.getEditorState().editor,
         renderResult.getEditorState().derived,
       ),
-    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/019-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
+    ).toEqual(`regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/019-attribute
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
 
     // Select the entry we plan to drag.
     const elementPathToDrag = EP.fromString(
@@ -823,17 +828,17 @@ describe('conditionals in the navigator', () => {
         renderResult.getEditorState().editor,
         renderResult.getEditorState().derived,
       ),
-    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
-              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sibling-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/019-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
+    ).toEqual(`regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sibling-div
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/019-attribute
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
 
     expect(
       getConditionalCaseFromPath(
@@ -845,18 +850,18 @@ describe('conditionals in the navigator', () => {
   it('can reorder to before the conditional', async () => {
     const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
 
-    const expectedNavigatorStructure = `  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
-              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`
+    const expectedNavigatorStructure = `regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`
 
     expect(
       navigatorStructure(
@@ -927,18 +932,18 @@ describe('conditionals in the navigator', () => {
         renderResult.getEditorState().editor,
         renderResult.getEditorState().derived,
       ),
-    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
-              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
+    ).toEqual(`regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
   })
   it('dragging into an empty inactive clause, takes the place of the empty value and makes it active', async () => {
     const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
@@ -948,18 +953,18 @@ describe('conditionals in the navigator', () => {
         renderResult.getEditorState().editor,
         renderResult.getEditorState().derived,
       ),
-    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
-              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
+    ).toEqual(`regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
 
     // Select the entry we plan to drag.
     const elementPathToDrag = EP.fromString(
@@ -1019,17 +1024,17 @@ describe('conditionals in the navigator', () => {
         renderResult.getEditorState().editor,
         renderResult.getEditorState().derived,
       ),
-    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div-element-then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
-              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sibling-div
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
+    ).toEqual(`regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div-element-then-then-div
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sibling-div
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
 
     expect(
       getConditionalCaseFromPath(
@@ -1078,18 +1083,18 @@ describe('conditionals in the navigator', () => {
         renderResult.getEditorState().editor,
         renderResult.getEditorState().derived,
       ),
-    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
-              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
+    ).toEqual(`regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
 
     // Select the entry we plan to drag.
     const elementPathToDrag = EP.fromString(
@@ -1166,19 +1171,19 @@ describe('conditionals in the navigator', () => {
         renderResult.getEditorState().editor,
         renderResult.getEditorState().derived,
       ),
-    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
-              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/${removedOriginalUID}-attribute
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/else-div`)
+    ).toEqual(`regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/${removedOriginalUID}-attribute
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/else-div`)
   })
   it('dragging out of an active clause, replaces with null', async () => {
     const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
@@ -1188,18 +1193,18 @@ describe('conditionals in the navigator', () => {
         renderResult.getEditorState().editor,
         renderResult.getEditorState().derived,
       ),
-    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
-              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
+    ).toEqual(`regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
 
     // Select the entry we plan to drag.
     const elementPathToDrag = EP.fromString(
@@ -1265,19 +1270,19 @@ describe('conditionals in the navigator', () => {
         renderResult.getEditorState().editor,
         renderResult.getEditorState().derived,
       ),
-    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/${removedOriginalUID}-attribute
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/then-then-div`)
+    ).toEqual(`regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/${removedOriginalUID}-attribute
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/d84-attribute
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/then-then-div`)
   })
   it('dragging into child of an active clause, works as it would without the conditional', async () => {
     const projectCode = getProjectCodeNotEmpty()
@@ -1336,14 +1341,14 @@ describe('conditionals in the navigator', () => {
         renderResult.getEditorState().editor,
         renderResult.getEditorState().derived,
       ),
-    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/then-div
-            regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/then-div/sibling-div
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
+    ).toEqual(`regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/then-div
+        regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/then-div/sibling-div
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div`)
   })
   it('can select and delete an inactive clause', async () => {
     const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
@@ -1403,14 +1408,14 @@ describe('conditionals in the navigator', () => {
         renderResult.getEditorState().editor,
         renderResult.getEditorState().derived,
       ),
-    ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-element-conditional2
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/${removedOriginalUID}-attribute
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
+    ).toEqual(`regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-element-conditional2
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/${removedOriginalUID}-attribute
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`)
   })
   it('can be collapsed', async () => {
     const renderResult = await renderTestEditorWithCode(getProjectCode(), 'await-first-dom-report')
@@ -1498,18 +1503,18 @@ describe('conditionals in the navigator', () => {
         replaceWithSingleElement(),
       ),
       expectedToasts: [],
-      expectedNavigatorStructure: `  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
-              synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div-element-then-then-div
-            conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
-              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sib
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`,
+      expectedNavigatorStructure: `regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-true-case
+          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/then-then-div-element-then-then-div
+      conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2-false-case
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/conditional2/sib
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional1-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional1/else-div-element-else-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/sibling-div`,
       postPasteValidation: (
         pasteTestCase: PasteTestCase,
         startingEditorStore: EditorStorePatched,
@@ -1702,19 +1707,19 @@ describe('conditionals in the navigator', () => {
           renderResult.getEditorState().editor,
           renderResult.getEditorState().derived,
         ),
-      ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/dd4
-            regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/dd4/dbc~~~1
-              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/dd4/dbc~~~1/58f
-            regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/dd4/dbc~~~2
-              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/dd4/dbc~~~2/58f
-            regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/dd4/dbc~~~3
-              regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/dd4/dbc~~~3/58f
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional/else-div-element-else-div`)
+      ).toEqual(`regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/dd4
+        regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/dd4/dbc~~~1
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/dd4/dbc~~~1/58f
+        regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/dd4/dbc~~~2
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/dd4/dbc~~~2/58f
+        regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/dd4/dbc~~~3
+          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/dd4/dbc~~~3/58f
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional/else-div-element-else-div`)
     })
     it('keeps the right order for inlined map expressions with multiple values (null inactive branch)', async () => {
       const renderResult = await renderTestEditorWithCode(
@@ -1727,21 +1732,21 @@ describe('conditionals in the navigator', () => {
           renderResult.getEditorState().editor,
           renderResult.getEditorState().derived,
         ),
-      ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/505
-            regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/505/7d5~~~1
-            regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/505/7d5~~~2
-            regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/505/7d5~~~3
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional/d84-attribute
-    regular-utopia-storyboard-uid/scene-aaa/268
-      regular-utopia-storyboard-uid/scene-aaa/268/5d1~~~1
-      regular-utopia-storyboard-uid/scene-aaa/268/5d1~~~2
-      regular-utopia-storyboard-uid/scene-aaa/268/5d1~~~3
-    regular-utopia-storyboard-uid/scene-aaa/hey`)
+      ).toEqual(`regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/505
+        regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/505/7d5~~~1
+        regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/505/7d5~~~2
+        regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/505/7d5~~~3
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional/d84-attribute
+regular-utopia-storyboard-uid/scene-aaa/268
+  regular-utopia-storyboard-uid/scene-aaa/268/5d1~~~1
+  regular-utopia-storyboard-uid/scene-aaa/268/5d1~~~2
+  regular-utopia-storyboard-uid/scene-aaa/268/5d1~~~3
+regular-utopia-storyboard-uid/scene-aaa/hey`)
     })
     it('keeps the right order for inlined map expressions with multiple values (not-null inactive branch)', async () => {
       const renderResult = await renderTestEditorWithCode(
@@ -1754,21 +1759,21 @@ describe('conditionals in the navigator', () => {
           renderResult.getEditorState().editor,
           renderResult.getEditorState().derived,
         ),
-      ).toEqual(`  regular-utopia-storyboard-uid/scene-aaa
-    regular-utopia-storyboard-uid/scene-aaa/containing-div
-      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-true-case
-          regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/50c
-            regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/50c/46b~~~1
-            regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/50c/46b~~~2
-            regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/50c/46b~~~3
-        conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-false-case
-          synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional/false-branch-element-false-branch
-    regular-utopia-storyboard-uid/scene-aaa/268
-      regular-utopia-storyboard-uid/scene-aaa/268/981~~~1
-      regular-utopia-storyboard-uid/scene-aaa/268/981~~~2
-      regular-utopia-storyboard-uid/scene-aaa/268/981~~~3
-    regular-utopia-storyboard-uid/scene-aaa/hey`)
+      ).toEqual(`regular-utopia-storyboard-uid/scene-aaa
+regular-utopia-storyboard-uid/scene-aaa/containing-div
+  regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-true-case
+      regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/50c
+        regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/50c/46b~~~1
+        regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/50c/46b~~~2
+        regular-utopia-storyboard-uid/scene-aaa/containing-div/conditional/50c/46b~~~3
+  conditional-clause-utopia-storyboard-uid/scene-aaa/containing-div/conditional-false-case
+      synthetic-utopia-storyboard-uid/scene-aaa/containing-div/conditional/false-branch-element-false-branch
+regular-utopia-storyboard-uid/scene-aaa/268
+  regular-utopia-storyboard-uid/scene-aaa/268/981~~~1
+  regular-utopia-storyboard-uid/scene-aaa/268/981~~~2
+  regular-utopia-storyboard-uid/scene-aaa/268/981~~~3
+regular-utopia-storyboard-uid/scene-aaa/hey`)
     })
   })
 })

--- a/editor/src/components/navigator/navigator-drag-layer.tsx
+++ b/editor/src/components/navigator/navigator-drag-layer.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useDragLayer } from 'react-dnd'
-import type { RegularNavigatorEntry } from '../editor/store/editor-state'
-import { navigatorEntryToKey, regularNavigatorEntry } from '../editor/store/editor-state'
+import { regularNavigatorEntry } from '../editor/store/editor-state'
 import {
   NavigatorItemDragType,
   type NavigatorItemDragAndDropWrapperProps,
@@ -13,21 +12,7 @@ import { NO_OP } from '../../core/shared/utils'
 import { colorTheme, FlexRow, Icn } from '../../uuiui'
 import { useLayoutOrElementIcon } from './layout-element-icons'
 import { emptyElementPath } from '../../core/shared/element-path'
-import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
-import { navigatorDepth } from './navigator-utils'
 import { getElementPadding } from './navigator-item/navigator-item'
-import { metadataSelector } from '../inspector/inpector-selectors'
-import createCachedSelector from 're-reselect'
-import type { MetadataSubstate } from '../editor/store/store-hook-substore-types'
-import type { NavigatorRow } from './navigator-row'
-
-const depthSelector = createCachedSelector(
-  metadataSelector,
-  (_: MetadataSubstate, rows: NavigatorRow[]) => rows,
-  (_: MetadataSubstate, __rows: NavigatorRow[], navigatorEntry: RegularNavigatorEntry) =>
-    navigatorEntry,
-  (metadata, rows, navigatorEntry) => navigatorDepth(navigatorEntry, metadata, rows) + 1,
-)((_, __, navigatorEntry) => navigatorEntryToKey(navigatorEntry))
 
 export const NavigatorDragLayer = React.memo(() => {
   const { item, initialOffset, difference } = useDragLayer((monitor) => ({
@@ -45,14 +30,6 @@ export const NavigatorDragLayer = React.memo(() => {
 
   const draggedItemIsNavigatorItem = item != null && item.type === NavigatorItemDragType
   const hidden = !draggedItemIsNavigatorItem
-
-  const navigatorRows = useRefEditorState((store) => store.derived.navigatorRows)
-
-  const entryNavigatorDepth = useEditorState(
-    Substores.metadata,
-    (store) => depthSelector(store, navigatorRows.current, navigatorEntry),
-    'NavigatorDragLayer metadata',
-  )
 
   const offset = windowPoint({
     x: initialOffset.x + difference.x - (containerRef.current?.getBoundingClientRect()?.x ?? 0),
@@ -78,7 +55,7 @@ export const NavigatorDragLayer = React.memo(() => {
     >
       <FlexRow
         style={{
-          paddingLeft: getElementPadding(entryNavigatorDepth),
+          paddingLeft: getElementPadding(item.indentation),
           width: '300px',
           transform: `translate(${offset.x}px, ${offset.y}px)`,
           fontWeight: 600,

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -382,7 +382,7 @@ function onHoverDropTargetLine(
       regularNavigatorEntry(propsOfDropTargetItem.elementPath),
     )
 
-    const maximumTargetDepth = baseNavigatorDepth(propsOfDraggedItem.elementPath) // this differs from the `indentation` prop as it needs to be calculated on the actual path length
+    const maximumTargetDepth = baseNavigatorDepth(propsOfDropTargetItem.elementPath) // this differs from the `indentation` prop as it needs to be calculated on the actual path length
     const cursorTargetDepth = 1 + Math.floor(Math.abs(cursorDelta.x) / WiggleUnit)
 
     const nPathPartsToDrop = Math.min(

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -559,7 +559,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
   const navigatorTargets = useEditorState(
     Substores.derived,
     (store) => store.derived.navigatorTargets,
-    'NavigatorItemDndWrapper moveToElementPath',
+    'NavigatorItemDndWrapper navigatorTargets',
   )
 
   const isFirstSibling = React.useMemo(() => {

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -382,7 +382,7 @@ function onHoverDropTargetLine(
       regularNavigatorEntry(propsOfDropTargetItem.elementPath),
     )
 
-    const maximumTargetDepth = propsOfDropTargetItem.indentation
+    const maximumTargetDepth = baseNavigatorDepth(propsOfDraggedItem.elementPath) // this differs from the `indentation` prop as it needs to be calculated on the actual path length
     const cursorTargetDepth = 1 + Math.floor(Math.abs(cursorDelta.x) / WiggleUnit)
 
     const nPathPartsToDrop = Math.min(

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -562,6 +562,8 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
     'NavigatorItemDndWrapper navigatorTargets',
   )
 
+  const navigatorRows = useRefEditorState((store) => store.derived.navigatorRows)
+
   const isFirstSibling = React.useMemo(() => {
     const siblings = MetadataUtils.getSiblingsOrdered(
       editorStateRef.current.jsxMetadata,
@@ -801,7 +803,11 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
     }
 
     return getHintPaddingForDepth(
-      navigatorDepth(dropTargetHint.targetParent, editorStateRef.current.jsxMetadata),
+      navigatorDepth(
+        dropTargetHint.targetParent,
+        editorStateRef.current.jsxMetadata,
+        navigatorRows.current,
+      ),
     )
   })()
 

--- a/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-dnd-container.tsx
@@ -18,7 +18,6 @@ import {
 import type {
   AllElementProps,
   ConditionalClauseNavigatorEntry,
-  DerivedState,
   DropTargetHint,
   DropTargetType,
   EditorState,
@@ -31,7 +30,6 @@ import {
   regularNavigatorEntry,
   renderPropNavigatorEntry,
   slotNavigatorEntry,
-  syntheticNavigatorEntry,
   varSafeNavigatorEntryToKey,
 } from '../../editor/store/editor-state'
 import {
@@ -47,7 +45,7 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { getEmptyImage } from 'react-dnd-html5-backend'
 import { when } from '../../../utils/react-conditionals'
 import { metadataSelector } from '../../inspector/inpector-selectors'
-import { baseNavigatorDepth, navigatorDepth } from '../navigator-utils'
+import { baseNavigatorDepth } from '../navigator-utils'
 import type {
   ElementInstanceMetadataMap,
   JSXElementChild,
@@ -66,7 +64,7 @@ import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import { useAtom, atom } from 'jotai'
 import { AlwaysFalse, usePubSubAtomReadOnly } from '../../../core/shared/atom-with-pub-sub'
 import type { CanvasPoint } from '../../../core/shared/math-utils'
-import { canvasPoint, zeroCanvasPoint } from '../../../core/shared/math-utils'
+import { zeroCanvasPoint } from '../../../core/shared/math-utils'
 import { createNavigatorReparentPostActionActions } from '../../canvas/canvas-strategies/post-action-options/post-action-options'
 import createCachedSelector from 're-reselect'
 import type { MetadataSubstate } from '../../editor/store/store-hook-substore-types'
@@ -102,7 +100,6 @@ export interface NavigatorItemDragAndDropWrapperPropsBase {
   type: typeof NavigatorItemDragType
   index: number
   indentation: number
-  entryDepth: number
   appropriateDropTargetHint: DropTargetHint | null
   editorDispatch: EditorDispatch
   selected: boolean
@@ -384,7 +381,7 @@ function onHoverDropTargetLine(
       regularNavigatorEntry(propsOfDropTargetItem.elementPath),
     )
 
-    const maximumTargetDepth = propsOfDropTargetItem.entryDepth
+    const maximumTargetDepth = propsOfDropTargetItem.indentation
     const cursorTargetDepth = 1 + Math.floor(Math.abs(cursorDelta.x) / WiggleUnit)
 
     const nPathPartsToDrop = Math.min(
@@ -561,8 +558,6 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
     (store) => store.derived.navigatorTargets,
     'NavigatorItemDndWrapper navigatorTargets',
   )
-
-  const navigatorRows = useRefEditorState((store) => store.derived.navigatorRows)
 
   const isFirstSibling = React.useMemo(() => {
     const siblings = MetadataUtils.getSiblingsOrdered(
@@ -802,13 +797,7 @@ export const NavigatorItemContainer = React.memo((props: NavigatorItemDragAndDro
       return 0
     }
 
-    return getHintPaddingForDepth(
-      navigatorDepth(
-        dropTargetHint.targetParent,
-        editorStateRef.current.jsxMetadata,
-        navigatorRows.current,
-      ),
-    )
+    return getHintPaddingForDepth(props.indentation)
   })()
 
   const parentOutline = React.useMemo((): ParentOutline => {

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -29,7 +29,7 @@ import {
   navigatorEntriesEqual,
   navigatorEntryToKey,
 } from '../../editor/store/editor-state'
-import { Substores, useEditorState, useRefEditorState } from '../../editor/store/store-hook'
+import { Substores, useEditorState } from '../../editor/store/store-hook'
 import type {
   DerivedSubstate,
   MetadataSubstate,
@@ -37,7 +37,6 @@ import type {
   PropertyControlsInfoSubstate,
 } from '../../editor/store/store-hook-substore-types'
 import { isRegulaNavigatorRow, type NavigatorRow } from '../navigator-row'
-import { navigatorDepth } from '../navigator-utils'
 import type {
   ConditionalClauseNavigatorItemContainerProps,
   ErrorNavigatorItemContainerProps,
@@ -325,16 +324,6 @@ const SingleEntryNavigatorItemWrapper: React.FunctionComponent<
   )
   const label = getNavigatorEntryLabel(props.navigatorEntry, labelForTheElement)
 
-  const rows = useRefEditorState((store) => store.derived.navigatorRows)
-
-  const entryDepth = useEditorState(
-    Substores.metadata,
-    (store) => {
-      return navigatorDepth(props.navigatorEntry, store.editor.jsxMetadata, rows.current)
-    },
-    'NavigatorItemWrapper entryDepth',
-  )
-
   const visibleNavigatorTargets = useEditorState(
     Substores.derived,
     (store) => store.derived.visibleNavigatorTargets,
@@ -382,7 +371,6 @@ const SingleEntryNavigatorItemWrapper: React.FunctionComponent<
     index: props.index,
     indentation: props.indentation,
     editorDispatch: dispatch,
-    entryDepth: entryDepth,
     selected: isSelected,
     highlighted: isHighlighted,
     collapsed: isCollapsed,

--- a/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
+++ b/editor/src/components/navigator/navigator-item/navigator-item-wrapper.tsx
@@ -29,7 +29,7 @@ import {
   navigatorEntriesEqual,
   navigatorEntryToKey,
 } from '../../editor/store/editor-state'
-import { Substores, useEditorState } from '../../editor/store/store-hook'
+import { Substores, useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 import type {
   DerivedSubstate,
   MetadataSubstate,
@@ -325,10 +325,12 @@ const SingleEntryNavigatorItemWrapper: React.FunctionComponent<
   )
   const label = getNavigatorEntryLabel(props.navigatorEntry, labelForTheElement)
 
+  const rows = useRefEditorState((store) => store.derived.navigatorRows)
+
   const entryDepth = useEditorState(
     Substores.metadata,
     (store) => {
-      return navigatorDepth(props.navigatorEntry, store.editor.jsxMetadata)
+      return navigatorDepth(props.navigatorEntry, store.editor.jsxMetadata, rows.current)
     },
     'NavigatorItemWrapper entryDepth',
   )

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -75,6 +75,7 @@ export function navigatorDepth(
   let result: number = baseNavigatorDepth(path)
 
   for (const ancestorPath of EP.getAncestors(path)) {
+    // if the ancestor is a condensed row, indent back
     const condensedAncestorRoot = navigatorRows.find(
       (row) =>
         isCondensedNavigatorRow(row) && EP.pathsEqual(row.entries[0].elementPath, ancestorPath),
@@ -85,12 +86,15 @@ export function navigatorDepth(
 
     const elementMetadata = MetadataUtils.findElementByElementPath(metadata, ancestorPath)
     if (elementMetadata != null) {
+      // if the ancestor is a scene, indent back
       if (
         MetadataUtils.isProbablySceneFromMetadata(elementMetadata) ||
         MetadataUtils.isProbablyRemixSceneFromMetadata(elementMetadata)
       ) {
         result = result - 1
       }
+
+      // if the ancestor is a conditional, indent forward
       const isConditional = foldEither(
         () => false,
         (e) => isJSXConditionalExpression(e),
@@ -107,6 +111,7 @@ export function navigatorDepth(
     result = result + 1
   }
 
+  // if the element itself is a scene, indent back as well
   if (
     MetadataUtils.isProbablyScene(metadata, navigatorEntry.elementPath) ||
     MetadataUtils.isProbablyRemixScene(metadata, navigatorEntry.elementPath)
@@ -114,6 +119,7 @@ export function navigatorDepth(
     result = result - 1
   }
 
+  // make sure 0 is the minimum indentation no matter what
   return Math.max(0, result)
 }
 

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -85,9 +85,16 @@ export function navigatorDepth(
 ): number {
   const path = navigatorEntry.elementPath
   let result: number = baseNavigatorDepth(path)
+
   for (const ancestorPath of EP.getAncestors(path)) {
     const elementMetadata = MetadataUtils.findElementByElementPath(metadata, ancestorPath)
     if (elementMetadata != null) {
+      if (
+        MetadataUtils.isProbablySceneFromMetadata(elementMetadata) ||
+        MetadataUtils.isProbablyRemixSceneFromMetadata(elementMetadata)
+      ) {
+        result = result - 1
+      }
       const isConditional = foldEither(
         () => false,
         (e) => isJSXConditionalExpression(e),
@@ -104,7 +111,14 @@ export function navigatorDepth(
     result = result + 1
   }
 
-  return result
+  if (
+    MetadataUtils.isProbablyScene(metadata, navigatorEntry.elementPath) ||
+    MetadataUtils.isProbablyRemixScene(metadata, navigatorEntry.elementPath)
+  ) {
+    result = result - 1
+  }
+
+  return Math.max(0, result)
 }
 
 type RegularNavigatorTree = {

--- a/editor/src/components/navigator/navigator-utils.ts
+++ b/editor/src/components/navigator/navigator-utils.ts
@@ -79,11 +79,8 @@ export function navigatorDepth(
       (row) =>
         isCondensedNavigatorRow(row) && EP.pathsEqual(row.entries[0].elementPath, ancestorPath),
     )
-    if (
-      condensedAncestorRoot != null &&
-      (condensedAncestorRoot as CondensedNavigatorRow).entries.length > 1
-    ) {
-      result = result - 1
+    if (condensedAncestorRoot != null) {
+      result = result - ((condensedAncestorRoot as CondensedNavigatorRow).entries.length - 1)
     }
 
     const elementMetadata = MetadataUtils.findElementByElementPath(metadata, ancestorPath)


### PR DESCRIPTION
**Problem:**

Navigator drag and drop hints are not always indented correctly.

**Fix:**

Use the row/item's `indentation` prop directly, and remove outdated code.

Before/after:


https://github.com/concrete-utopia/utopia/assets/1081051/aa022f06-af30-4ce7-a17b-77047723fe89



**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5938 
