### PR TITLE
Show grid lines while hovering over grid in draw-to-insert mode

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
@@ -49,6 +49,7 @@ import { getTargetCell, setGridPropsCommands } from './grid-helpers'
 import { newReparentSubjects } from './reparent-helpers/reparent-strategy-helpers'
 import { getReparentTargetUnified } from './reparent-helpers/reparent-strategy-parent-lookup'
 import { stripNulls } from '../../../../core/shared/array-utils'
+import { showGridControls } from '../../commands/show-grid-controls-command'
 
 export const gridDrawToInsertText: CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -165,6 +166,7 @@ const gridDrawToInsertStrategyInner =
             wildcardPatch('mid-interaction', {
               selectedViews: { $set: [] },
             }),
+            showGridControls('mid-interaction', targetParent),
             updateHighlightedViews('mid-interaction', [targetParent]),
           ])
         }

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -86,6 +86,10 @@ import { runPushIntendedBoundsAndUpdateGroups } from './push-intended-bounds-and
 import type { PushIntendedBoundsAndUpdateHuggingElements } from './push-intended-bounds-and-update-hugging-elements-command'
 import { runPushIntendedBoundsAndUpdateHuggingElements } from './push-intended-bounds-and-update-hugging-elements-command'
 import { runSetActiveFrames, type SetActiveFrames } from './set-active-frames-command'
