### PR TITLE
Click to open the annotation file of component

### DIFF
--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -309,17 +309,6 @@ export function importInfoFromImportDetails(
   return foundImportDetail
 }
 
-export function getFilePathForImportedComponent(
-  element: ElementInstanceMetadata | null,
-): string | null {
-  const importInfo = element?.importInfo
-  if (importInfo != null && isImportedOrigin(importInfo)) {
-    return importInfo.filePath
-  } else {
-    return null
-  }
-}
-
 export function isImportedComponentFromProjectFiles(
   element: ElementInstanceMetadata | null,
   filePathMappings: FilePathMappings,


### PR DESCRIPTION
**Problem:**
Clicking on the Components inspector section's ◇ logo opens the annotation file for the given component.
(First task of https://github.com/concrete-utopia/utopia/issues/5971 )

**Fix:**
- Originally the full title row of the component section took you to the component instance itself. After this PR only the component name takes you to the component instance, and the ◇ logo takes you to the annotation file.
- Taking you to the component instance was buggy: it tried to navigate to the importInfo of the component, but that does not contain the file extension, and potentially can contain import aliases. I removed this code and it just jumps to the selected instance now. If this should jump to the component implementation and not to the selected instance (that is not what the name suggested though), that can be implemented in a subsequent PR.
- I removed the function `getFilePathForImportedComponent`, because it is not called anymore, and its name is misleading (it does not return the real filepath, just an import path).

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

