### PR TITLE
Fix resizing grid for extra cells

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.spec.browser2.tsx
@@ -249,7 +249,7 @@ export var storyboard = (
         width: 600,
         height: 600,
         gridTemplateColumns: '2.4fr 1fr 1fr',
-        gridTemplateRows: '99px 129px 90px',
+        gridTemplateRows: '99px 129px 90px 0px',
         height: 'max-content',
       }}
     >

--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.ts
@@ -1,4 +1,4 @@
-import { fromArrayIndex, fromField } from '../../../../core/shared/optics/optic-creators'
+import { fromArrayIndex, fromField, notNull } from '../../../../core/shared/optics/optic-creators'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
 import * as PP from '../../../../core/shared/property-path'
@@ -107,9 +107,9 @@ export const resizeGridStrategy: CanvasStrategyFactory = (
         }),
       }
 
-      const unitOptic = fromArrayIndex<GridCSSNumber>(control.columnOrRow).compose(
-        fromField('unit'),
-      )
+      const unitOptic = fromArrayIndex<GridCSSNumber>(control.columnOrRow)
+        .compose(fromField('unit'))
+        .compose(notNull())
       const valueOptic = fromArrayIndex<GridCSSNumber>(control.columnOrRow).compose(
         fromField('value'),
       )


### PR DESCRIPTION
**Problem:**

If a grid contains more cell elements than what's declared in the grid template, the grid resize stops working for the overflowing rows/columns.

For example, try to resize the last column in this grid  https://utopia.fish/p/c6133e47-eight-cork

**Fix:**

1. Do not rely on the gird template from props but only the calculated grid values, which are the same used in the other grid strategies (e.g. to display the grid shadows)
2. For now, just stick to converting everything to calculated units (e.g. resizing a `fr` unit will transform the template to `px`) - I think it's ok for now until we decide how to tackle those cases, and we have to deal with simpler code in the meantime
3. When the grid is resized, apply the new "fixed" templates too (so if you have an actual grid that contradicts the template, update the template accordingly).

Fix #6071 