### PR TITLE
Fix disappearing content during interaction

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -223,8 +223,9 @@ export function createComponentRendererComponent(params: {
       throw new Error(`Element hierarchy is too deep, potentially has become infinite.`)
     }
 
+    const shouldUpdateResult = shouldUpdate()
     // either this updateInvalidatedPaths or the one in SpyWrapper is probably redundant
-    if (shouldUpdate()) {
+    if (shouldUpdateResult) {
       updateInvalidatedPaths((invalidPaths) => {
         // Do not add `svg` elements that are the root element of a component.
         // As they will not be cleared by the DOM walker as they are not instances
@@ -363,7 +364,7 @@ export function createComponentRendererComponent(params: {
           null,
         )
       }
-    } else if (shouldUpdate() || buildResult.current === null) {
+    } else if (shouldUpdateResult || buildResult.current === null) {
       buildResult.current = buildComponentRenderResult(utopiaJsxComponent.rootElement)
     }
     return buildResult.current

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -261,7 +261,9 @@ export function createComponentRendererComponent(params: {
       filePathMappings: rerenderUtopiaContext.filePathMappings,
     }
 
-    const buildResult = React.useRef<React.ReactElement | null>(null)
+    const buildResult = React.useRef<React.ReactElement | undefined>(
+      buildComponentRenderResult(utopiaJsxComponent.rootElement),
+    )
 
     let earlyReturn: EarlyReturn | null = null
     if (utopiaJsxComponent.arbitraryJSBlock != null) {
@@ -312,7 +314,7 @@ export function createComponentRendererComponent(params: {
           break
         case 'EARLY_RETURN_VOID':
           earlyReturn = arbitraryBlockResult
-          buildResult.current = undefined as any
+          buildResult.current = undefined
           break
         case 'EARLY_RETURN_RESULT':
           earlyReturn = arbitraryBlockResult

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -223,9 +223,8 @@ export function createComponentRendererComponent(params: {
       throw new Error(`Element hierarchy is too deep, potentially has become infinite.`)
     }
 
-    const shouldUpdateResult = shouldUpdate()
     // either this updateInvalidatedPaths or the one in SpyWrapper is probably redundant
-    if (shouldUpdateResult) {
+    if (shouldUpdate()) {
       updateInvalidatedPaths((invalidPaths) => {
         // Do not add `svg` elements that are the root element of a component.
         // As they will not be cleared by the DOM walker as they are not instances
@@ -364,7 +363,7 @@ export function createComponentRendererComponent(params: {
           null,
         )
       }
-    } else if (shouldUpdateResult || buildResult.current === null) {
+    } else if (shouldUpdate()) {
       buildResult.current = buildComponentRenderResult(utopiaJsxComponent.rootElement)
     }
     return buildResult.current

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -261,7 +261,7 @@ export function createComponentRendererComponent(params: {
       filePathMappings: rerenderUtopiaContext.filePathMappings,
     }
 
-    const buildResult = React.useRef<React.ReactElement | undefined>(
+    const buildResult = React.useRef<React.ReactElement | null>(
       buildComponentRenderResult(utopiaJsxComponent.rootElement),
     )
 
@@ -314,7 +314,7 @@ export function createComponentRendererComponent(params: {
           break
         case 'EARLY_RETURN_VOID':
           earlyReturn = arbitraryBlockResult
-          buildResult.current = undefined
+          buildResult.current = undefined as any
           break
         case 'EARLY_RETURN_RESULT':
           earlyReturn = arbitraryBlockResult

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -261,9 +261,7 @@ export function createComponentRendererComponent(params: {
       filePathMappings: rerenderUtopiaContext.filePathMappings,
     }
 
-    const buildResult = React.useRef<React.ReactElement | null>(
-      buildComponentRenderResult(utopiaJsxComponent.rootElement),
-    )
+    const buildResult = React.useRef<React.ReactElement | null>(null)
 
     let earlyReturn: EarlyReturn | null = null
     if (utopiaJsxComponent.arbitraryJSBlock != null) {
@@ -365,7 +363,7 @@ export function createComponentRendererComponent(params: {
           null,
         )
       }
-    } else if (shouldUpdate()) {
+    } else if (shouldUpdate() || buildResult.current === null) {
       buildResult.current = buildComponentRenderResult(utopiaJsxComponent.rootElement)
     }
     return buildResult.current

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-component-renderer.tsx
@@ -363,7 +363,7 @@ export function createComponentRendererComponent(params: {
           null,
         )
       }
-    } else if (shouldUpdate()) {
+    } else if (shouldUpdate() || buildResult.current === null) {
       buildResult.current = buildComponentRenderResult(utopiaJsxComponent.rootElement)
     }
     return buildResult.current

--- a/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-functional-components.spec.ts
@@ -103,6 +103,14 @@ export var whatever = ({prop, ...otherProps}) => {
 }
 `
 
+const codeWithDestructuredPropsObjectWithElementNamePropAndRestParam = `import React from "react";
+export var whatever = ({As = 'div', ...otherProps}) => {
+  return (
+    <As data-uid={'aaa'} />
+  )
+}
+`
+
 const codeWithDestructuredArray = `import React from "react";
 import { View } from "utopia-api";
 export var whatever = ([prop]) => {
@@ -1057,6 +1065,10 @@ describe('Parsing, printing, reparsing a function component with props', () => {
 
   it('Correctly parses back and forth a destructured props object that uses a rest param', () => {
     testParsePrintParse(codeWithDestructuredPropsObjectWithRestParam)
+  })
+
+  it('Correctly parses back and forth a destructured props object with element name prop and rest param', () => {
+    testParsePrintParse(codeWithDestructuredPropsObjectWithElementNamePropAndRestParam)
   })
 
   it('Correctly parses back and forth a destructured props array', () => {

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -3630,12 +3630,7 @@ export function parseOutJSXElements(
         definedElsewhere.push(...attrs.definedElsewhere)
         const isFragment = TS.isJsxFragment(tsElement)
         return flatMapEither((elementName) => {
-          if (
-            (isFragment && elementName == null) ||
-            (!isFragment &&
-              elementName != null &&
-              isJsxNameKnown(elementName, topLevelNames, imports))
-          ) {
+          if ((isFragment && elementName == null) || (!isFragment && elementName != null)) {
             const childrenMinusWhitespaceOnlyTexts: Array<JSXElementChild> =
               getChildrenWithoutWhitespaceOnlyText(childElems)
 
@@ -3811,31 +3806,6 @@ export function parseOutJSXElements(
 }
 
 export const CanvasMetadataName = 'canvasMetadata'
-
-function isJsxNameKnown(
-  name: JSXElementName,
-  knownElements: Array<string>,
-  imports: Imports,
-): boolean {
-  if (isIntrinsicElement(name)) {
-    return true
-  } else {
-    const importsArray = Object.values(imports)
-    const knownImportedNames = stripNulls(
-      flatMapArray(
-        (imp) => [
-          imp.importedWithName,
-          imp.importedAs,
-          ...imp.importedFromWithin.map((i) => i.alias),
-        ],
-        importsArray,
-      ),
-    )
-    const knownNames = knownElements.concat(knownImportedNames as string[])
-    const result = [...knownNames, 'Fragment'].includes(name.baseVariable)
-    return result
-  }
-}
 
 function isReactFragmentName(name: JSXElementName, imports: Imports): boolean {
   if (imports == null) {

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -114,6 +114,7 @@ import {
   jsAssignmentStatement,
   clearAssignmentUniqueIDsAndSourceMaps,
   clearJSExpressionOtherJavaScriptUniqueIDs,
+  propertiesExposedByParams,
 } from '../../shared/element-template'
 import { maybeToArray, forceNotNull } from '../../shared/optional-utils'
 import type {
@@ -4105,10 +4106,9 @@ export function parseOutFunctionContents(
         jsBlock = null
       }
 
-      let declared: Array<string> = [...topLevelNames]
+      let declared: Array<string> = [...topLevelNames, ...propertiesExposedByParams(params)]
       if (jsBlock != null) {
         declared.push(...jsBlock.definedWithin)
-        declared.push(...jsBlock.definedElsewhere)
       }
 
       const parsedElements = parseOutJSXElements(


### PR DESCRIPTION
**Problem:**
See https://github.com/concrete-utopia/utopia/issues/5834

There is a way to reproduce this bug without the sample store, just resize the pink rectangle in this project: https://utopia.pizza/project/d8bb2af5

The bug happens in the following situation:
- there is a component (Container in the example) which has a prop coming from an object spread parameter of the component
- this prop specifies the rendered root component/element (in the example the default value is 'div')
- this component has children, and when you interact (e.g. resize) with one of its children, those siblings which are components are not visible during the interaction (MyComp in the example)

You need all of this to reproduce the issue.
- If the sibling is not a component, it is rendered perfectly
- If the prop from the object spread is not used directly but assigned to a local variable, then everything works perfectly.
 
The faulty behavior is a result of 2 bugs:
1. The component is parsed as ARBITRARY_JS_BLOCK and not as UTOPIA_JSX_COMPONENT. Because of this the Container component is unmounted and remounted at the beginning of the interaction. It is parsed as a js block, because we only allow parsing as a component when the jsx name is known, and the props from the object spread are not included in the known names in the check. 
2. ComponentRendererComponent is buggy, and loses its buildResult cached value when a component is remounted and shouldUpdate() is false. This happens because buildResult is a ref initialized with null and it is only filled with the proper value when shouldUpdate() is true.

**Fix:**
1. I don't think the parser should check if a jsx name is known. When the syntax is clearly jsx, we should parse that as a jsx component. When the jsx name is not known, we will see the proper runtime exception. 
However, fully removing this condition causes problems, because it allows the function below to be parsed as component:
```
function wrappedComponent(Component) => {
  return <Component />
}
```
If we parse this as a component our runtime fails to execute it. I think this is a deeper parser issue, and it seems it is mostly pure luck that we parse this as arbitrary block (just because it thinks `Component` is not known).
I did not dive deeper and just added properties exposed by the params to the list of known names, but I think this problem worth a more detailed investigation. What makes a component a component besides it being a function and returning a jsx?

2. Update the buildResult ref in ComponentRendererComponent even if shouldUpdate is false when its value is 'null'

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5834
