### PR TITLE
Prevent None Controls From Adding Rows To Inspector.

### DIFF
--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -8,6 +8,7 @@ import type {
   ArrayControlDescription,
   BaseControlDescription,
   ControlDescription,
+  NoneControlDescription,
   ObjectControlDescription,
   RegularControlDescription,
   TupleControlDescription,
@@ -934,6 +935,11 @@ const ArrayControlItem = React.memo((props: ArrayControlItemProps) => {
   const contextMenuItems = Utils.stripNulls([addOnUnsetValues([index], propMetadata.onUnsetValues)])
 
   const contextMenuId = `context-menu-for-${PP.toString(propPathWithIndex)}`
+
+  if (controlDescription.propertyControl.control === 'none') {
+    return null
+  }
+
   return (
     <InspectorContextMenuWrapper
       id={contextMenuId}
@@ -1082,6 +1088,12 @@ const TupleControlItem = React.memo((props: TupleControlItemProps) => {
   )
   const contextMenuItems = Utils.stripNulls([addOnUnsetValues([index], propMetadata.onUnsetValues)])
 
+  const indexedPropertyControls = controlDescription.propertyControls[index]
+
+  if (indexedPropertyControls.control === 'none') {
+    return null
+  }
+
   return (
     <InspectorContextMenuWrapper
       id={`context-menu-for-${PP.toString(propPathWithIndex)}`}
@@ -1090,7 +1102,7 @@ const TupleControlItem = React.memo((props: TupleControlItemProps) => {
       key={index}
     >
       <RowForControl
-        controlDescription={controlDescription.propertyControls[index]}
+        controlDescription={indexedPropertyControls}
         isScene={isScene}
         propPath={PP.appendPropertyPathElems(propPath, [index])}
         setGlobalCursor={props.setGlobalCursor}
@@ -1244,6 +1256,9 @@ const RowForObjectControl = React.memo((props: RowForObjectControlProps) => {
         open,
         mapToArray((innerControl: RegularControlDescription, prop: string, index: number) => {
           const innerPropPath = PP.appendPropertyPathElems(propPath, [prop])
+          if (innerControl.control === 'none') {
+            return null
+          }
           return (
             <RowForControl
               key={`object-control-row-${PP.toString(innerPropPath)}`}
@@ -1343,7 +1358,7 @@ const RowForUnionControl = React.memo((props: RowForUnionControlProps) => {
 RowForUnionControl.displayName = 'RowForUnionControl'
 
 interface RowForControlProps extends AbstractRowForControlProps {
-  controlDescription: RegularControlDescription
+  controlDescription: Exclude<RegularControlDescription, NoneControlDescription>
   disableToggling?: boolean
 }
 

--- a/editor/src/components/inspector/sections/component-section/folder-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/folder-section.tsx
@@ -88,6 +88,9 @@ export const FolderSection = React.memo((props: FolderSectionProps) => {
 
   const createRowForControl = (propName: string, focusOnMount: boolean) => {
     const controlDescription = props.propertyControls[propName]
+    if (controlDescription.control === 'none') {
+      return null
+    }
     return (
       <RowOrFolderWrapper
         key={`section-row-${propName}`}
@@ -126,19 +129,23 @@ export const FolderSection = React.memo((props: FolderSectionProps) => {
               propValue,
               propName,
             )
-            return (
-              <RowForControl
-                key={propName}
-                propPath={PP.create(propName)}
-                controlDescription={controlDescription}
-                isScene={false}
-                setGlobalCursor={props.setGlobalCursor}
-                indentationLevel={props.indentationLevel}
-                shouldIncreaseIdentation={true}
-                showHiddenControl={props.showHiddenControl}
-                focusOnMount={false}
-              />
-            )
+            if (controlDescription.control === 'none') {
+              return null
+            } else {
+              return (
+                <RowForControl
+                  key={propName}
+                  propPath={PP.create(propName)}
+                  controlDescription={controlDescription}
+                  isScene={false}
+                  setGlobalCursor={props.setGlobalCursor}
+                  indentationLevel={props.indentationLevel}
+                  shouldIncreaseIdentation={true}
+                  showHiddenControl={props.showHiddenControl}
+                  focusOnMount={false}
+                />
+              )
+            }
           }
         }),
       )}

--- a/editor/src/components/inspector/sections/component-section/row-or-folder-wrapper.tsx
+++ b/editor/src/components/inspector/sections/component-section/row-or-folder-wrapper.tsx
@@ -19,6 +19,9 @@ type RowOrFolderWrapperProps = {
 }
 
 export const RowOrFolderWrapper = React.memo((props: RowOrFolderWrapperProps) => {
+  if (props.controlDescription.control === 'none') {
+    return null
+  }
   return (
     <UIGridRow padded={false} tall={false} variant='<-------------1fr------------->'>
       <RowForControl


### PR DESCRIPTION
**Problem:**
Annotations: the 'none' control accidentally creates an empty row.

**Fix:**
Added conditions to return null for the `none` cases, as well as changing the type for `RowForControl` to prevent it from being possible to use `none` control with it.

**Commit Details:**
- Added in cases to stop `none` controls from reaching a `RowForControl`.
- Changed `RowForControlProps.controlDescription` to `exclude `NoneControlDescription`.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #6002
