### PR TITLE
Support area names in grid templates

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -241,8 +241,8 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
       >
         {props.axis === 'row' ? '↕' : '↔'}
         {when(
-          props.dimension.label != null,
-          <span style={{ position: 'absolute', top: 12 }}>{props.dimension.label}</span>,
+          props.dimension.areaName != null,
+          <span style={{ position: 'absolute', top: 12 }}>{props.dimension.areaName}</span>,
         )}
       </div>
       {when(

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -229,6 +229,7 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
           justifyContent: 'center',
           cursor: gridEdgeToCSSCursor(props.axis === 'column' ? 'column-start' : 'row-start'),
           fontSize: 8,
+          position: 'relative',
         }}
         css={{
           opacity: resizing ? 1 : 0.5,
@@ -239,6 +240,10 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
         onMouseDown={mouseDownHandler}
       >
         {props.axis === 'row' ? '↕' : '↔'}
+        {when(
+          props.dimension.label != null,
+          <span style={{ position: 'absolute', top: 12 }}>{props.dimension.label}</span>,
+        )}
       </div>
       {when(
         resizing,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1975,7 +1975,7 @@ export const GridCSSNumberKeepDeepEquality: KeepDeepEqualityCall<GridCSSNumber> 
     createCallWithTripleEquals<number>(),
     (cssNum) => cssNum.unit,
     nullableDeepEquality(createCallWithTripleEquals<GridCSSNumberUnit>()),
-    (cssNum) => cssNum.label,
+    (cssNum) => cssNum.areaName,
     nullableDeepEquality(StringKeepDeepEquality),
     gridCSSNumber,
   )

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -1970,11 +1970,13 @@ export const CSSNumberKeepDeepEquality: KeepDeepEqualityCall<CSSNumber> = combin
 )
 
 export const GridCSSNumberKeepDeepEquality: KeepDeepEqualityCall<GridCSSNumber> =
-  combine2EqualityCalls(
+  combine3EqualityCalls(
     (cssNum) => cssNum.value,
     createCallWithTripleEquals<number>(),
     (cssNum) => cssNum.unit,
     nullableDeepEquality(createCallWithTripleEquals<GridCSSNumberUnit>()),
+    (cssNum) => cssNum.label,
+    nullableDeepEquality(StringKeepDeepEquality),
     gridCSSNumber,
   )
 

--- a/editor/src/components/inspector/common/css-utils.spec.ts
+++ b/editor/src/components/inspector/common/css-utils.spec.ts
@@ -71,6 +71,7 @@ import {
   RegExpLibrary,
   toggleSimple,
   toggleStylePropPath,
+  tokenizeGridTemplate,
 } from './css-utils'
 
 describe('toggleStyleProp', () => {
@@ -1805,5 +1806,36 @@ describe('printBackgroundSize', () => {
         "value": "auto, auto auto, 100px, 100% 100%",
       }
     `)
+  })
+})
+
+describe('tokenizeGridTemplate', () => {
+  it('tokenizes the grid template strings (no units)', async () => {
+    expect(tokenizeGridTemplate('123 456 78 9')).toEqual(['123', '456', '78', '9'])
+  })
+  it('tokenizes the grid template strings (with units)', async () => {
+    expect(tokenizeGridTemplate('123 456px 78 9rem')).toEqual(['123', '456px', '78', '9rem'])
+  })
+  it('tokenizes the grid template strings (with some labels)', async () => {
+    expect(tokenizeGridTemplate('[foo] 123 456px 78 9rem')).toEqual([
+      '[foo] 123',
+      '456px',
+      '78',
+      '9rem',
+    ])
+    expect(tokenizeGridTemplate('123 [foo]456px 78 [bar]       9rem')).toEqual([
+      '123',
+      '[foo] 456px',
+      '78',
+      '[bar] 9rem',
+    ])
+  })
+  it('tokenizes the grid template strings (with all labels)', async () => {
+    expect(tokenizeGridTemplate('[foo] 123 [bar]456px [baz]       78  [QUX]9rem')).toEqual([
+      '[foo] 123',
+      '[bar] 456px',
+      '[baz] 78',
+      '[QUX] 9rem',
+    ])
   })
 })

--- a/editor/src/components/inspector/common/css-utils.spec.ts
+++ b/editor/src/components/inspector/common/css-utils.spec.ts
@@ -1816,7 +1816,7 @@ describe('tokenizeGridTemplate', () => {
   it('tokenizes the grid template strings (with units)', async () => {
     expect(tokenizeGridTemplate('123 456px 78 9rem')).toEqual(['123', '456px', '78', '9rem'])
   })
-  it('tokenizes the grid template strings (with some labels)', async () => {
+  it('tokenizes the grid template strings (with some area names)', async () => {
     expect(tokenizeGridTemplate('[foo] 123 456px 78 9rem')).toEqual([
       '[foo] 123',
       '456px',
@@ -1830,7 +1830,7 @@ describe('tokenizeGridTemplate', () => {
       '[bar] 9rem',
     ])
   })
-  it('tokenizes the grid template strings (with all labels)', async () => {
+  it('tokenizes the grid template strings (with all area names)', async () => {
     expect(tokenizeGridTemplate('[foo] 123 [bar]456px [baz]       78  [QUX]9rem')).toEqual([
       '[foo] 123',
       '[bar] 456px',

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -589,18 +589,18 @@ const GridCSSNumberUnits: Array<GridCSSNumberUnit> = [...LengthUnits, ...Resolut
 export interface GridCSSNumber {
   value: number
   unit: GridCSSNumberUnit | null
-  label: string | null
+  areaName: string | null
 }
 
 export function gridCSSNumber(
   value: number,
   unit: GridCSSNumberUnit | null,
-  label: string | null,
+  areaName: string | null,
 ): GridCSSNumber {
   return {
-    value,
-    unit,
-    label,
+    value: value,
+    unit: unit,
+    areaName: areaName,
   }
 }
 
@@ -768,9 +768,9 @@ export function printArrayCSSNumber(array: Array<GridCSSNumber>): string {
   return array
     .map((dimension) => {
       const printed = printCSSNumber(dimension, null)
-      const label = dimension.label != null ? `[${dimension.label}] ` : ''
+      const areaName = dimension.areaName != null ? `[${dimension.areaName}] ` : ''
       const value = typeof printed === 'string' ? printed : `${printed}`
-      return `${label}${value}`
+      return `${areaName}${value}`
     })
     .join(' ')
 }
@@ -850,20 +850,20 @@ export function parseToCSSGridNumber(input: unknown): Either<string, GridCSSNumb
       const match = input.match(gridCSSTemplateNumberRegex)
       if (match != null) {
         return {
-          label: match[1],
+          areaName: match[1],
           inputToParse: match[2],
         }
       }
     }
-    return { label: null, inputToParse: input }
+    return { areaName: null, inputToParse: input }
   }
-  const { label, inputToParse } = getParts()
+  const { areaName, inputToParse } = getParts()
 
   return mapEither((value) => {
     return {
       value: value.value,
       unit: value.unit as GridCSSNumberUnit | null,
-      label: label,
+      areaName: areaName,
     }
   }, parseCSSGrid(inputToParse))
 }
@@ -912,6 +912,8 @@ export function parseGridRange(input: unknown): Either<string, GridRange> {
   }
 }
 
+const reGridAreaNameBrackets = /^\[.+\]$/
+
 export function tokenizeGridTemplate(str: string): string[] {
   let tokens: string[] = []
   let parts = str.replace(/\]/g, '] ').split(/\s+/)
@@ -921,9 +923,9 @@ export function tokenizeGridTemplate(str: string): string[] {
     if (part == null) {
       break
     }
-    if (part.match(/^\[.+\]$/) != null && parts.length > 0) {
-      const withLabel = `${part} ${parts.shift()}`
-      tokens.push(withLabel)
+    if (part.match(reGridAreaNameBrackets) != null && parts.length > 0) {
+      const withAreaName = `${part} ${parts.shift()}`
+      tokens.push(withAreaName)
     } else {
       tokens.push(part)
     }

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -769,8 +769,7 @@ export function printArrayCSSNumber(array: Array<GridCSSNumber>): string {
     .map((dimension) => {
       const printed = printCSSNumber(dimension, null)
       const areaName = dimension.areaName != null ? `[${dimension.areaName}] ` : ''
-      const value = typeof printed === 'string' ? printed : `${printed}`
-      return `${areaName}${value}`
+      return `${areaName}${printed}`
     })
     .join(' ')
 }


### PR DESCRIPTION
**Problem:**

Parsed CSS grid templates should support area names.

**Fix:**

Parse area names along with the CSS number for grid templates. The label is stored in the number itself, so we can reuse it later (e.g. for targeting via other style props).

To make it more apparent, I added the area name under the resize handles, but it's definitely not a requirement (although I think it could/should be shown somewhere!).

https://github.com/user-attachments/assets/5aba975d-3b24-48be-8d69-c19f774bb351


Fixes #6079 
