### PR TITLE
Fix resizing reordered panels

### DIFF
--- a/editor/src/components/canvas/stored-layout.ts
+++ b/editor/src/components/canvas/stored-layout.ts
@@ -41,6 +41,8 @@ export interface GridPanelData {
 
 export type PanelName = Menu | Pane
 
+export type PanelVisibility = Record<PanelName, boolean>
+
 export interface StoredPanel {
   name: PanelName
   type: 'menu' | 'pane'


### PR DESCRIPTION
**Problem:**

A reordered panel that is the only element of a column cannot be resized.

**Fix:**

When calculating non empty columns, take into account the visibility of the column panels too, which would otherwise return a zombie column index and mess up the resizing calculations.

https://github.com/concrete-utopia/utopia/assets/1081051/4b07009e-6849-4008-b1f8-8e3479126b2c

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #6005 
