### PR TITLE
Fix/wrap undo

### DIFF
--- a/editor/src/components/canvas/commands/add-elements-command.ts
+++ b/editor/src/components/canvas/commands/add-elements-command.ts
@@ -1,20 +1,25 @@
+import type { Spec } from 'immutability-helper'
+import { includeToastPatch } from '../../../components/editor/actions/toast-helpers'
+import type { EditorState, EditorStatePatch } from '../../../components/editor/store/editor-state'
+import { forUnderlyingTargetFromEditorState } from '../../../components/editor/store/editor-state'
+import { insertJSXElementChildren } from '../../../core/model/element-template-utils'
+import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
+import type { JSXElementChild } from '../../../core/shared/element-template'
+import type { Imports } from '../../../core/shared/project-file-types'
+import { mergeImports } from '../../../core/workers/common/project-file-utils'
+import type { IndexPosition } from '../../../utils/utils'
 import type { InsertionPath } from '../../editor/store/insertion-path'
 import {
   getElementPathFromInsertionPath,
   insertionPathToString,
 } from '../../editor/store/insertion-path'
-import type { EditorState, EditorStatePatch } from '../../../components/editor/store/editor-state'
-import { forUnderlyingTargetFromEditorState } from '../../../components/editor/store/editor-state'
-import { getUtopiaJSXComponentsFromSuccess } from '../../../core/model/project-file-utils'
-import type { JSXElementChild } from '../../../core/shared/element-template'
-import type { Imports } from '../../../core/shared/project-file-types'
-import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
+import type { InteractionLifecycle } from '../canvas-strategies/canvas-strategy-types'
+import {
+  addToReparentedToPaths,
+  runAddToReparentedToPaths,
+} from './add-to-reparented-to-paths-command'
+import type { BaseCommand, CommandFunctionResult, WhenToRun } from './commands'
 import { getPatchForComponentChange } from './commands'
-import { includeToastPatch } from '../../../components/editor/actions/toast-helpers'
-import type { IndexPosition } from '../../../utils/utils'
-import { mergeImports } from '../../../core/workers/common/project-file-utils'
-import type { Spec } from 'immutability-helper'
-import { insertJSXElementChildren } from '../../../core/model/element-template-utils'
 
 export interface AddElements extends BaseCommand {
   type: 'ADD_ELEMENTS'
@@ -43,10 +48,11 @@ export function addElements(
   }
 }
 
-export const runAddElements: CommandFunction<AddElements> = (
+export const runAddElements = (
   editorState: EditorState,
   command: AddElements,
-) => {
+  commandLifecycle: InteractionLifecycle,
+): CommandFunctionResult => {
   let editorStatePatches: Array<EditorStatePatch> = []
   forUnderlyingTargetFromEditorState(
     getElementPathFromInsertionPath(command.parentPath),
@@ -75,20 +81,15 @@ export const runAddElements: CommandFunction<AddElements> = (
         underlyingFilePathNewParent,
       )
 
-      const newElementPathsPatch: Spec<EditorState> = {
-        canvas: {
-          controls: {
-            reparentedToPaths: {
-              $push: insertionResult.insertedChildrenPaths,
-            },
-          },
-        },
-      }
+      const newElementPathsPatch: Array<Spec<EditorState>> = runAddToReparentedToPaths(
+        addToReparentedToPaths('mid-interaction', insertionResult.insertedChildrenPaths),
+        commandLifecycle,
+      ).editorStatePatches
 
       editorStatePatches = [
         editorStatePatchNewParentFile,
         includeToastPatch(insertionResult.insertionDetails, editorState),
-        newElementPathsPatch,
+        ...newElementPathsPatch,
       ]
     },
   )

--- a/editor/src/components/canvas/commands/add-to-reparented-to-paths-command.ts
+++ b/editor/src/components/canvas/commands/add-to-reparented-to-paths-command.ts
@@ -1,7 +1,8 @@
 import type { Spec } from 'immutability-helper'
-import type { EditorState } from '../../editor/store/editor-state'
 import type { ElementPath } from '../../../core/shared/project-file-types'
-import type { BaseCommand, CommandFunction, CommandFunctionResult, WhenToRun } from './commands'
+import type { EditorState } from '../../editor/store/editor-state'
+import type { InteractionLifecycle } from '../canvas-strategies/canvas-strategy-types'
+import type { BaseCommand, CommandFunctionResult, WhenToRun } from './commands'
 
 export interface AddToReparentedToPaths extends BaseCommand {
   type: 'ADD_TO_REPARENTED_TO_PATHS'
@@ -19,10 +20,16 @@ export function addToReparentedToPaths(
   }
 }
 
-export const runAddToReparentedToPaths: CommandFunction<AddToReparentedToPaths> = (
-  editorState: EditorState,
+export const runAddToReparentedToPaths = (
   command: AddToReparentedToPaths,
+  commandLifecycle: InteractionLifecycle,
 ): CommandFunctionResult => {
+  if (commandLifecycle === 'end-interaction') {
+    return {
+      editorStatePatches: [],
+      commandDescription: `Updated reparented to paths. No changes made.`,
+    }
+  }
   const editorStatePatch: Spec<EditorState> = {
     canvas: {
       controls: {

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -202,7 +202,7 @@ export function runCanvasCommand(
     case 'ADD_ELEMENT':
       return runAddElement(editorState, command)
     case 'ADD_ELEMENTS':
-      return runAddElements(editorState, command)
+      return runAddElements(editorState, command, commandLifecycle)
     case 'HIGHLIGHT_ELEMENTS_COMMAND':
       return runHighlightElementsCommand(editorState, command)
     case 'CONVERT_CSS_PERCENT_TO_PX':

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -196,7 +196,7 @@ export function runCanvasCommand(
     case 'ADD_IMPORTS_TO_FILE':
       return runAddImportsToFile(editorState, command)
     case 'ADD_TO_REPARENTED_TO_PATHS':
-      return runAddToReparentedToPaths(editorState, command)
+      return runAddToReparentedToPaths(command, commandLifecycle)
     case 'INSERT_ELEMENT_INSERTION_SUBJECT':
       return runInsertElementInsertionSubject(editorState, command)
     case 'ADD_ELEMENT':


### PR DESCRIPTION
**Problem:**
When wrapping an element and then immediately undoing, the editor gets in a stuck state showing a "no entry" mouse pointer. 

**Investigation**
The issue turned out to be a problem in the `AddElements` command executed by `insertIntoWrapper` called by `UPDATE_FNS.WRAP_IN_ELEMENT`:

The AddElements command sets _the unpatched_ EditorState's `canvas.controls.reparentedToPaths` to an array containing the added element. This problem was then compounded by the undo's `restoreEditorState` setting `EditorState.canvas.controls` to `currentEditor.canvas.controls` which means we always keep the current reparentedToPaths alive, even if we undo! 
This normally shouldn't be a problem because we have an implicit, _unchecked_ contract that `UnpatchedEditor.canvas.controls.reparentedToPaths` is always an empty array. 
(As @bkrmendy pointed out, we should have stronger types in place that disallow setting the unpatched editor state to a non-empty array here.)

**Fix**
- The `AddElements` command now uses `AddToReparentedToPaths` command instead of hand rolling the setting of `reparentedToPaths`
- Both `AddElements` and `AddToReparentedToPaths` become interaction lifecycle aware: `AddToReparentedToPaths` only adds to the reparented paths `mid-interaction`, meaning it will NEVER emit a non-empty array for the unpatched editor.