+import {
+  runShowGridControlsCommand,
+  type ShowGridControlsCommand,
+} from './show-grid-controls-command'
 
 export interface CommandFunctionResult {
   editorStatePatches: Array<EditorStatePatch>
@@ -140,6 +144,7 @@ export type CanvasCommand =
   | QueueTrueUpElement
   | SetActiveFrames
   | UpdateBulkProperties
+  | ShowGridControlsCommand
 
 export function runCanvasCommand(
   editorState: EditorState,
@@ -226,6 +231,8 @@ export function runCanvasCommand(
       return runQueueTrueUpElement(editorState, command)
     case 'SET_ACTIVE_FRAMES':
       return runSetActiveFrames(editorState, command)
+    case 'SHOW_GRID_CONTROLS':
+      return runShowGridControlsCommand(editorState, command)
     default:
       const _exhaustiveCheck: never = command
       throw new Error(`Unhandled canvas command ${JSON.stringify(command)}`)

--- a/editor/src/components/canvas/commands/show-grid-controls-command.ts
+++ b/editor/src/components/canvas/commands/show-grid-controls-command.ts
@@ -1,0 +1,36 @@
+import type { ElementPath } from 'utopia-shared/src/types'
+import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
+import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+
+export interface ShowGridControlsCommand extends BaseCommand {
+  type: 'SHOW_GRID_CONTROLS'
+  target: ElementPath
+}
+
+export function showGridControls(
+  whenToRun: WhenToRun,
+  target: ElementPath,
+): ShowGridControlsCommand {
+  return {
+    type: 'SHOW_GRID_CONTROLS',
+    whenToRun: whenToRun,
+    target: target,
+  }
+}
+
+export const runShowGridControlsCommand: CommandFunction<ShowGridControlsCommand> = (
+  _: EditorState,
+  command: ShowGridControlsCommand,
+) => {
+  const editorStatePatch: EditorStatePatch = {
+    canvas: {
+      controls: {
+        gridControls: { $set: command.target },
+      },
+    },
+  }
+  return {
+    editorStatePatches: [editorStatePatch],
+    commandDescription: `Show Grid Controls`,
+  }
+}

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -12,7 +12,7 @@ import {
   printGridCSSNumber,
 } from '../../../components/inspector/common/css-utils'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { mapDropNulls } from '../../../core/shared/array-utils'
+import { mapDropNulls, stripNulls } from '../../../core/shared/array-utils'
 import { defaultEither } from '../../../core/shared/either'
 import * as EP from '../../../core/shared/element-path'
 import {
@@ -429,66 +429,75 @@ export const GridControls = controlForStrategyMemoized(() => {
     [interactionLatestMetadata, editorMetadata],
   )
 
+  const hoveredGrids = useEditorState(
+    Substores.canvas,
+    (store) => stripNulls([store.editor.canvas.controls.gridControls]),
+    'FlexReparentTargetIndicator lines',
+  )
+
   const grids = useEditorState(
     Substores.metadata,
     (store) => {
-      return mapDropNulls((view) => {
-        const element = MetadataUtils.findElementByElementPath(jsxMetadata, view)
-        const parent = MetadataUtils.findElementByElementPath(jsxMetadata, EP.parentPath(view))
+      return mapDropNulls(
+        (view) => {
+          const element = MetadataUtils.findElementByElementPath(jsxMetadata, view)
+          const parent = MetadataUtils.findElementByElementPath(jsxMetadata, EP.parentPath(view))
 
-        const targetGridContainer = MetadataUtils.isGridLayoutedContainer(element)
-          ? element
-          : MetadataUtils.isGridLayoutedContainer(parent)
-          ? parent
-          : null
+          const targetGridContainer = MetadataUtils.isGridLayoutedContainer(element)
+            ? element
+            : MetadataUtils.isGridLayoutedContainer(parent)
+            ? parent
+            : null
 
-        if (
-          targetGridContainer == null ||
-          targetGridContainer.globalFrame == null ||
-          !isFiniteRectangle(targetGridContainer.globalFrame)
-        ) {
-          return null
-        }
+          if (
+            targetGridContainer == null ||
+            targetGridContainer.globalFrame == null ||
+            !isFiniteRectangle(targetGridContainer.globalFrame)
+          ) {
+            return null
+          }
 
-        const gap = targetGridContainer.specialSizeMeasurements.gap
-        const rowGap = targetGridContainer.specialSizeMeasurements.rowGap
-        const columnGap = targetGridContainer.specialSizeMeasurements.columnGap
-        const padding = targetGridContainer.specialSizeMeasurements.padding
+          const gap = targetGridContainer.specialSizeMeasurements.gap
+          const rowGap = targetGridContainer.specialSizeMeasurements.rowGap
+          const columnGap = targetGridContainer.specialSizeMeasurements.columnGap
+          const padding = targetGridContainer.specialSizeMeasurements.padding
 
-        const gridTemplateColumns =
-          targetGridContainer.specialSizeMeasurements.containerGridProperties.gridTemplateColumns
-        const gridTemplateRows =
-          targetGridContainer.specialSizeMeasurements.containerGridProperties.gridTemplateRows
-        const gridTemplateColumnsFromProps =
-          targetGridContainer.specialSizeMeasurements.containerGridPropertiesFromProps
-            .gridTemplateColumns
-        const gridTemplateRowsFromProps =
-          targetGridContainer.specialSizeMeasurements.containerGridPropertiesFromProps
-            .gridTemplateRows
+          const gridTemplateColumns =
+            targetGridContainer.specialSizeMeasurements.containerGridProperties.gridTemplateColumns
+          const gridTemplateRows =
+            targetGridContainer.specialSizeMeasurements.containerGridProperties.gridTemplateRows
+          const gridTemplateColumnsFromProps =
+            targetGridContainer.specialSizeMeasurements.containerGridPropertiesFromProps
+              .gridTemplateColumns
+          const gridTemplateRowsFromProps =
+            targetGridContainer.specialSizeMeasurements.containerGridPropertiesFromProps
+              .gridTemplateRows
 
-        const columns = getCellsCount(
-          targetGridContainer.specialSizeMeasurements.containerGridProperties.gridTemplateColumns,
-        )
-        const rows = getCellsCount(
-          targetGridContainer.specialSizeMeasurements.containerGridProperties.gridTemplateRows,
-        )
+          const columns = getCellsCount(
+            targetGridContainer.specialSizeMeasurements.containerGridProperties.gridTemplateColumns,
+          )
+          const rows = getCellsCount(
+            targetGridContainer.specialSizeMeasurements.containerGridProperties.gridTemplateRows,
+          )
 
-        return {
-          elementPath: targetGridContainer.elementPath,
-          frame: targetGridContainer.globalFrame,
-          gridTemplateColumns: gridTemplateColumns,
-          gridTemplateRows: gridTemplateRows,
-          gridTemplateColumnsFromProps: gridTemplateColumnsFromProps,
-          gridTemplateRowsFromProps: gridTemplateRowsFromProps,
-          gap: gap,
-          rowGap: rowGap,
-          columnGap: columnGap,
-          padding: padding,
-          rows: rows,
-          columns: columns,
-          cells: rows * columns,
-        }
-      }, store.editor.selectedViews)
+          return {
+            elementPath: targetGridContainer.elementPath,
+            frame: targetGridContainer.globalFrame,
+            gridTemplateColumns: gridTemplateColumns,
+            gridTemplateRows: gridTemplateRows,
+            gridTemplateColumnsFromProps: gridTemplateColumnsFromProps,
+            gridTemplateRowsFromProps: gridTemplateRowsFromProps,
+            gap: gap,
+            rowGap: rowGap,
+            columnGap: columnGap,
+            padding: padding,
+            rows: rows,
+            columns: columns,
+            cells: rows * columns,
+          }
+        },
+        [...store.editor.selectedViews, ...hoveredGrids],
+      )
     },
     'GridControls grids',
   )

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -821,6 +821,7 @@ export interface EditorStateCanvasControls {
   reparentedToPaths: Array<ElementPath>
   dragToMoveIndicatorFlags: DragToMoveIndicatorFlags
   parentOutlineHighlight: ElementPath | null
+  gridControls: ElementPath | null
 }
 
 export function editorStateCanvasControls(
@@ -832,6 +833,7 @@ export function editorStateCanvasControls(
   reparentedToPaths: Array<ElementPath>,
   dragToMoveIndicatorFlagsValue: DragToMoveIndicatorFlags,
   parentOutlineHighlight: ElementPath | null,
+  gridControls: ElementPath | null,
 ): EditorStateCanvasControls {
   return {
     snappingGuidelines: snappingGuidelines,
@@ -842,6 +844,7 @@ export function editorStateCanvasControls(
     reparentedToPaths: reparentedToPaths,
     dragToMoveIndicatorFlags: dragToMoveIndicatorFlagsValue,
     parentOutlineHighlight: parentOutlineHighlight,
+    gridControls: gridControls,
   }
 }
 
@@ -2626,6 +2629,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
         reparentedToPaths: [],
         dragToMoveIndicatorFlags: emptyDragToMoveIndicatorFlags,
         parentOutlineHighlight: null,
+        gridControls: null,
       },
     },
     inspector: {
@@ -3000,6 +3004,7 @@ export function editorModelFromPersistentModel(
         reparentedToPaths: [],
         dragToMoveIndicatorFlags: emptyDragToMoveIndicatorFlags,
         parentOutlineHighlight: null,
+        gridControls: null,
       },
     },
     inspector: {

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -2629,7 +2629,7 @@ export const DragToMoveIndicatorFlagsKeepDeepEquality: KeepDeepEqualityCall<Drag
   )
 
 export const EditorStateCanvasControlsKeepDeepEquality: KeepDeepEqualityCall<EditorStateCanvasControls> =
-  combine8EqualityCalls(
+  combine9EqualityCalls(
     (controls) => controls.snappingGuidelines,
     arrayDeepEquality(GuidelineWithSnappingVectorAndPointsOfRelevanceKeepDeepEquality),
     (controls) => controls.outlineHighlights,
@@ -2645,6 +2645,8 @@ export const EditorStateCanvasControlsKeepDeepEquality: KeepDeepEqualityCall<Edi
     (controls) => controls.dragToMoveIndicatorFlags,
     DragToMoveIndicatorFlagsKeepDeepEquality,
     (controls) => controls.parentOutlineHighlight,
+    nullableDeepEquality(ElementPathKeepDeepEquality),
+    (controls) => controls.gridControls,
     nullableDeepEquality(ElementPathKeepDeepEquality),
     editorStateCanvasControls,
   )

--- a/editor/src/components/editor/store/store-hook-substore-helpers.ts
+++ b/editor/src/components/editor/store/store-hook-substore-helpers.ts
@@ -88,6 +88,7 @@ export const EmptyEditorStateForKeysOnly: EditorState = {
       reparentedToPaths: [],
       dragToMoveIndicatorFlags: null as any,
       parentOutlineHighlight: null,
+      gridControls: null,
     },
   },
   inspector: {

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -464,6 +464,7 @@ export function runLocalCanvasAction(
             [],
             emptyDragToMoveIndicatorFlags,
             null,
+            null,
           ),
         },
       }


### PR DESCRIPTION
## Problem
During draw to insert, the grid controls are not shown before one starts to draw, which doesn't make it easy to hit the right grid cell

## Fix
Show the grid controls on hover
