### PR TITLE
change all sides border radius icon 

### DIFF
--- a/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/radius-row.tsx
@@ -239,7 +239,7 @@ export const BorderRadiusControl = React.memo(() => {
         bottom: <Icons.BorderRadiusBottomRight color='on-highlight-secondary' />,
         left: <Icons.BorderRadiusBottomLeft color='on-highlight-secondary' />,
         right: <Icons.BorderRadiusTopRight color='on-highlight-secondary' />,
-        oneValue: <Icons.BorderRadius color='on-highlight-secondary' />,
+        oneValue: <Icons.BorderRadiusTopLeft color='on-highlight-secondary' />,
       }}
       tooltips={{
         oneValue: 'Radius',


### PR DESCRIPTION
The icon for the border radius inspector control, that controls *all sides*, isn't as easily recognizable as the icon depicting just one corner. Let's use that one instead.

| Before  | After |
| ------------- | ------------- |
| <img width="272" alt="Screenshot 2024-08-05 at 11 12 01 AM" src="https://github.com/user-attachments/assets/daf84b80-4a34-4ef2-b01d-447617844c04"> | <img width="271" alt="Screenshot 2024-08-05 at 11 11 30 AM" src="https://github.com/user-attachments/assets/d7f43114-92a6-4daa-8de1-85cc9da5874d">  |


