### PR TITLE
fix(homepage): link to projects page instead of the editor

### DIFF
--- a/utopia-remix/app/components/next.tsx
+++ b/utopia-remix/app/components/next.tsx
@@ -13,7 +13,7 @@ const mainNavigation = [
   { name: 'Discord', href: 'https://discord.gg/NEEnPKCgzC' },
   {
     name: 'Play with Utopia',
-    href: 'https://utopia.app/p/36ae27be-welcome-to-utopia',
+    href: 'https://utopia.app/projects',
     primary: true,
   },
 ]
@@ -216,7 +216,7 @@ export const GhostBrowser = (props: {
 )
 
 const contactUsNavigation = [
-  { name: 'Play with Utopia', href: 'https://utopia.app/p/36ae27be-welcome-to-utopia' },
+  { name: 'Play with Utopia', href: 'https://utopia.app/projects' },
   { name: 'Join our Discord', href: 'https://discord.gg/NEEnPKCgzC' },
   { name: 'Check us on Github', href: 'https://github.com/concrete-utopia/utopia' },
   { name: 'Privacy Policy', href: '/policies#privacy-policy' },

--- a/website-next/components/contact-us.js
+++ b/website-next/components/contact-us.js
@@ -1,7 +1,7 @@
-import { BasicEmailSignup } from './email-signup'
+import React, { BasicEmailSignup } from './email-signup'
 
 const navigation = [
-  { name: 'Play with Utopia', href: 'https://utopia.app/p/36ae27be-welcome-to-utopia' },
+  { name: 'Play with Utopia', href: 'https://utopia.app/projects' },
   { name: 'Join our Discord', href: 'https://discord.gg/NEEnPKCgzC' },
   { name: 'Check us on Github', href: 'https://github.com/concrete-utopia/utopia' },
   { name: 'Privacy Policy', href: '/policies#privacy-policy' },

--- a/website-next/components/menu.js
+++ b/website-next/components/menu.js
@@ -1,4 +1,4 @@
-import { Fragment } from 'react'
+import React, { Fragment } from 'react'
 import { Popover, Transition } from '@headlessui/react'
 import { MenuIcon, XIcon } from '@heroicons/react/outline'
 import { HostedImage } from './hosted-image'
@@ -14,7 +14,7 @@ const navigation = [
   { name: 'Discord', href: 'https://discord.gg/NEEnPKCgzC' },
   {
     name: 'Play with Utopia',
-    href: 'https://utopia.app/p/36ae27be-welcome-to-utopia',
+    href: 'https://utopia.app/projects',
     primary: true,
   },
 ]


### PR DESCRIPTION
Change the link in our site to point to `utopia.app/projects` instead of `utopia.app/p/36ae27be-welcome-to-utopia`