### PR TITLE
Tweak cell resize handles

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -631,6 +631,22 @@ export function gridCellHandle(params: { id: string }): GridCellHandle {
 export const GridResizeEdges = ['row-start', 'row-end', 'column-start', 'column-end'] as const
 export type GridResizeEdge = (typeof GridResizeEdges)[number]
 
+export type GridResizeEdgeProperties = {
+  isRow: boolean
+  isColumn: boolean
+  isStart: boolean
+  isEnd: boolean
+}
+
+export function gridResizeEdgeProperties(edge: GridResizeEdge): GridResizeEdgeProperties {
+  return {
+    isRow: edge === 'row-start' || edge === 'row-end',
+    isColumn: edge === 'column-start' || edge === 'column-end',
+    isStart: edge === 'row-start' || edge === 'column-start',
+    isEnd: edge === 'row-end' || edge === 'column-end',
+  }
+}
+
 export interface GridResizeHandle {
   type: 'GRID_RESIZE_HANDLE'
   id: string

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -26,6 +26,7 @@ import {
   offsetPoint,
   pointDifference,
   pointsEqual,
+  scaleRect,
   windowPoint,
   zeroRectIfNullOrInfinity,
 } from '../../../core/shared/math-utils'
@@ -1109,7 +1110,8 @@ export const GridResizeControls = controlForStrategyMemoized<GridResizeControlPr
       if (element?.globalFrame == null || isInfinityRectangle(element.globalFrame)) {
         return false
       }
-      return element.globalFrame.width * scale > 40 && element.globalFrame.height > 40
+      const scaledFrame = scaleRect(element.globalFrame, scale)
+      return scaledFrame.width * scale > 30 && scaledFrame.height > 30
     }, [element, scale, isResizing])
 
     if (


### PR DESCRIPTION
**Problem:**

The grid cell resize handles don't scale correctly with zoom < 1, and they get off-center if the element frame is too small.

**Fix:**

1. Use a different rendering strategy for the elements (position: absolute instead of grid) so they can scale more easily when the relative container frame gets tiny
2. Hide the handles if the frame is too tiny (relative to the zoom too)
3. Hide the other three inactive edge handles when resizing is in progress, so they don't look off

| Before | After |
|--------|------------|
| ![Kapture 2024-07-15 at 18 04 36](https://github.com/user-attachments/assets/6f919b88-4bd7-4592-b788-a0939eb96520) | ![Kapture 2024-07-15 at 18 03 10](https://github.com/user-attachments/assets/3778cebb-1ab0-409f-b256-21d7ed3300ef) |
| https://github.com/user-attachments/assets/d6ba7995-c73e-4715-b4a1-1efb92ae3d5d | https://github.com/user-attachments/assets/a889a07b-60fa-4519-bd37-8001ca583f35 |

_I have no idea why GH is truncating those GIFs, see the mp4 attachments for reference_



Fixes #6081 
