### PR TITLE
Disabling flaky "Does not update the metadata in select mode"

### DIFF
--- a/editor/src/components/canvas/dom-walker.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-walker.spec.browser2.tsx
@@ -526,7 +526,7 @@ describe('Observing runtime changes', () => {
     expect(metadataAfter).not.toBeNull()
   })
 
-  it('Does not update the metadata in select mode', async () => {
+  xit('Does not update the metadata in select mode', async () => {
     const renderResult = await renderTestEditorWithCode(
       changingProjectCode,
       'await-first-dom-report',


### PR DESCRIPTION
**Problem:**
the observer test "Does not update the metadata in select mode" is flaky.

I am disabling it for now, and making a follow up ticket to re-enable and debug it.

I have a suspicion that it became flaky with #5838 but I did not verify this, just basing the hunch on the tests's name.

