### PR TITLE
Grid resize better handles

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -231,7 +231,7 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
           fontSize: 8,
         }}
         css={{
-          opacity: 0.5,
+          opacity: resizing ? 1 : 0.5,
           ':hover': {
             opacity: 1,
           },

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -1,3 +1,6 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { jsx } from '@emotion/react'
 import type { AnimationControls } from 'framer-motion'
 import { motion, useAnimationControls } from 'framer-motion'
 import React from 'react'
@@ -123,7 +126,8 @@ function getLabelForAxis(
 }
 
 const SHADOW_SNAP_ANIMATION = 'shadow-snap'
-const GRID_RESIZE_HANDLE_SIZE = 30 // px
+const GRID_RESIZE_HANDLE_CONTAINER_SIZE = 30 // px
+const GRID_RESIZE_HANDLE_SIZE = 15 // px
 
 export interface GridResizingControlProps {
   dimension: GridCSSNumber
@@ -186,8 +190,8 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
 
   const shadowSize = React.useMemo(() => {
     return props.axis === 'column'
-      ? props.containingFrame.height + GRID_RESIZE_HANDLE_SIZE
-      : props.containingFrame.width + GRID_RESIZE_HANDLE_SIZE
+      ? props.containingFrame.height + GRID_RESIZE_HANDLE_CONTAINER_SIZE
+      : props.containingFrame.width + GRID_RESIZE_HANDLE_CONTAINER_SIZE
   }, [props.containingFrame, props.axis])
 
   return (
@@ -210,8 +214,8 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
       <div
         style={{
           zoom: 1 / scale,
-          width: 17,
-          height: 17,
+          width: GRID_RESIZE_HANDLE_SIZE,
+          height: GRID_RESIZE_HANDLE_SIZE,
           borderRadius: '100%',
           border: `1px solid ${colorTheme.border0.value}`,
           boxShadow: `${colorTheme.canvasControlsSizeBoxShadowColor50.value} 0px 0px
@@ -223,7 +227,13 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
           alignItems: 'center',
           justifyContent: 'center',
           cursor: gridEdgeToCSSCursor(props.axis === 'column' ? 'column-start' : 'row-start'),
-          fontSize: 9,
+          fontSize: 8,
+        }}
+        css={{
+          opacity: 0.5,
+          ':hover': {
+            opacity: 1,
+          },
         }}
         onMouseDown={mouseDownHandler}
       >
@@ -233,8 +243,8 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
         <div
           style={{
             position: 'absolute',
-            top: props.axis === 'column' ? GRID_RESIZE_HANDLE_SIZE : 0,
-            left: props.axis === 'row' ? GRID_RESIZE_HANDLE_SIZE : 0,
+            top: props.axis === 'column' ? GRID_RESIZE_HANDLE_CONTAINER_SIZE : 0,
+            left: props.axis === 'row' ? GRID_RESIZE_HANDLE_CONTAINER_SIZE : 0,
             right: 0,
             bottom: 0,
             display: 'flex',
@@ -280,7 +290,7 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
   }
   switch (props.axisValues.type) {
     case 'DIMENSIONS':
-      const size = GRID_RESIZE_HANDLE_SIZE / canvasScale
+      const size = GRID_RESIZE_HANDLE_CONTAINER_SIZE / canvasScale
       return (
         <div
           style={{
@@ -334,7 +344,6 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
       return null
     default:
       assertNever(props.axisValues)
-      return null
   }
 })
 GridResizing.displayName = 'GridResizing'
@@ -679,7 +688,7 @@ export const GridControls = controlForStrategyMemoized(() => {
                   >
                     {when(
                       features.Grid.dotgrid,
-                      <>
+                      <React.Fragment>
                         <div
                           style={{
                             position: 'absolute',
@@ -734,7 +743,7 @@ export const GridControls = controlForStrategyMemoized(() => {
                             right: -1,
                           }}
                         />
-                      </>,
+                      </React.Fragment>,
                     )}
                   </div>
                 )

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -51,7 +51,7 @@ import {
 } from '../canvas-strategies/interaction-state'
 import { windowToCanvasCoordinates } from '../dom-lookup'
 import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
-import { color, Icn, Icons, useColorTheme, UtopiaStyles } from '../../../uuiui'
+import { useColorTheme, UtopiaStyles } from '../../../uuiui'
 import { gridCellTargetId } from '../canvas-strategies/strategies/grid-helpers'
 import { resizeBoundingBoxFromSide } from '../canvas-strategies/strategies/resize-helpers'
 import type { EdgePosition } from '../canvas-types'

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -123,6 +123,7 @@ function getLabelForAxis(
 }
 
 const SHADOW_SNAP_ANIMATION = 'shadow-snap'
+const GRID_RESIZE_HANDLE_SIZE = 30 // px
 
 export interface GridResizingControlProps {
   dimension: GridCSSNumber
@@ -186,8 +187,8 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
 
   const shadowSize = React.useMemo(() => {
     return props.axis === 'column'
-      ? props.containingFrame.height + 30
-      : props.containingFrame.width + 30
+      ? props.containingFrame.height + GRID_RESIZE_HANDLE_SIZE
+      : props.containingFrame.width + GRID_RESIZE_HANDLE_SIZE
   }, [props.containingFrame, props.axis])
 
   return (
@@ -233,8 +234,8 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
         <div
           style={{
             position: 'absolute',
-            top: props.axis === 'column' ? 30 : 0,
-            left: props.axis === 'row' ? 30 : 0,
+            top: props.axis === 'column' ? GRID_RESIZE_HANDLE_SIZE : 0,
+            left: props.axis === 'row' ? GRID_RESIZE_HANDLE_SIZE : 0,
             right: 0,
             bottom: 0,
             display: 'flex',
@@ -282,7 +283,7 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
     case 'DIMENSIONS':
       let workingPrefix: number =
         props.axis === 'column' ? props.containingFrame.x : props.containingFrame.y
-      const size = 30 / canvasScale
+      const size = GRID_RESIZE_HANDLE_SIZE / canvasScale
       return (
         <div
           style={{

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -240,7 +240,8 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
       >
         {props.axis === 'row' ? '↕' : '↔'}
       </div>
-      {resizing ? (
+      {when(
+        resizing,
         <div
           style={{
             position: 'absolute',
@@ -263,8 +264,8 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
             color={colorTheme.brandNeonPink.value}
             textColor={colorTheme.white.value}
           />
-        </div>
-      ) : null}
+        </div>,
+      )}
     </div>
   )
 })

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -130,7 +130,6 @@ export interface GridResizingControlProps {
   dimensionIndex: number
   axis: 'row' | 'column'
   containingFrame: CanvasRectangle
-  workingPrefix: number
   fromPropsAxisValues: GridAutoOrTemplateBase | null
   padding: number | null
 }
@@ -281,8 +280,6 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
   }
   switch (props.axisValues.type) {
     case 'DIMENSIONS':
-      let workingPrefix: number =
-        props.axis === 'column' ? props.containingFrame.x : props.containingFrame.y
       const size = GRID_RESIZE_HANDLE_SIZE / canvasScale
       return (
         <div
@@ -314,17 +311,6 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
           }}
         >
           {props.axisValues.dimensions.flatMap((dimension, dimensionIndex) => {
-            // Assumes pixels currently.
-            workingPrefix += dimension.value
-            if (dimensionIndex === 0) {
-              // Shift by half the gap initially...
-              workingPrefix += (props.gap ?? 0) / 2
-            } else {
-              // ...Then by the full gap, as it would be half from the prior entry
-              // and half from the current one.
-              workingPrefix += props.gap ?? 0
-            }
-
             return (
               <GridResizingControl
                 dimensionIndex={dimensionIndex}
@@ -332,7 +318,6 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
                 fromPropsAxisValues={props.fromPropsAxisValues}
                 axis={props.axis}
                 containingFrame={props.containingFrame}
-                workingPrefix={workingPrefix}
                 padding={
                   props.padding == null
                     ? 0

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -212,6 +212,7 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
       }}
     >
       <div
+        data-testid={labelId}
         style={{
           zoom: 1 / scale,
           width: GRID_RESIZE_HANDLE_SIZE,
@@ -253,7 +254,6 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
           }}
         >
           <CanvasLabel
-            testId={labelId}
             value={getLabelForAxis(
               props.dimension,
               props.dimensionIndex,


### PR DESCRIPTION
**Problem:**

The resize grid strategy has some UI issues:

1. the handles are only shown when a grid cell is selected, not the grid itself
2. the handles are not positioned correctly relatively to the grid itself
3. it's hard to discern precisely the resize effects

**Fix:**

1. Enable the grid resizing if the grid is selected too
2. Position the handles centered relatively to the grid rows/columns
3. Replace the "numbered handles" with more subtle draggable circles
4. During drag, show a striped background for the affected row or column, with the measurements centered in the striped area

**Note**
The handles icons are placeholders/ideas.


| Before | After |
|--------|-----------|
| ![Kapture 2024-07-10 at 14 19 33](https://github.com/concrete-utopia/utopia/assets/1081051/0b310d2d-fda5-443e-b685-299556b90ef6) | ![Kapture 2024-07-10 at 14 17 58](https://github.com/concrete-utopia/utopia/assets/1081051/d6b005df-8e9b-4219-a5b6-8c976e85cc0a) |

