### PR TITLE
Add grayscale/opacity css to the segment controls

### DIFF
--- a/editor/src/components/inspector/controls/option-control.tsx
+++ b/editor/src/components/inspector/controls/option-control.tsx
@@ -162,8 +162,18 @@ export const OptionControl: React.FunctionComponent<
               rc === 'all' || rc === 'left' || rc === 'bottomLeft' || rc === 'bottom'
                 ? UtopiaTheme.inputBorderRadius
                 : undefined,
+
+            filter: isChecked && props.controlStatus !== 'disabled' ? undefined : 'grayscale(1)',
             '&:hover': {
               opacity: props.controlStatus == 'disabled' ? undefined : controlOpacity + 0.2,
+              filter: props.controlStatus == 'disabled' ? undefined : 'grayscale(0)',
+            },
+
+            '.control-option-icon-component': {
+              opacity: 0.5,
+            },
+            '&:hover .control-option-icon-component': {
+              opacity: 1,
             },
             '&:active': {
               opacity: props.controlStatus == 'disabled' ? undefined : 1,
@@ -191,6 +201,7 @@ export const OptionControl: React.FunctionComponent<
               display: 'flex',
               justifyContent: 'center',
               alignItems: 'center',
+              gap: 4,
             }}
           >
             {controlOptions.icon != null ? (
@@ -199,7 +210,9 @@ export const OptionControl: React.FunctionComponent<
                 {...controlOptions.icon}
               />
             ) : (
-              controlOptions.iconComponent ?? null
+              <div className='control-option-icon-component'>
+                {controlOptions.iconComponent ?? null}
+              </div>
             )}
             {controlOptions.labelInner != null ? controlOptions.labelInner : null}
           </div>


### PR DESCRIPTION
**Problem:**
https://github.com/concrete-utopia/utopia/issues/5908

**Fix:**
https://screenshot.click/14-08-lg988-d8r7h.mp4

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
