### PR TITLE
Remove grid children props when removing layout

### DIFF
--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -429,11 +429,23 @@ export const flexContainerProps = [
 
 export const gridContainerProps = [
   styleP('gap'),
+  styleP('gridGap'),
   styleP('display'),
   styleP('gridTemplateRows'),
   styleP('gridTemplateColumns'),
   styleP('gridAutoColumns'),
   styleP('gridAutoRows'),
+  styleP('rowGap'),
+  styleP('columnGap'),
+]
+
+export const gridElementProps = [
+  styleP('gridColumn'),
+  styleP('gridColumnStart'),
+  styleP('gridColumnEnd'),
+  styleP('gridRow'),
+  styleP('gridRowStart'),
+  styleP('gridRowEnd'),
 ]
 
 export const flexChildProps = [

--- a/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.spec.browser2.tsx
@@ -53,15 +53,15 @@ describe('remove-flex-convert-to-absolute strategy', () => {
     expect(root.style.gap).toEqual('')
     expect(root.style.paddingTop).toEqual('10px')
     expect(root.style.paddingBottom).toEqual('10px')
-    expect(root.style.width).toEqual('500px')
-    expect(root.style.height).toEqual('400px')
+    expect(root.style.width).toEqual('540px')
+    expect(root.style.height).toEqual('420px')
 
     const one = editor.renderedDOM.getByTestId('one')
     expect(one.style.position).toEqual('absolute')
-    expect(one.style.left).toEqual('173px')
-    expect(one.style.top).toEqual('140px')
-    expect(one.style.height).toEqual('250px')
-    expect(one.style.width).toEqual('154px')
+    expect(one.style.left).toEqual('187px')
+    expect(one.style.top).toEqual('147px')
+    expect(one.style.height).toEqual('264px')
+    expect(one.style.width).toEqual('167px')
     expect(one.style.gridColumn).toEqual('')
     expect(one.style.gridColumnStart).toEqual('')
     expect(one.style.gridColumnEnd).toEqual('')
@@ -73,8 +73,8 @@ describe('remove-flex-convert-to-absolute strategy', () => {
     expect(two.style.position).toEqual('absolute')
     expect(two.style.left).toEqual('10px')
     expect(two.style.top).toEqual('10px')
-    expect(two.style.height).toEqual('120px')
-    expect(two.style.width).toEqual('480px')
+    expect(two.style.height).toEqual('127px')
+    expect(two.style.width).toEqual('520px')
     expect(two.style.gridColumn).toEqual('')
     expect(two.style.gridColumnStart).toEqual('')
     expect(two.style.gridColumnEnd).toEqual('')
@@ -165,8 +165,8 @@ export var storyboard = (
       style={{
         backgroundColor: '#fff',
         position: 'absolute',
-        width: 500,
-        height: 400,
+        width: 540,
+        height: 420,
         gap: 10,
         display: 'grid',
         gridTemplateColumns: '1fr 1fr 1fr',

--- a/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.spec.browser2.tsx
+++ b/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.spec.browser2.tsx
@@ -7,7 +7,7 @@ import { AddRemoveLayoutSystemControlTestId } from '../add-remove-layout-system-
 
 describe('remove-flex-convert-to-absolute strategy', () => {
   it('remove flex layout', async () => {
-    const editor = await renderTestEditorWithCode(project(), 'await-first-dom-report')
+    const editor = await renderTestEditorWithCode(flexProject(), 'await-first-dom-report')
     const root = await selectDiv(editor)
 
     await expectSingleUndo2Saves(editor, async () => {
@@ -37,6 +37,51 @@ describe('remove-flex-convert-to-absolute strategy', () => {
     expect(right.style.height).toEqual('362px')
     expect(right.style.width).toEqual('259px')
   })
+
+  it('remove grid layout', async () => {
+    const editor = await renderTestEditorWithCode(gridProject(), 'await-first-dom-report')
+
+    const root = await selectDiv(editor)
+
+    await expectSingleUndo2Saves(editor, async () => {
+      await clickOn(editor)
+    })
+
+    expect(root.style.display).toEqual('')
+    expect(root.style.alignItems).toEqual('')
+    expect(root.style.justifyContent).toEqual('')
+    expect(root.style.gap).toEqual('')
+    expect(root.style.paddingTop).toEqual('10px')
+    expect(root.style.paddingBottom).toEqual('10px')
+    expect(root.style.width).toEqual('500px')
+    expect(root.style.height).toEqual('400px')
+
+    const one = editor.renderedDOM.getByTestId('one')
+    expect(one.style.position).toEqual('absolute')
+    expect(one.style.left).toEqual('173px')
+    expect(one.style.top).toEqual('140px')
+    expect(one.style.height).toEqual('250px')
+    expect(one.style.width).toEqual('154px')
+    expect(one.style.gridColumn).toEqual('')
+    expect(one.style.gridColumnStart).toEqual('')
+    expect(one.style.gridColumnEnd).toEqual('')
+    expect(one.style.gridRow).toEqual('')
+    expect(one.style.gridRowStart).toEqual('')
+    expect(one.style.gridRowEnd).toEqual('')
+
+    const two = editor.renderedDOM.getByTestId('two')
+    expect(two.style.position).toEqual('absolute')
+    expect(two.style.left).toEqual('10px')
+    expect(two.style.top).toEqual('10px')
+    expect(two.style.height).toEqual('120px')
+    expect(two.style.width).toEqual('480px')
+    expect(two.style.gridColumn).toEqual('')
+    expect(two.style.gridColumnStart).toEqual('')
+    expect(two.style.gridColumnEnd).toEqual('')
+    expect(two.style.gridRow).toEqual('')
+    expect(two.style.gridRowStart).toEqual('')
+    expect(two.style.gridRowEnd).toEqual('')
+  })
 })
 
 async function selectDiv(editor: EditorRenderResult): Promise<HTMLElement> {
@@ -59,7 +104,7 @@ async function clickOn(editor: EditorRenderResult): Promise<void> {
   await mouseClickAtPoint(plusButton, { x: 2, y: 2 })
 }
 
-function project(): string {
+function flexProject(): string {
   return `import * as React from 'react'
         import { Storyboard } from 'utopia-api'
         
@@ -106,4 +151,51 @@ function project(): string {
           </Storyboard>
         )
         `
+}
+
+function gridProject(): string {
+  return `
+import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+export var storyboard = (
+  <Storyboard data-uid='0cd'>
+    <div
+      data-uid='root'
+      data-testid='root'
+      style={{
+        backgroundColor: '#fff',
+        position: 'absolute',
+        width: 500,
+        height: 400,
+        gap: 10,
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr 1fr',
+        gridTemplateRows: '1fr 1fr 1fr',
+        padding: 10,
+      }}
+    >
+      <div
+        data-uid='one'
+        data-testid='one'
+        style={{
+          backgroundColor: '#f90',
+          gridRow: '2 / 4',
+          gridColumn: 2,
+        }}
+      />
+      <div
+        data-uid='two'
+        data-testid='two'
+        style={{
+          backgroundColor: '#09f',
+          gridRowStart: 1,
+          gridRowEnd: 2,
+          gridColumnStart: 1,
+          gridColumnEnd: 4,
+        }}
+      />
+    </div>
+  </Storyboard>
+)
+`
 }

--- a/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/remove-flex-convert-to-absolute-strategy.ts
@@ -12,8 +12,10 @@ import {
   getConvertIndividualElementToAbsoluteCommandsFromMetadata,
   filterKeepGridContainers,
   gridContainerProps,
+  gridElementProps,
 } from '../inspector-common'
 import type { InspectorStrategy } from './inspector-strategy'
+import { deleteProperties } from '../../canvas/commands/delete-properties-command'
 
 function removeFlexConvertToAbsoluteOne(
   metadata: ElementInstanceMetadataMap,
@@ -58,6 +60,7 @@ export const removeGridConvertToAbsolute = (
         ...children.flatMap((c) =>
           getConvertIndividualElementToAbsoluteCommandsFromMetadata(c, metadata, pathTrees),
         ), // all children are converted to absolute,
+        ...children.map((path) => deleteProperties('always', path, gridElementProps)), // remove grid-specific child props
         ...sizeToVisualDimensions(metadata, pathTrees, elementPath), // container is sized to keep its visual dimensions
       ]
     })


### PR DESCRIPTION
Followup to https://github.com/concrete-utopia/utopia/pull/6097

**Problem:**
When removing a grid layout, its children still contain grid-specific props after being converted to absolute, which can cause all sorts of unpredictable/unintuitive issues.

**Fix:**

Prune those props.

Fixes #6137 