### PR TITLE
Grid cells shorthand notation and area names

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -87,6 +87,15 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
         return emptyStrategyApplicationResult
       }
 
+      const container = MetadataUtils.findElementByElementPath(
+        canvasState.startingMetadata,
+        EP.parentPath(selectedElement),
+      )
+      if (container == null) {
+        return emptyStrategyApplicationResult
+      }
+      const gridTemplate = container.specialSizeMeasurements.containerGridProperties
+
       let gridProps: GridElementProperties = MetadataUtils.findElementByElementPath(
         canvasState.startingMetadata,
         selectedElement,
@@ -127,7 +136,7 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
       }
 
       return strategyApplicationResult(
-        setGridPropsCommands(selectedElement, gridPropsWithDragOver(gridProps)),
+        setGridPropsCommands(selectedElement, gridTemplate, gridPropsWithDragOver(gridProps)),
         {
           grid: { ...customState.grid, targetCell },
         },

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -6,9 +6,7 @@ import type { FramePin } from 'utopia-api/core'
 import {
   FlexAlignment,
   FlexJustifyContent,
-  FlexLength,
   FlexWrap,
-  isPercentPin,
   LayoutSystem,
   UtopiaUtils,
 } from 'utopia-api/core'
@@ -16,7 +14,6 @@ import type { LayoutPropertyTypes, StyleLayoutProp } from '../../../core/layout/
 import { findLastIndex } from '../../../core/shared/array-utils'
 import type { Either, Right as EitherRight } from '../../../core/shared/either'
 import {
-  alternativeEither,
   applicative2Either,
   bimapEither,
   eitherToMaybe,
@@ -37,6 +34,7 @@ import type {
   GridPosition,
   GridRange,
   GridAutoOrTemplateBase,
+  GridContainerProperties,
 } from '../../../core/shared/element-template'
 import {
   emptyComments,
@@ -882,10 +880,34 @@ export const parseCSSNumber = (
   }
 }
 
-export function parseGridPosition(input: unknown): Either<string, GridPosition> {
+export function parseGridPosition(
+  container: GridContainerProperties,
+  axis: 'row' | 'column',
+  edge: 'start' | 'end',
+  shorthand: GridPosition | null,
+  input: unknown,
+): Either<string, GridPosition> {
   if (input === 'auto') {
     return right('auto')
   } else if (typeof input === 'string') {
+    const referenceTemplate =
+      axis === 'row' ? container.gridTemplateRows : container.gridTemplateColumns
+    if (referenceTemplate?.type === 'DIMENSIONS') {
+      const maybeArea = referenceTemplate.dimensions.findIndex((dim) => dim.areaName === input)
+      if (maybeArea >= 0) {
+        let value = gridPositionValue(maybeArea + 1)
+        if (
+          edge === 'end' &&
+          shorthand != null &&
+          shorthand !== 'auto' &&
+          shorthand.numericalPosition === value.numericalPosition
+        ) {
+          value.numericalPosition = (value.numericalPosition ?? 0) + 1
+        }
+        return right(value)
+      }
+    }
+
     const asNumber = parseNumber(input)
     return mapEither(gridPositionValue, asNumber)
   } else if (typeof input === 'number') {
@@ -895,16 +917,26 @@ export function parseGridPosition(input: unknown): Either<string, GridPosition> 
   }
 }
 
-export function parseGridRange(input: unknown): Either<string, GridRange> {
+export function parseGridRange(
+  container: GridContainerProperties,
+  axis: 'row' | 'column',
+  input: unknown,
+): Either<string, GridRange> {
   if (typeof input === 'string') {
     if (input.includes('/')) {
       const splitInput = input.split('/')
-      const startParsed = parseGridPosition(splitInput[0])
-      const endParsed = parseGridPosition(splitInput[1])
+      const startParsed = parseGridPosition(container, axis, 'start', null, splitInput[0])
+      const endParsed = parseGridPosition(container, axis, 'end', null, splitInput[1])
       return applicative2Either(gridRange, startParsed, endParsed)
     } else {
-      const startParsed = parseGridPosition(input)
-      return mapEither((start) => gridRange(start, null), startParsed)
+      const startParsed = parseGridPosition(container, axis, 'start', null, input)
+      return mapEither((start) => {
+        const end =
+          start !== 'auto' && start.numericalPosition != null
+            ? gridPositionValue(start.numericalPosition + 1)
+            : null
+        return gridRange(start, end)
+      }, startParsed)
     }
   } else {
     return left('Not a valid grid range.')


### PR DESCRIPTION
**Problem:**

Shorthand notation for grid cells positioning should be supported across the board (moving / resizing, not just parsing) and likewise area names from the template should be reflected in the positioning props.

**Fix:**

1. Print the area names instead of the number values for grid positioning (`gridRowStart`, `gridRowEnd`, ...) if there's a match
2. Use (and understand) the shorthand notation (`gridRow`, `gridColumn`) when the underlying values are either the same or skewed by 1 (for start → end)
3. Unify the CSS property set logic so it can be reused among strategies, making it behave according to the above ^

**Notes**
- We do support parsing shorthand notations with `/`-separated values, but they are never printed for now. If there are multiple values, it will currently use the longhand notation.

**Demo:** 

https://github.com/user-attachments/assets/c70ee34b-c921-44c0-a269-2d13af70da2d

Fixes #6084 
