### PR TITLE
Navigate to the annotation in the sidecar file

### DIFF
--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -227,14 +227,17 @@ export function isDefaultComponentDescriptor(
 export interface ComponentDescriptorFromDescriptorFile {
   type: 'DESCRIPTOR_FILE'
   sourceDescriptorFile: string
+  lineNumber: number | null
 }
 
 export function componentDescriptorFromDescriptorFile(
   sourceDescriptorFile: string,
+  lineNumber: number | null,
 ): ComponentDescriptorFromDescriptorFile {
   return {
     type: 'DESCRIPTOR_FILE',
     sourceDescriptorFile: sourceDescriptorFile,
+    lineNumber: lineNumber,
   }
 }
 

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -53,6 +53,7 @@ import { getProjectFileByFilePath } from '../assets'
 import type { EditorDispatch } from '../editor/action-types'
 import { StylingOptions } from 'utopia-api'
 import type { Emphasis, Focus, Icon, Styling } from 'utopia-api'
+import type { Bounds } from 'utopia-vscode-common'
 
 type ModuleExportTypes = { [name: string]: ExportType }
 
@@ -227,17 +228,17 @@ export function isDefaultComponentDescriptor(
 export interface ComponentDescriptorFromDescriptorFile {
   type: 'DESCRIPTOR_FILE'
   sourceDescriptorFile: string
-  lineNumber: number | null
+  bounds: Bounds | null
 }
 
 export function componentDescriptorFromDescriptorFile(
   sourceDescriptorFile: string,
-  lineNumber: number | null,
+  bounds: Bounds | null,
 ): ComponentDescriptorFromDescriptorFile {
   return {
     type: 'DESCRIPTOR_FILE',
     sourceDescriptorFile: sourceDescriptorFile,
-    lineNumber: lineNumber,
+    bounds: bounds,
   }
 }
 

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -81,6 +81,7 @@ import type { MapLike } from 'typescript'
 import type { CommentFilterMode } from '../inspector/sections/comment-section'
 import type { Collaborator } from '../../core/shared/multiplayer'
 import type { PageTemplate } from '../canvas/remix/remix-utils'
+import type { Bounds } from 'utopia-vscode-common'
 export { isLoggedIn, loggedInUser, notLoggedIn } from '../../common/user'
 export type { LoginState, UserDetails } from '../../common/user'
 
@@ -644,7 +645,7 @@ export interface OpenCodeEditorFile {
   action: 'OPEN_CODE_EDITOR_FILE'
   filename: string
   forceShowCodeEditor: boolean
-  lineNumber: number | null
+  bounds: Bounds | null
 }
 
 export interface CloseDesignerFile {

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -644,6 +644,7 @@ export interface OpenCodeEditorFile {
   action: 'OPEN_CODE_EDITOR_FILE'
   filename: string
   forceShowCodeEditor: boolean
+  lineNumber: number | null
 }
 
 export interface CloseDesignerFile {

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -265,6 +265,7 @@ import type { SetHuggingParentToFixed } from '../../canvas/canvas-strategies/str
 import type { CommentFilterMode } from '../../inspector/sections/comment-section'
 import type { Collaborator } from '../../../core/shared/multiplayer'
 import type { PageTemplate } from '../../canvas/remix/remix-utils'
+import type { Bounds } from 'utopia-vscode-common'
 
 export function clearSelection(): EditorAction {
   return {
@@ -1055,13 +1056,13 @@ export function addFolder(parentPath: string, fileName: string): AddFolder {
 export function openCodeEditorFile(
   filename: string,
   forceShowCodeEditor: boolean,
-  lineNumber: number | null = null,
+  bounds: Bounds | null = null,
 ): OpenCodeEditorFile {
   return {
     action: 'OPEN_CODE_EDITOR_FILE',
     filename: filename,
     forceShowCodeEditor: forceShowCodeEditor,
-    lineNumber: lineNumber,
+    bounds: bounds,
   }
 }
 

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -1055,11 +1055,13 @@ export function addFolder(parentPath: string, fileName: string): AddFolder {
 export function openCodeEditorFile(
   filename: string,
   forceShowCodeEditor: boolean,
+  lineNumber: number | null = null,
 ): OpenCodeEditorFile {
   return {
     action: 'OPEN_CODE_EDITOR_FILE',
     filename: filename,
     forceShowCodeEditor: forceShowCodeEditor,
+    lineNumber: lineNumber,
   }
 }
 

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -3795,12 +3795,7 @@ export const UPDATE_FNS = {
   },
   OPEN_CODE_EDITOR_FILE: (action: OpenCodeEditorFile, editor: EditorModel): EditorModel => {
     // Side effect.
-    sendOpenFileMessage(
-      action.filename,
-      action.lineNumber != null
-        ? boundsInFile(action.filename, action.lineNumber, 0, action.lineNumber, 0)
-        : undefined,
-    )
+    sendOpenFileMessage(action.filename, action.bounds)
     if (action.forceShowCodeEditor) {
       return {
         ...editor,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -427,7 +427,7 @@ import {
 import { loadStoredState } from '../stored-state'
 import { applyMigrations } from './migrations/migrations'
 
-import { defaultConfig } from 'utopia-vscode-common'
+import { boundsInFile, defaultConfig } from 'utopia-vscode-common'
 import { reorderElement } from '../../../components/canvas/commands/reorder-element-command'
 import type { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { fetchNodeModules } from '../../../core/es-modules/package-manager/fetch-packages'
@@ -593,7 +593,7 @@ import {
   getPrintAndReparseCodeResult,
 } from '../../../core/workers/parser-printer/parser-printer-worker'
 import { isSteganographyEnabled } from '../../../core/shared/stegano-text'
-import type { ParsedTextFileWithPath } from '../../../core/property-controls/property-controls-local'
+import type { TextFileContentsWithPath } from '../../../core/property-controls/property-controls-local'
 import {
   updatePropertyControlsOnDescriptorFileDelete,
   isComponentDescriptorFile,
@@ -3795,7 +3795,12 @@ export const UPDATE_FNS = {
   },
   OPEN_CODE_EDITOR_FILE: (action: OpenCodeEditorFile, editor: EditorModel): EditorModel => {
     // Side effect.
-    sendOpenFileMessage(action.filename)
+    sendOpenFileMessage(
+      action.filename,
+      action.lineNumber != null
+        ? boundsInFile(action.filename, action.lineNumber, 0, action.lineNumber, 0)
+        : undefined,
+    )
     if (action.forceShowCodeEditor) {
       return {
         ...editor,
@@ -6073,11 +6078,11 @@ export const UPDATE_FNS = {
   ): EditorModel => {
     const evaluator = createModuleEvaluator(state)
 
-    const filesToUpdate: ParsedTextFileWithPath[] = []
+    const filesToUpdate: TextFileContentsWithPath[] = []
     for (const filePath of action.paths) {
       const file = getProjectFileByFilePath(state.projectContents, filePath)
       if (file != null && file.type === 'TEXT_FILE') {
-        filesToUpdate.push({ path: filePath, file: file.fileContents.parsed })
+        filesToUpdate.push({ path: filePath, file: file.fileContents })
       }
     }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -548,7 +548,7 @@ import type {
 import { fontSettings } from '../../inspector/common/css-utils'
 import type { ElementPaste, ProjectListing } from '../action-types'
 import { projectListing } from '../action-types'
-import type { UtopiaVSCodeConfig } from 'utopia-vscode-common'
+import type { Bounds, UtopiaVSCodeConfig } from 'utopia-vscode-common'
 import type { MouseButtonsPressed } from '../../../utils/mouse'
 import { assertNever } from '../../../core/shared/utils'
 import type {
@@ -3129,6 +3129,23 @@ export const HighlightBoundsKeepDeepEquality: KeepDeepEqualityCall<HighlightBoun
     highlightBounds,
   )
 
+export const BoundsKeepDeepEquality: KeepDeepEqualityCall<Bounds> = combine4EqualityCalls(
+  (bounds) => bounds.startLine,
+  NumberKeepDeepEquality,
+  (bounds) => bounds.startCol,
+  NumberKeepDeepEquality,
+  (bounds) => bounds.endLine,
+  NumberKeepDeepEquality,
+  (bounds) => bounds.endCol,
+  NumberKeepDeepEquality,
+  (startLine, startCol, endLine, endCol) => ({
+    startLine,
+    startCol,
+    endLine,
+    endCol,
+  }),
+)
+
 export const HighlightBoundsForUidsKeepDeepEquality: KeepDeepEqualityCall<HighlightBoundsForUids> =
   objectDeepEquality(HighlightBoundsKeepDeepEquality)
 
@@ -3489,8 +3506,8 @@ export const DescriptorFileComponentDescriptorKeepDeepEquality: KeepDeepEquality
     StringKeepDeepEquality,
     (descriptor) => descriptor.sourceDescriptorFile,
     StringKeepDeepEquality,
-    (descriptor) => descriptor.lineNumber,
-    nullableDeepEquality(NumberKeepDeepEquality),
+    (descriptor) => descriptor.bounds,
+    nullableDeepEquality(BoundsKeepDeepEquality),
     (_, sourceDescriptorFile, lineNumber) =>
       componentDescriptorFromDescriptorFile(sourceDescriptorFile, lineNumber),
   )

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -3484,12 +3484,15 @@ const PreferredChildComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<Pr
   )
 
 export const DescriptorFileComponentDescriptorKeepDeepEquality: KeepDeepEqualityCall<ComponentDescriptorFromDescriptorFile> =
-  combine2EqualityCalls(
+  combine3EqualityCalls(
     (descriptor) => descriptor.type,
     StringKeepDeepEquality,
     (descriptor) => descriptor.sourceDescriptorFile,
     StringKeepDeepEquality,
-    componentDescriptorFromDescriptorFile,
+    (descriptor) => descriptor.lineNumber,
+    nullableDeepEquality(NumberKeepDeepEquality),
+    (_, sourceDescriptorFile, lineNumber) =>
+      componentDescriptorFromDescriptorFile(sourceDescriptorFile, lineNumber),
   )
 
 export function ComponentDescriptorSourceKeepDeepEquality(): KeepDeepEqualityCall<ComponentDescriptorSource> {

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -1470,7 +1470,10 @@ export const ComponentSectionInner = React.memo((props: ComponentSectionProps) =
 
       const descriptorFile =
         registeredComponent?.source.type === 'DESCRIPTOR_FILE'
-          ? registeredComponent?.source.sourceDescriptorFile
+          ? {
+              path: registeredComponent?.source.sourceDescriptorFile,
+              lineNumber: registeredComponent?.source.lineNumber,
+            }
           : null
 
       if (registeredComponent?.label == null) {
@@ -1493,7 +1496,13 @@ export const ComponentSectionInner = React.memo((props: ComponentSectionProps) =
 
   const openDescriptorFile = React.useCallback(() => {
     if (componentData?.descriptorFile != null) {
-      dispatch([openCodeEditorFile(componentData?.descriptorFile, true)])
+      dispatch([
+        openCodeEditorFile(
+          componentData.descriptorFile.path,
+          true,
+          componentData.descriptorFile.lineNumber,
+        ),
+      ])
     }
   }, [dispatch, componentData?.descriptorFile])
 

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -1469,12 +1469,7 @@ export const ComponentSectionInner = React.memo((props: ComponentSectionProps) =
       )
 
       const descriptorFile =
-        registeredComponent?.source.type === 'DESCRIPTOR_FILE'
-          ? {
-              path: registeredComponent?.source.sourceDescriptorFile,
-              lineNumber: registeredComponent?.source.lineNumber,
-            }
-          : null
+        registeredComponent?.source.type === 'DESCRIPTOR_FILE' ? registeredComponent.source : null
 
       if (registeredComponent?.label == null) {
         return {
@@ -1498,9 +1493,9 @@ export const ComponentSectionInner = React.memo((props: ComponentSectionProps) =
     if (componentData?.descriptorFile != null) {
       dispatch([
         openCodeEditorFile(
-          componentData.descriptorFile.path,
+          componentData.descriptorFile.sourceDescriptorFile,
           true,
-          componentData.descriptorFile.lineNumber,
+          componentData.descriptorFile.bounds,
         ),
       ])
     }

--- a/editor/src/core/property-controls/component-descriptor-parser.ts
+++ b/editor/src/core/property-controls/component-descriptor-parser.ts
@@ -1,7 +1,6 @@
 import * as BabelParser from '@babel/parser'
 import traverse from '@babel/traverse'
 import type { Bounds } from 'utopia-vscode-common'
-import { boundsInFile } from 'utopia-vscode-common'
 import type { TextFileContentsWithPath } from './property-controls-local'
 
 export type ComponentBoundsByModule = {
@@ -75,13 +74,12 @@ export function generateComponentBounds(
           const componentName = component.key.name
           const { loc } = component
           if (loc != null) {
-            componentBoundsByModule[moduleName][componentName] = boundsInFile(
-              descriptorFile.path,
-              loc.start.line,
-              loc.start.column,
-              loc.end.line,
-              loc.end.column,
-            )
+            componentBoundsByModule[moduleName][componentName] = {
+              startLine: loc.start.line,
+              startCol: loc.start.column,
+              endLine: loc.end.line,
+              endCol: loc.end.column,
+            }
           }
         })
       })

--- a/editor/src/core/property-controls/component-descriptor-parser.ts
+++ b/editor/src/core/property-controls/component-descriptor-parser.ts
@@ -1,0 +1,80 @@
+import * as BabelParser from '@babel/parser'
+import traverse from '@babel/traverse'
+import type { Bounds } from 'utopia-vscode-common'
+import { boundsInFile } from 'utopia-vscode-common'
+import type { TextFileContentsWithPath } from './property-controls-local'
+
+export type ComponentBoundsByModule = {
+  [moduleName: string]: { [componentName: string]: Bounds }
+}
+
+export function generateComponentBounds(
+  descriptorFile: TextFileContentsWithPath,
+): ComponentBoundsByModule {
+  const ast = BabelParser.parse(descriptorFile.file.code, {
+    sourceType: 'module',
+    plugins: ['jsx'],
+  })
+
+  const bounds: ComponentBoundsByModule = {}
+
+  // Store variable declarations
+  const variableDeclarations: Record<string, any> = {}
+  // Traverse the AST to collect variable declarations
+  traverse(ast, {
+    VariableDeclarator(path) {
+      const { id, init } = path.node
+      if (id.type === 'Identifier' && init != null) {
+        variableDeclarations[id.name] = init
+      }
+    },
+  })
+
+  // Function to resolve a variable to its object value
+  function resolveVariable(node: any): any {
+    if (node.type === 'Identifier' && variableDeclarations[node.name] != null) {
+      return variableDeclarations[node.name]
+    }
+    return node
+  }
+
+  // Traverse the AST to find the default export and process the Components object
+  traverse(ast, {
+    ExportDefaultDeclaration(path) {
+      const declaration = path.node.declaration
+      if (declaration.type === 'Identifier') {
+        const variableName = declaration.name
+        const componentsNode = variableDeclarations[variableName]
+        if (componentsNode?.type === 'ObjectExpression') {
+          componentsNode.properties.forEach((prop: any) => {
+            if (prop.type === 'ObjectProperty' && prop.key.type === 'StringLiteral') {
+              const moduleName = prop.key.value
+              if (bounds[moduleName] == null) {
+                bounds[moduleName] = {}
+              }
+              const moduleValue = resolveVariable(prop.value)
+              if (moduleValue.type === 'ObjectExpression') {
+                moduleValue.properties.forEach((innerProp: any) => {
+                  if (innerProp.type === 'ObjectProperty' && innerProp.key.type === 'Identifier') {
+                    const componentName = innerProp.key.name
+                    const { loc } = innerProp
+                    if (loc != null) {
+                      bounds[moduleName][componentName] = boundsInFile(
+                        descriptorFile.path,
+                        loc.start.line,
+                        loc.start.column,
+                        loc.end.line,
+                        loc.end.column,
+                      )
+                    }
+                  }
+                })
+              }
+            }
+          })
+        }
+      }
+    },
+  })
+  return bounds
+}

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -144,7 +144,6 @@ describe('registered property controls', () => {
             "bounds": Object {
               "endCol": 5,
               "endLine": 42,
-              "filePath": "/utopia/components.utopia.js",
               "startCol": 4,
               "startLine": 5,
             },
@@ -381,7 +380,6 @@ describe('registered property controls', () => {
             "bounds": Object {
               "endCol": 5,
               "endLine": 16,
-              "filePath": "/utopia/components.utopia.js",
               "startCol": 4,
               "startLine": 6,
             },
@@ -1015,7 +1013,6 @@ describe('registered property controls', () => {
             "bounds": Object {
               "endCol": 5,
               "endLine": 32,
-              "filePath": "/utopia/components.utopia.js",
               "startCol": 4,
               "startLine": 5,
             },
@@ -1936,7 +1933,6 @@ describe('registered property controls', () => {
               "bounds": Object {
                 "endCol": 5,
                 "endLine": 34,
-                "filePath": "/utopia/components.utopia.js",
                 "startCol": 4,
                 "startLine": 6,
               },
@@ -2694,7 +2690,6 @@ describe('Lifecycle management of registering components', () => {
           "bounds": Object {
             "endCol": 5,
             "endLine": 12,
-            "filePath": "/utopia/components1.utopia.js",
             "startCol": 4,
             "startLine": 5,
           },
@@ -2712,7 +2707,6 @@ describe('Lifecycle management of registering components', () => {
           "bounds": Object {
             "endCol": 5,
             "endLine": 12,
-            "filePath": "/utopia/components2.utopia.js",
             "startCol": 4,
             "startLine": 5,
           },
@@ -2754,7 +2748,6 @@ describe('Lifecycle management of registering components', () => {
           "bounds": Object {
             "endCol": 5,
             "endLine": 12,
-            "filePath": "/utopia/components1.utopia.js",
             "startCol": 4,
             "startLine": 5,
           },
@@ -2806,7 +2799,6 @@ describe('Lifecycle management of registering components', () => {
           "bounds": Object {
             "endCol": 5,
             "endLine": 12,
-            "filePath": "/utopia/components1.utopia.js",
             "startCol": 4,
             "startLine": 5,
           },

--- a/editor/src/core/property-controls/property-controls-local.spec.tsx
+++ b/editor/src/core/property-controls/property-controls-local.spec.tsx
@@ -141,6 +141,13 @@ describe('registered property controls', () => {
             },
           },
           "source": Object {
+            "bounds": Object {
+              "endCol": 5,
+              "endLine": 42,
+              "filePath": "/utopia/components.utopia.js",
+              "startCol": 4,
+              "startLine": 5,
+            },
             "sourceDescriptorFile": "/utopia/components.utopia.js",
             "type": "DESCRIPTOR_FILE",
           },
@@ -287,6 +294,7 @@ describe('registered property controls', () => {
             },
           },
           "source": Object {
+            "bounds": null,
             "sourceDescriptorFile": "/utopia/components.utopia.js",
             "type": "DESCRIPTOR_FILE",
           },
@@ -370,6 +378,13 @@ describe('registered property controls', () => {
             },
           },
           "source": Object {
+            "bounds": Object {
+              "endCol": 5,
+              "endLine": 16,
+              "filePath": "/utopia/components.utopia.js",
+              "startCol": 4,
+              "startLine": 6,
+            },
             "sourceDescriptorFile": "/utopia/components.utopia.js",
             "type": "DESCRIPTOR_FILE",
           },
@@ -997,6 +1012,13 @@ describe('registered property controls', () => {
             },
           },
           "source": Object {
+            "bounds": Object {
+              "endCol": 5,
+              "endLine": 32,
+              "filePath": "/utopia/components.utopia.js",
+              "startCol": 4,
+              "startLine": 5,
+            },
             "sourceDescriptorFile": "/utopia/components.utopia.js",
             "type": "DESCRIPTOR_FILE",
           },
@@ -1911,6 +1933,13 @@ describe('registered property controls', () => {
               },
             },
             "source": Object {
+              "bounds": Object {
+                "endCol": 5,
+                "endLine": 34,
+                "filePath": "/utopia/components.utopia.js",
+                "startCol": 4,
+                "startLine": 6,
+              },
               "sourceDescriptorFile": "/utopia/components.utopia.js",
               "type": "DESCRIPTOR_FILE",
             },
@@ -2662,6 +2691,13 @@ describe('Lifecycle management of registering components', () => {
       expect(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']['Card'].source)
         .toMatchInlineSnapshot(`
         Object {
+          "bounds": Object {
+            "endCol": 5,
+            "endLine": 12,
+            "filePath": "/utopia/components1.utopia.js",
+            "startCol": 4,
+            "startLine": 5,
+          },
           "sourceDescriptorFile": "/utopia/components1.utopia.js",
           "type": "DESCRIPTOR_FILE",
         }
@@ -2673,6 +2709,13 @@ describe('Lifecycle management of registering components', () => {
       expect(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']['Card'].source)
         .toMatchInlineSnapshot(`
         Object {
+          "bounds": Object {
+            "endCol": 5,
+            "endLine": 12,
+            "filePath": "/utopia/components2.utopia.js",
+            "startCol": 4,
+            "startLine": 5,
+          },
           "sourceDescriptorFile": "/utopia/components2.utopia.js",
           "type": "DESCRIPTOR_FILE",
         }
@@ -2708,6 +2751,13 @@ describe('Lifecycle management of registering components', () => {
       expect(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']['Card'].source)
         .toMatchInlineSnapshot(`
         Object {
+          "bounds": Object {
+            "endCol": 5,
+            "endLine": 12,
+            "filePath": "/utopia/components1.utopia.js",
+            "startCol": 4,
+            "startLine": 5,
+          },
           "sourceDescriptorFile": "/utopia/components1.utopia.js",
           "type": "DESCRIPTOR_FILE",
         }
@@ -2753,6 +2803,13 @@ describe('Lifecycle management of registering components', () => {
       expect(renderResult.getEditorState().editor.propertyControlsInfo['/src/card']['Card'].source)
         .toMatchInlineSnapshot(`
         Object {
+          "bounds": Object {
+            "endCol": 5,
+            "endLine": 12,
+            "filePath": "/utopia/components1.utopia.js",
+            "startCol": 4,
+            "startLine": 5,
+          },
           "sourceDescriptorFile": "/utopia/components1.utopia.js",
           "type": "DESCRIPTOR_FILE",
         }

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -125,8 +125,8 @@ import type { ScriptLine } from '../../third-party/react-error-overlay/utils/sta
 import { intrinsicHTMLElementNamesAsStrings } from '../shared/dom-utils'
 import { valueOrArrayToArray } from '../shared/array-utils'
 import { optionalMap } from '../shared/optional-utils'
-import type { RenderContext } from 'src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils'
-import { ObjectExpression } from '@babel/types'
+import type { BoundsInFile } from 'utopia-vscode-common'
+import { boundsInFile } from 'utopia-vscode-common'
 
 const exportedNameSymbol = Symbol('__utopia__exportedName')
 const moduleNameSymbol = Symbol('__utopia__moduleName')
@@ -379,64 +379,7 @@ async function getComponentDescriptorPromisesFromParseResult(
   if (exportDefaultIdentifier?.name == null) {
     return { descriptors: [], errors: [{ type: 'no-export-default' }] }
   }
-  const ast = BabelParser.parse(descriptorFile.file.code, {
-    sourceType: 'module',
-    plugins: ['jsx'],
-  })
-
-  const lineNumbers: { [moduleName: string]: { [componentName: string]: number } } = {}
-
-  // Store variable declarations
-  const variableDeclarations: Record<string, any> = {}
-  // Traverse the AST to collect variable declarations
-  traverse(ast, {
-    VariableDeclarator(path) {
-      const { id, init } = path.node
-      if (id.type === 'Identifier' && init != null) {
-        variableDeclarations[id.name] = init
-      }
-    },
-  })
-
-  // Function to resolve a variable to its object value
-  function resolveVariable(node: any): any {
-    if (node.type === 'Identifier' && variableDeclarations[node.name] != null) {
-      return variableDeclarations[node.name]
-    }
-    return node
-  }
-
-  // Traverse the AST to find the default export and process the Components object
-  traverse(ast, {
-    ExportDefaultDeclaration(path) {
-      const declaration = path.node.declaration
-      if (declaration.type === 'Identifier') {
-        const variableName = declaration.name
-        const componentsNode = variableDeclarations[variableName]
-        if (componentsNode?.type === 'ObjectExpression') {
-          componentsNode.properties.forEach((prop: any) => {
-            if (prop.type === 'ObjectProperty' && prop.key.type === 'StringLiteral') {
-              const moduleName = prop.key.value
-              if (lineNumbers[moduleName] == null) {
-                lineNumbers[moduleName] = {}
-              }
-              const moduleValue = resolveVariable(prop.value)
-              if (moduleValue.type === 'ObjectExpression') {
-                moduleValue.properties.forEach((innerProp: any) => {
-                  if (innerProp.type === 'ObjectProperty' && innerProp.key.type === 'Identifier') {
-                    const componentName = innerProp.key.name
-                    const componentStartLine = innerProp.loc?.start.line
-                    const componentEndLine = innerProp.loc?.end.line
-                    lineNumbers[moduleName][componentName] = componentStartLine
-                  }
-                })
-              }
-            }
-          })
-        }
-      }
-    },
-  })
+  const componentBounds = generateComponentBounds(descriptorFile)
 
   try {
     const evaluatedFile = evaluator(descriptorFile.path)
@@ -484,7 +427,7 @@ async function getComponentDescriptorPromisesFromParseResult(
           workers,
           componentDescriptorFromDescriptorFile(
             descriptorFile.path,
-            lineNumbers[moduleName][componentName],
+            componentBounds[moduleName][componentName]?.startLine ?? null,
           ),
         )
 
@@ -508,6 +451,81 @@ async function getComponentDescriptorPromisesFromParseResult(
     console.error(e)
     return { descriptors: [], errors: [{ type: 'evaluation-error', evaluationError: e }] }
   }
+}
+
+export type ComponentBoundsByModule = {
+  [moduleName: string]: { [componentName: string]: BoundsInFile }
+}
+
+function generateComponentBounds(
+  descriptorFile: TextFileContentsWithPath,
+): ComponentBoundsByModule {
+  const ast = BabelParser.parse(descriptorFile.file.code, {
+    sourceType: 'module',
+    plugins: ['jsx'],
+  })
+
+  const bounds: ComponentBoundsByModule = {}
+
+  // Store variable declarations
+  const variableDeclarations: Record<string, any> = {}
+  // Traverse the AST to collect variable declarations
+  traverse(ast, {
+    VariableDeclarator(path) {
+      const { id, init } = path.node
+      if (id.type === 'Identifier' && init != null) {
+        variableDeclarations[id.name] = init
+      }
+    },
+  })
+
+  // Function to resolve a variable to its object value
+  function resolveVariable(node: any): any {
+    if (node.type === 'Identifier' && variableDeclarations[node.name] != null) {
+      return variableDeclarations[node.name]
+    }
+    return node
+  }
+
+  // Traverse the AST to find the default export and process the Components object
+  traverse(ast, {
+    ExportDefaultDeclaration(path) {
+      const declaration = path.node.declaration
+      if (declaration.type === 'Identifier') {
+        const variableName = declaration.name
+        const componentsNode = variableDeclarations[variableName]
+        if (componentsNode?.type === 'ObjectExpression') {
+          componentsNode.properties.forEach((prop: any) => {
+            if (prop.type === 'ObjectProperty' && prop.key.type === 'StringLiteral') {
+              const moduleName = prop.key.value
+              if (bounds[moduleName] == null) {
+                bounds[moduleName] = {}
+              }
+              const moduleValue = resolveVariable(prop.value)
+              if (moduleValue.type === 'ObjectExpression') {
+                moduleValue.properties.forEach((innerProp: any) => {
+                  if (innerProp.type === 'ObjectProperty' && innerProp.key.type === 'Identifier') {
+                    const componentName = innerProp.key.name
+                    const { loc } = innerProp
+                    if (loc != null) {
+                      bounds[moduleName][componentName] = boundsInFile(
+                        descriptorFile.path,
+                        loc.start.line,
+                        loc.start.column,
+                        loc.end.line,
+                        loc.end.column,
+                      )
+                    }
+                  }
+                })
+              }
+            }
+          })
+        }
+      }
+    },
+  })
+  return bounds
 }
 
 function simpleErrorMessage(

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -1,6 +1,3 @@
-import * as BabelParser from '@babel/parser'
-import traverse from '@babel/traverse'
-
 import type {
   RegularControlDescription as RegularControlDescriptionFromUtopia,
   JSXControlDescription as JSXControlDescriptionFromUtopia,
@@ -125,8 +122,7 @@ import type { ScriptLine } from '../../third-party/react-error-overlay/utils/sta
 import { intrinsicHTMLElementNamesAsStrings } from '../shared/dom-utils'
 import { valueOrArrayToArray } from '../shared/array-utils'
 import { optionalMap } from '../shared/optional-utils'
-import type { BoundsInFile } from 'utopia-vscode-common'
-import { boundsInFile } from 'utopia-vscode-common'
+import { generateComponentBounds } from './component-descriptor-parser'
 
 const exportedNameSymbol = Symbol('__utopia__exportedName')
 const moduleNameSymbol = Symbol('__utopia__moduleName')
@@ -427,7 +423,7 @@ async function getComponentDescriptorPromisesFromParseResult(
           workers,
           componentDescriptorFromDescriptorFile(
             descriptorFile.path,
-            componentBounds[moduleName][componentName]?.startLine ?? null,
+            componentBounds[moduleName][componentName] ?? null,
           ),
         )
 
@@ -451,81 +447,6 @@ async function getComponentDescriptorPromisesFromParseResult(
     console.error(e)
     return { descriptors: [], errors: [{ type: 'evaluation-error', evaluationError: e }] }
   }
-}
-
-export type ComponentBoundsByModule = {
-  [moduleName: string]: { [componentName: string]: BoundsInFile }
-}
-
-function generateComponentBounds(
-  descriptorFile: TextFileContentsWithPath,
-): ComponentBoundsByModule {
-  const ast = BabelParser.parse(descriptorFile.file.code, {
-    sourceType: 'module',
-    plugins: ['jsx'],
-  })
-
-  const bounds: ComponentBoundsByModule = {}
-
-  // Store variable declarations
-  const variableDeclarations: Record<string, any> = {}
-  // Traverse the AST to collect variable declarations
-  traverse(ast, {
-    VariableDeclarator(path) {
-      const { id, init } = path.node
-      if (id.type === 'Identifier' && init != null) {
-        variableDeclarations[id.name] = init
-      }
-    },
-  })
-
-  // Function to resolve a variable to its object value
-  function resolveVariable(node: any): any {
-    if (node.type === 'Identifier' && variableDeclarations[node.name] != null) {
-      return variableDeclarations[node.name]
-    }
-    return node
-  }
-
-  // Traverse the AST to find the default export and process the Components object
-  traverse(ast, {
-    ExportDefaultDeclaration(path) {
-      const declaration = path.node.declaration
-      if (declaration.type === 'Identifier') {
-        const variableName = declaration.name
-        const componentsNode = variableDeclarations[variableName]
-        if (componentsNode?.type === 'ObjectExpression') {
-          componentsNode.properties.forEach((prop: any) => {
-            if (prop.type === 'ObjectProperty' && prop.key.type === 'StringLiteral') {
-              const moduleName = prop.key.value
-              if (bounds[moduleName] == null) {
-                bounds[moduleName] = {}
-              }
-              const moduleValue = resolveVariable(prop.value)
-              if (moduleValue.type === 'ObjectExpression') {
-                moduleValue.properties.forEach((innerProp: any) => {
-                  if (innerProp.type === 'ObjectProperty' && innerProp.key.type === 'Identifier') {
-                    const componentName = innerProp.key.name
-                    const { loc } = innerProp
-                    if (loc != null) {
-                      bounds[moduleName][componentName] = boundsInFile(
-                        descriptorFile.path,
-                        loc.start.line,
-                        loc.start.column,
-                        loc.end.line,
-                        loc.end.column,
-                      )
-                    }
-                  }
-                })
-              }
-            }
-          })
-        }
-      }
-    },
-  })
-  return bounds
 }
 
 function simpleErrorMessage(

--- a/editor/src/core/property-controls/property-controls-local.ts
+++ b/editor/src/core/property-controls/property-controls-local.ts
@@ -375,7 +375,7 @@ async function getComponentDescriptorPromisesFromParseResult(
   if (exportDefaultIdentifier?.name == null) {
     return { descriptors: [], errors: [{ type: 'no-export-default' }] }
   }
-  const componentBounds = generateComponentBounds(descriptorFile)
+  const componentBoundsByModule = generateComponentBounds(descriptorFile)
 
   try {
     const evaluatedFile = evaluator(descriptorFile.path)
@@ -423,7 +423,7 @@ async function getComponentDescriptorPromisesFromParseResult(
           workers,
           componentDescriptorFromDescriptorFile(
             descriptorFile.path,
-            componentBounds[moduleName][componentName] ?? null,
+            componentBoundsByModule[moduleName][componentName] ?? null,
           ),
         )
 

--- a/editor/src/core/property-controls/property-controls-utils.spec.ts
+++ b/editor/src/core/property-controls/property-controls-utils.spec.ts
@@ -106,7 +106,7 @@ export const App = (props) => {
     supportsChildren: true,
     preferredChildComponents: [],
     variants: [],
-    source: componentDescriptorFromDescriptorFile('/components.utopia.js'),
+    source: componentDescriptorFromDescriptorFile('/components.utopia.js', 0),
     focus: 'default',
     inspector: { type: 'hidden' },
     emphasis: 'regular',

--- a/editor/src/core/property-controls/property-controls-utils.spec.ts
+++ b/editor/src/core/property-controls/property-controls-utils.spec.ts
@@ -106,7 +106,7 @@ export const App = (props) => {
     supportsChildren: true,
     preferredChildComponents: [],
     variants: [],
-    source: componentDescriptorFromDescriptorFile('/components.utopia.js', 0),
+    source: componentDescriptorFromDescriptorFile('/components.utopia.js', null),
     focus: 'default',
     inspector: { type: 'hidden' },
     emphasis: 'regular',

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -6,6 +6,7 @@ import type {
   SelectedElementChanged,
   UpdateDecorationsMessage,
   ForceNavigation,
+  BoundsInFile,
 } from 'utopia-vscode-common'
 import {
   boundsInFile,
@@ -177,8 +178,8 @@ export function sendMessage(message: FromUtopiaToVSCodeMessage) {
   vscodeIFrame?.postMessage(message, { targetOrigin: '*' })
 }
 
-export function sendOpenFileMessage(filePath: string) {
-  sendMessage(toVSCodeExtensionMessage(openFileMessage(filePath)))
+export function sendOpenFileMessage(filePath: string, bounds?: BoundsInFile) {
+  sendMessage(toVSCodeExtensionMessage(openFileMessage(filePath, bounds)))
 }
 
 export function sendSetFollowSelectionEnabledMessage(enabled: boolean) {

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -6,7 +6,7 @@ import type {
   SelectedElementChanged,
   UpdateDecorationsMessage,
   ForceNavigation,
-  BoundsInFile,
+  Bounds,
 } from 'utopia-vscode-common'
 import {
   boundsInFile,
@@ -178,7 +178,7 @@ export function sendMessage(message: FromUtopiaToVSCodeMessage) {
   vscodeIFrame?.postMessage(message, { targetOrigin: '*' })
 }
 
-export function sendOpenFileMessage(filePath: string, bounds?: BoundsInFile) {
+export function sendOpenFileMessage(filePath: string, bounds: Bounds | null) {
   sendMessage(toVSCodeExtensionMessage(openFileMessage(filePath, bounds)))
 }
 

--- a/utopia-vscode-common/src/messages.ts
+++ b/utopia-vscode-common/src/messages.ts
@@ -6,11 +6,11 @@ export interface OpenFileMessage {
   bounds: Bounds | null
 }
 
-export function openFileMessage(filePath: string, bounds?: Bounds): OpenFileMessage {
+export function openFileMessage(filePath: string, bounds: Bounds | null): OpenFileMessage {
   return {
     type: 'OPEN_FILE',
     filePath: filePath,
-    bounds: bounds ?? null,
+    bounds: bounds,
   }
 }
 

--- a/utopia-vscode-common/src/messages.ts
+++ b/utopia-vscode-common/src/messages.ts
@@ -3,12 +3,14 @@ import type { UtopiaVSCodeConfig } from './utopia-vscode-config'
 export interface OpenFileMessage {
   type: 'OPEN_FILE'
   filePath: string
+  bounds: BoundsInFile | null
 }
 
-export function openFileMessage(filePath: string): OpenFileMessage {
+export function openFileMessage(filePath: string, bounds?: BoundsInFile): OpenFileMessage {
   return {
     type: 'OPEN_FILE',
     filePath: filePath,
+    bounds: bounds ?? null,
   }
 }
 

--- a/utopia-vscode-common/src/messages.ts
+++ b/utopia-vscode-common/src/messages.ts
@@ -3,10 +3,10 @@ import type { UtopiaVSCodeConfig } from './utopia-vscode-config'
 export interface OpenFileMessage {
   type: 'OPEN_FILE'
   filePath: string
-  bounds: BoundsInFile | null
+  bounds: Bounds | null
 }
 
-export function openFileMessage(filePath: string, bounds?: BoundsInFile): OpenFileMessage {
+export function openFileMessage(filePath: string, bounds?: Bounds): OpenFileMessage {
   return {
     type: 'OPEN_FILE',
     filePath: filePath,

--- a/utopia-vscode-common/src/vscode-communication.ts
+++ b/utopia-vscode-common/src/vscode-communication.ts
@@ -138,7 +138,7 @@ async function initIndexedDBBridge(
     await sendMessage(getUtopiaVSCodeConfig())
     watchForChanges()
     if (openFilePath != null) {
-      await sendMessage(openFileMessage(openFilePath))
+      await sendMessage(openFileMessage(openFilePath, null))
     } else {
       window.top?.postMessage(fromVSCodeExtensionMessage(clearLoadingScreen()), '*')
     }

--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -338,7 +338,11 @@ function initMessaging(context: vscode.ExtensionContext, workspaceRootUri: vscod
   function handleMessage(message: ToVSCodeMessage): void {
     switch (message.type) {
       case 'OPEN_FILE':
-        openFile(vscode.Uri.joinPath(workspaceRootUri, message.filePath))
+        if (message.bounds) {
+          revealRangeIfPossible(workspaceRootUri, message.bounds)
+        } else {
+          openFile(vscode.Uri.joinPath(workspaceRootUri, message.filePath))
+        }
         break
       case 'UPDATE_DECORATIONS':
         currentDecorations = message.decorations

--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -338,7 +338,7 @@ function initMessaging(context: vscode.ExtensionContext, workspaceRootUri: vscod
   function handleMessage(message: ToVSCodeMessage): void {
     switch (message.type) {
       case 'OPEN_FILE':
-        if (message.bounds) {
+        if (message.bounds != null) {
           revealRangeIfPossible(workspaceRootUri, { ...message.bounds, filePath: message.filePath })
         } else {
           openFile(vscode.Uri.joinPath(workspaceRootUri, message.filePath))

--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -339,7 +339,7 @@ function initMessaging(context: vscode.ExtensionContext, workspaceRootUri: vscod
     switch (message.type) {
       case 'OPEN_FILE':
         if (message.bounds) {
-          revealRangeIfPossible(workspaceRootUri, message.bounds)
+          revealRangeIfPossible(workspaceRootUri, { ...message.bounds, filePath: message.filePath })
         } else {
           openFile(vscode.Uri.joinPath(workspaceRootUri, message.filePath))
         }


### PR DESCRIPTION
**Problem:**
Followup to https://github.com/concrete-utopia/utopia/pull/5989
Clicking on the Components inspector section's ◇ logo opens the annotation file for the given component AND jumps to the annotation of the component in the file.

(Second task of https://github.com/concrete-utopia/utopia/issues/5971 )


**Fix:**
I used the Babel parser to find the component annotation in the sidecar file.
- It can find the annotation if it in the exported object literal, or even if it is in a variable referred from this file. It does not support imports though, everything has to be in this file.
- This is a best effort to find the annotation, if it can not do it like this (e.g. the annotation is dynamically generated, or anything which the parser is not prepared for), then it just doesn't save the bounds. Clicking on the button will still open the sidecar file.

The bounds are stored in the component descriptor source object (which until now only stored the file path itself).

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
