### PR TITLE
Grid row/col gap inspector control

### DIFF
--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -47,8 +47,8 @@ import type { DeleteProperties } from './delete-properties-command'
 import { runDeleteProperties } from './delete-properties-command'
 import type { AddImportsToFile } from './add-imports-to-file-command'
 import { runAddImportsToFile } from './add-imports-to-file-command'
-import type { SetProperty } from './set-property-command'
-import { runSetProperty } from './set-property-command'
+import type { UpdateBulkProperties, SetProperty } from './set-property-command'
+import { runBulkUpdateProperties, runSetProperty } from './set-property-command'
 import type { AddToReparentedToPaths } from './add-to-reparented-to-paths-command'
 import { runAddToReparentedToPaths } from './add-to-reparented-to-paths-command'
 import type { InsertElementInsertionSubject } from './insert-element-insertion-subject'
@@ -139,6 +139,7 @@ export type CanvasCommand =
   | WrapInContainerCommand
   | QueueTrueUpElement
   | SetActiveFrames
+  | UpdateBulkProperties
 
 export function runCanvasCommand(
   editorState: EditorState,
@@ -191,6 +192,8 @@ export function runCanvasCommand(
       return runDeleteProperties(editorState, command)
     case 'SET_PROPERTY':
       return runSetProperty(editorState, command)
+    case 'UPDATE_BULK_PROPERTIES':
+      return runBulkUpdateProperties(editorState, command)
     case 'UPDATE_PROP_IF_EXISTS':
       return runUpdatePropIfExists(editorState, command)
     case 'ADD_IMPORTS_TO_FILE':

--- a/editor/src/components/canvas/commands/set-property-command.ts
+++ b/editor/src/components/canvas/commands/set-property-command.ts
@@ -9,6 +9,7 @@ import * as PP from '../../../core/shared/property-path'
 import type { EditorState } from '../../editor/store/editor-state'
 import { applyValuesAtPath } from './adjust-number-command'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
+import { deleteValuesAtPath } from './delete-properties-command'
 
 type PositionProp = 'left' | 'top' | 'right' | 'bottom' | 'width' | 'height'
 
@@ -17,6 +18,31 @@ export interface SetProperty extends BaseCommand {
   element: ElementPath
   property: PropertyPath
   value: string | number
+}
+
+export type PropertyToUpdate =
+  | { type: 'SET'; path: PropertyPath; value: string | number }
+  | { type: 'DELETE'; path: PropertyPath }
+
+export function propertyToSet(path: PropertyPath, value: string | number): PropertyToUpdate {
+  return {
+    type: 'SET',
+    path: path,
+    value: value,
+  }
+}
+
+export function propertyToDelete(path: PropertyPath): PropertyToUpdate {
+  return {
+    type: 'DELETE',
+    path: path,
+  }
+}
+
+export interface UpdateBulkProperties extends BaseCommand {
+  type: 'UPDATE_BULK_PROPERTIES'
+  element: ElementPath
+  properties: PropertyToUpdate[]
 }
 
 export function setProperty<T extends PropertyPathPart>(
@@ -31,6 +57,19 @@ export function setProperty<T extends PropertyPathPart>(
     element: element,
     property: property,
     value: value,
+  }
+}
+
+export function updateBulkProperties(
+  whenToRun: WhenToRun,
+  element: ElementPath,
+  properties: PropertyToUpdate[],
+): UpdateBulkProperties {
+  return {
+    type: 'UPDATE_BULK_PROPERTIES',
+    whenToRun: whenToRun,
+    element: element,
+    properties: properties,
   }
 }
 
@@ -65,5 +104,39 @@ export const runSetProperty: CommandFunction<SetProperty> = (
       null,
       2,
     )} on ${EP.toUid(command.element)}`,
+  }
+}
+
+export const runBulkUpdateProperties: CommandFunction<UpdateBulkProperties> = (
+  editorState: EditorState,
+  command: UpdateBulkProperties,
+) => {
+  // 1. Apply DELETE updates
+  const propsToDelete = command.properties.filter((p) => p.type === 'DELETE')
+  const withDeletedProps = deleteValuesAtPath(
+    editorState,
+    command.element,
+    propsToDelete.map((d) => d.path),
+  )
+
+  // 2. Apply SET updates
+  const propsToSet = command.properties.filter((p) => p.type === 'SET')
+  const withSetProps = applyValuesAtPath(
+    withDeletedProps.editorStateWithChanges,
+    command.element,
+    propsToSet.map((property) => ({
+      path: property.path,
+      value: jsExpressionValue(property.value, emptyComments),
+    })),
+  )
+
+  // Final patch
+  const patch = withSetProps.editorStatePatch
+
+  return {
+    editorStatePatches: [patch],
+    commandDescription: `Set Properties ${command.properties.map((property) =>
+      PP.toString(property.path),
+    )}=${JSON.stringify(command.properties, null, 2)} on ${EP.toUid(command.element)}`,
   }
 }

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -425,7 +425,7 @@ export const GridControls = controlForStrategyMemoized(() => {
   )
 
   const grids = useEditorState(
-    Substores.metadataAndPropertyControlsInfo,
+    Substores.metadata,
     (store) => {
       return mapDropNulls((view) => {
         const element = MetadataUtils.findElementByElementPath(jsxMetadata, view)
@@ -449,6 +449,7 @@ export const GridControls = controlForStrategyMemoized(() => {
         const rowGap = targetGridContainer.specialSizeMeasurements.rowGap
         const columnGap = targetGridContainer.specialSizeMeasurements.columnGap
         const padding = targetGridContainer.specialSizeMeasurements.padding
+
         const gridTemplateColumns =
           targetGridContainer.specialSizeMeasurements.containerGridProperties.gridTemplateColumns
         const gridTemplateRows =
@@ -648,35 +649,45 @@ export const GridControls = controlForStrategyMemoized(() => {
         {/* grid lines */}
         {grids.map((grid) => {
           const placeholders = Array.from(Array(grid.cells).keys())
+          let style: CSSProperties = {
+            position: 'absolute',
+            top: grid.frame.y,
+            left: grid.frame.x,
+            width: grid.frame.width,
+            height: grid.frame.height,
+            display: 'grid',
+            gridTemplateColumns: getNullableAutoOrTemplateBaseString(grid.gridTemplateColumns),
+            gridTemplateRows: getNullableAutoOrTemplateBaseString(grid.gridTemplateRows),
+            backgroundColor:
+              activelyDraggingOrResizingCell != null ? colorTheme.primary10.value : 'transparent',
+            border: `1px solid ${
+              activelyDraggingOrResizingCell != null ? colorTheme.primary.value : 'transparent'
+            }`,
+            padding:
+              grid.padding == null
+                ? 0
+                : `${grid.padding.top}px ${grid.padding.right}px ${grid.padding.bottom}px ${grid.padding.left}px`,
+          }
+
+          // Gap needs to be set only if the other two are not present or we'll have rendering issues
+          // due to how measurements are calculated.
+          if (grid.rowGap != null && grid.columnGap != null) {
+            style.rowGap = grid.rowGap
+            style.columnGap = grid.columnGap
+          } else {
+            if (grid.gap != null) {
+              style.gap = grid.gap
+            }
+            if (grid.rowGap != null) {
+              style.rowGap = grid.rowGap
+            }
+            if (grid.columnGap != null) {
+              style.columnGap = grid.columnGap
+            }
+          }
 
           return (
-            <div
-              key={`grid-${EP.toString(grid.elementPath)}`}
-              style={{
-                position: 'absolute',
-                top: grid.frame.y,
-                left: grid.frame.x,
-                width: grid.frame.width,
-                height: grid.frame.height,
-                display: 'grid',
-                gridTemplateColumns: getNullableAutoOrTemplateBaseString(grid.gridTemplateColumns),
-                gridTemplateRows: getNullableAutoOrTemplateBaseString(grid.gridTemplateRows),
-                backgroundColor:
-                  activelyDraggingOrResizingCell != null
-                    ? colorTheme.primary10.value
-                    : 'transparent',
-                border: `1px solid ${
-                  activelyDraggingOrResizingCell != null ? colorTheme.primary.value : 'transparent'
-                }`,
-                gap: grid.gap ?? 0,
-                rowGap: grid.rowGap ?? 0,
-                columnGap: grid.columnGap ?? 0,
-                padding:
-                  grid.padding == null
-                    ? 0
-                    : `${grid.padding.top}px ${grid.padding.right}px ${grid.padding.bottom}px ${grid.padding.left}px`,
-              }}
-            >
+            <div key={`grid-${EP.toString(grid.elementPath)}`} style={style}>
               {placeholders.map((cell) => {
                 const countedRow = Math.floor(cell / grid.columns) + 1
                 const countedColumn = Math.floor(cell % grid.columns) + 1

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -2156,6 +2156,12 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       newSize.elementGridPropertiesFromProps,
     ).areEqual
 
+    const rowGapEquals = NullableNumberKeepDeepEquality(oldSize.rowGap, newSize.rowGap).areEqual
+    const columnGapEquals = NullableNumberKeepDeepEquality(
+      oldSize.columnGap,
+      newSize.columnGap,
+    ).areEqual
+
     const areEqual =
       offsetResult.areEqual &&
       coordinateSystemBoundsResult.areEqual &&
@@ -2201,7 +2207,9 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       gridContainerPropertiesEqual &&
       gridElementPropertiesEqual &&
       gridContainerPropertiesFromPropsEqual &&
-      gridElementPropertiesFromPropsEqual
+      gridElementPropertiesFromPropsEqual &&
+      rowGapEquals &&
+      columnGapEquals
     if (areEqual) {
       return keepDeepEqualityResult(oldSize, true)
     } else {

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -4412,6 +4412,8 @@ export interface ParsedCSSProperties {
   flexBasis: CSSNumber | undefined
   gap: CSSNumber
   zIndex: CSSNumber | undefined
+  rowGap: CSSNumber
+  columnGap: CSSNumber
 }
 
 export type ParsedCSSPropertiesKeys = keyof ParsedCSSProperties
@@ -4618,6 +4620,14 @@ export const cssEmptyValues: ParsedCSSProperties = {
     unit: null,
   },
   zIndex: undefined,
+  rowGap: {
+    value: 0,
+    unit: null,
+  },
+  columnGap: {
+    value: 0,
+    unit: null,
+  },
 }
 
 type CSSParsers = {
@@ -4690,6 +4700,8 @@ export const cssParsers: CSSParsers = {
   height: parseCSSLengthPercent,
   flexBasis: parseCSSLengthPercent,
   zIndex: parseCSSUnitless,
+  rowGap: parseCSSLengthPercent,
+  columnGap: parseCSSLengthPercent,
 }
 
 type CSSPrinters = {
@@ -4764,6 +4776,8 @@ const cssPrinters: CSSPrinters = {
   flexBasis: printCSSNumberOrUndefinedAsAttributeValue('px'),
   gap: printCSSNumberAsAttributeValue('px'),
   zIndex: printCSSNumberUnitlessOrUndefinedAsAttributeValue,
+  rowGap: printCSSNumberAsAttributeValue('px'),
+  columnGap: printCSSNumberAsAttributeValue('px'),
 }
 
 export interface UtopianElementProperties {
@@ -5478,6 +5492,14 @@ export const trivialDefaultValues: ParsedPropertiesWithNonTrivial = {
     unit: 'px',
   },
   zIndex: undefined,
+  rowGap: {
+    value: 0,
+    unit: 'px',
+  },
+  columnGap: {
+    value: 0,
+    unit: 'px',
+  },
 }
 
 export function isTrivialDefaultValue(

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -189,6 +189,7 @@ export const FlexSection = React.memo(() => {
           <UIGridRow padded tall={false} variant={'<-------------1fr------------->'}>
             {grid != null ? (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                <GapRowColumnControl />
                 <TemplateDimensionControl
                   axis={'column'}
                   grid={grid}
@@ -196,7 +197,6 @@ export const FlexSection = React.memo(() => {
                   title='Columns'
                 />
                 <TemplateDimensionControl axis={'row'} grid={grid} values={rows} title='Rows' />
-                <GapRowColumnControl />
               </div>
             ) : null}
           </UIGridRow>,

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -26,11 +26,23 @@ import {
 import { executeFirstApplicableStrategy } from './inspector-strategies/inspector-strategy'
 import type { DetectedLayoutSystem } from 'utopia-shared/src/types'
 import { assertNever, NO_OP } from '../../core/shared/utils'
-import { Icons, NumberInput, SquareButton, Subdued, useColorTheme } from '../../uuiui'
+import { Icons, NumberInput, SquareButton, Subdued } from '../../uuiui'
 import type { CSSNumber, GridCSSNumberUnit, UnknownOrEmptyInput } from './common/css-utils'
-import { gridCSSNumber, isCSSNumber, type GridCSSNumber } from './common/css-utils'
+import {
+  cssNumber,
+  cssNumberToString,
+  gridCSSNumber,
+  isCSSNumber,
+  type GridCSSNumber,
+} from './common/css-utils'
 import { applyCommandsAction } from '../editor/actions/action-creators'
-import { setProperty } from '../canvas/commands/set-property-command'
+import type { PropertyToUpdate } from '../canvas/commands/set-property-command'
+import {
+  propertyToDelete,
+  propertyToSet,
+  updateBulkProperties,
+  setProperty,
+} from '../canvas/commands/set-property-command'
 import * as PP from '../../core/shared/property-path'
 import type {
   GridAutoOrTemplateBase,
@@ -46,6 +58,7 @@ import { setGridPropsCommands } from '../canvas/canvas-strategies/strategies/gri
 import { type CanvasCommand } from '../canvas/commands/commands'
 import type { DropdownMenuItem } from '../../uuiui/radix-components'
 import { DropdownMenu } from '../../uuiui/radix-components'
+import { useInspectorLayoutInfo } from './common/property-path-hooks'
 
 const axisDropdownMenuButton = 'axisDropdownMenuButton'
 
@@ -175,19 +188,18 @@ export const FlexSection = React.memo(() => {
         {when(
           layoutSystem === 'grid',
           <UIGridRow padded tall={false} variant={'<-------------1fr------------->'}>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-              {grid != null ? (
-                <React.Fragment>
-                  <TemplateDimensionControl
-                    axis={'column'}
-                    grid={grid}
-                    values={columns}
-                    title='Columns'
-                  />
-                  <TemplateDimensionControl axis={'row'} grid={grid} values={rows} title='Rows' />
-                </React.Fragment>
-              ) : null}
-            </div>
+            {grid != null ? (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                <TemplateDimensionControl
+                  axis={'column'}
+                  grid={grid}
+                  values={columns}
+                  title='Columns'
+                />
+                <TemplateDimensionControl axis={'row'} grid={grid} values={rows} title='Rows' />
+                <GapRowColumnControl />
+              </div>
+            ) : null}
           </UIGridRow>,
         )}
         {when(
@@ -596,3 +608,111 @@ const reAlphanumericDashUnderscore = /[^0-9a-z\-_]+/gi
 function sanitizeAreaName(areaName: string): string {
   return areaName.replace(reAlphanumericDashUnderscore, '-')
 }
+
+const GapRowColumnControl = React.memo(() => {
+  const dispatch = useDispatch()
+
+  const grid = useEditorState(
+    Substores.metadata,
+    (store) => {
+      if (store.editor.selectedViews.length !== 1) {
+        return null
+      }
+      const element = MetadataUtils.findElementByElementPath(
+        store.editor.jsxMetadata,
+        store.editor.selectedViews[0],
+      )
+      if (!MetadataUtils.isGridLayoutedContainer(element)) {
+        return null
+      }
+      return element
+    },
+    'GapRowColumnControl grid',
+  )
+
+  const gap = useInspectorLayoutInfo('gap') // also matches gridGap
+  const columnGap = useInspectorLayoutInfo('columnGap')
+  const rowGap = useInspectorLayoutInfo('rowGap')
+
+  const onSubmit = React.useCallback(
+    (target: 'columnGap' | 'rowGap') => (value: UnknownOrEmptyInput<CSSNumber>) => {
+      if (grid == null) {
+        return
+      }
+
+      function serializeValue(v: CSSNumber) {
+        return v.unit == null || v.unit === 'px' ? v.value : cssNumberToString(v)
+      }
+
+      if (isCSSNumber(value)) {
+        let updates: PropertyToUpdate[] = []
+
+        // set the new value on the target prop
+        updates.push(propertyToSet(PP.create('style', target), serializeValue(value)))
+
+        // if there's a gap, it needs to be stripped out and replaced with explicit
+        // rowGap/colGap pairs.
+        if (gap.controlStatus === 'detected') {
+          // clean up the other gaps
+          updates.push(
+            propertyToDelete(PP.create('style', 'gap')),
+            propertyToDelete(PP.create('style', 'gridGap')),
+          )
+          // set the counterpart props
+          if (target === 'columnGap' && rowGap.controlStatus !== 'unset') {
+            updates.push(propertyToSet(PP.create('style', 'rowGap'), serializeValue(rowGap.value)))
+          }
+          if (target === 'rowGap' && columnGap.controlStatus !== 'unset') {
+            updates.push(
+              propertyToSet(PP.create('style', 'columnGap'), serializeValue(columnGap.value)),
+            )
+          }
+        }
+        dispatch([applyCommandsAction([updateBulkProperties('always', grid.elementPath, updates)])])
+      }
+    },
+    [columnGap, rowGap, dispatch, grid, gap],
+  )
+
+  if (grid == null) {
+    return null
+  }
+
+  return (
+    <UIGridRow padded={false} variant='<--1fr--><--1fr-->'>
+      <NumberInput
+        value={
+          grid.specialSizeMeasurements.columnGap === null
+            ? null
+            : cssNumber(grid.specialSizeMeasurements.columnGap)
+        }
+        numberType={'Length'}
+        onSubmitValue={onSubmit('columnGap')}
+        onTransientSubmitValue={onSubmit('columnGap')}
+        onForcedSubmitValue={onSubmit('columnGap')}
+        defaultUnitToHide={'px'}
+        testId={`grid-column-gap`}
+        labelInner={{
+          category: 'inspector-element',
+          type: 'gapHorizontal',
+          color: 'subdued',
+        }}
+      />
+      <NumberInput
+        value={rowGap.value}
+        numberType={'Length'}
+        onSubmitValue={onSubmit('rowGap')}
+        onTransientSubmitValue={onSubmit('rowGap')}
+        onForcedSubmitValue={onSubmit('rowGap')}
+        defaultUnitToHide={'px'}
+        testId={`grid-row-gap`}
+        labelInner={{
+          category: 'inspector-element',
+          type: 'gapVertical',
+          color: 'subdued',
+        }}
+      />
+    </UIGridRow>
+  )
+})
+GapRowColumnControl.displayName = 'GapRowColumnControl'

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -106,6 +106,8 @@ export type StyleLayoutProp =
   | 'borderBottomLeftRadius'
   | 'borderBottomRightRadius'
   | 'zIndex'
+  | 'rowGap'
+  | 'columnGap'
 
 export function framePointForPinnedProp(pinnedProp: LayoutPinnedProp): FramePoint {
   switch (pinnedProp) {


### PR DESCRIPTION
**Problem:**

It should be possible to control `rowGap` and `columnGap` from the grid subsection in the inspector.

**Fix:**

- Add two number controls for col/row gaps
- If `gap` is specified, get rid of it when updating those two gaps
- Added a utility command to perform bulk set/delete operations at the same time for element properties

**Notes**
- The icons for the controls are placeholders, I just used what felt like a good option for now.

https://github.com/user-attachments/assets/caa7667a-3b36-4caa-a1b5-35d5d32fc2e9


Fixes #6130 
