### PR TITLE
fix(requireFn): stub Node's tty module

### DIFF
--- a/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
@@ -8,6 +8,7 @@ import * as ReactDOM from 'react-dom'
 import * as ReactRouter from 'react-router'
 import * as ReactJsxRuntime from 'react/jsx-runtime'
 import * as UtopiaAPI from 'utopia-api'
+import * as TTYStub from './node-builtin-shims/tty-stub'
 import * as UUIUI from '../../../uuiui'
 import * as UUIUIDeps from '../../../uuiui-deps'
 import * as RemixServerBuild from './built-in-third-party-dependencies/remix-server-build'
@@ -121,5 +122,7 @@ export function createBuiltInDependenciesList(
     builtInDependency('@remix-run/eslint-config', Stub, '2.1.0'),
     builtInDependency('@shopify/cli', Stub, '3.50.0'),
     builtInDependency('@shopify/cli-hydrogen', Stub, '6.0.0'),
+    // Node builtins
+    builtInDependency('tty', TTYStub, '*'),
   ]
 }

--- a/editor/src/core/es-modules/package-manager/node-builtin-shims/tty-stub.ts
+++ b/editor/src/core/es-modules/package-manager/node-builtin-shims/tty-stub.ts
@@ -1,0 +1,9 @@
+export const isatty = () => false
+
+export function ReadStream() {
+  throw new Error('tty.ReadStream is not implemented')
+}
+
+export function WriteStream() {
+  throw new Error('tty.WriteStream is not implemented')
+}

--- a/editor/src/core/tailwind/tailwind.ts
+++ b/editor/src/core/tailwind/tailwind.ts
@@ -124,6 +124,7 @@ function getTailwindConfig(
         return left('Tailwind config contains no default export')
       }
     } catch (error) {
+      console.error('Error loading tailwind config', error)
       return left(error)
     }
   }


### PR DESCRIPTION
**Problem:**
Our sample store project uses Tailwind's plugins that are meant to run on Node, requiring `tty` module and breaking the `twind` process

**Fix:**
Stub the `tty` module. The future complete solution would be to stub all of Node builtin modules, or to run Tailwind on the server or container

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode

Fixes #[ticket_number] (<< pls delete this line if it's not relevant)
