### PR TITLE
Add missing param to getGridCellUnderMouse

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -78,7 +78,7 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
       )
 
       let targetCell = customState.grid.targetCell
-      const cellUnderMouse = getGridCellUnderMouse(mouseWindowPoint)
+      const cellUnderMouse = getGridCellUnderMouse(mouseWindowPoint, canvasState.scale)
       if (cellUnderMouse != null) {
         targetCell = cellUnderMouse.coordinates
       }


### PR DESCRIPTION
## Problem
The main branch now doesn't typecheck because of a missing param to `getGridCellUnderMouse` in `grid-resize-element-strategy.ts`

## Fix
Fix it

