### PR TITLE
Support `repeat()` in grid templates

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.spec.browser2.tsx
@@ -5,7 +5,7 @@ import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import { mouseDownAtPoint, mouseMoveToPoint, mouseUpAtPoint } from '../../event-helpers.test-utils'
 import { canvasPoint } from '../../../../core/shared/math-utils'
 
-const testProject = `
+const makeTestProject = (columns: string, rows: string) => `
 import * as React from 'react'
 import { Storyboard } from 'utopia-api'
 
@@ -22,8 +22,8 @@ export var storyboard = (
         gap: 10,
         width: 600,
         height: 600,
-        gridTemplateColumns: '2.4fr 1fr 1fr',
-        gridTemplateRows: '99px 109px 90px',
+        gridTemplateColumns: '${columns}',
+        gridTemplateRows: '${rows}',
         height: 'max-content',
       }}
     >
@@ -97,7 +97,10 @@ export var storyboard = (
 
 describe('resize a grid', () => {
   it('update a fractionally sized column', async () => {
-    const renderResult = await renderTestEditorWithCode(testProject, 'await-first-dom-report')
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProject('2.4fr 1fr 1fr', '99px 109px 90px'),
+      'await-first-dom-report',
+    )
     const target = EP.fromString(`sb/grid/row-1-column-2`)
     await renderResult.dispatch(selectComponents([target], false), true)
     await renderResult.getDispatchFollowUpActionsFinished()
@@ -210,7 +213,10 @@ export var storyboard = (
   })
 
   it('update a pixel sized row', async () => {
-    const renderResult = await renderTestEditorWithCode(testProject, 'await-first-dom-report')
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProject('2.4fr 1fr 1fr', '99px 109px 90px'),
+      'await-first-dom-report',
+    )
     const target = EP.fromString(`sb/grid/row-1-column-2`)
     await renderResult.dispatch(selectComponents([target], false), true)
     await renderResult.getDispatchFollowUpActionsFinished()
@@ -250,6 +256,122 @@ export var storyboard = (
         height: 600,
         gridTemplateColumns: '2.4fr 1fr 1fr',
         gridTemplateRows: '99px 129px 90px 0px',
+        height: 'max-content',
+      }}
+    >
+      <div
+        data-uid='row-1-column-1'
+        data-testid='row-1-column-1'
+        style={{
+          backgroundColor: 'green',
+          gridColumnStart: 1,
+          gridColumnEnd: 1,
+          gridRowStart: 2,
+          gridRowEnd: 2,
+        }}
+      />
+      <div
+        data-uid='row-1-column-2'
+        data-testid='row-1-column-2'
+        style={{ backgroundColor: 'blue' }}
+      />
+      <div
+        data-uid='row-1-column-3'
+        data-testid='row-1-column-3'
+        style={{ backgroundColor: 'pink' }}
+      />
+      <div
+        data-uid='row-2-column-1'
+        data-testid='row-2-column-1'
+        style={{
+          backgroundColor: 'green',
+          gridColumnStart: 3,
+          gridColumnEnd: 4,
+          gridRowStart: 2,
+          gridRowEnd: 4,
+        }}
+      />
+      <div
+        data-uid='row-2-column-2'
+        data-testid='row-2-column-2'
+        style={{
+          backgroundColor: 'blue',
+          gridColumnStart: 2,
+          gridColumnEnd: 2,
+          gridRowStart: 2,
+          gridRowEnd: 2,
+        }}
+      />
+      <div
+        data-uid='row-2-column-3'
+        data-testid='row-2-column-3'
+        style={{ backgroundColor: 'pink' }}
+      />
+      <div
+        data-uid='row-3-column-1'
+        data-testid='row-3-column-1'
+        style={{ backgroundColor: 'green' }}
+      />
+      <div
+        data-uid='row-3-column-2'
+        data-testid='row-3-column-2'
+        style={{ backgroundColor: 'blue' }}
+      />
+      <div
+        data-uid='row-3-column-3'
+        data-testid='row-3-column-3'
+        style={{ backgroundColor: 'pink' }}
+      />
+    </div>
+  </Storyboard>
+)
+`)
+  })
+
+  it('update a repeat (fr) sized column', async () => {
+    const renderResult = await renderTestEditorWithCode(
+      makeTestProject('repeat(3, 1fr)', '99px 109px 90px'),
+      'await-first-dom-report',
+    )
+    const target = EP.fromString(`sb/grid/row-1-column-2`)
+    await renderResult.dispatch(selectComponents([target], false), true)
+    await renderResult.getDispatchFollowUpActionsFinished()
+    const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+    const resizeControl = renderResult.renderedDOM.getByTestId(`grid-column-handle-1`)
+    const resizeControlRect = resizeControl.getBoundingClientRect()
+    const startPoint = canvasPoint({
+      x: resizeControlRect.x + resizeControlRect.width / 2,
+      y: resizeControlRect.y + resizeControlRect.height / 2,
+    })
+    const endPoint = canvasPoint({
+      x: startPoint.x + 20,
+      y: startPoint.y,
+    })
+    await mouseMoveToPoint(resizeControl, startPoint)
+    await mouseDownAtPoint(resizeControl, startPoint)
+    await mouseMoveToPoint(canvasControlsLayer, endPoint)
+    await mouseUpAtPoint(canvasControlsLayer, endPoint)
+    await renderResult.getDispatchFollowUpActionsFinished()
+
+    expect(getPrintedUiJsCode(renderResult.getEditorState()))
+      .toEqual(`import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-uid='grid'
+      data-testid='grid'
+      style={{
+        position: 'absolute',
+        left: 25,
+        top: 305,
+        display: 'grid',
+        gap: 10,
+        width: 600,
+        height: 600,
+        gridTemplateColumns: '1fr 2fr 1fr',
+        gridTemplateRows: '99px 109px 90px',
         height: 'max-content',
       }}
     >

--- a/editor/src/components/inspector/common/css-tree-utils.ts
+++ b/editor/src/components/inspector/common/css-tree-utils.ts
@@ -1,0 +1,68 @@
+import * as csstree from 'css-tree'
+
+export function parseCssTreeNodeValue(str: string): csstree.CssNode {
+  return csstree.parse(str, { context: 'value' })
+}
+
+export function cssTreeNodeList(nodes: csstree.CssNode[]): csstree.List<csstree.CssNode> {
+  let list = new csstree.List<csstree.CssNode>()
+  nodes.forEach((node) => list.appendData(node))
+  return list
+}
+
+export function cssTreeNodeValue(children: csstree.List<csstree.CssNode>): csstree.Value {
+  return {
+    type: 'Value',
+    children: children,
+  }
+}
+
+export function expandCssTreeNodeValue(node: csstree.CssNode): csstree.Value {
+  return cssTreeNodeValue(expandNode(node))
+}
+
+function expandNode(node: csstree.CssNode): csstree.List<csstree.CssNode> {
+  if (node.type === 'Function' && node.name === 'repeat') {
+    // specific expansion for repeat functions
+    return expandRepeatFunction(node)
+  } else if (node.type === 'Value') {
+    // recursively expand children of Value nodes
+    const children = node.children.toArray()
+    const expanded = children.flatMap((child) => expandNode(child).toArray())
+    return cssTreeNodeList(expanded)
+  } else {
+    // fallback to just the verbatim node
+    return cssTreeNodeList([node])
+  }
+}
+
+function expandRepeatFunction(fnNode: csstree.FunctionNode): csstree.List<csstree.CssNode> {
+  // The node should have 3+ children, because it should be [Number + Operator (,) + Value(s)]
+  // TODO this should be extended to support non-numeric, keyword repeaters
+  const children = fnNode.children.toArray()
+  if (children.length < 3) {
+    // just return the original children if the format is not supported
+    return fnNode.children
+  }
+
+  // 1. parse the repeat number
+  const repeatNumber = children[0]
+  if (repeatNumber.type !== 'Number') {
+    return fnNode.children
+  }
+  const times = parseInt(repeatNumber.value)
+
+  // 2. grab ALL the values to repeat (rightside of the comma), wrap them in a new Value node,
+  // and expand them so they support nested repeats
+  const valuesToRepeat = children.slice(2)
+  const nodeToRepeat = cssTreeNodeValue(cssTreeNodeList(valuesToRepeat))
+  const expandedValues = expandNode(nodeToRepeat)
+
+  // 3. append the expanded values N times, where N is the number of repeats parsed earlier
+  let result = new csstree.List<csstree.CssNode>()
+  for (let i = 0; i < times; i++) {
+    expandedValues.forEach((v) => result.appendData(v))
+  }
+
+  return result
+}

--- a/editor/src/components/inspector/common/css-utils.spec.ts
+++ b/editor/src/components/inspector/common/css-utils.spec.ts
@@ -1849,7 +1849,7 @@ describe('expandRepeatFunctions', () => {
     expect(expandRepeatFunctions('repeat(2, 1fr 2fr 3fr)')).toEqual('1fr 2fr 3fr 1fr 2fr 3fr')
   })
   it('expands repeat with spacing', () => {
-    expect(expandRepeatFunctions('repeat ( 4       , 1fr )')).toEqual('1fr 1fr 1fr 1fr')
+    expect(expandRepeatFunctions('repeat( 4       , 1fr )')).toEqual('1fr 1fr 1fr 1fr')
   })
   it('expands repeat with decimals', () => {
     expect(expandRepeatFunctions('repeat(4, 1.5fr)')).toEqual('1.5fr 1.5fr 1.5fr 1.5fr')

--- a/editor/src/components/inspector/common/css-utils.spec.ts
+++ b/editor/src/components/inspector/common/css-utils.spec.ts
@@ -1851,6 +1851,9 @@ describe('expandRepeatFunctions', () => {
   it('expands repeat with spacing', () => {
     expect(expandRepeatFunctions('repeat ( 4       , 1fr )')).toEqual('1fr 1fr 1fr 1fr')
   })
+  it('expands repeat with decimals', () => {
+    expect(expandRepeatFunctions('repeat(4, 1.5fr)')).toEqual('1.5fr 1.5fr 1.5fr 1.5fr')
+  })
   it('expands nested', () => {
     expect(expandRepeatFunctions('repeat(2, repeat(3, 1fr))')).toEqual('1fr 1fr 1fr 1fr 1fr 1fr')
 

--- a/editor/src/components/inspector/common/css-utils.spec.ts
+++ b/editor/src/components/inspector/common/css-utils.spec.ts
@@ -54,6 +54,7 @@ import {
   defaultCSSRadialGradientSize,
   defaultCSSRadialOrConicGradientCenter,
   disabledFunctionName,
+  expandRepeatFunctions,
   parseBackgroundColor,
   parseBackgroundImage,
   parseBorderRadius,
@@ -1837,5 +1838,25 @@ describe('tokenizeGridTemplate', () => {
       '[baz] 78',
       '[QUX] 9rem',
     ])
+  })
+})
+
+describe('expandRepeatFunctions', () => {
+  it('expands repeat', async () => {
+    expect(expandRepeatFunctions('repeat(4, 1fr)')).toEqual('1fr 1fr 1fr 1fr')
+  })
+  it('expands repeat with multiple units', () => {
+    expect(expandRepeatFunctions('repeat(2, 1fr 2fr 3fr)')).toEqual('1fr 2fr 3fr 1fr 2fr 3fr')
+  })
+  it('expands repeat with spacing', () => {
+    expect(expandRepeatFunctions('repeat ( 4       , 1fr )')).toEqual('1fr 1fr 1fr 1fr')
+  })
+  it('expands nested', () => {
+    expect(expandRepeatFunctions('repeat(2, repeat(3, 1fr))')).toEqual('1fr 1fr 1fr 1fr 1fr 1fr')
+
+    // Note: crazytown, I'm not even sure this is valid CSS *but still*
+    expect(expandRepeatFunctions('repeat(2, repeat(2, 1fr repeat(3, 2fr 4em)))')).toEqual(
+      '1fr 2fr 4em 2fr 4em 2fr 4em 1fr 2fr 4em 2fr 4em 2fr 4em 1fr 2fr 4em 2fr 4em 2fr 4em 1fr 2fr 4em 2fr 4em 2fr 4em',
+    )
   })
 })

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -953,16 +953,23 @@ export function expandRepeatFunctions(str: string): string {
 
 const reGridAreaNameBrackets = /^\[.+\]$/
 
-export function tokenizeGridTemplate(str: string): string[] {
-  let tokens: string[] = []
-  let parts =
-    // 1. expand any `repeat()` functions
-    expandRepeatFunctions(str)
-      // 2. make sure square brackets have a trailing whitespace so we can normalize the parsing
-      .replace(/\]/g, '] ')
-      // 3. tokenize by whitespace
-      .split(/\s+/)
+function normalizeGridTemplate(template: string): string {
+  type normalizeFn = (s: string) => string
 
+  const normalizePasses: normalizeFn[] = [
+    // 1. expand repeat functions
+    expandRepeatFunctions,
+    // 2. normalize area names spacing
+    (s) => s.replace(/\]/g, '] ').replace(/\[/g, ' ['),
+  ]
+
+  return normalizePasses.reduce((working, normalize) => normalize(working), template).trim()
+}
+
+export function tokenizeGridTemplate(template: string): string[] {
+  let parts = normalizeGridTemplate(template).split(/\s+/)
+
+  let tokens: string[] = []
   while (parts.length > 0) {
     const part = parts.shift()?.trim()
     if (part == null) {

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -967,9 +967,8 @@ function normalizeGridTemplate(template: string): string {
 }
 
 export function tokenizeGridTemplate(template: string): string[] {
-  let parts = normalizeGridTemplate(template).split(/\s+/)
-
   let tokens: string[] = []
+  let parts = normalizeGridTemplate(template).split(/\s+/)
   while (parts.length > 0) {
     const part = parts.shift()?.trim()
     if (part == null) {

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -943,7 +943,8 @@ export function parseGridRange(
   }
 }
 
-// this regex matches 'repeat ( [unit] , [value] )', capturing groups around the unit (1) and the value (2)
+// This regex matches 'repeat ( [times] , [value] )', capturing groups around the unit (1) and the value (2)
+// TODO this should be extended to support non-numeric, keyword repeaters
 const reRepeatFunction = /repeat\s*\(\s*(\d+)\s*,\s*([^,\)]+)\s*\)/
 
 export function expandRepeatFunctions(str: string): string {

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -86,6 +86,8 @@ import { memoize } from '../../../core/shared/memoize'
 import { parseCSSArray } from '../../../printer-parsers/css/css-parser-utils'
 import type { ParseError } from '../../../utils/value-parser-utils'
 import { descriptionParseError } from '../../../utils/value-parser-utils'
+import * as csstree from 'css-tree'
+import { expandCssTreeNodeValue, parseCssTreeNodeValue } from './css-tree-utils'
 
 var combineRegExp = function (regexpList: Array<RegExp | string>, flags?: string) {
   let source: string = ''
@@ -943,23 +945,10 @@ export function parseGridRange(
   }
 }
 
-// This regex matches 'repeat ( [times] , [value] )', capturing groups around the repeater (1) and the value (2)
-// TODO this should be extended to support non-numeric, keyword repeaters
-const reRepeatFunction = /repeat\s*\(\s*(\d+)\s*,\s*([^,\)]+)\s*\)/
-
 export function expandRepeatFunctions(str: string): string {
-  let expanded = str
-
-  // If the string matches the regex, calculate its expansion and replace it in-place,
-  // and try again so we can keep expanding nested repeats.
-  let match: RegExpMatchArray | null = null
-  while ((match = expanded.match(reRepeatFunction)) != null) {
-    const times = parseInt(match[1])
-    const value = match[2]
-    expanded = expanded.replace(match[0], `${value.trim()} `.repeat(times).trim())
-  }
-
-  return expanded
+  const node = parseCssTreeNodeValue(str)
+  const expanded = expandCssTreeNodeValue(node)
+  return csstree.generate(expanded)
 }
 
 const reGridAreaNameBrackets = /^\[.+\]$/

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -943,7 +943,7 @@ export function parseGridRange(
   }
 }
 
-// This regex matches 'repeat ( [times] , [value] )', capturing groups around the unit (1) and the value (2)
+// This regex matches 'repeat ( [times] , [value] )', capturing groups around the repeater (1) and the value (2)
 // TODO this should be extended to support non-numeric, keyword repeaters
 const reRepeatFunction = /repeat\s*\(\s*(\d+)\s*,\s*([^,\)]+)\s*\)/
 
@@ -955,8 +955,8 @@ export function expandRepeatFunctions(str: string): string {
   let match: RegExpMatchArray | null = null
   while ((match = expanded.match(reRepeatFunction)) != null) {
     const times = parseInt(match[1])
-    const unit = match[2]
-    expanded = expanded.replace(match[0], `${unit.trim()} `.repeat(times).trim())
+    const value = match[2]
+    expanded = expanded.replace(match[0], `${value.trim()} `.repeat(times).trim())
   }
 
   return expanded


### PR DESCRIPTION
**Problem:**

Grids with `repeat()` in their template are correctly displayed, but cannot be resized because the dimensions are `FALLBACK`.

**Fix:**

Expand the `repeat()` functions inside the templates when parsing them, so they are calculated correctly.


https://github.com/user-attachments/assets/7744262c-f701-4685-a357-6ddaf9685bca



Fixes #6089 
