### PR TITLE
Remove preview shortcut

### DIFF
--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -74,7 +74,6 @@ import {
   TOGGLE_INSPECTOR_AND_NAVIGATOR_SHORTCUT,
   TOGGLE_NAVIGATOR,
   TOGGLE_LIVE_CANVAS_SHORTCUT,
-  TOGGLE_PREVIEW_SHORTCUT,
   TOGGLE_INSPECTOR,
   TOGGLE_SHADOW_SHORTCUT,
   UNDO_CHANGES_SHORTCUT,
@@ -624,9 +623,6 @@ export function handleKeyDown(
           }
         }
         return []
-      },
-      [TOGGLE_PREVIEW_SHORTCUT]: () => {
-        return [EditorActions.togglePanel('preview')]
       },
       [TOGGLE_LIVE_CANVAS_SHORTCUT]: () => {
         return [EditorActions.toggleCanvasIsLive()]

--- a/editor/src/components/editor/shortcut-definitions.ts
+++ b/editor/src/components/editor/shortcut-definitions.ts
@@ -47,7 +47,6 @@ export const WRAP_ELEMENT_PICKER_SHORTCUT = 'wrap-element-picker'
 export const GROUP_ELEMENT_DEFAULT_SHORTCUT = 'group-element-default'
 export const TOGGLE_HIDDEN_SHORTCUT = 'toggle-hidden'
 export const INSERT_IMAGE_SHORTCUT = 'insert-image'
-export const TOGGLE_PREVIEW_SHORTCUT = 'toggle-preview'
 export const TOGGLE_LIVE_CANVAS_SHORTCUT = 'toggle-live-canvas'
 export const START_RENAMING_SHORTCUT = 'start-renaming'
 export const INSERT_RECTANGLE_SHORTCUT = 'insert-rectangle'
@@ -152,7 +151,6 @@ const shortcutDetailsWithDefaults: ShortcutDetails = {
   [GROUP_ELEMENT_DEFAULT_SHORTCUT]: shortcut('Group elements with a div.', key('g', 'cmd')),
   [TOGGLE_HIDDEN_SHORTCUT]: shortcut('Toggle element as hidden.', key('h', ['cmd', 'shift'])),
   [INSERT_IMAGE_SHORTCUT]: shortcut('Insert an image.', key('i', [])),
-  [TOGGLE_PREVIEW_SHORTCUT]: shortcut('Toggle the preview panel.', key('p', 'cmd')),
   [TOGGLE_LIVE_CANVAS_SHORTCUT]: shortcut(
     'Toggle the canvas between live and edit mode.',
     key('p', ['cmd', 'shift']),


### PR DESCRIPTION
**Problem:**
Preview doesn't work, let's remove its keyboard shortcut (which interferes with vscode's open file shortcut).

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

