### PR TITLE
Including Text Content Now Filters For Text Content

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -482,7 +482,7 @@ export function runDomWalker({
       return getCanvasRectangleFromElement(
         canvasRootContainer,
         scale,
-        'without-content',
+        'without-text-content',
         'nearest-half',
       )
     })
@@ -677,7 +677,7 @@ function collectMetadataForElement(
     element,
     scale,
     containerRectLazy,
-    'without-content',
+    'without-text-content',
     'nearest-half',
   )
   const localFrame = localRectangle(Utils.offsetRect(globalFrame, Utils.negate(parentPoint)))
@@ -685,7 +685,7 @@ function collectMetadataForElement(
     element,
     scale,
     containerRectLazy,
-    'without-content',
+    'without-text-content',
     'no-rounding',
   )
 
@@ -952,7 +952,7 @@ function getSpecialMeasurements(
           element.offsetParent,
           scale,
           containerRectLazy,
-          'without-content',
+          'without-text-content',
           'nearest-half',
         )
       : null
@@ -963,7 +963,7 @@ function getSpecialMeasurements(
           element.parentElement,
           scale,
           containerRectLazy,
-          'without-content',
+          'without-text-content',
           'nearest-half',
         )
       : null
@@ -1048,7 +1048,7 @@ function getSpecialMeasurements(
     elementOrContainingParent,
     scale,
     containerRectLazy,
-    'without-content',
+    'without-text-content',
     'nearest-half',
   )
 
@@ -1056,7 +1056,7 @@ function getSpecialMeasurements(
     element,
     scale,
     containerRectLazy,
-    'with-content',
+    'with-text-content',
     'nearest-half',
   )
 
@@ -1103,18 +1103,21 @@ function getSpecialMeasurements(
   const textDecorationLine = elementStyle.textDecorationLine
 
   const textBounds = elementContainsOnlyText(element)
-    ? stretchRect(getCanvasRectangleFromElement(element, scale, 'only-content', 'nearest-half'), {
-        w:
-          maybeValueFromComputedStyle(elementStyle.paddingLeft) +
-          maybeValueFromComputedStyle(elementStyle.paddingRight) +
-          maybeValueFromComputedStyle(elementStyle.marginLeft) +
-          maybeValueFromComputedStyle(elementStyle.marginRight),
-        h:
-          maybeValueFromComputedStyle(elementStyle.paddingTop) +
-          maybeValueFromComputedStyle(elementStyle.paddingBottom) +
-          maybeValueFromComputedStyle(elementStyle.marginTop) +
-          maybeValueFromComputedStyle(elementStyle.marginBottom),
-      })
+    ? stretchRect(
+        getCanvasRectangleFromElement(element, scale, 'only-text-content', 'nearest-half'),
+        {
+          w:
+            maybeValueFromComputedStyle(elementStyle.paddingLeft) +
+            maybeValueFromComputedStyle(elementStyle.paddingRight) +
+            maybeValueFromComputedStyle(elementStyle.marginLeft) +
+            maybeValueFromComputedStyle(elementStyle.marginRight),
+          h:
+            maybeValueFromComputedStyle(elementStyle.paddingTop) +
+            maybeValueFromComputedStyle(elementStyle.paddingBottom) +
+            maybeValueFromComputedStyle(elementStyle.marginTop) +
+            maybeValueFromComputedStyle(elementStyle.marginBottom),
+        },
+      )
     : null
 
   const computedStyleMap =
@@ -1204,7 +1207,7 @@ function globalFrameForElement(
   element: HTMLElement,
   scale: number,
   containerRectLazy: () => CanvasRectangle,
-  withContent: 'without-content' | 'with-content',
+  withContent: 'without-text-content' | 'with-text-content',
   rounding: 'nearest-half' | 'no-rounding',
 ) {
   const elementRect = getCanvasRectangleFromElement(element, scale, withContent, rounding)
@@ -1339,7 +1342,7 @@ function walkSceneInner(
     scene,
     globalProps.scale,
     globalProps.containerRectLazy,
-    'without-content',
+    'without-text-content',
     'nearest-half',
   )
 
@@ -1418,7 +1421,7 @@ function walkElements(
       element,
       globalProps.scale,
       globalProps.containerRectLazy,
-      'without-content',
+      'without-text-content',
       'nearest-half',
     )
 

--- a/editor/src/core/shared/dom-utils.ts
+++ b/editor/src/core/shared/dom-utils.ts
@@ -279,7 +279,7 @@ function getRoundingFn(rounding: 'nearest-half' | 'no-rounding') {
 export function getCanvasRectangleFromElement(
   element: HTMLElement,
   canvasScale: number,
-  withContent: 'without-content' | 'with-content' | 'only-content',
+  withContent: 'without-text-content' | 'with-text-content' | 'only-text-content',
   rounding: 'nearest-half' | 'no-rounding',
 ): CanvasRectangle {
   const scale = canvasScale < 1 ? 1 / canvasScale : 1
@@ -301,17 +301,22 @@ export function getCanvasRectangleFromElement(
 
   const boundingRect = element.getBoundingClientRect()
   const elementRect = domRectToScaledCanvasRectangle(boundingRect)
-  if (withContent === 'without-content') {
+  if (withContent === 'without-text-content') {
     return elementRect
   }
 
   const range = document.createRange()
   switch (withContent) {
-    case 'only-content':
-      range.selectNodeContents(element)
-      break
-    case 'with-content':
-      range.selectNode(element)
+    case 'only-text-content':
+    case 'with-text-content':
+      for (const childNode of element.childNodes) {
+        if (childNode.nodeType === Node.TEXT_NODE) {
+          range.selectNode(childNode)
+        }
+      }
+      if (withContent === 'with-text-content') {
+        range.selectNode(element)
+      }
       break
     default:
       assertNever(withContent)
@@ -322,9 +327,9 @@ export function getCanvasRectangleFromElement(
   const contentRect = domRectToScaledCanvasRectangle(rangeBounding)
 
   switch (withContent) {
-    case 'only-content':
+    case 'only-text-content':
       return contentRect
-    case 'with-content':
+    case 'with-text-content':
       return boundingRectangle(elementRect, contentRect)
     default:
       assertNever(withContent)

--- a/editor/src/utils/utils.test-utils.tsx
+++ b/editor/src/utils/utils.test-utils.tsx
@@ -624,7 +624,7 @@ export function boundingClientRectToCanvasRectangle(
   const canvasRootRectangle = getCanvasRectangleFromElement(
     canvasRootContainer,
     canvasScale,
-    'without-content',
+    'without-text-content',
     'nearest-half',
   )
   const canvasBounds = offsetRect(canvasRectangle(elementBounds), negate(canvasRootRectangle))


### PR DESCRIPTION
**Problem:**
In the example project it was observed that it is possible to highlight an element from outside its bounds.

**Fix:**
Elements that weren't text elements were being included in the content bounds.

**Commit Details:**
- Changed the parameter `withContent` for `getCanvasRectangleFromElement` to make it clear that it means text content.
- `getCanvasRectangleFromElement` filters for text nodes when including text content in the dimensions.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #5984
