### PR TITLE
Fix grid resize handles container width

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -298,10 +298,7 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
             position: 'absolute',
             top: props.containingFrame.y - (props.axis === 'column' ? size : 0),
             left: props.containingFrame.x - (props.axis === 'row' ? size : 0),
-            width:
-              props.axis === 'column'
-                ? props.containingFrame.width
-                : size + props.containingFrame.width,
+            width: props.axis === 'column' ? props.containingFrame.width : size,
             height: props.axis === 'row' ? props.containingFrame.height : size,
             display: 'grid',
             gridTemplateColumns:


### PR DESCRIPTION
Fix for a typo in the container width calculations of https://github.com/concrete-utopia/utopia/pull/6058 which would end up being too large.