### PR TITLE
Make sure grid cell parents have children and have a template

### DIFF
--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -373,7 +373,13 @@ export const MetadataUtils = {
   },
   isGridCell(metadata: ElementInstanceMetadataMap, path: ElementPath): boolean {
     const parent = MetadataUtils.findElementByElementPath(metadata, EP.parentPath(path))
-    return MetadataUtils.isGridLayoutedContainer(parent)
+    return (
+      parent != null &&
+      isRight(parent.element) &&
+      isJSXElement(parent.element.value) &&
+      parent.element.value.children.length > 0 &&
+      MetadataUtils.isGridLayoutedContainer(parent)
+    )
   },
   isPositionAbsolute(instance: ElementInstanceMetadata | null): boolean {
     return instance?.specialSizeMeasurements.position === 'absolute'

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -378,6 +378,8 @@ export const MetadataUtils = {
       isRight(parent.element) &&
       isJSXElement(parent.element.value) &&
       parent.element.value.children.length > 0 &&
+      parent.specialSizeMeasurements.containerGridProperties.gridTemplateColumns != null &&
+      parent.specialSizeMeasurements.containerGridProperties.gridTemplateRows != null &&
       MetadataUtils.isGridLayoutedContainer(parent)
     )
   },


### PR DESCRIPTION
**Problem:**

An element can be detected as a grid cell even if it's not inside a grid parent.

**Fix:**

Fix that.

Fixes #6125 