### PR TITLE
Fix grid wireframe doubled lines

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -651,8 +651,8 @@ export const GridControls = controlForStrategyMemoized(() => {
           const placeholders = Array.from(Array(grid.cells).keys())
           let style: CSSProperties = {
             position: 'absolute',
-            top: grid.frame.y,
-            left: grid.frame.x,
+            top: grid.frame.y - 1, // account for border!
+            left: grid.frame.x - 1, // account for border!
             width: grid.frame.width,
             height: grid.frame.height,
             display: 'grid',
@@ -707,7 +707,17 @@ export const GridControls = controlForStrategyMemoized(() => {
                     id={id}
                     data-testid={id}
                     style={{
-                      border: `1px solid ${borderColor}`,
+                      borderTop: `1px solid ${borderColor}`,
+                      borderLeft: `1px solid ${borderColor}`,
+                      borderBottom:
+                        countedRow >= grid.rows || (grid.rowGap != null && grid.rowGap > 0)
+                          ? `1px solid ${borderColor}`
+                          : undefined,
+                      borderRight:
+                        countedColumn >= grid.columns ||
+                        (grid.columnGap != null && grid.columnGap > 0)
+                          ? `1px solid ${borderColor}`
+                          : undefined,
                       position: 'relative',
                     }}
                     data-grid-row={countedRow}


### PR DESCRIPTION
**Problem:**

Grid wireframe lines are horribly doubled when there's no gap between cells.

**Fix:**

Make lines always appear single, and adjust the grid positioning.

| Before | After |
|--------|----------|
| ![Kapture 2024-07-30 at 14 01 53](https://github.com/user-attachments/assets/fe1d0ef4-10b8-498c-be24-1127052f0056) | ![Kapture 2024-07-30 at 14 00 12](https://github.com/user-attachments/assets/f88463ed-0584-423d-a7b1-a6c433366d97) |

Fixes #6145
