### PR TITLE
Tweak grid colors

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -1135,7 +1135,7 @@ export const GridResizeControls = controlForStrategyMemoized<GridResizeControlPr
             left: bounds?.x ?? element.globalFrame.x,
             width: bounds?.width ?? element.globalFrame.width,
             height: bounds?.height ?? element.globalFrame.height,
-            backgroundColor: isResizing ? colorTheme.whiteOpacity30.value : 'transparent',
+            backgroundColor: isResizing ? colorTheme.primary25.value : 'transparent',
           }}
         >
           <div

--- a/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
+++ b/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
@@ -44,7 +44,7 @@ const defaultRollYourOwnFeatures: RollYourOwnFeatures = {
     adaptiveOpacity: true,
     activeGridColor: '#0099ff77',
     dotgridColor: '#0099ffaa',
-    inactiveGridColor: '#0000000a',
+    inactiveGridColor: '#00000033',
     opacityBaseline: 0.25,
   },
 }


### PR DESCRIPTION
**Problem:**

Some grid-related colors are too subtle.

**Fix:**

1. make the inactive grid lines more visible
<img width="1512" alt="Screenshot 2024-07-18 at 12 44 00" src="https://github.com/user-attachments/assets/e462da73-6241-4ea7-b06d-1844631c78a1">

2. make the cell resizing shadow use the primary color

https://github.com/user-attachments/assets/6a9a0c50-d3f5-4600-b60f-59e777060769

