### PR TITLE
Better Remix Reset Handling.

### DIFF
--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -84,7 +84,10 @@ import {
   createModuleEvaluator,
   isComponentDescriptorFile,
 } from '../../../core/property-controls/property-controls-local'
-import { setReactRouterErrorHasBeenLogged } from '../../../core/shared/runtime-report-logs'
+import {
+  hasReactRouterErrorBeenLogged,
+  setReactRouterErrorHasBeenLogged,
+} from '../../../core/shared/runtime-report-logs'
 import type { PropertyControlsInfo } from '../../custom-code/code-file'
 import { getFilePathMappings } from '../../../core/model/project-file-utils'
 
@@ -495,18 +498,6 @@ export function editorDispatchActionRunner(
   return result
 }
 
-function reactRouterErrorTriggeredReset(
-  editor: EditorState,
-  reactRouterErrorPreviouslyLogged: boolean,
-): EditorState {
-  if (reactRouterErrorPreviouslyLogged) {
-    setReactRouterErrorHasBeenLogged(false)
-    return UPDATE_FNS.RESET_CANVAS(EditorActions.resetCanvas(), editor)
-  } else {
-    return editor
-  }
-}
-
 export function editorDispatchClosingOut(
   boundDispatch: EditorDispatch,
   dispatchedActions: readonly EditorAction[],
@@ -727,13 +718,6 @@ export function editorDispatchClosingOut(
         ...finalStoreV1Final.unpatchedEditor,
         filesModifiedByAnotherUser: updatedFilesModifiedByElsewhere,
       },
-    }
-
-    if (filesChanged.length > 0) {
-      finalStoreV1Final.unpatchedEditor = reactRouterErrorTriggeredReset(
-        finalStoreV1Final.unpatchedEditor,
-        reactRouterErrorPreviouslyLogged,
-      )
     }
   }
 

--- a/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
+++ b/editor/src/core/es-modules/package-manager/built-in-dependencies-list.ts
@@ -12,7 +12,7 @@ import * as TTYStub from './node-builtin-shims/tty-stub'
 import * as UUIUI from '../../../uuiui'
 import * as UUIUIDeps from '../../../uuiui-deps'
 import * as RemixServerBuild from './built-in-third-party-dependencies/remix-server-build'
-import { SafeLink, SafeOutlet } from './canvas-safe-remix'
+import { SafeLink, SafeOutlet, useErrorRecordingRouteError } from './canvas-safe-remix'
 import { UtopiaApiGroup } from './group-component'
 
 import utopiaAPIPackageJSON from '../../../../../utopia-api/package.json'
@@ -98,6 +98,7 @@ export function createBuiltInDependenciesList(
         ...RemixRunReact,
         Link: SafeLink,
         Outlet: SafeOutlet,
+        useRouteError: useErrorRecordingRouteError,
       },
       editorPackageJSON.dependencies['@remix-run/react'],
     ),

--- a/editor/src/core/es-modules/package-manager/canvas-safe-remix.tsx
+++ b/editor/src/core/es-modules/package-manager/canvas-safe-remix.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
-import { Link, Outlet } from '@remix-run/react'
+import { Link, Outlet, useRouteError } from '@remix-run/react'
 import type { LinkProps } from '@remix-run/react'
 import { useInRouterContext, Router } from 'react-router'
 import type { Navigator } from 'react-router'
 import { OutletPathContext } from '../../../components/canvas/remix/remix-utils'
 import { UTOPIA_PATH_KEY } from '../../model/utopia-constants'
 import * as EP from '../../shared/element-path'
+import { setReactRouterErrorHasBeenLogged } from '../../../core/shared/runtime-report-logs'
 
 const dummyNavigator: Navigator = {
   createHref: () => '',
@@ -35,6 +36,14 @@ export const SafeLink: typeof Link = React.forwardRef<HTMLAnchorElement, LinkPro
     }
   },
 )
+
+export function useErrorRecordingRouteError(): unknown {
+  const error = useRouteError()
+  if (error != null) {
+    setReactRouterErrorHasBeenLogged(true)
+  }
+  return error
+}
 
 type SafeOutletProps = typeof Outlet & {
   [UTOPIA_PATH_KEY]?: string

--- a/editor/src/core/shared/runtime-report-logs.tsx
+++ b/editor/src/core/shared/runtime-report-logs.tsx
@@ -19,6 +19,8 @@ import StackFrame from '../../third-party/react-error-overlay/utils/stack-frame'
 import { useEditorState, Substores } from '../../components/editor/store/store-hook'
 import type { ErrorMessage } from './error-messages'
 import { fastForEach } from './utils'
+import type { EditorAction } from '../../components/editor/action-types'
+import * as EditorActions from '../../components/editor/actions/action-creators'
 
 const EmptyArray: Array<RuntimeErrorInfo> = []
 
@@ -87,6 +89,16 @@ export function hasReactRouterErrorBeenLogged(): boolean {
 
 export function setReactRouterErrorHasBeenLogged(value: boolean): void {
   reactRouterErrorLogged = value
+}
+
+export function reactRouterErrorTriggeredReset(): Array<EditorAction> {
+  const reactRouterErrorPreviouslyLogged = hasReactRouterErrorBeenLogged()
+  if (reactRouterErrorPreviouslyLogged) {
+    setReactRouterErrorHasBeenLogged(false)
+    return [EditorActions.resetCanvas()]
+  } else {
+    return []
+  }
 }
 
 export interface OverlayError {


### PR DESCRIPTION
**Problem:**
In our sample project when correcting a typo in a route, it has been observed that the canvas doesn't update with the now fixed code.

**Cause:**
There are two main causes to this:
- The previous logic that caught errors was only being triggered from the two error boundaries it had been written for.
- Seemingly the canvas reset didn't work in this case, potentially because no other change was triggered, as the canvas store was updated before the mount count was bumped.

**Fix:**
The two causes were addressed like so:
- A wrapper was implemented around `useRouteError` so that if it returns a non-null value, the pre-existing flag is set to true indicating an error happened.
- The logic for resetting the canvas has been moved to a dispatched action which is fired alongside the action for updating the code editor.

**Commit Details:**
- Removed handling of reset triggering from `editorDispatchClosingOut`.
- Added `useRouteError` wrapper to `createBuiltInDependenciesList`.
- `reactRouterErrorTriggeredReset` now returns a `RESET_CANVAS` action as required.
- Incoming updates from the code editor can now trigger the canvas reset.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode