### PR TITLE
Correctly position grid resize controls.

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -171,12 +171,13 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
                 workingPrefix += props.gap ?? 0
               }
 
-              const id = `grid-${props.axis}-handle-${dimensionIndex}-container`
+              const labelId = `grid-${props.axis}-handle-${dimensionIndex}`
+              const containerId = `${labelId}-container`
 
               return (
                 <div
-                  key={id}
-                  data-testid={id}
+                  key={containerId}
+                  data-testid={containerId}
                   style={{
                     position: 'absolute',
                     left:
@@ -196,6 +197,7 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
                   }}
                 >
                   <CanvasLabel
+                    testId={labelId}
                     value={getLabelForAxis(dimension, dimensionIndex, props.fromPropsAxisValues)}
                     scale={scale}
                     color={colorTheme.brandNeonPink.value}

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -123,7 +123,11 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
   const colorTheme = useColorTheme()
   const dispatch = useDispatch()
   const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
-  const scaleRef = useRefEditorState((store) => store.editor.canvas.scale)
+  const scale = useEditorState(
+    Substores.canvas,
+    (store) => store.editor.canvas.scale,
+    'GridResizing scale',
+  )
 
   if (props.axisValues == null) {
     return null
@@ -137,7 +141,7 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
             {props.axisValues.dimensions.flatMap((dimension, dimensionIndex) => {
               const mouseDownHandler = (event: React.MouseEvent): void => {
                 const start = windowToCanvasCoordinates(
-                  scaleRef.current,
+                  scale,
                   canvasOffsetRef.current,
                   windowPoint({ x: event.nativeEvent.x, y: event.nativeEvent.y }),
                 )
@@ -182,8 +186,8 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
                     top:
                       props.axis === 'row'
                         ? workingPrefix - GridResizingContainerSize / 2
-                        : props.containingFrame.y - 30,
-                    right: props.axis === 'row' ? 10 - props.containingFrame.x : undefined,
+                        : props.containingFrame.y - 30 / scale,
+                    right: props.axis === 'row' ? 10 / scale - props.containingFrame.x : undefined,
                     width: props.axis === 'column' ? GridResizingContainerSize : `max-content`,
                     height: props.axis === 'row' ? GridResizingContainerSize : `max-content`,
                     display: 'flex',
@@ -193,7 +197,7 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
                 >
                   <CanvasLabel
                     value={getLabelForAxis(dimension, dimensionIndex, props.fromPropsAxisValues)}
-                    scale={scaleRef.current}
+                    scale={scale}
                     color={colorTheme.brandNeonPink.value}
                     textColor={colorTheme.white.value}
                     // eslint-disable-next-line react/jsx-no-bind

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -104,6 +104,7 @@ interface CanvasLabelProps {
   textColor: string
   value: string | number
   onMouseDown?: React.MouseEventHandler
+  testId?: string
 }
 
 export const CanvasLabel = React.memo((props: CanvasLabelProps): JSX.Element => {
@@ -114,6 +115,7 @@ export const CanvasLabel = React.memo((props: CanvasLabelProps): JSX.Element => 
   const borderRadius = BorderRadius / scale
   return (
     <div
+      data-testid={props.testId}
       style={{
         display: 'flex',
         alignItems: 'center',

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -103,6 +103,7 @@ interface CanvasLabelProps {
   color: string
   textColor: string
   value: string | number
+  onMouseDown?: React.MouseEventHandler
 }
 
 export const CanvasLabel = React.memo((props: CanvasLabelProps): JSX.Element => {
@@ -126,6 +127,7 @@ export const CanvasLabel = React.memo((props: CanvasLabelProps): JSX.Element => 
         borderRadius: borderRadius,
         height: ExplicitHeightHacked / scale,
       }}
+      onMouseDown={props.onMouseDown}
     >
       {value}
     </div>


### PR DESCRIPTION
**Problem:**
The grid resize controls had their positioning quickly thrown together and somewhat implemented by eye.

**Fix:**
As part of this work the two big blocks of code for columns and rows were unified into a single `GridResizing` component.

The positions have been better positioned by creating a container element which straddles the center line of the gap and then the control is appropriately justified within that to keep it centered or in the case of the row controls right justified.

It also uses the `CanvasLabel` component to handle most of the work for actually displaying things.

**Screenshot:**
![image](https://github.com/concrete-utopia/utopia/assets/217400/9e95bdce-44cd-4723-8941-97f11d4459a7)

**Commit Details:**
- Create a common component of `GridResizing`.
- Use the new `GridResizing` component in place of the embedded column and row handling.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode