### PR TITLE
Expand valid Remix cases for route modules.

### DIFF
--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -858,7 +858,7 @@ export function getDefaultExportedTopLevelElement(file: TextFile): JSXElementChi
 export function getDefaultExportNameAndUidFromFile(
   projectContents: ProjectContentTreeRoot,
   filePath: string,
-): { name: string; uid: string } | null {
+): { name: string; uid: string | null } | null {
   const file = getProjectFileByFilePath(projectContents, filePath)
   if (
     file == null ||
@@ -875,13 +875,11 @@ export function getDefaultExportNameAndUidFromFile(
     return null
   }
 
-  const elementUid = file.fileContents.parsed.topLevelElements.find(
-    (t): t is UtopiaJSXComponent =>
-      t.type === 'UTOPIA_JSX_COMPONENT' && t.name === defaultExportName,
-  )?.rootElement.uid
-  if (elementUid == null) {
-    return null
-  }
+  const elementUid =
+    file.fileContents.parsed.topLevelElements.find(
+      (t): t is UtopiaJSXComponent =>
+        t.type === 'UTOPIA_JSX_COMPONENT' && t.name === defaultExportName,
+    )?.rootElement.uid ?? null
 
   return { name: defaultExportName, uid: elementUid }
 }


### PR DESCRIPTION
**Problem:**
Sometimes when changing some code the canvas stops rendering in a Remix project.

**Cause:**
When building the `routeModules` value, if a file has a default export but it's impossible to find a matching `UTOPIA_JSX_COMPONENT` then an error occurs in the Remix internals.

**Fix:**
The `getDefaultExportNameAndUidFromFile` function is partly responsible for populating `routeModules` and that has been modified to return an optional UID not just an optional result. This means that `routeModules` can be populated with an entry for a file that has a default export but that export can't be parsed into a `UTOPIA_JSX_COMPONENT`.

**Commit Details:**
- Change `getDefaultExportNameAndUidFromFile` to optionally return a uid. Permitting a file that exists with a default export to be included if it doesn't have a `UTOPIA_JSX_COMPONENT` matching that export.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode