### PR TITLE
Handle Padding Indicator Scaling

### DIFF
--- a/editor/src/components/canvas/controls/distance-guideline.tsx
+++ b/editor/src/components/canvas/controls/distance-guideline.tsx
@@ -124,14 +124,14 @@ export class DistanceGuideline extends React.Component<DistanceGuidelineProps> {
     return (
       <CanvasOffsetWrapper>
         <div
-          key={id}
+          data-testid={`distance-text-container-${id}`}
           style={{
             visibility: distance > 0 ? 'visible' : 'hidden',
             position: 'absolute',
-            top: Math.min(from.y, to.y),
-            left: Math.min(from.x, to.x),
-            width: isHorizontal ? Math.abs(from.x - to.x) : undefined,
-            height: isHorizontal ? undefined : Math.abs(from.y - to.y),
+            top: Math.min(from.y, to.y) + (isHorizontal ? 4 : 0), // Offset by 4px to keep the control off the line.
+            left: Math.min(from.x, to.x) + (isHorizontal ? 0 : 4), // Offset by 4px to keep the control off the line.
+            width: isHorizontal ? Math.abs(from.x - to.x) : `max-content`,
+            height: isHorizontal ? `max-content` : Math.abs(from.y - to.y),
             pointerEvents: 'none',
             display: 'flex',
             flexDirection: isHorizontal ? 'row' : 'column',
@@ -140,13 +140,15 @@ export class DistanceGuideline extends React.Component<DistanceGuidelineProps> {
         >
           <div
             style={{
-              margin: 4 / this.props.scale,
-              paddingLeft: 4 / this.props.scale,
-              paddingRight: 4 / this.props.scale,
-              borderRadius: 4 / this.props.scale,
+              padding: `0 ${2 / this.props.scale}`,
+              borderRadius: 2 / this.props.scale,
               color: colorTheme.white.value,
               backgroundColor: StrokeColor,
               fontSize: 11 / this.props.scale,
+              width: 'min-content',
+              display: 'flex',
+              alignItems: 'center',
+              height: `${16 / this.props.scale}px`,
             }}
             data-testid={id}
           >

--- a/editor/src/components/canvas/controls/distance-guideline.tsx
+++ b/editor/src/components/canvas/controls/distance-guideline.tsx
@@ -140,7 +140,7 @@ export class DistanceGuideline extends React.Component<DistanceGuidelineProps> {
         >
           <div
             style={{
-              padding: `0 ${2 / this.props.scale}`,
+              padding: `0px ${2.5 / this.props.scale}px`,
               borderRadius: 2 / this.props.scale,
               color: colorTheme.white.value,
               backgroundColor: StrokeColor,
@@ -148,6 +148,7 @@ export class DistanceGuideline extends React.Component<DistanceGuidelineProps> {
               width: 'min-content',
               display: 'flex',
               alignItems: 'center',
+              minHeight: `${16 / this.props.scale}px`,
               height: `${16 / this.props.scale}px`,
             }}
             data-testid={id}

--- a/editor/src/components/canvas/controls/distance-guideline.tsx
+++ b/editor/src/components/canvas/controls/distance-guideline.tsx
@@ -128,8 +128,8 @@ export class DistanceGuideline extends React.Component<DistanceGuidelineProps> {
           style={{
             visibility: distance > 0 ? 'visible' : 'hidden',
             position: 'absolute',
-            top: Math.min(from.y, to.y) + (isHorizontal ? 4 : 0), // Offset by 4px to keep the control off the line.
-            left: Math.min(from.x, to.x) + (isHorizontal ? 0 : 4), // Offset by 4px to keep the control off the line.
+            top: Math.min(from.y, to.y) + (isHorizontal ? 4 : 0) / this.props.scale, // Offset by 4px to keep the control off the line.
+            left: Math.min(from.x, to.x) + (isHorizontal ? 0 : 4) / this.props.scale, // Offset by 4px to keep the control off the line.
             width: isHorizontal ? Math.abs(from.x - to.x) : `max-content`,
             height: isHorizontal ? `max-content` : Math.abs(from.y - to.y),
             pointerEvents: 'none',


### PR DESCRIPTION
**Problem:**
Padding indicators at 50% zoom render incorrectly.

**Fix:**
The two divs that wrap around the padding value have been adjusted to properly wrap around the content and size appropriately with the scaling in either direction.

**Screenshots:**
![image](https://github.com/concrete-utopia/utopia/assets/217400/ebba575c-bab7-4252-9f62-5c9bc11a9c70)
![image](https://github.com/concrete-utopia/utopia/assets/217400/ad331e39-b277-4da7-b8d7-0dcb0db8181d)
![image](https://github.com/concrete-utopia/utopia/assets/217400/f4c4b6da-5ed7-41a2-8cc0-2503f06b25f1)

**Commit Details:**
- Reworked a lot of the position and size properties for the two divs that wrap around the padding value itself.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5937
