### PR TITLE
List index in navigator

### DIFF
--- a/editor/src/components/navigator/navigator-item/layout-icon.tsx
+++ b/editor/src/components/navigator/navigator-item/layout-icon.tsx
@@ -269,9 +269,9 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
           listIndex != null,
           <div
             style={{
-              position: 'absolute',
+              position: 'relative',
               top: 4,
-              right: 13,
+              right: 2,
               fontSize: 8,
               fontWeight: 700,
             }}

--- a/editor/src/components/navigator/navigator-item/layout-icon.tsx
+++ b/editor/src/components/navigator/navigator-item/layout-icon.tsx
@@ -221,6 +221,23 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
       }
     }, [addAbsoluteMarkerToIcon, color, warningText, isErroredGroupChild, iconTestId])
 
+    const listIndex = useEditorState(
+      Substores.metadata,
+      (store) => {
+        const generatedIndex = EP.extractIndexFromIndexedUid(
+          EP.toUid(props.navigatorEntry.elementPath),
+        )
+        if (generatedIndex == null) {
+          return null
+        }
+        const parent = EP.parentPath(props.navigatorEntry.elementPath)
+        return MetadataUtils.isJSXMapExpression(parent, store.editor.jsxMetadata)
+          ? generatedIndex
+          : null
+      },
+      'NavigatorRowLabel listIndex',
+    )
+
     return (
       <div
         style={{
@@ -246,6 +263,20 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
             }}
           >
             {marker}
+          </div>,
+        )}
+        {when(
+          listIndex != null,
+          <div
+            style={{
+              position: 'absolute',
+              top: 4,
+              right: 13,
+              fontSize: 8,
+              fontWeight: 700,
+            }}
+          >
+            {listIndex}
           </div>,
         )}
         {icon}

--- a/editor/src/components/navigator/navigator-item/layout-icon.tsx
+++ b/editor/src/components/navigator/navigator-item/layout-icon.tsx
@@ -269,11 +269,12 @@ export const LayoutIcon: React.FunctionComponent<React.PropsWithChildren<LayoutI
           listIndex != null,
           <div
             style={{
-              position: 'relative',
+              position: 'absolute',
               top: 4,
-              right: 2,
+              right: 13,
               fontSize: 8,
               fontWeight: 700,
+              textAlign: 'right',
             }}
           >
             {listIndex}


### PR DESCRIPTION
**Problem:**
For list children, add a number to the navigator item, see https://github.com/concrete-utopia/utopia/issues/5961

<img width="138" alt="image" src="https://github.com/concrete-utopia/utopia/assets/127662/6b6cdc97-9607-4be6-b347-1ae63bdc38bc">


**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5961
