### PR TITLE
Drag grid elements that don't have grid props set

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -175,7 +175,7 @@ export function runGridRearrangeMove(
 
   const gridTemplate = containerMetadata.specialSizeMeasurements.containerGridProperties
 
-  const cellGridProperties = getElementGridProperties(originalElementMetadata)
+  const cellGridProperties = getElementGridProperties(originalElementMetadata, newTargetCell)
 
   // calculate the difference between the cell the mouse started the interaction from, and the "root"
   // cell of the element, meaning the top-left-most cell the element occupies.
@@ -321,7 +321,10 @@ function getTargetCell(
   return cell
 }
 
-function getElementGridProperties(element: ElementInstanceMetadata): {
+function getElementGridProperties(
+  element: ElementInstanceMetadata,
+  cellUnderMouse: { row: number; column: number },
+): {
   row: number
   width: number
   column: number
@@ -330,12 +333,15 @@ function getElementGridProperties(element: ElementInstanceMetadata): {
   // get the grid fixtures (start and end for column and row) from the element metadata
   function getGridProperty(field: keyof GridElementProperties, fallback: number) {
     const propValue = element.specialSizeMeasurements.elementGridProperties[field]
-    return propValue == null || propValue === 'auto' ? 0 : propValue.numericalPosition ?? fallback
+    if (propValue == null || propValue === 'auto') {
+      return fallback
+    }
+    return propValue.numericalPosition ?? fallback
   }
-  const column = getGridProperty('gridColumnStart', 0)
-  const height = getGridProperty('gridColumnEnd', 1) - column
-  const row = getGridProperty('gridRowStart', 0)
-  const width = getGridProperty('gridRowEnd', 1) - row
+  const column = getGridProperty('gridColumnStart', cellUnderMouse.column)
+  const height = getGridProperty('gridColumnEnd', cellUnderMouse.column + 1) - column
+  const row = getGridProperty('gridRowStart', cellUnderMouse.row)
+  const width = getGridProperty('gridRowEnd', cellUnderMouse.row + 1) - row
 
   return {
     row,

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.spec.browser2.tsx
@@ -9,8 +9,11 @@ import { gridCellTargetId } from './grid-helpers'
 
 describe('grid rearrange move strategy', () => {
   it('can rearrange elements on a grid', async () => {
+    const testId = 'aaa'
     const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } = await runMoveTest({
       scale: 1,
+      pathString: `sb/scene/grid/${testId}`,
+      testId: testId,
     })
     expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
       gridColumnEnd: '7',
@@ -19,9 +22,28 @@ describe('grid rearrange move strategy', () => {
       gridRowStart: '2',
     })
   })
+
+  it('can rearrange element with no explicit grid props set', async () => {
+    const testId = 'bbb'
+    const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } = await runMoveTest({
+      scale: 1,
+      pathString: `sb/scene/grid/${testId}`,
+      testId: testId,
+    })
+    expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+      gridColumnEnd: 'auto',
+      gridColumnStart: '3',
+      gridRowEnd: 'auto',
+      gridRowStart: '2',
+    })
+  })
+
   it('can rearrange elements on a grid (zoom out)', async () => {
+    const testId = 'aaa'
     const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } = await runMoveTest({
       scale: 0.5,
+      pathString: `sb/scene/grid/${testId}`,
+      testId: testId,
     })
     expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
       gridColumnEnd: '7',
@@ -32,8 +54,11 @@ describe('grid rearrange move strategy', () => {
   })
 
   it('can rearrange elements on a grid (zoom in)', async () => {
+    const testId = 'aaa'
     const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } = await runMoveTest({
       scale: 2,
+      pathString: `sb/scene/grid/${testId}`,
+      testId: testId,
     })
     expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
       gridColumnEnd: '7',
@@ -44,10 +69,10 @@ describe('grid rearrange move strategy', () => {
   })
 })
 
-async function runMoveTest(props: { scale: number }) {
+async function runMoveTest(props: { scale: number; pathString: string; testId: string }) {
   const editor = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')
 
-  const elementPathToDrag = EP.fromString('sb/scene/grid/aaa')
+  const elementPathToDrag = EP.fromString(props.pathString)
 
   await selectComponentsForTest(editor, [elementPathToDrag])
 
@@ -77,7 +102,7 @@ async function runMoveTest(props: { scale: number }) {
     ),
   )
 
-  return editor.renderedDOM.getByTestId('aaa').style
+  return editor.renderedDOM.getByTestId(props.testId).style
 }
 
 const ProjectCode = `import * as React from 'react'
@@ -125,16 +150,13 @@ export var storyboard = (
           data-uid='aaa'
           data-testid='aaa'
         />
-        <Placeholder
+        <div
           style={{
             minHeight: 0,
             backgroundColor: '#23565b',
-            gridColumnStart: 5,
-            gridColumnEnd: 7,
-            gridRowStart: 1,
-            gridRowEnd: 3,
           }}
           data-uid='bbb'
+          data-testid='bbb'
         />
         <Placeholder
           style={{


### PR DESCRIPTION
## Problem
When a grid child without grid props is dragged, it jumps back to the top left of the grid no matter where it's dragged

## Fix
If a grid child doesn't have grid props set, we take it as if was set to occupy the grid column/row under the mouse pointer at start of the interaction (since that's where it's positioned by the browser)