### PR TITLE
Data Picker Simpler Property Accessors 

### DIFF
--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.spec.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.spec.ts
@@ -54,7 +54,7 @@ describe('orderVariablesForRelevance', () => {
           "matches": "child-matches",
           "props": Array [
             Object {
-              "expression": "style['left']",
+              "expression": "style.left",
               "expressionPathPart": "left",
               "insertionCeiling": Object {
                 "parts": Array [
@@ -69,7 +69,7 @@ describe('orderVariablesForRelevance', () => {
               "value": 300,
             },
             Object {
-              "expression": "style['position']",
+              "expression": "style.position",
               "expressionPathPart": "position",
               "insertionCeiling": Object {
                 "parts": Array [
@@ -141,7 +141,7 @@ describe('orderVariablesForRelevance', () => {
           "matches": "matches",
           "props": Array [
             Object {
-              "expression": "style['left']",
+              "expression": "style.left",
               "expressionPathPart": "left",
               "insertionCeiling": Object {
                 "parts": Array [
@@ -156,7 +156,7 @@ describe('orderVariablesForRelevance', () => {
               "value": 300,
             },
             Object {
-              "expression": "style['position']",
+              "expression": "style.position",
               "expressionPathPart": "position",
               "insertionCeiling": Object {
                 "parts": Array [

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -290,7 +290,7 @@ export function variableInfoFromValue(
         matches: 'does-not-match',
         props: mapDropNulls(([key, propValue]) => {
           return variableInfoFromValue(
-            `${expression}['${key}']`,
+            createPropertyAccessExpressionString(expression, key),
             key,
             propValue,
             insertionCeiling,
@@ -309,6 +309,17 @@ function variableInfoFromVariableData(variableNamesInScope: VariableData): Array
   )
 
   return info
+}
+
+const varSafeStringRegex = /[\p{L}\p{Nl}$\p{Mn}\p{Mc}\p{Nd}\p{Pc}]*$/
+
+function createPropertyAccessExpressionString(expressionSoFar: string, toAppend: string): string {
+  const toAppendIsVarsafeString = varSafeStringRegex.test(toAppend)
+  if (toAppendIsVarsafeString) {
+    return `${expressionSoFar}.${toAppend}`
+  } else {
+    return `${expressionSoFar}['${toAppend}']`
+  }
 }
 
 function getTargetPropertyFromControlDescription(

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -311,7 +311,7 @@ function variableInfoFromVariableData(variableNamesInScope: VariableData): Array
   return info
 }
 
-const varSafeStringRegex = /[\p{L}\p{Nl}$\p{Mn}\p{Mc}\p{Nd}\p{Pc}]*$/
+const varSafeStringRegex = /^[a-zA-Z_$][0-9a-zA-Z_$]*$/
 
 function createPropertyAccessExpressionString(expressionSoFar: string, toAppend: string): string {
   const toAppendIsVarsafeString = varSafeStringRegex.test(toAppend)


### PR DESCRIPTION
**Problem:**
The data picker would generate code such as
`reviews['references']['nodes'][0]['id']` which is hard to read and does not pass our bar of trying to write code a real developer would write.

**Fix:**
Using a simple regex from here https://stackoverflow.com/questions/1661197/what-characters-are-valid-for-javascript-variable-names, we test if the property accessor name is trivially safe. if it is safe, we append it with a `.id`. if it's not safe, we append it as `['id']`. We keep array element accesses as number.

**Result:**
`reviews.references.nodes[0].id` – this is how I would write it too!