### PR TITLE
Support `rowGap`/`columnGap` in grid controls

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -446,6 +446,8 @@ export const GridControls = controlForStrategyMemoized(() => {
         }
 
         const gap = targetGridContainer.specialSizeMeasurements.gap
+        const rowGap = targetGridContainer.specialSizeMeasurements.rowGap
+        const columnGap = targetGridContainer.specialSizeMeasurements.columnGap
         const padding = targetGridContainer.specialSizeMeasurements.padding
         const gridTemplateColumns =
           targetGridContainer.specialSizeMeasurements.containerGridProperties.gridTemplateColumns
@@ -473,6 +475,8 @@ export const GridControls = controlForStrategyMemoized(() => {
           gridTemplateColumnsFromProps: gridTemplateColumnsFromProps,
           gridTemplateRowsFromProps: gridTemplateRowsFromProps,
           gap: gap,
+          rowGap: rowGap,
+          columnGap: columnGap,
           padding: padding,
           rows: rows,
           columns: columns,
@@ -665,6 +669,8 @@ export const GridControls = controlForStrategyMemoized(() => {
                   activelyDraggingOrResizingCell != null ? colorTheme.primary.value : 'transparent'
                 }`,
                 gap: grid.gap ?? 0,
+                rowGap: grid.rowGap ?? 0,
+                columnGap: grid.columnGap ?? 0,
                 padding:
                   grid.padding == null
                     ? 0

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -1147,6 +1147,16 @@ function getSpecialMeasurements(
     mapEither((n) => n.value, parseCSSLength(elementStyle.gap)),
   )
 
+  const rowGap = defaultEither(
+    null,
+    mapEither((n) => n.value, parseCSSLength(elementStyle.rowGap)),
+  )
+
+  const columnGap = defaultEither(
+    null,
+    mapEither((n) => n.value, parseCSSLength(elementStyle.columnGap)),
+  )
+
   const flexGapValue = parseCSSLength(parentElementStyle?.gap)
   const parsedFlexGapValue = isRight(flexGapValue) ? flexGapValue.value.value : 0
 
@@ -1252,6 +1262,8 @@ function getSpecialMeasurements(
     containerElementProperties,
     containerGridPropertiesFromProps,
     containerElementPropertiesFromProps,
+    rowGap,
+    columnGap,
   )
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -2263,6 +2263,8 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
         newSize.elementGridProperties,
         newSize.containerGridPropertiesFromProps,
         newSize.elementGridPropertiesFromProps,
+        newSize.rowGap,
+        newSize.columnGap,
       )
       return keepDeepEqualityResult(sizeMeasurements, false)
     }

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -2720,6 +2720,8 @@ export interface SpecialSizeMeasurements {
   elementGridProperties: GridElementProperties
   containerGridPropertiesFromProps: GridContainerProperties
   elementGridPropertiesFromProps: GridElementProperties
+  rowGap: number | null
+  columnGap: number | null
 }
 
 export function specialSizeMeasurements(
@@ -2768,6 +2770,8 @@ export function specialSizeMeasurements(
   elementGridProperties: GridElementProperties,
   containerGridPropertiesFromProps: GridContainerProperties,
   elementGridPropertiesFromProps: GridElementProperties,
+  rowGap: number | null,
+  columnGap: number | null,
 ): SpecialSizeMeasurements {
   return {
     offset,
@@ -2815,6 +2819,8 @@ export function specialSizeMeasurements(
     elementGridProperties,
     containerGridPropertiesFromProps,
     elementGridPropertiesFromProps,
+    rowGap,
+    columnGap,
   }
 }
 
@@ -2887,6 +2893,8 @@ export const emptySpecialSizeMeasurements = specialSizeMeasurements(
     gridRowStart: null,
     gridRowEnd: null,
   },
+  null,
+  null,
 )
 
 export function walkElement(


### PR DESCRIPTION
**Problem:**

Grid controls don't support/show correctly grids with `rowGap` and `columnGap` properties.
Specifically, they both show incorrect grid lines as well as not having correct drag targets for the mouse-based interactions.

**Fix:**

1. Include those two props in the `specialSizeMeasurements`
2. Carry them over when displaying the grid shadow and targets

| Before | After |
|--------|-----------|
| <img width="614" alt="Screenshot 2024-07-18 at 18 02 19" src="https://github.com/user-attachments/assets/8b15207b-a783-4b80-9e47-57caefdad0e1"> | <img width="614" alt="Screenshot 2024-07-18 at 18 02 16" src="https://github.com/user-attachments/assets/c7406499-57b6-4336-8bc5-a1605a8dc0bb"> |



Fixes #6101 
