### PR TITLE
fix(preload) - preload existing assets, don't preload the dearly departed ones

### DIFF
--- a/editor/src/utils/hashed-assets.ts
+++ b/editor/src/utils/hashed-assets.ts
@@ -39,14 +39,14 @@ export function getPossiblyHashedURL(url: string): string {
   return appendToPath(STATIC_BASE_URL, relativeURL)
 }
 
+// prioritise the toolbar assets for now, so first click shows them immediately
 const prioritisedAssets = [
-  '/editor/icons/light/semantic/hamburgermenu-black-24x24@2x.png',
-  '/editor/icons/light/semantic/closedcube-black-24x24@2x.png',
-  '/editor/icons/light/semantic/closedcube-white-24x24@2x.png',
-  '/editor/icons/light/filetype/ui-darkgray-18x18@2x.png',
-  '/editor/icons/light/filetype/js-darkgray-18x18@2x.png',
-  '/editor/icons/light/semantic/externallink-large-black-24x24@2x.png',
-  '/editor/icons/light/semantic/cross-small-gray-16x16@2x.png',
+  '/editor/icons/tools/comment-white-18x18@2x.png',
+  // next line is for the pointer when it's not selected (by default it is)
+  '/editor/icons/tools/pointer-black-18x18@2x.png',
+  '/editor/icons/tools/play-white-18x18@2x.png',
+  '/editor/icons/tools/text-white-18x18@2x.png',
+  '/editor/icons/tools/panels-white-18x18@2x.png',
 ]
 
 export function preloadPrioritizedAssets() {

--- a/editor/src/utils/hashed-assets.ts
+++ b/editor/src/utils/hashed-assets.ts
@@ -41,13 +41,12 @@ export function getPossiblyHashedURL(url: string): string {
 
 // prioritise the toolbar assets for now, so first click shows them immediately
 const prioritisedAssets = [
-  '/editor/icons/semantic/checkmark-white-16x16@2x.png',
-  '/editor/icons/tools/comment-white-18x18@2x.png',
+  '/editor/icons/light/semantic/checkmark-white-16x16@2x.png',
+  '/editor/icons/light/tools/comment-white-18x18@2x.png',
   // next line is for the pointer when it's not selected (by default it is)
-  '/editor/icons/tools/pointer-black-18x18@2x.png',
-  '/editor/icons/tools/play-white-18x18@2x.png',
-  '/editor/icons/tools/text-white-18x18@2x.png',
-  '/editor/icons/tools/panels-white-18x18@2x.png',
+  '/editor/icons/light/tools/pointer-black-18x18@2x.png',
+  '/editor/icons/light/tools/text-white-18x18@2x.png',
+  '/editor/icons/light/tools/panels-white-18x18@2x.png',
 ]
 
 export function preloadPrioritizedAssets() {

--- a/editor/src/utils/hashed-assets.ts
+++ b/editor/src/utils/hashed-assets.ts
@@ -41,6 +41,7 @@ export function getPossiblyHashedURL(url: string): string {
 
 // prioritise the toolbar assets for now, so first click shows them immediately
 const prioritisedAssets = [
+  '/editor/icons/semantic/checkmark-white-16x16@2x.png',
   '/editor/icons/tools/comment-white-18x18@2x.png',
   // next line is for the pointer when it's not selected (by default it is)
   '/editor/icons/tools/pointer-black-18x18@2x.png',


### PR DESCRIPTION
**Problem:**
We were pre-loading assets that don't exist anymore (the icons for the _former_ toolbar). This was cluttering up the console on first load (and blocked the slot of other assets we actually _want_ to preload)

<img width="797" alt="image" src="https://github.com/user-attachments/assets/22aede4f-f715-4463-b1ad-3718d3682028">

**Fix:**
Swapped out the ghost assets for new ones that actually exist (specifically the not-initially-shown mode icons in the toolbar, so first click doesn't lag on those). We can add others here if we want.

**NB**
1) VSCode _also_ marks certain files as preloadable, and since we don't open the code editor on launch by default, those don't get shown and often lead to a console warning (preloaded asset not used within 3 seconds of load, or similar). This isn't addressed here.
2) there's still a `pyramid_fullsize` that's not preloaded from here but throws a console error. I think it's sample project related.
<img width="803" alt="image" src="https://github.com/user-attachments/assets/3d7220a3-afc9-4427-8ff6-86c5025faf63">
