### PR TITLE
Roll your own tab (mostly empty)

### DIFF
--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -36,7 +36,7 @@ import { useAllowedToEditProject } from '../editor/store/collaborative-editing'
 import { useCanComment } from '../../core/commenting/comment-hooks'
 import { ElementsOutsideVisibleAreaIndicator } from '../editor/elements-outside-visible-area-indicator'
 import { isFeatureEnabled } from '../../utils/feature-switches'
-import { RollYourOwnPane } from '../navigator/left-pane/roll-your-own-pane'
+import { RollYourOwnFeaturesPane } from '../navigator/left-pane/roll-your-own-pane'
 
 function isCodeEditorEnabled(): boolean {
   if (typeof window !== 'undefined') {
@@ -250,7 +250,7 @@ export const RightPane = React.memo<ResizableRightPaneProps>((props) => {
         {when(selectedTab === RightMenuTab.Inspector, <InspectorEntryPoint />)}
         {when(selectedTab === RightMenuTab.Settings, <SettingsPane />)}
         {when(selectedTab === RightMenuTab.Comments, <CommentsPane />)}
-        {when(selectedTab === RightMenuTab.RollYourOwn, <RollYourOwnPane />)}
+        {when(selectedTab === RightMenuTab.RollYourOwn, <RollYourOwnFeaturesPane />)}
       </SimpleFlexRow>
       <CanvasStrategyInspector />
     </FlexColumn>

--- a/editor/src/components/canvas/design-panel-root.tsx
+++ b/editor/src/components/canvas/design-panel-root.tsx
@@ -35,6 +35,8 @@ import { EditorModes, isCommentMode } from '../editor/editor-modes'
 import { useAllowedToEditProject } from '../editor/store/collaborative-editing'
 import { useCanComment } from '../../core/commenting/comment-hooks'
 import { ElementsOutsideVisibleAreaIndicator } from '../editor/elements-outside-visible-area-indicator'
+import { isFeatureEnabled } from '../../utils/feature-switches'
+import { RollYourOwnPane } from '../navigator/left-pane/roll-your-own-pane'
 
 function isCodeEditorEnabled(): boolean {
   if (typeof window !== 'undefined') {
@@ -158,6 +160,10 @@ export const RightPane = React.memo<ResizableRightPaneProps>((props) => {
     onClickTab(RightMenuTab.Settings)
   }, [onClickTab])
 
+  const onClickRollYourOwnTab = React.useCallback(() => {
+    onClickTab(RightMenuTab.RollYourOwn)
+  }, [onClickTab])
+
   const canComment = useCanComment()
 
   const allowedToEdit = useAllowedToEditProject()
@@ -219,6 +225,14 @@ export const RightPane = React.memo<ResizableRightPaneProps>((props) => {
           selected={selectedTab === RightMenuTab.Settings}
           onClick={onClickSettingsTab}
         />
+        {when(
+          isFeatureEnabled('Roll Your Own'),
+          <MenuTab
+            label={'RYO'}
+            selected={selectedTab === RightMenuTab.RollYourOwn}
+            onClick={onClickRollYourOwnTab}
+          />,
+        )}
       </FlexRow>
       <SimpleFlexRow
         className='Inspector-entrypoint'
@@ -236,6 +250,7 @@ export const RightPane = React.memo<ResizableRightPaneProps>((props) => {
         {when(selectedTab === RightMenuTab.Inspector, <InspectorEntryPoint />)}
         {when(selectedTab === RightMenuTab.Settings, <SettingsPane />)}
         {when(selectedTab === RightMenuTab.Comments, <CommentsPane />)}
+        {when(selectedTab === RightMenuTab.RollYourOwn, <RollYourOwnPane />)}
       </SimpleFlexRow>
       <CanvasStrategyInspector />
     </FlexColumn>

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -214,6 +214,7 @@ export enum RightMenuTab {
   Inspector = 'inspector',
   Settings = 'settings',
   Comments = 'comments',
+  RollYourOwn = 'roll-your-own',
 }
 
 // TODO: this should just contain an NpmDependency and a status

--- a/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
+++ b/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import { FlexColumn, FlexRow, Section } from '../../../uuiui'
+import { when } from '../../../utils/react-conditionals'
+
+const sections = ['Grid'] as const
+type Section = (typeof sections)[number]
+
+export const RollYourOwnPane = React.memo(() => {
+  const [currentSection, setCurrentSection] = React.useState<Section | null>(null)
+
+  const onChangeSection = React.useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    const maybeSectionValue = e.target.value as Section
+    if (sections.includes(maybeSectionValue)) {
+      setCurrentSection(maybeSectionValue)
+    } else {
+      setCurrentSection(null)
+    }
+  }, [])
+
+  return (
+    <FlexColumn
+      id='leftPaneRollYourOwn'
+      key='leftPaneRollYourOwn'
+      style={{
+        display: 'relative',
+        alignItems: 'stretch',
+        paddingBottom: 50,
+        overflowY: 'scroll',
+        alignSelf: 'stretch',
+      }}
+    >
+      <Section>
+        <FlexRow
+          style={{
+            margin: 8,
+            gap: 12,
+            height: 22,
+          }}
+        >
+          <span style={{ fontWeight: 600 }}>Roll Your Own</span>
+        </FlexRow>
+        <FlexRow style={{ gap: 12, margin: 8 }}>
+          <select
+            value={currentSection ?? undefined}
+            style={{ flex: 1 }}
+            onChange={onChangeSection}
+          >
+            <option value=''>–</option>
+            {sections.map((section) => {
+              return (
+                <option key={`section-${section}`} value={section}>
+                  {section}
+                </option>
+              )
+            })}
+          </select>
+        </FlexRow>
+
+        {when(currentSection === 'Grid', <GridSection />)}
+      </Section>
+    </FlexColumn>
+  )
+})
+RollYourOwnPane.displayName = 'RollYourOwnPane'
+
+const GridSection = React.memo(() => {
+  return <FlexColumn style={{ gap: 10 }}>{/* TODO */}</FlexColumn>
+})
+GridSection.displayName = 'GridSection'

--- a/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
+++ b/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
@@ -38,7 +38,7 @@ export const RollYourOwnFeaturesPane = React.memo(() => {
   const [features, setFeatures] = useAtom(rollYourOwnFeatures)
 
   const onChange = React.useCallback(
-    (base: RollYourOwnFeatures) => async (update: Partial<RollYourOwnFeatures>) => {
+    (base: RollYourOwnFeatures) => (update: Partial<RollYourOwnFeatures>) => {
       setFeatures({ ...base, ...update })
     },
     [setFeatures],

--- a/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
+++ b/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
@@ -35,14 +35,6 @@ export const rollYourOwnFeatures = atomWithStorage(
 
 export const RollYourOwnFeaturesPane = React.memo(() => {
   const [currentSection, setCurrentSection] = React.useState<Section | null>(null)
-  const [features, setFeatures] = useAtom(rollYourOwnFeatures)
-
-  const onChange = React.useCallback(
-    (base: RollYourOwnFeatures) => (update: Partial<RollYourOwnFeatures>) => {
-      setFeatures({ ...base, ...update })
-    },
-    [setFeatures],
-  )
 
   const onChangeSection = React.useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
     const maybeSectionValue = e.target.value as Section
@@ -92,44 +84,49 @@ export const RollYourOwnFeaturesPane = React.memo(() => {
           </select>
         </FlexRow>
 
-        {when(
-          currentSection === 'Grid',
-          <GridSection features={features.Grid} onChange={onChange(features)} />,
-        )}
+        {when(currentSection === 'Grid', <GridSection />)}
       </Section>
     </FlexColumn>
   )
 })
 RollYourOwnFeaturesPane.displayName = 'RollYourOwnFeaturesPane'
 
-const GridSection = React.memo(
-  (props: { features: GridFeatures; onChange: (update: Partial<RollYourOwnFeatures>) => void }) => {
-    const onChange = React.useCallback(
-      (feat: keyof GridFeatures) => (e: React.ChangeEvent<HTMLInputElement>) => {
-        return props.onChange({ Grid: { ...props.features, [feat]: e.target.checked } })
-      },
-      [props],
-    )
+const GridSection = React.memo(() => {
+  const [features, setFeatures] = useAtom(rollYourOwnFeatures)
 
-    return (
-      <FlexColumn style={{ gap: 10 }}>
-        {Object.entries(props.features).map(([feat, value]) => {
-          return (
-            <UIGridRow padded variant='<--1fr--><--1fr-->' key={`feat-${feat}`}>
-              <div>{feat}</div>
-              {when(
-                typeof value === 'boolean',
-                <input
-                  type='checkbox'
-                  checked={value}
-                  onChange={onChange(feat as keyof GridFeatures)}
-                />,
-              )}
-            </UIGridRow>
-          )
-        })}
-      </FlexColumn>
-    )
-  },
-)
+  const onChange = React.useCallback(
+    (feat: keyof GridFeatures) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      setFeatures((existing) => {
+        return {
+          ...existing,
+          Grid: {
+            ...existing.Grid,
+            [feat]: e.target.checked,
+          },
+        }
+      })
+    },
+    [setFeatures],
+  )
+
+  return (
+    <FlexColumn style={{ gap: 10 }}>
+      {Object.entries(features.Grid).map(([feat, value]) => {
+        return (
+          <UIGridRow padded variant='<--1fr--><--1fr-->' key={`feat-${feat}`}>
+            <div>{feat}</div>
+            {when(
+              typeof value === 'boolean',
+              <input
+                type='checkbox'
+                checked={value}
+                onChange={onChange(feat as keyof GridFeatures)}
+              />,
+            )}
+          </UIGridRow>
+        )
+      })}
+    </FlexColumn>
+  )
+})
 GridSection.displayName = 'GridSection'

--- a/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
+++ b/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { FlexColumn, FlexRow, Section } from '../../../uuiui'
 import { when } from '../../../utils/react-conditionals'
-import { useAtom } from 'jotai'
+import { atom, useAtom } from 'jotai'
 import { UIGridRow } from '../../inspector/widgets/ui-grid-row'
 import { atomWithStorage } from 'jotai/utils'
+import { IS_TEST_ENVIRONMENT } from '../../../common/env-vars'
 
 const sections = ['Grid'] as const
 type Section = (typeof sections)[number]
@@ -28,10 +29,9 @@ let defaultRollYourOwnFeatures: RollYourOwnFeatures = {
 
 const ROLL_YOUR_OWN_FEATURES_KEY: string = 'roll-your-own-features'
 
-export const rollYourOwnFeatures = atomWithStorage(
-  ROLL_YOUR_OWN_FEATURES_KEY,
-  defaultRollYourOwnFeatures,
-)
+export const rollYourOwnFeatures = IS_TEST_ENVIRONMENT
+  ? atom(defaultRollYourOwnFeatures)
+  : atomWithStorage(ROLL_YOUR_OWN_FEATURES_KEY, defaultRollYourOwnFeatures)
 
 export const RollYourOwnFeaturesPane = React.memo(() => {
   const [currentSection, setCurrentSection] = React.useState<Section | null>(null)

--- a/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
+++ b/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
@@ -33,7 +33,7 @@ export const rollYourOwnFeatures = atomWithStorage(
   defaultRollYourOwnFeatures,
 )
 
-export const RollYourOwnPane = React.memo(() => {
+export const RollYourOwnFeaturesPane = React.memo(() => {
   const [currentSection, setCurrentSection] = React.useState<Section | null>(null)
   const [features, setFeatures] = useAtom(rollYourOwnFeatures)
 
@@ -100,7 +100,7 @@ export const RollYourOwnPane = React.memo(() => {
     </FlexColumn>
   )
 })
-RollYourOwnPane.displayName = 'RollYourOwnPane'
+RollYourOwnFeaturesPane.displayName = 'RollYourOwnFeaturesPane'
 
 const GridSection = React.memo(
   (props: { features: GridFeatures; onChange: (update: Partial<RollYourOwnFeatures>) => void }) => {

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -15,6 +15,7 @@ export type FeatureName =
   | 'Debug - Print UIDs'
   | 'Debug – Connections'
   | 'Condensed Navigator Entries'
+  | 'Roll Your Own'
 
 export const AllFeatureNames: FeatureName[] = [
   // 'Dragging Reparents By Default', // Removing this option so that we can experiment on this later
@@ -30,6 +31,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Debug - Print UIDs',
   'Debug – Connections',
   'Condensed Navigator Entries',
+  'Roll Your Own',
 ]
 
 let FeatureSwitches: { [feature in FeatureName]: boolean } = {
@@ -45,6 +47,7 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Debug - Print UIDs': false,
   'Debug – Connections': false,
   'Condensed Navigator Entries': !IS_TEST_ENVIRONMENT,
+  'Roll Your Own': false,
 }
 
 export const STEGANOGRAPHY_ENABLED = false


### PR DESCRIPTION
This is groundwork for https://github.com/concrete-utopia/utopia/pull/6027.

The `Roll Your Own` floating thing made in the spike becomes a tab in the right pane (in the future we might want to have it as a floating panel, but we can incrementally extract it later on).

The `Grid` section is left deliberately empty so we can fill it in with the other grid-related PRs.

**Context/history**

As part of the exploratory work on grid interactions (https://github.com/concrete-utopia/utopia/pull/6027) I added a way to test individual interaction/UI pieces in the spirit of [the classic Steve Jobs calculator story](https://www.reddit.com/r/mac/comments/o89l6i/the_apple_team_created_an_app_so_that_steve_jobs/) - called `Roll Your Own Grid`

<img width="368" alt="Screenshot 2024-07-01 at 17 55 30" src="https://github.com/concrete-utopia/utopia/assets/1081051/c99a46a8-60ba-4a7c-ae03-ed4145ea7c3a">

There's a good chance this stuff will be useful for more than Grid in the future (e.g. the inspector, the canvas etc) so we can reuse this idea in other contexts, while keeping the original concept.

**Note**
The PR includes a demo feature type for `Grid` for illustration purposes only; it should be replaced with the actual features.