### PR TITLE
Remove TargetGridCell from grid move

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -11,6 +11,7 @@ import type { StrategyApplicationStatus } from './interaction-state'
 import type { ElementPathTrees } from '../../../core/shared/element-path-tree'
 import type { ActiveFrameAction } from '../commands/set-active-frames-command'
 import type { PropertyControlsInfo } from '../../custom-code/code-file'
+import type { GridCellCoordinates } from '../controls/grid-controls'
 
 // TODO: fill this in, maybe make it an ADT for different strategies
 export interface CustomStrategyState {
@@ -20,6 +21,7 @@ export interface CustomStrategyState {
   strategyGeneratedUidsCache: { [elementPath: string]: string | undefined }
   elementsToRerender: Array<ElementPath>
   action: ActiveFrameAction | null
+  targetGridCell: GridCellCoordinates | null
 }
 
 export type CustomStrategyStatePatch = Partial<CustomStrategyState>
@@ -32,6 +34,7 @@ export function defaultCustomStrategyState(): CustomStrategyState {
     strategyGeneratedUidsCache: {},
     elementsToRerender: [],
     action: null,
+    targetGridCell: null,
   }
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -1,0 +1,24 @@
+import type { WindowPoint } from '../../../../core/shared/math-utils'
+import type { GridCellCoordinates } from '../../controls/grid-controls'
+import { gridCellCoordinates } from '../../controls/grid-controls'
+
+export function getGridCellUnderMouse(
+  windowPoint: WindowPoint,
+): { id: string; coordinates: GridCellCoordinates } | null {
+  const cellsUnderMouse = document
+    .elementsFromPoint(windowPoint.x, windowPoint.y)
+    .filter((el) => el.id.startsWith(`gridcell-`))
+  if (cellsUnderMouse.length > 0) {
+    const cellUnderMouse = cellsUnderMouse[0]
+    const row = cellUnderMouse.getAttribute('data-grid-row')
+    const column = cellUnderMouse.getAttribute('data-grid-column')
+    return {
+      id: cellsUnderMouse[0].id,
+      coordinates: gridCellCoordinates(
+        row == null ? 0 : parseInt(row),
+        column == null ? 0 : parseInt(column),
+      ),
+    }
+  }
+  return null
+}

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -46,16 +46,15 @@ import {
 import { windowToCanvasCoordinates } from '../dom-lookup'
 import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
 import { useColorTheme } from '../../../uuiui'
+import { getGridCellUnderMouse } from '../canvas-strategies/strategies/grid-helpers'
 
 export const GridCellTestId = (elementPath: ElementPath) => `grid-cell-${EP.toString(elementPath)}`
 
-type GridCellCoordinates = { row: number; column: number }
+export type GridCellCoordinates = { row: number; column: number }
 
-function emptyGridCellCoordinates(): GridCellCoordinates {
-  return { row: 0, column: 0 }
+export function gridCellCoordinates(row: number, column: number): GridCellCoordinates {
+  return { row: row, column: column }
 }
-
-export let TargetGridCell = { current: emptyGridCellCoordinates() }
 
 function getCellsCount(template: GridAutoOrTemplateBase | null): number {
   if (template == null) {
@@ -271,8 +270,6 @@ export const GridControls = controlForStrategyMemoized(() => {
   const startInteractionWithUid = React.useCallback(
     (params: { uid: string; row: number; column: number; frame: CanvasRectangle }) =>
       (event: React.MouseEvent) => {
-        TargetGridCell.current = emptyGridCellCoordinates()
-
         setInitialShadowFrame(params.frame)
 
         const start = windowToCanvasCoordinates(
@@ -763,16 +760,12 @@ function useMouseMove(activelyDraggingOrResizingCell: string | null) {
         setHoveringStart(null)
         return
       }
-      const cellsUnderMouse = document
-        .elementsFromPoint(e.clientX, e.clientY)
-        .filter((el) => el.id.startsWith(`gridcell-`))
 
-      if (cellsUnderMouse.length > 0) {
-        const cellUnderMouse = cellsUnderMouse[0]
-        const row = cellUnderMouse.getAttribute('data-grid-row')
-        const column = cellUnderMouse.getAttribute('data-grid-column')
-        TargetGridCell.current.row = row == null ? 0 : parseInt(row)
-        TargetGridCell.current.column = column == null ? 0 : parseInt(column)
+      // TODO most of this logic can be simplified consistently
+      // by moving the hovering cell info to the editor state, dispatched
+      // from the grid-rearrange-move-strategy logic.
+      const cellUnderMouse = getGridCellUnderMouse(windowPoint({ x: e.clientX, y: e.clientY }))
+      if (cellUnderMouse != null) {
         setHoveringCell(cellUnderMouse.id)
 
         const newMouseCanvasPosition = windowToCanvasCoordinates(

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -198,6 +198,7 @@ describe('interactionStart', () => {
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
+          "targetGridCell": null,
         },
         "sortedApplicableStrategies": null,
         "startingAllElementProps": Object {},
@@ -260,6 +261,7 @@ describe('interactionStart', () => {
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
+          "targetGridCell": null,
         },
         "sortedApplicableStrategies": null,
         "startingAllElementProps": Object {},
@@ -342,6 +344,7 @@ describe('interactionUpdate', () => {
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
+          "targetGridCell": null,
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -424,6 +427,7 @@ describe('interactionUpdate', () => {
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
+          "targetGridCell": null,
         },
         "sortedApplicableStrategies": null,
         "startingAllElementProps": Object {},
@@ -500,6 +504,7 @@ describe('interactionHardReset', () => {
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
+          "targetGridCell": null,
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -584,6 +589,7 @@ describe('interactionHardReset', () => {
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
+          "targetGridCell": null,
         },
         "sortedApplicableStrategies": null,
         "startingAllElementProps": Object {},
@@ -674,6 +680,7 @@ describe('interactionUpdate with user changed strategy', () => {
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
+          "targetGridCell": null,
         },
         "sortedApplicableStrategies": Array [
           Object {
@@ -759,6 +766,7 @@ describe('interactionUpdate with user changed strategy', () => {
           "escapeHatchActivated": false,
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
+          "targetGridCell": null,
         },
         "sortedApplicableStrategies": null,
         "startingAllElementProps": Object {},


### PR DESCRIPTION
**Problem:**

The target grid cell during the move strategy relies on a super ugly singleton variable.

**Fix:**

Get rid of `TargetGridCell` and instead do the proper adjustments inside the move strategy.

**Notes:**
- No behavioral changes
- The code can be improved further by moving hovering cell data into the editor state (I added a comment in the code) but I left it out of this PR and potentially do it incrementally.
