### PR TITLE
Clear Highlights On Other Panels

### DIFF
--- a/editor/src/components/canvas/grid-panel.tsx
+++ b/editor/src/components/canvas/grid-panel.tsx
@@ -9,6 +9,8 @@ import {
   GridPanelHorizontalGapHalf,
   GridPanelVerticalGapHalf,
 } from './stored-layout'
+import { useDispatch } from '../editor/store/dispatch-context'
+import { clearHighlightedViews } from '../editor/actions/action-creators'
 
 interface GridPanelProps {
   onDrop: (itemToMove: StoredPanel, newPosition: LayoutUpdate) => void
@@ -84,6 +86,12 @@ const GridPanelInner = React.memo<GridPanelProps>((props) => {
     }
   })()
 
+  const dispatch = useDispatch()
+
+  const onMouseEnter = React.useCallback(() => {
+    dispatch([clearHighlightedViews()], 'everyone')
+  }, [dispatch])
+
   return (
     <div
       style={{
@@ -99,6 +107,7 @@ const GridPanelInner = React.memo<GridPanelProps>((props) => {
         paddingTop: GridPanelVerticalGapHalf,
         paddingBottom: GridPanelVerticalGapHalf,
       }}
+      onMouseEnter={onMouseEnter}
     >
       {draggablePanelComponent}
       <div


### PR DESCRIPTION
**Problem:**
Highlights end up getting stuck if the user mouses over an element and into a panel like the inspector.

**Fix:**
The common `GridPanelInner` component used by the inspector/navigator/code editor clears highlights when the mouse enters it.

**Commit Details:**
- Added an `onMouseEnter` handler to `GridPanelInner` which clears the highlights.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #6008
