### PR TITLE
Fix: getCollaborators inflated query

### DIFF
--- a/utopia-remix/app/models/project.server.ts
+++ b/utopia-remix/app/models/project.server.ts
@@ -206,7 +206,9 @@ export async function listSharedWithMeProjectsAndCollaborators(params: {
       Project: {
         select: {
           ...selectProjectWithoutContent,
-          ProjectCollaborator: { select: { User: true } },
+          ProjectCollaborator: {
+            select: { User: { select: { user_id: true, name: true, picture: true } } },
+          },
         },
       },
     },

--- a/utopia-remix/app/models/project.server.ts
+++ b/utopia-remix/app/models/project.server.ts
@@ -16,6 +16,7 @@ import {
 } from '../types'
 import { ensure } from '../util/api.server'
 import { Status } from '../util/statusCodes'
+import { selectUserDetailsForProjectCollaborator } from './projectCollaborators.server'
 
 const selectProjectWithoutContent: Record<keyof ProjectWithoutContentFromDB, true> = {
   id: true,
@@ -207,7 +208,7 @@ export async function listSharedWithMeProjectsAndCollaborators(params: {
         select: {
           ...selectProjectWithoutContent,
           ProjectCollaborator: {
-            select: { User: { select: { user_id: true, name: true, picture: true } } },
+            select: { User: { select: selectUserDetailsForProjectCollaborator } },
           },
         },
       },

--- a/utopia-remix/app/models/projectCollaborators.server.ts
+++ b/utopia-remix/app/models/projectCollaborators.server.ts
@@ -4,6 +4,13 @@ import { prisma } from '../db.server'
 import { userToCollaborator, type CollaboratorsByProject } from '../types'
 import type { GetBatchResult } from 'prisma-client/runtime/library.js'
 
+export const selectUserDetailsForProjectCollaborator: Partial<Record<keyof UserDetails, boolean>> =
+  {
+    user_id: true,
+    name: true,
+    picture: true,
+  }
+
 export async function getCollaborators(params: {
   ids: string[]
   userId: string
@@ -13,7 +20,7 @@ export async function getCollaborators(params: {
     select: {
       proj_id: true,
       ProjectCollaborator: {
-        select: { User: { select: { user_id: true, name: true, picture: true } } },
+        select: { User: { select: selectUserDetailsForProjectCollaborator } },
       },
     },
   })
@@ -23,6 +30,8 @@ export async function getCollaborators(params: {
     const collaboratorUserDetails = project.ProjectCollaborator.map(({ User }) => User)
     collaboratorsByProject[project.proj_id] = collaboratorUserDetails.map(userToCollaborator)
   }
+
+  // TODO this could return a much slimmer payload by having two objects: 1) projectId -> userId[], 2) userId -> userDetails
   return collaboratorsByProject
 }
 

--- a/utopia-remix/app/models/projectCollaborators.server.ts
+++ b/utopia-remix/app/models/projectCollaborators.server.ts
@@ -1,8 +1,7 @@
-import type { ProjectCollaborator, UserDetails } from 'prisma-client'
+import type { UserDetails } from 'prisma-client'
 import type { UtopiaPrismaClient } from '../db.server'
 import { prisma } from '../db.server'
-import type { CollaboratorsByProject } from '../types'
-import { userToCollaborator } from '../types'
+import { userToCollaborator, type CollaboratorsByProject } from '../types'
 import type { GetBatchResult } from 'prisma-client/runtime/library.js'
 
 export async function getCollaborators(params: {
@@ -11,7 +10,12 @@ export async function getCollaborators(params: {
 }): Promise<CollaboratorsByProject> {
   const projects = await prisma.project.findMany({
     where: { proj_id: { in: params.ids }, owner_id: params.userId },
-    include: { ProjectCollaborator: { include: { User: true } } },
+    select: {
+      proj_id: true,
+      ProjectCollaborator: {
+        select: { User: { select: { user_id: true, name: true, picture: true } } },
+      },
+    },
   })
 
   let collaboratorsByProject: CollaboratorsByProject = {}

--- a/utopia-remix/app/types.ts
+++ b/utopia-remix/app/types.ts
@@ -53,7 +53,9 @@ export interface Collaborator {
 
 export type CollaboratorsByProject = { [projectId: string]: Collaborator[] }
 
-export function userToCollaborator(user: UserDetails): Collaborator {
+export function userToCollaborator(
+  user: Pick<UserDetails, 'user_id' | 'name' | 'picture'>,
+): Collaborator {
   return {
     id: user.user_id,
     name: user.name,


### PR DESCRIPTION
**Problem:**

The `getCollaborators` query is not correctly filtering out unneeded project data which can lead to a scary looking bug:

<img width="822" alt="Screenshot 2024-06-19 at 4 52 39 PM" src="https://github.com/concrete-utopia/utopia/assets/1081051/fdfbee87-a0bb-45bc-9dc4-4f8480dd887e">

**Fix:**

Select only what's needed, symmetrically for both owned and shared projects.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
