### PR TITLE
Remove empty div from flex section layout

### DIFF
--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -49,14 +49,25 @@ import { DropdownMenu } from '../../uuiui/radix-components'
 
 const axisDropdownMenuButton = 'axisDropdownMenuButton'
 
-export const layoutSystemSelector = createSelector(
+function getLayoutSystem(
+  layoutSystem: DetectedLayoutSystem | null | undefined,
+): 'grid' | 'flex' | null {
+  if (layoutSystem === 'grid' || layoutSystem === 'flex') {
+    return layoutSystem
+  }
+
+  return null
+}
+
+const layoutSystemSelector = createSelector(
   metadataSelector,
   selectedViewsSelector,
   (metadata, selectedViews) => {
-    const detectedLayoutSystems = selectedViews.map(
-      (path) =>
+    const detectedLayoutSystems = selectedViews.map((path) =>
+      getLayoutSystem(
         MetadataUtils.findElementByElementPath(metadata, path)?.specialSizeMeasurements
-          .layoutSystemForChildren ?? null,
+          .layoutSystemForChildren,
+      ),
     )
 
     const allLayoutSystemsTheSame = strictEvery(
@@ -161,55 +172,55 @@ export const FlexSection = React.memo(() => {
   return (
     <div>
       <AddRemoveLayoutSystemControl />
-      <FlexCol css={{ gap: 10, paddingBottom: 10 }}>
-        {when(
-          layoutSystem === 'grid' || layoutSystem === 'flex',
+      {when(
+        layoutSystem != null,
+        <FlexCol css={{ gap: 10, paddingBottom: 10 }}>
           <UIGridRow padded={true} variant='<-------------1fr------------->'>
             <LayoutSystemControl
               layoutSystem={layoutSystem}
               providesCoordinateSystemForChildren={false}
               onChange={onLayoutSystemChange}
             />
-          </UIGridRow>,
-        )}
-        {when(
-          layoutSystem === 'grid',
-          <UIGridRow padded tall={false} variant={'<-------------1fr------------->'}>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-              {grid != null ? (
-                <React.Fragment>
-                  <TemplateDimensionControl
-                    axis={'column'}
-                    grid={grid}
-                    values={columns}
-                    title='Columns'
-                  />
-                  <TemplateDimensionControl axis={'row'} grid={grid} values={rows} title='Rows' />
-                </React.Fragment>
-              ) : null}
-            </div>
-          </UIGridRow>,
-        )}
-        {when(
-          layoutSystem === 'flex',
-          <React.Fragment>
-            <UIGridRow padded variant='<--1fr--><--1fr-->'>
-              <UIGridRow padded={false} variant='<-------------1fr------------->'>
-                <NineBlockControl />
-                <ThreeBarControl />
+          </UIGridRow>
+          {when(
+            layoutSystem === 'grid',
+            <UIGridRow padded tall={false} variant={'<-------------1fr------------->'}>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                {grid != null ? (
+                  <React.Fragment>
+                    <TemplateDimensionControl
+                      axis={'column'}
+                      grid={grid}
+                      values={columns}
+                      title='Columns'
+                    />
+                    <TemplateDimensionControl axis={'row'} grid={grid} values={rows} title='Rows' />
+                  </React.Fragment>
+                ) : null}
+              </div>
+            </UIGridRow>,
+          )}
+          {when(
+            layoutSystem === 'flex',
+            <React.Fragment>
+              <UIGridRow padded variant='<--1fr--><--1fr-->'>
+                <UIGridRow padded={false} variant='<-------------1fr------------->'>
+                  <NineBlockControl />
+                  <ThreeBarControl />
+                </UIGridRow>
+                <FlexCol css={{ gap: 10 }}>
+                  <FlexDirectionToggle />
+                  <FlexContainerControls seeMoreVisible={true} />
+                  <FlexGapControl />
+                </FlexCol>
               </UIGridRow>
-              <FlexCol css={{ gap: 10 }}>
-                <FlexDirectionToggle />
-                <FlexContainerControls seeMoreVisible={true} />
-                <FlexGapControl />
-              </FlexCol>
-            </UIGridRow>
-            <UIGridRow padded={false} variant='<-------------1fr------------->'>
-              <SpacedPackedControl />
-            </UIGridRow>
-          </React.Fragment>,
-        )}
-      </FlexCol>
+              <UIGridRow padded={false} variant='<-------------1fr------------->'>
+                <SpacedPackedControl />
+              </UIGridRow>
+            </React.Fragment>,
+          )}
+        </FlexCol>,
+      )}
     </div>
   )
 })


### PR DESCRIPTION
## Problem
if there's no layout system, this extra div shouldn't even be rendered (it still takes up space now)

![image](https://github.com/user-attachments/assets/6d13c427-caef-440d-8476-77d86b4404d5)

## Fix
Don't render the div if the detected layout system is not one of `'flex'` or `'grid'`. Also, tweak `layoutSystemSelector` so that it only returns a non-null detected layout system if the layout system is one of `'flex'` or `'grid'` (since we don't offer any controls for the other values).

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
