### PR TITLE
chore(tsconfig): change ts target to es2023

### DIFF
--- a/editor/src/utils/canvas-react-utils.spec.tsx
+++ b/editor/src/utils/canvas-react-utils.spec.tsx
@@ -65,7 +65,7 @@ describe('Monkey Function', () => {
   it('class components have a working context', () => {
     const MyContext = React.createContext({ value: 'wrong!' })
     class TestClass extends React.Component {
-      context!: React.ContextType<typeof MyContext>
+      context: React.ContextType<typeof MyContext> = { value: '' }
       render() {
         return (
           <div data-uid='inner-div' data-path='inner-div'>
@@ -91,7 +91,7 @@ describe('Monkey Function', () => {
   it('class components have a working context, third variant', () => {
     const MyContext = React.createContext({ value: 'wrong!' })
     class TestClass extends React.Component {
-      context!: React.ContextType<typeof MyContext>
+      context: React.ContextType<typeof MyContext> = { value: '' }
       render() {
         return (
           <div data-uid='inner-div' data-path='inner-div'>

--- a/editor/src/utils/canvas-react-utils.spec.tsx
+++ b/editor/src/utils/canvas-react-utils.spec.tsx
@@ -65,7 +65,7 @@ describe('Monkey Function', () => {
   it('class components have a working context', () => {
     const MyContext = React.createContext({ value: 'wrong!' })
     class TestClass extends React.Component {
-      declare context: React.ContextType<typeof MyContext>
+      context!: React.ContextType<typeof MyContext>
       render() {
         return (
           <div data-uid='inner-div' data-path='inner-div'>
@@ -91,7 +91,7 @@ describe('Monkey Function', () => {
   it('class components have a working context, third variant', () => {
     const MyContext = React.createContext({ value: 'wrong!' })
     class TestClass extends React.Component {
-      declare context: React.ContextType<typeof MyContext>
+      context!: React.ContextType<typeof MyContext>
       render() {
         return (
           <div data-uid='inner-div' data-path='inner-div'>

--- a/editor/src/utils/canvas-react-utils.spec.tsx
+++ b/editor/src/utils/canvas-react-utils.spec.tsx
@@ -65,7 +65,7 @@ describe('Monkey Function', () => {
   it('class components have a working context', () => {
     const MyContext = React.createContext({ value: 'wrong!' })
     class TestClass extends React.Component {
-      context: any
+      declare context: React.ContextType<typeof MyContext>
       render() {
         return (
           <div data-uid='inner-div' data-path='inner-div'>
@@ -91,7 +91,7 @@ describe('Monkey Function', () => {
   it('class components have a working context, third variant', () => {
     const MyContext = React.createContext({ value: 'wrong!' })
     class TestClass extends React.Component {
-      context: any
+      declare context: React.ContextType<typeof MyContext>
       render() {
         return (
           <div data-uid='inner-div' data-path='inner-div'>

--- a/editor/tsconfig.json
+++ b/editor/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./lib",
-    "target": "es2023",
+    "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Node",
     "esModuleInterop": true,

--- a/editor/tsconfig.json
+++ b/editor/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./lib",
-    "target": "es2019",
+    "target": "es2023",
     "module": "ESNext",
     "moduleResolution": "Node",
     "esModuleInterop": true,

--- a/utopia-remix/tsconfig.json
+++ b/utopia-remix/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
-    "target": "ES2023",
+    "target": "ESNext",
     "strict": true,
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,

--- a/utopia-remix/tsconfig.json
+++ b/utopia-remix/tsconfig.json
@@ -7,7 +7,7 @@
     "jsx": "react-jsx",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
-    "target": "ES2022",
+    "target": "ES2023",
     "strict": true,
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
**Problem:**
currently we can't use modern JS api such as `Array.protoype.with`

**Fix:**
Change the TS target to `es2023` to support modern JS features

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode
