### PR TITLE
Only show grid active background on past drag

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -371,7 +371,9 @@ export const GridControls = controlForStrategyMemoized(() => {
     Substores.canvas,
     (store) =>
       store.editor.canvas.interactionSession != null &&
-      store.editor.canvas.interactionSession.activeControl.type === 'GRID_CELL_HANDLE'
+      store.editor.canvas.interactionSession.activeControl.type === 'GRID_CELL_HANDLE' &&
+      store.editor.canvas.interactionSession?.interactionData.type === 'DRAG' &&
+      store.editor.canvas.interactionSession?.interactionData.drag != null
         ? store.editor.canvas.interactionSession.activeControl.id
         : null,
     'GridControls activelyDraggingOrResizingCell',
@@ -659,7 +661,9 @@ export const GridControls = controlForStrategyMemoized(() => {
             gridTemplateColumns: getNullableAutoOrTemplateBaseString(grid.gridTemplateColumns),
             gridTemplateRows: getNullableAutoOrTemplateBaseString(grid.gridTemplateRows),
             backgroundColor:
-              activelyDraggingOrResizingCell != null ? colorTheme.primary10.value : 'transparent',
+              activelyDraggingOrResizingCell != null
+                ? features.Grid.activeGridBackground
+                : 'transparent',
             border: `1px solid ${
               activelyDraggingOrResizingCell != null ? colorTheme.primary.value : 'transparent'
             }`,

--- a/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
+++ b/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { Button, FlexColumn, FlexRow, Section } from '../../../uuiui'
+import { Button, colorTheme, FlexColumn, FlexRow, Section } from '../../../uuiui'
 import { when } from '../../../utils/react-conditionals'
 import { atom, useAtom, useSetAtom } from 'jotai'
 import { UIGridRow } from '../../inspector/widgets/ui-grid-row'
 import { atomWithStorage } from 'jotai/utils'
 import { IS_TEST_ENVIRONMENT } from '../../../common/env-vars'
+import { Ellipsis } from './github-pane/github-file-changes-list'
 
 const sections = ['Grid'] as const
 type Section = (typeof sections)[number]
@@ -22,6 +23,7 @@ type GridFeatures = {
   dotgridColor: string
   inactiveGridColor: string
   opacityBaseline: number
+  activeGridBackground: string
 }
 
 type RollYourOwnFeaturesTypes = {
@@ -43,6 +45,7 @@ const defaultRollYourOwnFeatures: RollYourOwnFeatures = {
     shadow: true,
     adaptiveOpacity: true,
     activeGridColor: '#0099ff77',
+    activeGridBackground: colorTheme.primary10.value,
     dotgridColor: '#0099ffaa',
     inactiveGridColor: '#00000033',
     opacityBaseline: 0.25,
@@ -173,7 +176,7 @@ const GridSection = React.memo(() => {
         const value = features.Grid[feat] ?? defaultRollYourOwnFeatures.Grid[feat]
         return (
           <UIGridRow padded variant='<----------1fr---------><-auto->' key={`feat-${feat}`}>
-            <div>{feat}</div>
+            <Ellipsis title={feat}>{feat}</Ellipsis>
             {typeof value === 'boolean' ? (
               <input type='checkbox' checked={value} onChange={onChange(feat)} />
             ) : typeof value === 'string' ? (


### PR DESCRIPTION
**Problem:**

The active grid background triggers immediately on mouse down, which is confusing.

**Fix:**

Only trigger it on past drag. Also, allow customizing its background colour via RYO.

| Before | After |
|--------|----------|
| ![Kapture 2024-07-30 at 13 35 11](https://github.com/user-attachments/assets/31db24ba-712f-4fd4-bc34-ce1fd41911d4) | ![Kapture 2024-07-30 at 13 33 30](https://github.com/user-attachments/assets/224a527f-b486-4db7-9a0d-236b7b014672) |


Fixes #6143 