### PR TITLE
Grid dimensions supporting keywords

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.ts
@@ -131,8 +131,7 @@ export const resizeGridStrategy: CanvasStrategyFactory = (
       const calculatedValue = toFirst(valueOptic, calculatedValues.dimensions)
       const mergedValue = toFirst(valueOptic, mergedValues.dimensions)
       const mergedUnit = toFirst(unitOptic, mergedValues.dimensions)
-      const isFractional =
-        isRight(mergedUnit) && isCSSNumber(mergedUnit.value) && mergedUnit.value.unit === 'fr'
+      const isFractional = isRight(mergedUnit) && mergedUnit.value === 'fr'
       const precision = modifiers.cmd ? 'coarse' : 'precise'
 
       const newSetting = modify(

--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.ts
@@ -1,4 +1,9 @@
-import { fromArrayIndex, fromField, notNull } from '../../../../core/shared/optics/optic-creators'
+import {
+  fromArrayIndex,
+  fromField,
+  fromTypeGuard,
+  notNull,
+} from '../../../../core/shared/optics/optic-creators'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
 import * as PP from '../../../../core/shared/property-path'
@@ -13,8 +18,12 @@ import {
   strategyApplicationResult,
 } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
-import type { GridCSSNumber } from '../../../../components/inspector/common/css-utils'
-import { printArrayCSSNumber } from '../../../../components/inspector/common/css-utils'
+import type { GridDimension } from '../../../../components/inspector/common/css-utils'
+import {
+  isCSSNumber,
+  isGridCSSNumber,
+  printArrayGridDimension,
+} from '../../../../components/inspector/common/css-utils'
 import { modify, toFirst } from '../../../../core/shared/optics/optic-utilities'
 import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rerender-command'
 import type { Either } from '../../../../core/shared/either'
@@ -109,17 +118,21 @@ export const resizeGridStrategy: CanvasStrategyFactory = (
         }),
       }
 
-      const unitOptic = fromArrayIndex<GridCSSNumber>(control.columnOrRow)
+      const unitOptic = fromArrayIndex<GridDimension>(control.columnOrRow)
+        .compose(fromTypeGuard(isGridCSSNumber))
+        .compose(fromField('value'))
         .compose(fromField('unit'))
         .compose(notNull())
-      const valueOptic = fromArrayIndex<GridCSSNumber>(control.columnOrRow).compose(
-        fromField('value'),
-      )
+      const valueOptic = fromArrayIndex<GridDimension>(control.columnOrRow)
+        .compose(fromTypeGuard(isGridCSSNumber))
+        .compose(fromField('value'))
+        .compose(fromField('value'))
 
       const calculatedValue = toFirst(valueOptic, calculatedValues.dimensions)
       const mergedValue = toFirst(valueOptic, mergedValues.dimensions)
       const mergedUnit = toFirst(unitOptic, mergedValues.dimensions)
-      const isFractional = isRight(mergedUnit) && mergedUnit.value === 'fr'
+      const isFractional =
+        isRight(mergedUnit) && isCSSNumber(mergedUnit.value) && mergedUnit.value.unit === 'fr'
       const precision = modifiers.cmd ? 'coarse' : 'precise'
 
       const newSetting = modify(
@@ -133,7 +146,7 @@ export const resizeGridStrategy: CanvasStrategyFactory = (
           ),
         mergedValues.dimensions,
       )
