### PR TITLE
Feat/zipball remote updates

### DIFF
--- a/editor/src/components/editor/server.ts
+++ b/editor/src/components/editor/server.ts
@@ -708,6 +708,8 @@ type GetBranchProjectContentsRequest = {
   type: 'GET_BRANCH_PROJECT_CONTENTS_REQUEST'
   existingAssets: ExistingAsset[] | null
   uploadAssets: boolean
+  previousCommitSha: string | null
+  specificCommitSha: string | null
 }
 
 function getBranchProjectContentsRequest(
@@ -725,6 +727,8 @@ export function getBranchProjectContents(operationContext: GithubOperationContex
     owner: string
     repo: string
     branch: string
+    previousCommitSha: string | null
+    specificCommitSha: string | null
     existingAssets: ExistingAsset[]
   }): Promise<GetBranchContentResponse> {
     const url = GithubEndpoints.getBranchProjectContents({
@@ -742,6 +746,8 @@ export function getBranchProjectContents(operationContext: GithubOperationContex
         getBranchProjectContentsRequest({
           existingAssets: params.existingAssets,
           uploadAssets: true,
+          previousCommitSha: params.previousCommitSha,
+          specificCommitSha: params.specificCommitSha,
         }),
       ),
     })

--- a/editor/src/components/navigator/left-pane/github-pane/index.tsx
+++ b/editor/src/components/navigator/left-pane/github-pane/index.tsx
@@ -1213,10 +1213,20 @@ export const GithubPane = React.memo(() => {
 
   const [refreshingGithubData, setRefreshingGithubData] = React.useState(false)
 
+  const projectId = useEditorState(
+    Substores.restOfEditor,
+    (store) => store.editor.id,
+    'GithubPane projectId',
+  )
+
   const onClickRefresh = React.useCallback(() => {
+    if (projectId == null) {
+      return
+    }
     setRefreshingGithubData(true)
     void refreshGithubData(
       dispatch,
+      projectId,
       githubData.targetRepository,
       githubData.branchName,
       branchOriginContentsChecksums,
@@ -1227,7 +1237,7 @@ export const GithubPane = React.memo(() => {
     ).finally(() => {
       setRefreshingGithubData(false)
     })
-  }, [dispatch, githubData, branchOriginContentsChecksums])
+  }, [dispatch, githubData, branchOriginContentsChecksums, projectId])
 
   return (
     <div style={{ height: '100%', overflowY: 'scroll' }} onFocus={onFocus}>

--- a/editor/src/core/shared/github/github.spec.ts
+++ b/editor/src/core/shared/github/github.spec.ts
@@ -90,6 +90,7 @@ describe('github helpers', () => {
 
         const got = await getRefreshGithubActions(
           mockDispatch,
+          'project-id',
           null,
           null,
           null,
@@ -146,6 +147,7 @@ describe('github helpers', () => {
 
         const got = await getRefreshGithubActions(
           mockDispatch,
+          'project-id',
           { owner: 'foo', repository: 'bar' },
           null,
           null,
@@ -201,6 +203,7 @@ describe('github helpers', () => {
 
         const got = await getRefreshGithubActions(
           mockDispatch,
+          'project-id',
           { owner: 'foo', repository: 'bar' },
           null,
           null,

--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -115,7 +115,7 @@ export interface BranchContent {
 
 export interface GetBranchContentSuccess {
   type: 'SUCCESS'
-  branch: BranchContent
+  branch: BranchContent | null
   noChanges: boolean
 }
 
@@ -1118,9 +1118,8 @@ async function updateUpstreamChanges(
       specificCommitSha: null,
     })
     if (branchContentResponse.type === 'SUCCESS') {
-      if (branchContentResponse.noChanges) {
-        upstreamChangesSuccess = true
-      } else {
+      upstreamChangesSuccess = true
+      if (branchContentResponse.branch != null) {
         const branchLatestChecksums = getProjectContentsChecksums(
           branchContentResponse.branch.content,
           {},

--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -13,6 +13,7 @@ import {
   isProjectContentFile,
   projectContentDirectory,
   projectContentFile,
+  walkContentsTree,
 } from '../../../components/assets'
 import { notice } from '../../../components/common/notice'
 import type { EditorAction, EditorDispatch } from '../../../components/editor/action-types'
@@ -70,6 +71,8 @@ import { GithubEndpoints } from './endpoints'
 import { getAllComponentDescriptorFilePaths } from '../../property-controls/property-controls-local'
 import React from 'react'
 import { useDispatch } from '../../../components/editor/store/dispatch-context'
+import type { ExistingAsset } from '../../../components/editor/server'
+import { getBranchProjectContents } from '../../../components/editor/server'
 
 export function dispatchPromiseActions(
   dispatch: EditorDispatch,
@@ -112,7 +115,8 @@ export interface BranchContent {
 
 export interface GetBranchContentSuccess {
   type: 'SUCCESS'
-  branch: BranchContent | null
+  branch: BranchContent
+  noChanges: boolean
 }
 
 export type GetBranchContentResponse = GetBranchContentSuccess | GithubFailure
@@ -293,7 +297,8 @@ export function connectRepo(
   ]
 }
 
-export async function getBranchContentFromServer(
+// TODO Remove this once we're positive it's all working fine with the replacement getBranchProjectContents
+export async function getBranchContentFromServer_DEPRECATED(
   githubRepo: GithubRepo,
   branchName: string | null,
   commitSha: string | null,
@@ -896,10 +901,20 @@ export function useGithubPolling() {
     (store) => store.derived.branchOriginContentsChecksums,
     'useGithubPolling branchOriginContentsChecksums',
   )
+  const projectId = useEditorState(
+    Substores.restOfEditor,
+    (store) => store.editor.id,
+    'useGithubPolling projectId',
+  )
 
   const refreshAndScheduleGithubData = React.useCallback(async () => {
+    if (projectId == null) {
+      return
+    }
+
     await refreshGithubData(
       dispatch,
+      projectId,
       githubData.targetRepository,
       githubData.branchName,
       branchOriginContentsChecksums,
@@ -916,7 +931,7 @@ export function useGithubPolling() {
     //     setTick((t) => t + 1)
     //   }, GITHUB_REFRESH_INTERVAL_MILLISECONDS),
     // )
-  }, [dispatch, branchOriginContentsChecksums, githubData])
+  }, [dispatch, branchOriginContentsChecksums, githubData, projectId])
 
   const authState = React.useMemo((): GithubAuthState => {
     if (!githubAuthenticated) {
@@ -981,6 +996,7 @@ export function useGithubPolling() {
 
 export async function getRefreshGithubActions(
   dispatch: EditorDispatch,
+  projectId: string,
   githubRepo: GithubRepo | null,
   branchName: string | null,
   branchOriginChecksums: FileChecksumsWithFile | null,
@@ -1015,6 +1031,7 @@ export async function getRefreshGithubActions(
         if (originCommitSha != null) {
           // 3. get the checksums
           const checksums = await getBranchChecksums(operationContext)(
+            projectId,
             githubRepo,
             branchName,
             originCommitSha,
@@ -1034,6 +1051,7 @@ export async function getRefreshGithubActions(
     }
     // 5. finally update upstream changes
     const upstreamChanges = await updateUpstreamChanges(
+      projectId,
       branchName,
       branchOriginChecksums,
       githubRepo,
@@ -1050,6 +1068,7 @@ export async function getRefreshGithubActions(
 
 export async function refreshGithubData(
   dispatch: EditorDispatch,
+  projectId: string,
   githubRepo: GithubRepo | null,
   branchName: string | null,
   branchOriginChecksums: FileChecksumsWithFile | null,
@@ -1061,6 +1080,7 @@ export async function refreshGithubData(
   try {
     const actions = await getRefreshGithubActions(
       dispatch,
+      projectId,
       githubRepo,
       branchName,
       branchOriginChecksums,
@@ -1078,6 +1098,7 @@ export async function refreshGithubData(
 }
 
 async function updateUpstreamChanges(
+  projectId: string,
   branchName: string | null,
   branchOriginChecksums: FileChecksumsWithFile | null,
   githubRepo: GithubRepo,
@@ -1087,19 +1108,21 @@ async function updateUpstreamChanges(
   const actions: Array<EditorAction> = []
   let upstreamChangesSuccess = false
   if (branchName != null && branchOriginChecksums != null) {
-    const branchContentResponse = await getBranchContentFromServer(
-      githubRepo,
-      branchName,
-      null,
-      previousCommitSha,
-      operationContext,
-    )
-    if (branchContentResponse.ok) {
-      const branchLatestContent: GetBranchContentResponse = await branchContentResponse.json()
-      if (branchLatestContent.type === 'SUCCESS' && branchLatestContent.branch != null) {
+    const branchContentResponse = await getBranchProjectContents(operationContext)({
+      projectId: projectId,
+      owner: githubRepo.owner,
+      repo: githubRepo.repository,
+      branch: branchName,
+      existingAssets: [],
+      previousCommitSha: previousCommitSha,
+      specificCommitSha: null,
+    })
+    if (branchContentResponse.type === 'SUCCESS') {
+      if (branchContentResponse.noChanges) {
         upstreamChangesSuccess = true
+      } else {
         const branchLatestChecksums = getProjectContentsChecksums(
-          branchLatestContent.branch.content,
+          branchContentResponse.branch.content,
           {},
         )
         const upstreamChanges = deriveGithubFileChanges(
@@ -1110,13 +1133,10 @@ async function updateUpstreamChanges(
         actions.push(
           updateGithubData({
             upstreamChanges: upstreamChanges,
-            lastRefreshedCommit: branchLatestContent.branch.originCommit,
+            lastRefreshedCommit: branchContentResponse.branch.originCommit,
           }),
         )
       }
-    } else if (branchContentResponse.status === 304) {
-      // Not modified status means that the branch has the same commit SHA.
-      upstreamChangesSuccess = true
     }
   }
   if (!upstreamChangesSuccess) {
@@ -1276,3 +1296,13 @@ export const resolveConflict =
         throw new Error(`Unhandled conflict ${JSON.stringify(conflict)}`)
     }
   }
+
+export function getExistingAssets(currentProjectContents: ProjectContentTreeRoot): ExistingAsset[] {
+  let existingAssets: ExistingAsset[] = []
+  walkContentsTree(currentProjectContents, (path, file) => {
+    if (file.type === 'ASSET_FILE' || file.type === 'IMAGE_FILE') {
+      existingAssets.push({ gitBlobSha: file.gitBlobSha, path: path, type: file.type })
+    }
+  })
+  return existingAssets
+}

--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -116,7 +116,7 @@ export interface BranchContent {
 export interface GetBranchContentSuccess {
   type: 'SUCCESS'
   branch: BranchContent | null
-  noChanges: boolean
+  noChanges?: boolean
 }
 
 export type GetBranchContentResponse = GetBranchContentSuccess | GithubFailure
@@ -1118,7 +1118,8 @@ async function updateUpstreamChanges(
       specificCommitSha: null,
     })
     if (branchContentResponse.type === 'SUCCESS') {
-      upstreamChangesSuccess = true
+      upstreamChangesSuccess =
+        branchContentResponse.noChanges === true || branchContentResponse.branch != null
       if (branchContentResponse.branch != null) {
         const branchLatestChecksums = getProjectContentsChecksums(
           branchContentResponse.branch.content,

--- a/editor/src/core/shared/github/operations/commit-and-push.ts
+++ b/editor/src/core/shared/github/operations/commit-and-push.ts
@@ -72,7 +72,7 @@ export const saveProjectToGithub =
             previousCommitSha: null,
             specificCommitSha: null,
           })
-          if (getBranchResponse.type === 'SUCCESS') {
+          if (getBranchResponse.type === 'SUCCESS' && getBranchResponse.branch != null) {
             originCommit = getBranchResponse.branch.originCommit
           }
         }

--- a/editor/src/core/shared/github/operations/get-branch-checksums.ts
+++ b/editor/src/core/shared/github/operations/get-branch-checksums.ts
@@ -22,7 +22,7 @@ export const getBranchChecksums =
       existingAssets: [],
     })
 
-    if (specificCommitResponse.type === 'SUCCESS') {
+    if (specificCommitResponse.type === 'SUCCESS' && specificCommitResponse.branch != null) {
       return [updateBranchContents(specificCommitResponse.branch.content)]
     }
     return []

--- a/editor/src/core/shared/github/operations/load-branch.ts
+++ b/editor/src/core/shared/github/operations/load-branch.ts
@@ -25,7 +25,13 @@ import type { RequestedNpmDependency } from '../../npm-dependency-types'
 import { forceNotNull } from '../../optional-utils'
 import { isTextFile } from '../../project-file-types'
 import type { BranchContent, GithubOperationSource } from '../helpers'
-import { connectRepo, githubAPIError, runGithubOperation, saveGithubAsset } from '../helpers'
+import {
+  connectRepo,
+  getExistingAssets,
+  githubAPIError,
+  runGithubOperation,
+  saveGithubAsset,
+} from '../helpers'
 import type { GithubOperationContext } from './github-operation-context'
 import { createStoryboardFileIfNecessary } from '../../../../components/editor/actions/actions'
 import { getAllComponentDescriptorFilePaths } from '../../../property-controls/property-controls-local'
@@ -118,19 +124,14 @@ export const updateProjectWithBranchContent =
       dispatch,
       initiator,
       async (operation: GithubOperation) => {
-        let existingAssets: ExistingAsset[] = []
-        walkContentsTree(currentProjectContents, (path, file) => {
-          if (file.type === 'ASSET_FILE' || file.type === 'IMAGE_FILE') {
-            existingAssets.push({ gitBlobSha: file.gitBlobSha, path: path, type: file.type })
-          }
-        })
-
         const responseBody = await GithubOperations.getBranchProjectContents({
           projectId: projectID,
           owner: githubRepo.owner,
           repo: githubRepo.repository,
           branch: branchName,
-          existingAssets: existingAssets,
+          existingAssets: getExistingAssets(currentProjectContents),
+          previousCommitSha: null,
+          specificCommitSha: null,
         })
 
         switch (responseBody.type) {

--- a/editor/src/core/shared/github/operations/update-against-branch.ts
+++ b/editor/src/core/shared/github/operations/update-against-branch.ts
@@ -90,16 +90,16 @@ export const updateProjectAgainstGithub =
 
         dispatch(
           [
+            updateGithubData({
+              upstreamChanges: null,
+              lastRefreshedCommit: branchLatestResponse.branch.originCommit,
+            }),
             updateBranchContents(parsedLatestContent),
             updateAgainstGithub(
               parsedLatestContent,
               specificCommitResponse.branch.content,
               branchLatestResponse.branch.originCommit,
             ),
-            updateGithubData({
-              upstreamChanges: null,
-              lastRefreshedCommit: branchLatestResponse.branch.originCommit,
-            }),
             showToast(
               notice(`Github: Updated the project against the branch ${branchName}.`, 'SUCCESS'),
             ),

--- a/utopia-remix/app/routes-test/internal.projects.$id.github.branches.$owner.$repo.branches.$branch.spec.ts
+++ b/utopia-remix/app/routes-test/internal.projects.$id.github.branches.$owner.$repo.branches.$branch.spec.ts
@@ -111,6 +111,8 @@ describe('get branch project contents', () => {
           getBranchProjectContentsRequest({
             existingAssets: [],
             uploadAssets: true,
+            previousCommitSha: null,
+            specificCommitSha: null,
           }),
         ),
       }),
@@ -163,6 +165,8 @@ describe('get branch project contents', () => {
           getBranchProjectContentsRequest({
             existingAssets: [],
             uploadAssets: true,
+            previousCommitSha: null,
+            specificCommitSha: null,
           }),
         ),
       }),

--- a/utopia-remix/app/routes/internal.projects.$id.github.branches.$owner.$repo.branch.$branch.tsx
+++ b/utopia-remix/app/routes/internal.projects.$id.github.branches.$owner.$repo.branch.$branch.tsx
@@ -61,6 +61,8 @@ async function handler(req: Request, params: Params<string>) {
       branch: branch,
       uploadAssets: body.uploadAssets,
       existingAssets: body.existingAssets ?? [],
+      previousCommitSha: body.previousCommitSha,
+      specificCommitSha: body.specificCommitSha,
     }),
   )
 }

--- a/utopia-remix/app/types.ts
+++ b/utopia-remix/app/types.ts
@@ -409,6 +409,8 @@ export type GetBranchProjectContentsRequest = {
   type: 'GET_BRANCH_PROJECT_CONTENTS_REQUEST'
   existingAssets: ExistingAsset[] | null
   uploadAssets: boolean
+  previousCommitSha: string | null
+  specificCommitSha: string | null
 }
 
 export function getBranchProjectContentsRequest(

--- a/utopia-remix/app/util/github-branch-contents.server.ts
+++ b/utopia-remix/app/util/github-branch-contents.server.ts
@@ -46,7 +46,7 @@ export type BranchResponse = {
     originCommit: string
     content: ProjectContentTreeRoot
   } | null
-  noChanges: boolean
+  noChanges?: boolean
 }
 
 export function getBranchProjectContents(params: {
@@ -119,7 +119,6 @@ export function getBranchProjectContents(params: {
           originCommit: commit,
           content: projectContents,
         },
-        noChanges: false,
       })
     } finally {
       // 6. dispose of the zip file

--- a/utopia-remix/app/util/github-branch-contents.server.ts
+++ b/utopia-remix/app/util/github-branch-contents.server.ts
@@ -45,7 +45,7 @@ export type BranchResponse = {
     branchName: string
     originCommit: string
     content: ProjectContentTreeRoot
-  }
+  } | null
   noChanges: boolean
 }
 
@@ -76,11 +76,7 @@ export function getBranchProjectContents(params: {
 
     if (params.previousCommitSha != null && commit === params.previousCommitSha) {
       return toApiSuccess({
-        branch: {
-          branchName: params.branch,
-          originCommit: params.previousCommitSha,
-          content: {},
-        },
+        branch: null,
         noChanges: true,
       })
     }


### PR DESCRIPTION
**Problem:**

The remote changes detection is a) slow and b) prone to false-positives

**Fix:**

1. Use the zipball feature from https://github.com/concrete-utopia/utopia/pull/5639 to make those operations an order of magnitude faster
2. Update the assignment of `upstreamChangesSuccess`
3. Move the zeroing of `upstreamChanges` before all the other updates in `updateProjectAgainstGithub`

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5677 
