### PR TITLE
Fix canvas toolbar rerenders

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
+++ b/editor/src/components/canvas/controls/select-mode/canvas-strategy-picker.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
+import { twoLevelNestedEquals } from '../../../../core/shared/equality-utils'
 import { mod } from '../../../../core/shared/math-utils'
 import { when } from '../../../../utils/react-conditionals'
-import { FlexRow, FlexColumn, UtopiaStyles, colorTheme, UtopiaTheme } from '../../../../uuiui'
+import { colorTheme, FlexColumn, FlexRow, UtopiaStyles, UtopiaTheme } from '../../../../uuiui'
 import { useDispatch } from '../../../editor/store/dispatch-context'
 import { Substores, useEditorState } from '../../../editor/store/store-hook'
 import { stopPropagation } from '../../../inspector/common/inspector-utils'
@@ -11,12 +12,15 @@ import type { CanvasStrategy } from '../../canvas-strategies/canvas-strategy-typ
 
 export const CanvasStrategyPicker = React.memo(() => {
   const dispatch = useDispatch()
-  const { allApplicableStrategies } = useEditorState(
+  const allApplicableStrategies = useEditorState(
     Substores.restOfStore,
-    (store) => ({
-      allApplicableStrategies: store.strategyState.sortedApplicableStrategies,
-    }),
+    (store) =>
+      store.strategyState.sortedApplicableStrategies?.map((s) => ({
+        id: s.strategy.id,
+        name: s.name,
+      })),
     'CanvasStrategyPicker strategyState.currentStrategy',
+    twoLevelNestedEquals,
   )
   const activeStrategy = useDelayedCurrentStrategy()
   const isStrategyFailure = useEditorState(
@@ -26,8 +30,8 @@ export const CanvasStrategyPicker = React.memo(() => {
   )
 
   const onSetStrategy = React.useCallback(
-    (newStrategy: CanvasStrategy) => {
-      dispatch([CanvasActions.setUsersPreferredStrategy(newStrategy.id)])
+    (id: CanvasStrategy['id']) => {
+      dispatch([CanvasActions.setUsersPreferredStrategy(id)])
     },
     [dispatch],
   )
@@ -48,7 +52,7 @@ export const CanvasStrategyPicker = React.memo(() => {
 
         if (event.key === 'Tab') {
           const activeStrategyIndex = allApplicableStrategies.findIndex(
-            ({ strategy }) => strategy.id === activeStrategy,
+            ({ id }) => id === activeStrategy,
           )
 
           const newStrategyIndex = event.shiftKey
@@ -56,14 +60,14 @@ export const CanvasStrategyPicker = React.memo(() => {
             : activeStrategyIndex + 1
 
           const nextStrategyIndex = mod(newStrategyIndex, allApplicableStrategies.length)
-          const nextStrategy = allApplicableStrategies[nextStrategyIndex].strategy
+          const nextStrategy = allApplicableStrategies[nextStrategyIndex]
 
-          onSetStrategy(nextStrategy)
+          onSetStrategy(nextStrategy.id)
         } else if (!isNaN(keyIntValue)) {
           const index = keyIntValue - 1
           const nextStrategy = allApplicableStrategies[index]
           if (nextStrategy != null) {
-            onSetStrategy(nextStrategy.strategy)
+            onSetStrategy(nextStrategy.id)
           }
         }
       }
@@ -98,26 +102,23 @@ export const CanvasStrategyPicker = React.memo(() => {
               boxShadow: UtopiaStyles.shadowStyles.low.boxShadow,
             }}
           >
-            {allApplicableStrategies?.map(({ strategy, name }, index) => {
+            {allApplicableStrategies?.map(({ id, name }, index) => {
               return (
                 <FlexRow
-                  key={strategy.id}
+                  key={id}
                   style={{
                     height: 19,
                     paddingLeft: 4,
                     paddingRight: 4,
                     borderRadius: 6,
-                    backgroundColor:
-                      strategy.id === activeStrategy ? colorTheme.bg3.value : undefined,
+                    backgroundColor: id === activeStrategy ? colorTheme.bg3.value : undefined,
                     color: colorTheme.textColor.value,
-                    opacity: isStrategyFailure && strategy.id === activeStrategy ? 0.5 : 1,
+                    opacity: isStrategyFailure && id === activeStrategy ? 0.5 : 1,
                   }}
                 >
                   <KeyIndicator keyNumber={index + 1} />
                   <span
-                    data-testid={
-                      strategy.id === activeStrategy ? 'strategy-picker-active-row' : undefined
-                    }
+                    data-testid={id === activeStrategy ? 'strategy-picker-active-row' : undefined}
                   >
                     {name}
                   </span>

--- a/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
+++ b/editor/src/components/canvas/controls/select-mode/strategy-indicator.tsx
@@ -65,14 +65,11 @@ export const StrategyIndicator = React.memo(() => {
 export const MoveReorderReparentIndicatorID = 'move-reorder-reparent-indicator'
 
 const MoveReorderReparentIndicator = React.memo(() => {
-  const currentStrategyState = useEditorState(
+  const indicatorText = useEditorState(
     Substores.restOfStore,
-    (store) => store.strategyState,
+    (store) => store.strategyState.currentStrategyDescriptiveLabel ?? 'Interaction',
     'MoveReorderReparentIndicator currentStrategyState',
   )
-  const indicatorText = React.useMemo(() => {
-    return currentStrategyState.currentStrategyDescriptiveLabel ?? 'Interaction'
-  }, [currentStrategyState.currentStrategyDescriptiveLabel])
   const colorTheme = useColorTheme()
   return (
     <FlexRow

--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -278,14 +278,11 @@ export const CanvasToolbar = React.memo(() => {
     }
   }, [canvasToolbarMode.primary, dispatch, dispatchSwitchToSelectModeCloseMenus])
 
-  const currentStrategyState = useEditorState(
+  const editButtonIcon: CanvasStrategyIcon = useEditorState(
     Substores.restOfStore,
-    (store) => store.strategyState,
+    (store) => store.strategyState.currentStrategyIcon ?? { category: 'tools', type: 'pointer' },
     'SettingsPanel currentStrategyState',
   )
-  const editButtonIcon: CanvasStrategyIcon = React.useMemo(() => {
-    return currentStrategyState.currentStrategyIcon ?? { category: 'tools', type: 'pointer' }
-  }, [currentStrategyState.currentStrategyIcon])
 
   const wrapInSubmenu = React.useCallback((wrapped: React.ReactNode) => {
     return (


### PR DESCRIPTION
**Problem:**
The CanvasToolbar and some of its children components would unnecessarily rerender during canvas interactions.

**Fix:**
Fixing some useState hooks that caused the problems. 

**Commit Details:** (< vv pls delete this section if's not relevant)

- no longer get the entire currentStrategyState just so we can derive an icon name
- CanvasStrategyPicker no longer gets the full reference to the array of strategies, only their name and ID (which makes equality checks easier)
- similarly, MoveReorderReparentIndicator only gets the string to display instead of the full state
