### PR TITLE
More shouldUpdate optimizations

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -116,13 +116,13 @@ export function createComponentRendererComponent(params: {
       }
 
       if (ElementsToRerenderGLOBAL.current.length === 1) {
-        return isElementInChildrenOrPropsTreeSingle(
+        return isElementInChildrenOrPropsTree(
           EP.toString(ElementsToRerenderGLOBAL.current[0]),
           realPassedProps,
         )
       }
 
-      return isElementInChildrenOrPropsTreeMulti(
+      return isElementsInChildrenOrPropsTree(
         ElementsToRerenderGLOBAL.current.map(EP.toString),
         realPassedProps,
       )
@@ -393,7 +393,7 @@ function isRenderProp(prop: any): prop is { props: { [UTOPIA_PATH_KEY]: string }
   )
 }
 
-function isElementInChildrenOrPropsTreeSingle(elementPath: string, props: any): boolean {
+function isElementInChildrenOrPropsTree(elementPath: string, props: any): boolean {
   if (props.children == null || typeof props.children === 'string') {
     return false
   }
@@ -412,20 +412,20 @@ function isElementInChildrenOrPropsTreeSingle(elementPath: string, props: any): 
   }
 
   for (let c of childrenArr) {
-    if (isElementInChildrenOrPropsTreeSingle(elementPath, c.props)) {
+    if (isElementInChildrenOrPropsTree(elementPath, c.props)) {
       return true
     }
   }
 
   for (let p in props) {
-    if (isRenderProp(p) && isElementInChildrenOrPropsTreeSingle(elementPath, p.props)) {
+    if (isRenderProp(p) && isElementInChildrenOrPropsTree(elementPath, p.props)) {
       return true
     }
   }
 
   return false
 }
-function isElementInChildrenOrPropsTreeMulti(elementPaths: Array<string>, props: any): boolean {
+function isElementsInChildrenOrPropsTree(elementPaths: Array<string>, props: any): boolean {
   if (props.children == null || typeof props.children === 'string') {
     return false
   }
@@ -445,13 +445,13 @@ function isElementInChildrenOrPropsTreeMulti(elementPaths: Array<string>, props:
   }
 
   for (let c of childrenArr) {
-    if (isElementInChildrenOrPropsTreeMulti(elementPaths, c.props)) {
+    if (isElementsInChildrenOrPropsTree(elementPaths, c.props)) {
       return true
     }
   }
 
   for (let p in props) {
-    if (isRenderProp(p) && isElementInChildrenOrPropsTreeMulti(elementPaths, p.props)) {
+    if (isRenderProp(p) && isElementsInChildrenOrPropsTree(elementPaths, p.props)) {
       return true
     }
   }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -115,14 +115,7 @@ export function createComponentRendererComponent(params: {
         return true
       }
 
-      if (ElementsToRerenderGLOBAL.current.length === 1) {
-        return isElementInChildrenOrPropsTree(
-          EP.toString(ElementsToRerenderGLOBAL.current[0]),
-          realPassedProps,
-        )
-      }
-
-      return isElementsInChildrenOrPropsTree(
+      return areElementsInChildrenOrPropsTree(
         ElementsToRerenderGLOBAL.current.map(EP.toString),
         realPassedProps,
       )
@@ -393,39 +386,7 @@ function isRenderProp(prop: any): prop is { props: { [UTOPIA_PATH_KEY]: string }
   )
 }
 
-function isElementInChildrenOrPropsTree(elementPath: string, props: any): boolean {
-  if (props.children == null || typeof props.children === 'string') {
-    return false
-  }
-
-  const childrenArr = fastReactChildrenToArray(props.children)
-  for (let c of childrenArr) {
-    if ((c.props as any)[UTOPIA_PATH_KEY] === elementPath) {
-      return true
-    }
-  }
-
-  for (let p in props) {
-    if (React.isValidElement(p) && (p.props as any)[UTOPIA_PATH_KEY] === elementPath) {
-      return true
-    }
-  }
-
-  for (let c of childrenArr) {
-    if (isElementInChildrenOrPropsTree(elementPath, c.props)) {
-      return true
-    }
-  }
-
-  for (let p in props) {
-    if (isRenderProp(p) && isElementInChildrenOrPropsTree(elementPath, p.props)) {
-      return true
-    }
-  }
-
-  return false
-}
-function isElementsInChildrenOrPropsTree(elementPaths: Array<string>, props: any): boolean {
+function areElementsInChildrenOrPropsTree(elementPaths: Array<string>, props: any): boolean {
   if (props.children == null || typeof props.children === 'string') {
     return false
   }
@@ -445,13 +406,13 @@ function isElementsInChildrenOrPropsTree(elementPaths: Array<string>, props: any
   }
 
   for (let c of childrenArr) {
-    if (isElementsInChildrenOrPropsTree(elementPaths, c.props)) {
+    if (areElementsInChildrenOrPropsTree(elementPaths, c.props)) {
       return true
     }
   }
 
   for (let p in props) {
-    if (isRenderProp(p) && isElementsInChildrenOrPropsTree(elementPaths, p.props)) {
+    if (isRenderProp(p) && areElementsInChildrenOrPropsTree(elementPaths, p.props)) {
       return true
     }
   }

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -387,10 +387,6 @@ function isRenderProp(prop: any): prop is { props: { [UTOPIA_PATH_KEY]: string }
 }
 
 function areElementsInChildrenOrPropsTree(elementPaths: Array<string>, props: any): boolean {
-  if (props.children == null || typeof props.children === 'string') {
-    return false
-  }
-
   const childrenArr = fastReactChildrenToArray(props.children)
 
   for (let c of childrenArr) {
@@ -420,6 +416,9 @@ function areElementsInChildrenOrPropsTree(elementPaths: Array<string>, props: an
 }
 
 function fastReactChildrenToArray(children: any) {
+  if (children == null || typeof children === 'string') {
+    return []
+  }
   if (React.isValidElement(children)) {
     return [children]
   }


### PR DESCRIPTION
**Problem:**
Follow-up to https://github.com/concrete-utopia/utopia/pull/6070

**Fix:**
I introduced two more optimizations:

1. The bigger one is that shouldUpdate called `isElementInChildrenOrPropsTree` separately for each of the element paths in `ElementsToRerenderGLOBAL`, even though all these runs traversed the same subtree, because they were called with the same `props` parameter. I updated `isElementInChildrenOrPropsTree` to work on an array of element paths, and check for all of them in a single execution of the function. I was a bit worried that the added complexity of this function  may slow down the most typical single element use case, but I did not find the effect measurable.

This really heavily speeds up multiselection interactions, basically a multiselection with n elements is nearly n times faster with this code. 

3. I added an early return to not do anything at all when the props.children is null or a string (happens frequently).

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

