### PR TITLE
Fix gap & padding control default values

### DIFF
--- a/editor/src/components/canvas/gap-utils.ts
+++ b/editor/src/components/canvas/gap-utils.ts
@@ -187,7 +187,10 @@ export function maybeFlexGapData(
   const flexDirection = element.specialSizeMeasurements.flexDirection ?? 'row'
 
   return {
-    value: { renderedValuePx: gap, value: gapFromProps ?? cssNumber(0) },
+    value: {
+      renderedValuePx: gap,
+      value: gapFromProps ?? cssNumber(gap),
+    },
     direction: flexDirection,
   }
 }

--- a/editor/src/components/canvas/padding-utils.tsx
+++ b/editor/src/components/canvas/padding-utils.tsx
@@ -10,7 +10,7 @@ import { optionalMap } from '../../core/shared/optional-utils'
 import type { ElementPath } from '../../core/shared/project-file-types'
 import { assertNever } from '../../core/shared/utils'
 import type { CSSNumber, CSSNumberUnit, CSSPadding } from '../inspector/common/css-utils'
-import { printCSSNumber } from '../inspector/common/css-utils'
+import { cssNumber, printCSSNumber } from '../inspector/common/css-utils'
 import type { EdgePiece } from './canvas-types'
 import type {
   AdjustPrecision,
@@ -115,7 +115,7 @@ export function simplePaddingFromMetadata(
         (p) => cssNumberWithRenderedValue(p, paddingNumbers[prop]),
         padding?.[prop] ?? defaults[prop],
       ) ??
-      undefined
+      cssNumberWithRenderedValue(cssNumber(paddingNumbers[prop]), paddingNumbers[prop])
     )
   }
 


### PR DESCRIPTION
## Problem
https://github.com/concrete-utopia/utopia/issues/5981

The padding and gap controls are not resilient to tailwind classes

## Fix
Make the padding and gap controls always fall back to the values coming from the actual DOM measurements if they can't read the appropriate values from the `style` prop (because it's not there)

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