-      const propertyValueAsString = printArrayCSSNumber(newSetting)
+      const propertyValueAsString = printArrayGridDimension(newSetting)
 
       const commands = [
         setProperty(

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -6,8 +6,11 @@ import { motion, useAnimationControls } from 'framer-motion'
 import type { CSSProperties } from 'react'
 import React from 'react'
 import type { ElementPath } from 'utopia-shared/src/types'
-import type { GridCSSNumber } from '../../../components/inspector/common/css-utils'
-import { printGridAutoOrTemplateBase } from '../../../components/inspector/common/css-utils'
+import type { GridDimension } from '../../../components/inspector/common/css-utils'
+import {
+  printGridAutoOrTemplateBase,
+  printGridCSSNumber,
+} from '../../../components/inspector/common/css-utils'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../core/shared/array-utils'
 import { defaultEither } from '../../../core/shared/either'
@@ -111,19 +114,19 @@ function getNullableAutoOrTemplateBaseString(
   }
 }
 
-function getFromPropsOptic(index: number): Optic<GridAutoOrTemplateBase | null, GridCSSNumber> {
+function getFromPropsOptic(index: number): Optic<GridAutoOrTemplateBase | null, GridDimension> {
   return notNull<GridAutoOrTemplateBase>()
     .compose(fromTypeGuard(isGridAutoOrTemplateDimensions))
     .compose(fromField('dimensions'))
     .compose(fromArrayIndex(index))
 }
 
-function gridCSSNumberToLabel(gridCSSNumber: GridCSSNumber): string {
-  return `${gridCSSNumber.value}${gridCSSNumber.unit ?? ''}`
+function gridCSSNumberToLabel(gridCSSNumber: GridDimension): string {
+  return printGridCSSNumber(gridCSSNumber)
 }
 
 function getLabelForAxis(
-  fromDOM: GridCSSNumber,
+  fromDOM: GridDimension,
   index: number,
   fromProps: GridAutoOrTemplateBase | null,
 ): string {
@@ -136,7 +139,7 @@ const GRID_RESIZE_HANDLE_CONTAINER_SIZE = 30 // px
 const GRID_RESIZE_HANDLE_SIZE = 15 // px
 
 export interface GridResizingControlProps {
-  dimension: GridCSSNumber
+  dimension: GridDimension
   dimensionIndex: number
   axis: 'row' | 'column'
   containingFrame: CanvasRectangle
@@ -314,11 +317,11 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
             display: 'grid',
             gridTemplateColumns:
               props.axis === 'column'
-                ? props.axisValues.dimensions.map((dim) => `${dim.value}${dim.unit}`).join(' ')
+                ? props.axisValues.dimensions.map((dim) => printGridCSSNumber(dim)).join(' ')
                 : undefined,
             gridTemplateRows:
               props.axis === 'row'
-                ? props.axisValues.dimensions.map((dim) => `${dim.value}${dim.unit}`).join(' ')
+                ? props.axisValues.dimensions.map((dim) => printGridCSSNumber(dim)).join(' ')
                 : undefined,
             gap: props.gap ?? 0,
             paddingLeft:

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -79,7 +79,7 @@ import {
   exportType,
   singleFileBuildResult,
 } from '../../../core/workers/common/worker-types'
-import type { Sides, Focus, Styling, Emphasis, Icon, InspectorSpec } from 'utopia-api/core'
+import type { Sides, Focus, Styling, Emphasis, Icon } from 'utopia-api/core'
 import type {
   ElementInstanceMetadata,
   ElementInstanceMetadataMap,
@@ -131,7 +131,6 @@ import type {
   JSXConditionalExpression,
   ActiveAndDefaultConditionValues,
   JSXMapExpression,
-  JSExpressionMapOrOtherJavascript,
   JSExpressionOtherJavaScript,
   JSIdentifier,
   JSPropertyAccess,
@@ -157,11 +156,6 @@ import {
   elementInstanceMetadata,
   isArraySpread,
   isArrayValue,
-  modifiableAttributeIsAttributeFunctionCall,
-  modifiableAttributeIsAttributeNestedArray,
-  modifiableAttributeIsAttributeNestedObject,
-  modifiableAttributeIsAttributeOtherJavaScript,
-  isJSXAttributeValue,
   isJSXElement,
   isJSXFragment,
   isJSXTextBlock,
@@ -270,9 +264,7 @@ import {
   NullableNumberKeepDeepEquality,
   combine9EqualityCalls,
   unionDeepEquality,
-  combine14EqualityCalls,
   combine11EqualityCalls,
-  combine15EqualityCalls,
   combine16EqualityCalls,
 } from '../../../utils/deep-equality'
 import {
@@ -415,7 +407,6 @@ import {
   draggingFromSidebar,
   fileUploadInfo,
   fileRevertModal,
-  emptyGithubData,
   dragToMoveIndicatorFlags,
   projectGithubSettings,
   newColorSwatch,
@@ -567,10 +558,18 @@ import type {
   CSSTextAlign,
   CSSTextDecorationLine,
   FontSettings,
+  GridCSSKeyword,
   GridCSSNumber,
-  GridCSSNumberUnit,
+  GridDimension,
 } from '../../inspector/common/css-utils'
-import { cssNumber, fontSettings, gridCSSNumber } from '../../inspector/common/css-utils'
+import {
+  cssNumber,
+  fontSettings,
+  gridCSSKeyword,
+  gridCSSNumber,
+  isGridCSSKeyword,
+  isGridCSSNumber,
+} from '../../inspector/common/css-utils'
 import type { ElementPaste, ProjectListing } from '../action-types'
 import { projectListing } from '../action-types'
 import type { Bounds, UtopiaVSCodeConfig } from 'utopia-vscode-common'
@@ -1958,20 +1957,39 @@ export const CSSNumberKeepDeepEquality: KeepDeepEqualityCall<CSSNumber> = combin
 )
 
 export const GridCSSNumberKeepDeepEquality: KeepDeepEqualityCall<GridCSSNumber> =
-  combine3EqualityCalls(
-    (cssNum) => cssNum.value,
-    createCallWithTripleEquals<number>(),
-    (cssNum) => cssNum.unit,
-    nullableDeepEquality(createCallWithTripleEquals<GridCSSNumberUnit>()),
-    (cssNum) => cssNum.areaName,
-    nullableDeepEquality(StringKeepDeepEquality),
+  combine2EqualityCalls(
+    (p) => p.value,
+    CSSNumberKeepDeepEquality,
+    (p) => p.areaName,
+    NullableStringKeepDeepEquality,
     gridCSSNumber,
+  )
+
+export const GridCSSKeywordKeepDeepEquality: KeepDeepEqualityCall<GridCSSKeyword> =
+  combine2EqualityCalls(
+    (p) => p.value,
+    createCallWithTripleEquals(),
+    (p) => p.areaName,
+    NullableStringKeepDeepEquality,
+    gridCSSKeyword,
+  )
+
+export const GridDimensionKeepDeepEquality: KeepDeepEqualityCall<GridDimension> =
+  combine1EqualityCall(
+    (dimension) => dimension,
+    unionDeepEquality(
+      GridCSSNumberKeepDeepEquality,
+      GridCSSKeywordKeepDeepEquality,
+      isGridCSSNumber,
+      isGridCSSKeyword,
+    ),
+    (dimension) => dimension,
   )
 
 export const GridAutoOrTemplateDimensionsKeepDeepEquality: KeepDeepEqualityCall<GridAutoOrTemplateDimensions> =
   combine1EqualityCall(
     (value) => value.dimensions,
-    arrayDeepEquality(GridCSSNumberKeepDeepEquality),
+    arrayDeepEquality(GridDimensionKeepDeepEquality),
     gridAutoOrTemplateDimensions,
   )
 

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -597,14 +597,17 @@ export type GridCSSNumber = BaseGridDimension & {
 
 export type GridCSSKeyword = BaseGridDimension & {
   type: 'KEYWORD'
-  value: CSSKeyword<string>
+  value: CSSKeyword<ValidGridDimensionKeyword>
 }
 
 export function isGridCSSKeyword(dim: GridDimension): dim is GridCSSKeyword {
   return dim.type === 'KEYWORD'
 }
 
-export function gridCSSKeyword(value: CSSKeyword<string>, areaName: string | null): GridCSSKeyword {
+export function gridCSSKeyword(
+  value: CSSKeyword<ValidGridDimensionKeyword>,
+  areaName: string | null,
+): GridCSSKeyword {
   return {
     type: 'KEYWORD',
     value: value,
@@ -896,7 +899,7 @@ const validGridDimensionKeywords = [
   // NOTE: function keywords are omitted as they are treated separately
 ] as const
 
-type ValidGridDimensionKeyword = (typeof validGridDimensionKeywords)[number]
+export type ValidGridDimensionKeyword = (typeof validGridDimensionKeywords)[number]
 
 export function isValidGridDimensionKeyword(value: unknown): value is ValidGridDimensionKeyword {
   return validGridDimensionKeywords.includes(value as ValidGridDimensionKeyword)

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -868,7 +868,7 @@ export const parseCSSGrid = (input: unknown): Either<string, GridDimension> => {
   if (isRight(maybeNumber)) {
     return right(gridCSSNumber(maybeNumber.value, null))
   }
-  if (typeof input === 'string' && isValidGridDimensionKeyword(input)) {
+  if (isValidGridDimensionKeyword(input)) {
     return right(gridCSSKeyword(cssKeyword(input), null))
   }
   return left('invalid css grid dimension')
@@ -882,7 +882,7 @@ export const parseCSSUnitlessAsNumber = (input: unknown): Either<string, number>
   }
 }
 
-const validGridDimensionKeywords: string[] = [
+const validGridDimensionKeywords = [
   'auto',
   'min-content',
   'max-content',
@@ -894,10 +894,12 @@ const validGridDimensionKeywords: string[] = [
   'auto-fit',
   'auto-fill',
   // NOTE: function keywords are omitted as they are treated separately
-]
+] as const
 
-export function isValidGridDimensionKeyword(s: string): boolean {
-  return validGridDimensionKeywords.includes(s)
+type ValidGridDimensionKeyword = (typeof validGridDimensionKeywords)[number]
+
+export function isValidGridDimensionKeyword(value: unknown): value is ValidGridDimensionKeyword {
+  return validGridDimensionKeywords.includes(value as ValidGridDimensionKeyword)
 }
 
 const gridCSSTemplateNumberRegex = /^\[(.+)\]\s*(.+)$/

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -423,10 +423,10 @@ const TemplateDimensionControl = React.memo(
             <Icons.Plus width={12} height={12} onClick={onAdd} />
           </SquareButton>
         </div>
-        {values.map((col, index) => {
+        {values.map((value, index) => {
           return (
             <div
-              key={`col-${col}-${index}`}
+              key={`col-${value}-${index}`}
               style={{ display: 'flex', alignItems: 'center', gap: 6 }}
               css={{
                 [`& > .${axisDropdownMenuButton}`]: {
@@ -447,22 +447,22 @@ const TemplateDimensionControl = React.memo(
                     textOverflow: 'ellipsis',
                     whiteSpace: 'nowrap',
                   }}
-                  title={col.areaName ?? undefined}
+                  title={value.areaName ?? undefined}
                 >
-                  {col.areaName ?? index + 1}
+                  {value.areaName ?? index + 1}
                 </Subdued>
                 <NumberInput
                   style={{ flex: 1 }}
                   value={
                     // TODO: this is just temporary!!!
-                    isGridCSSNumber(col) ? col.value : cssNumber(0)
+                    isGridCSSNumber(value) ? value.value : cssNumber(0)
                   }
                   numberType={'Length'}
                   onSubmitValue={onUpdate(index)}
                   onTransientSubmitValue={onUpdate(index)}
                   onForcedSubmitValue={onUpdate(index)}
                   defaultUnitToHide={null}
-                  testId={`col-${col}-${index}`}
+                  testId={`col-${value}-${index}`}
                 />
               </div>
               <SquareButton className={axisDropdownMenuButton}>

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -21,7 +21,12 @@ import { useDispatch } from '../editor/store/dispatch-context'
 import type { DetectedLayoutSystem } from 'utopia-shared/src/types'
 import { NO_OP } from '../../core/shared/utils'
 import { Icons, NumberInput, SquareButton, Subdued } from '../../uuiui'
-import type { CSSKeyword, CSSNumber, UnknownOrEmptyInput } from './common/css-utils'
+import type {
+  CSSKeyword,
+  CSSNumber,
+  UnknownOrEmptyInput,
+  ValidGridDimensionKeyword,
+} from './common/css-utils'
 import {
   cssNumber,
   cssNumberToString,
@@ -194,44 +199,51 @@ const TemplateDimensionControl = React.memo(
     const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
 
     const onUpdate = React.useCallback(
-      (index: number) => (value: UnknownOrEmptyInput<CSSNumber | CSSKeyword<string>>) => {
-        if (isCSSKeyword(value)) {
-          const newValues = [...values]
-          newValues[index] = isCSSNumber(value)
-            ? gridCSSNumber(value, null)
-            : gridCSSKeyword(value, null)
+      (index: number) =>
+        (value: UnknownOrEmptyInput<CSSNumber | CSSKeyword<ValidGridDimensionKeyword>>) => {
+          if (isCSSKeyword(value)) {
+            const newValues = [...values]
+            newValues[index] = isCSSNumber(value)
+              ? gridCSSNumber(value, null)
+              : gridCSSKeyword(value, null)
 
-          return dispatch([
-            applyCommandsAction([
-              setProperty(
-                'always',
-                grid.elementPath,
-                PP.create('style', axis === 'column' ? 'gridTemplateColumns' : 'gridTemplateRows'),
-                gridNumbersToTemplateString(newValues),
-              ),
-            ]),
-          ])
-        } else if (isCSSNumber(value)) {
-          const gridValueAtIndex = values[index]
-          const maybeUnit = isGridCSSNumber(gridValueAtIndex) ? gridValueAtIndex.value.unit : null
-          const newValues = [...values]
-          newValues[index] = gridCSSNumber(
-            cssNumber(value.value, value.unit ?? maybeUnit),
-            gridValueAtIndex.areaName,
-          )
+            return dispatch([
+              applyCommandsAction([
+                setProperty(
+                  'always',
+                  grid.elementPath,
+                  PP.create(
+                    'style',
+                    axis === 'column' ? 'gridTemplateColumns' : 'gridTemplateRows',
+                  ),
+                  gridNumbersToTemplateString(newValues),
+                ),
+              ]),
+            ])
+          } else if (isCSSNumber(value)) {
+            const gridValueAtIndex = values[index]
+            const maybeUnit = isGridCSSNumber(gridValueAtIndex) ? gridValueAtIndex.value.unit : null
+            const newValues = [...values]
+            newValues[index] = gridCSSNumber(
+              cssNumber(value.value, value.unit ?? maybeUnit),
+              gridValueAtIndex.areaName,
+            )
 
-          dispatch([
-            applyCommandsAction([
-              setProperty(
-                'always',
-                grid.elementPath,
-                PP.create('style', axis === 'column' ? 'gridTemplateColumns' : 'gridTemplateRows'),
-                gridNumbersToTemplateString(newValues),
-              ),
-            ]),
-          ])
-        }
-      },
+            dispatch([
+              applyCommandsAction([
+                setProperty(
+                  'always',
+                  grid.elementPath,
+                  PP.create(
+                    'style',
+                    axis === 'column' ? 'gridTemplateColumns' : 'gridTemplateRows',
+                  ),
+                  gridNumbersToTemplateString(newValues),
+                ),
+              ]),
+            ])
+          }
+        },
       [grid, values, dispatch, axis],
     )
 

--- a/editor/src/components/inspector/inspector-strategies/hug-contents-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/hug-contents-strategy.ts
@@ -12,7 +12,7 @@ import {
 } from '../../canvas/commands/set-css-length-command'
 import { showToastCommand } from '../../canvas/commands/show-toast-command'
 import type { FlexDirection } from '../common/css-utils'
-import { cssKeyword } from '../common/css-utils'
+import { cssKeyword, isGridCSSNumber } from '../common/css-utils'
 import type { Axis } from '../inspector-common'
 import {
   detectFillHugFixedState,
@@ -94,7 +94,7 @@ function gridTemplateUsesFr(template: GridTemplate | null) {
   return (
     template != null &&
     template.type === 'DIMENSIONS' &&
-    template.dimensions.some((d) => d.unit === 'fr')
+    template.dimensions.some((d) => isGridCSSNumber(d) && d.value.unit === 'fr')
   )
 }
 

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -22,10 +22,9 @@ import { assertNever, fastForEach, unknownObjectProperty } from './utils'
 import { addAllUniquely, mapDropNulls } from './array-utils'
 import { objectMap } from './object-utils'
 import type {
-  CSSNumber,
   CSSPosition,
   FlexDirection,
-  GridCSSNumber,
+  GridDimension,
 } from '../../components/inspector/common/css-utils'
 import type { ModifiableAttribute } from './jsx-attributes'
 import * as EP from './element-path'
@@ -2604,11 +2603,11 @@ export function gridAutoOrTemplateFallback(value: string): GridAutoOrTemplateFal
 
 export interface GridAutoOrTemplateDimensions {
   type: 'DIMENSIONS'
-  dimensions: Array<GridCSSNumber>
+  dimensions: Array<GridDimension>
 }
 
 export function gridAutoOrTemplateDimensions(
-  dimensions: Array<GridCSSNumber>,
+  dimensions: Array<GridDimension>,
 ): GridAutoOrTemplateDimensions {
   return {
     type: 'DIMENSIONS',


### PR DESCRIPTION
**Problem:**

We need to support keywords inside grid template dimensions.

**Fix:**

Extend the grid dimensions type (renamed from `GridCSSNumber` to `GridDimension`) to be either a CSSNumber or a CSSKeyword, and the related parsing.

Important note: this is an intermediate PR towards #6155 and **temporarily** this PR defaults a col/row value to `0` if it's not a CSSNumber (as commented in the code).

No functional changes otherwise.

Fixes #6156 
Prerequisite for #6155 
