### PR TITLE
Grid col/row actions dropdown menu (delete + rename)

### DIFF
--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -227,7 +227,6 @@ const TemplateDimensionControl = React.memo(
     title: string
   }) => {
     const dispatch = useDispatch()
-    const colorTheme = useColorTheme()
 
     const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
 
@@ -411,11 +410,11 @@ const TemplateDimensionControl = React.memo(
             id: `remove-${axis}`,
             label: 'Delete',
             onSelect: onRemove(index),
-            highlightBackgroundColor: colorTheme.errorForeground.value,
+            danger: true,
           },
         ]
       },
-      [onRemove, axis, colorTheme, onRename],
+      [onRemove, axis, onRename],
     )
 
     const openDropdown = React.useCallback(

--- a/editor/src/uuiui/radix-components.tsx
+++ b/editor/src/uuiui/radix-components.tsx
@@ -1,3 +1,6 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { jsx } from '@emotion/react'
 import * as RadixDropdownMenu from '@radix-ui/react-dropdown-menu'
 import { styled } from '@stitches/react'
 import React from 'react'
@@ -37,6 +40,7 @@ export interface DropdownMenuItem {
   icon?: React.ReactNode
   checked?: boolean
   onSelect: () => void
+  highlightBackgroundColor?: string
 }
 
 export interface DropdownMenuProps {
@@ -82,6 +86,11 @@ export const DropdownMenu = React.memo<DropdownMenuProps>((props) => {
               data-testid={ItemContainerTestId(item.id)}
               key={item.id}
               onSelect={item.onSelect}
+              css={{
+                ':hover': {
+                  backgroundColor: item.highlightBackgroundColor,
+                },
+              }}
             >
               <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
                 {when(

--- a/editor/src/uuiui/radix-components.tsx
+++ b/editor/src/uuiui/radix-components.tsx
@@ -40,7 +40,7 @@ export interface DropdownMenuItem {
   icon?: React.ReactNode
   checked?: boolean
   onSelect: () => void
-  highlightBackgroundColor?: string
+  danger?: boolean
 }
 
 export interface DropdownMenuProps {
@@ -88,7 +88,7 @@ export const DropdownMenu = React.memo<DropdownMenuProps>((props) => {
               onSelect={item.onSelect}
               css={{
                 ':hover': {
-                  backgroundColor: item.highlightBackgroundColor,
+                  backgroundColor: item.danger ? colorTheme.errorForeground.value : undefined,
                 },
               }}
             >


### PR DESCRIPTION
**Problem:**

Grid col/row entries in the inspector should offer a dropdown menu for the delete and rename functionalities.

**Fix:**

1. Add a dropdown menu in place of the cross icon for col/row entries
2. Move the delete functionality inside that menu
3. Add a rename functionality to update (or clear) a col/row area name
4. When updating area names, make sure to update the grid children so they reference the right template value

https://github.com/user-attachments/assets/69aa0430-6361-4eaf-b4c9-5294dc5f44a9

Fixes #6121

