### PR TITLE
Sort data picker entries alphabetically

### DIFF
--- a/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
+++ b/editor/src/components/inspector/sections/component-section/data-selector-columns.tsx
@@ -98,10 +98,33 @@ const DataSelectorColumn = React.memo((props: DataSelectorColumnProps) => {
     [onTargetPathChange, parentScope],
   )
 
+  const sortedActiveScope = React.useMemo(() => {
+    let folders: DataPickerOption[] = []
+    let rest: DataPickerOption[] = []
+    activeScope.forEach((option) => {
+      switch (option.type) {
+        case 'array':
+        case 'object':
+          folders.push(option)
+          break
+        case 'jsx':
+        case 'primitive':
+          rest.push(option)
+          break
+        default:
+          assertNever(option)
+      }
+    })
+
+    folders.sort((a, b) => a.variableInfo.expression.localeCompare(b.variableInfo.expression))
+    rest.sort((a, b) => a.variableInfo.expression.localeCompare(b.variableInfo.expression))
+    return [...folders, ...rest]
+  }, [activeScope])
+
   return (
     <>
       <DataSelectorFlexColumn ref={columnRef} onClick={onClickColumnBackground}>
-        {activeScope.map((option, index) => {
+        {sortedActiveScope.map((option, index) => {
           const selected = arrayEqualsByReference(option.valuePath, targetPathInsideScope)
           const onActivePath = isPrefixOf(option.valuePath, targetPathInsideScope)
           return (


### PR DESCRIPTION
## Description

With this PR, objects/array are on the top of each column in the data selector, with the primitive values below the folders, and each group is alphabetically sorted

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #[ticket_number] (<< pls delete this line if it's not relevant)
