### PR TITLE
Refactor variable matching code

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -102,6 +102,9 @@ import { getRegisteredComponent } from '../../../../core/property-controls/prope
 import type { EditorAction } from '../../../editor/action-types'
 import {
   getCartoucheDataTypeForExpression,
+  matchForPropertyValue,
+  usePropertyControlDescriptions,
+  usePropertyValue,
   useVariablesInScopeForSelectedElement,
 } from './variables-in-scope-utils'
 import { useAtom } from 'jotai'
@@ -491,9 +494,18 @@ function useDataPickerButtonInComponentSection(
 ) {
   const dispatch = useDispatch()
 
+  const elementPath = selectedViews.at(0) ?? EP.emptyElementPath
+
+  const controlDescriptions = usePropertyControlDescriptions(propertyPath)
+  const currentPropertyValue = usePropertyValue(elementPath, propertyPath)
+
   const variableNamesInScope = useVariablesInScopeForSelectedElement(
     selectedViews.at(0) ?? EP.emptyElementPath,
-    propertyPath,
+    matchForPropertyValue(
+      controlDescriptions,
+      currentPropertyValue,
+      PP.lastPart(propertyPath).toString(),
+    ),
   )
 
   const metadata = useEditorState(

--- a/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-reference-cartouche.tsx
@@ -111,19 +111,20 @@ export const DataReferenceCartoucheControl = React.memo(
     const controlDescriptions = usePropertyControlDescriptions(maybePropertyPath)
     const currentPropertyValue = usePropertyValue(elementPath, maybePropertyPath)
 
-    const matcher = React.useMemo(
-      () =>
-        props.renderedAt.type === 'element-property-path'
-          ? matchForPropertyValue(
-              controlDescriptions,
-              currentPropertyValue,
-              optionalMap((p) => PP.lastPart(p).toString(), maybePropertyPath),
-            )
-          : props.renderedAt.type === 'child-node'
-          ? matchForChildrenProp
-          : assertNever(props.renderedAt),
-      [controlDescriptions, currentPropertyValue, maybePropertyPath, props.renderedAt],
-    )
+    const matcher = React.useMemo(() => {
+      switch (props.renderedAt.type) {
+        case 'child-node':
+          return matchForChildrenProp
+        case 'element-property-path':
+          return matchForPropertyValue(
+            controlDescriptions,
+            currentPropertyValue,
+            optionalMap((p) => PP.lastPart(p).toString(), maybePropertyPath),
+          )
+        default:
+          assertNever(props.renderedAt)
+      }
+    }, [controlDescriptions, currentPropertyValue, maybePropertyPath, props.renderedAt])
 
     const variableNamesInScope = useVariablesInScopeForSelectedElement(elementPath, matcher)
 

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.spec.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.spec.ts
@@ -3,9 +3,9 @@ import { maybeToArray } from '../../../../core/shared/optional-utils'
 import { emptySet } from '../../../../core/shared/set-utils'
 import type { ControlDescription } from '../../../custom-code/internal-property-controls'
 import type { PropertyValue, VariableInfo } from './variables-in-scope-utils'
-import { orderVariablesForRelevance, variableInfoFromValue } from './variables-in-scope-utils'
+import { matchForPropertyValue, variableInfoFromValue } from './variables-in-scope-utils'
 
-describe('orderVariablesForRelevance', () => {
+describe('matchForPropertyValue', () => {
   it('should be able to target a given property', () => {
     const variableNamesInScope: Array<VariableInfo> = maybeToArray(
       variableInfoFromValue(
@@ -31,12 +31,11 @@ describe('orderVariablesForRelevance', () => {
       },
     }
     const targetPropertyName = 'left'
-    const actualResult = orderVariablesForRelevance(
-      variableNamesInScope,
+    const actualResult = matchForPropertyValue(
       controlDescription,
       currentPropertyValue,
       targetPropertyName,
-    )
+    )(variableNamesInScope)
     expect(actualResult).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -117,12 +116,11 @@ describe('orderVariablesForRelevance', () => {
       },
     }
     const targetPropertyName = null
-    const actualResult = orderVariablesForRelevance(
-      variableNamesInScope,
+    const actualResult = matchForPropertyValue(
       controlDescription,
       currentPropertyValue,
       targetPropertyName,
-    )
+    )(variableNamesInScope)
     expect(actualResult).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
+++ b/editor/src/components/inspector/sections/component-section/variables-in-scope-utils.ts
@@ -9,13 +9,11 @@ import type { FileRootPath, VariableData, VariablesInScope } from '../../../canv
 import { useEditorState, Substores } from '../../../editor/store/store-hook'
 import type { DataPickerOption } from './data-picker-utils'
 import * as EP from '../../../../core/shared/element-path'
-import * as PP from '../../../../core/shared/property-path'
 import React from 'react'
 import { useGetPropertyControlsForSelectedComponents } from '../../common/property-controls-hooks'
 import { mapDropNulls } from '../../../../core/shared/array-utils'
-import { assertNever, identity } from '../../../../core/shared/utils'
+import { assertNever } from '../../../../core/shared/utils'
 import { isValidReactNode } from '../../../../utils/react-utils'
-import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { emptySet } from '../../../../core/shared/set-utils'
 import type { JSExpression, JSXElementChild } from '../../../../core/shared/element-template'
 import type { Either } from '../../../../core/shared/either'
@@ -147,7 +145,7 @@ function valuesFromVariable(
   }
 }
 
-function usePropertyControlDescriptions(
+export function usePropertyControlDescriptions(
   selectedProperty: PropertyPath | null,
 ): ControlDescription | null {
   const controls = useGetPropertyControlsForSelectedComponents()
@@ -322,102 +320,98 @@ function createPropertyAccessExpressionString(expressionSoFar: string, toAppend:
   }
 }
 
-function getTargetPropertyFromControlDescription(
-  controlDescription: ControlDescription | null,
-  targetPropertyName: string | null,
-): ControlDescription | null {
-  if (targetPropertyName == null || controlDescription == null) {
-    return controlDescription
-  } else {
-    switch (controlDescription.control) {
-      case 'object':
-        return controlDescription.object[targetPropertyName] ?? null
-      default:
-        return controlDescription
+type Matcher = (_: VariableInfo) => VariableMatches | null
+
+function matchVariables(
+  variableNamesInScope_MUTABLE: Array<VariableInfo>,
+  matchers: Array<Matcher>,
+): Array<VariableInfo> {
+  let categories: Array<VariableInfo[]> = matchers.map(() => [])
+  let rest: Array<VariableInfo> = []
+
+  const matchersWithIndex: Array<[Matcher, number]> = matchers.map((m, i) => [m, i])
+
+  variableNamesInScope_MUTABLE.forEach((variable) => {
+    if (variable.type === 'array') {
+      variable.elements = matchVariables(variable.elements, matchers)
+    } else if (variable.type === 'object') {
+      variable.props = matchVariables(variable.props, matchers)
     }
-  }
+
+    for (const [matcher, idx] of matchersWithIndex) {
+      const match = matcher(variable)
+      if (match != null) {
+        categories[idx].push({ ...variable, matches: match })
+        return
+      }
+    }
+    rest.push(variable)
+  })
+
+  return [...categories.flat(), ...rest]
 }
 
-export function orderVariablesForRelevance(
-  variableNamesInScope_MUTABLE: Array<VariableInfo>,
-  controlDescription: ControlDescription | null,
-  currentPropertyValue: PropertyValue,
-  targetPropertyName: string | null,
-): Array<VariableInfo> {
-  let valuesExactlyMatchingPropertyName: Array<VariableInfo> = []
-  let valuesExactlyMatchingPropertyDescription: Array<VariableInfo> = []
-  let valuesMatchingPropertyDescription: Array<VariableInfo> = []
-  let valuesMatchingPropertyShape: Array<VariableInfo> = []
-  let valueElementMatches: Array<VariableInfo> = []
-  let restOfValues: Array<VariableInfo> = []
+function predicateMatcher(cb: (_: VariableInfo) => boolean): Matcher {
+  return (variable: VariableInfo) => (cb(variable) ? 'matches' : null)
+}
 
-  for (let variable of variableNamesInScope_MUTABLE) {
-    if (variable.type === 'array') {
-      variable.elements = orderVariablesForRelevance(
-        variable.elements,
-        controlDescription,
-        currentPropertyValue,
-        targetPropertyName,
-      )
-    } else if (variable.type === 'object') {
-      variable.props = orderVariablesForRelevance(
-        variable.props,
-        controlDescription,
-        currentPropertyValue,
-        targetPropertyName,
-      )
-    }
+const valueElementMatches: Matcher = (variable) => {
+  const matches =
+    (variable.type === 'array' && variable.elements.some((e) => e.matches)) ||
+    (variable.type === 'object' && variable.props.some((e) => e.matches))
+  return matches ? 'child-matches' : null
+}
 
-    const valueExactlyMatchesPropertyName = variable.expressionPathPart === targetPropertyName
-
-    const variableCanBeMappedOver =
-      variable.type === 'array' && currentPropertyValue.type === 'mapped-value'
-
-    const valueExactlyMatchesControlDescription =
-      controlDescription?.control === 'jsx' && React.isValidElement(variable.value)
-
-    const targetControlDescription = getTargetPropertyFromControlDescription(
-      controlDescription,
-      targetPropertyName,
+export const matchForPropertyValue =
+  (
+    controlDescription: ControlDescription | null,
+    currentPropertyValue: PropertyValue,
+    targetPropertyName: string | null,
+  ) =>
+  (variableNamesInScope: Array<VariableInfo>) => {
+    const valuesExactlyMatchingPropertyDescription: Matcher = predicateMatcher(
+      (variable) => controlDescription?.control === 'jsx' && isValidReactNode(variable.value),
     )
-    const valueMatchesControlDescription =
-      targetControlDescription != null &&
-      variableMatchesControlDescription(variable.value, targetControlDescription)
 
-    const valueMatchesChildrenProp =
-      targetPropertyName === 'children' && isValidReactNode(variable.value)
+    const targetControlDescription =
+      targetPropertyName == null ||
+      controlDescription == null ||
+      controlDescription.control !== 'object'
+        ? controlDescription
+        : controlDescription.object[targetPropertyName] ?? null
 
-    const valueMatchesCurrentPropValue =
-      currentPropertyValue.type === 'existing' &&
-      variableShapesMatch(currentPropertyValue.value, variable.value)
+    const valuesMatchingPropertyDescription: Matcher = predicateMatcher(
+      (variable) =>
+        targetControlDescription != null &&
+        variableMatchesControlDescription(variable.value, targetControlDescription),
+    )
 
-    const arrayOrObjectChildMatches =
-      (variable.type === 'array' && variable.elements.some((e) => e.matches)) ||
-      (variable.type === 'object' && variable.props.some((e) => e.matches))
+    const valuesMatchingPropertyShape: Matcher = predicateMatcher(
+      (variable) =>
+        currentPropertyValue.type === 'existing' &&
+        variableShapesMatch(currentPropertyValue.value, variable.value),
+    )
 
-    if (valueExactlyMatchesPropertyName || variableCanBeMappedOver) {
-      valuesExactlyMatchingPropertyName.push({ ...variable, matches: 'matches' })
-    } else if (valueExactlyMatchesControlDescription) {
-      valuesExactlyMatchingPropertyDescription.push({ ...variable, matches: 'matches' })
-    } else if (valueMatchesControlDescription || valueMatchesChildrenProp) {
-      valuesMatchingPropertyDescription.push({ ...variable, matches: 'matches' })
-    } else if (arrayOrObjectChildMatches) {
-      valueElementMatches.push({ ...variable, matches: 'child-matches' })
-    } else if (valueMatchesCurrentPropValue) {
-      valuesMatchingPropertyShape.push({ ...variable, matches: 'matches' })
-    } else {
-      restOfValues.push(variable)
-    }
+    return matchVariables(variableNamesInScope, [
+      valuesExactlyMatchingPropertyDescription,
+      valuesMatchingPropertyDescription,
+      valuesMatchingPropertyShape,
+      valueElementMatches,
+    ])
   }
 
-  return [
-    ...valuesExactlyMatchingPropertyName,
-    ...valuesExactlyMatchingPropertyDescription,
-    ...valuesMatchingPropertyDescription,
-    ...valuesMatchingPropertyShape,
-    ...valueElementMatches,
-    ...restOfValues,
-  ]
+export function matchForChildrenProp(variableNamesInScope: Array<VariableInfo>) {
+  return matchVariables(variableNamesInScope, [
+    predicateMatcher((v) => isValidReactNode(v.value)),
+    valueElementMatches,
+  ])
+}
+
+export function matchForMappedValue(variableNamesInScope: Array<VariableInfo>) {
+  return matchVariables(variableNamesInScope, [
+    predicateMatcher((v) => v.type === 'array'),
+    valueElementMatches,
+  ])
 }
 
 const filterKeyFromObject =
@@ -443,48 +437,15 @@ const filterObjectPropFromVariablesInScope =
     return next
   }
 
-const keepLocalestScope =
-  () =>
-  (variablesInScope: VariableData): VariableData => {
-    let deepestInsertionCeiling = -Infinity
-    Object.values(variablesInScope).forEach((variable) => {
-      if (variable.insertionCeiling.type === 'file-root') {
-        return
-      }
-
-      deepestInsertionCeiling = Math.max(
-        deepestInsertionCeiling,
-        EP.fullDepth(variable.insertionCeiling),
-      )
-    })
-
-    const result: VariableData = {}
-    Object.entries(variablesInScope).forEach(([key, variable]) => {
-      if (variable.insertionCeiling.type === 'file-root') {
-        result[key] = variable
-        return
-      }
-
-      if (EP.fullDepth(variable.insertionCeiling) === deepestInsertionCeiling) {
-        result[key] = variable
-      }
-    })
-
-    return result
-  }
-
 export function useVariablesInScopeForSelectedElement(
   elementPath: ElementPath | null,
-  propertyPath: PropertyPath | null,
+  matchFn: (_: Array<VariableInfo>) => Array<VariableInfo>,
 ): Array<DataPickerOption> {
   const variablesInScope = useEditorState(
     Substores.restOfEditor,
     (store) => store.editor.variablesInScope,
     'useVariablesInScopeForSelectedElement variablesInScope',
   )
-
-  const controlDescriptions = usePropertyControlDescriptions(propertyPath)
-  const currentPropertyValue = usePropertyValue(elementPath, propertyPath)
 
   const variableNamesInScope = React.useMemo((): Array<DataPickerOption> => {
     if (elementPath == null) {
@@ -520,12 +481,7 @@ export function useVariablesInScopeForSelectedElement(
 
     const variableInfo = variableInfoFromVariableData(variablesInScopeForSelectedPath)
 
-    const orderedVariablesInScope = orderVariablesForRelevance(
-      variableInfo,
-      controlDescriptions,
-      currentPropertyValue,
-      propertyPath == null ? null : '' + PP.lastPart(propertyPath),
-    )
+    const orderedVariablesInScope = matchFn(variableInfo)
 
     return orderedVariablesInScope.flatMap((variable) =>
       valuesFromVariable(
@@ -537,7 +493,7 @@ export function useVariablesInScopeForSelectedElement(
         false,
       ),
     )
-  }, [controlDescriptions, currentPropertyValue, elementPath, variablesInScope, propertyPath])
+  }, [elementPath, matchFn, variablesInScope])
 
   return variableNamesInScope
 }
@@ -623,12 +579,9 @@ function variableMatchesControlDescription(
   return matches
 }
 
-export type PropertyValue =
-  | { type: 'existing'; value: unknown }
-  | { type: 'mapped-value' }
-  | { type: 'not-found' }
+export type PropertyValue = { type: 'existing'; value: unknown } | { type: 'not-found' }
 
-function usePropertyValue(
+export function usePropertyValue(
   selectedView: ElementPath | null,
   propertyPath: PropertyPath | null,
 ): PropertyValue {
@@ -638,18 +591,8 @@ function usePropertyValue(
     'usePropertyValue allElementProps',
   )
 
-  const metadata = useEditorState(
-    Substores.metadata,
-    (store) => store.editor.jsxMetadata,
-    'usePropertyValue metadata',
-  )
-
   if (selectedView == null) {
     return { type: 'not-found' }
-  }
-
-  if (MetadataUtils.isJSXMapExpression(selectedView, metadata)) {
-    return { type: 'mapped-value' }
   }
 
   const propsForThisElement = allElementProps[EP.toString(selectedView)] ?? null

--- a/editor/src/components/inspector/sections/data-reference-section.tsx
+++ b/editor/src/components/inspector/sections/data-reference-section.tsx
@@ -13,7 +13,6 @@ import {
   getTextContentOfElement,
 } from './component-section/data-reference-cartouche'
 import { useDataPickerButton } from './component-section/component-section'
-import { useAtom } from 'jotai'
 import * as EP from '../../../core/shared/element-path'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { replaceElementInScope } from '../../editor/actions/action-creators'
@@ -21,11 +20,11 @@ import { NO_OP } from '../../../core/shared/utils'
 import { dataPathSuccess, traceDataFromElement } from '../../../core/data-tracing/data-tracing'
 import {
   getCartoucheDataTypeForExpression,
+  matchForChildrenProp,
   useVariablesInScopeForSelectedElement,
 } from './component-section/variables-in-scope-utils'
 import { jsxElementChildToValuePath } from './component-section/data-picker-utils'
 import { CartoucheInspectorWrapper } from './component-section/cartouche-control'
-import * as PP from '../../../core/shared/property-path'
 
 export const DataReferenceSectionId = 'code-element-section-test-id'
 
@@ -82,7 +81,7 @@ export const DataReferenceSection = React.memo(({ paths }: { paths: ElementPath[
 
   const varsInScope = useVariablesInScopeForSelectedElement(
     elementPathForDataPicker,
-    PP.create('children'),
+    matchForChildrenProp,
   )
 
   const pathToCurrenlySelectedValue = React.useMemo(() => {

--- a/editor/src/components/inspector/sections/layout-section/list-source-cartouche.tsx
+++ b/editor/src/components/inspector/sections/layout-section/list-source-cartouche.tsx
@@ -14,10 +14,10 @@ import { useDataPickerButton } from '../component-section/component-section'
 import { useDispatch } from '../../../editor/store/dispatch-context'
 import type { JSExpressionOtherJavaScript } from '../../../../core/shared/element-template'
 import { replaceElementInScope } from '../../../editor/actions/action-creators'
-import { useAtom } from 'jotai'
 import { jsxElementChildToValuePath } from '../component-section/data-picker-utils'
 import {
   getCartoucheDataTypeForExpression,
+  matchForMappedValue,
   useVariablesInScopeForSelectedElement,
 } from '../component-section/variables-in-scope-utils'
 import { traceDataFromElement, dataPathSuccess } from '../../../../core/data-tracing/data-tracing'
@@ -86,7 +86,7 @@ const MapListSourceCartoucheInner = React.memo(
       [dispatch, target],
     )
 
-    const variableNamesInScope = useVariablesInScopeForSelectedElement(target, null)
+    const variableNamesInScope = useVariablesInScopeForSelectedElement(target, matchForMappedValue)
 
     const pathToMappedExpression = React.useMemo(
       () =>


### PR DESCRIPTION
## Problem
The variable matching code evolved in an "organic" way and needs trimming:
- matching for the children prop, arbitrary props and for mapped values are mushed together into one function
- we don't actaually want to order variables according to relevance anymore (we want to order them alphabetically, this is coming on a follow-up PR)

## Fix
- Revamp the matching code into a more general form, and derive specific matching functions to match for the children prop, arbitrary props and for mapped values
- adjust the call sites to provide the data for these matchers

## Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode


