### PR TITLE
Fix converting empty element to grid

### DIFF
--- a/editor/src/components/common/shared-strategies/convert-to-grid-strategy.ts
+++ b/editor/src/components/common/shared-strategies/convert-to-grid-strategy.ts
@@ -67,8 +67,8 @@ function guessMatchingGridSetup(children: Array<CanvasFrameAndTarget>): {
 
   return {
     gap: (horizontalData.averageGap + verticalData.averageGap) / 2,
-    numberOfColumns: horizontalData.nChildren,
-    numberOfRows: verticalData.nChildren,
+    numberOfColumns: Math.max(1, horizontalData.nChildren),
+    numberOfRows: Math.max(1, verticalData.nChildren),
   }
 }
 


### PR DESCRIPTION
**Problem:**

Converting an empty element to grid ends up with a broken template.

**Fix:**

Make sure the template rows/cols are at least 1.

| Before | After |
|--------|-----------|
| ![Kapture 2024-08-05 at 17 51 42](https://github.com/user-attachments/assets/b11de584-07b8-4951-b83a-7fcd5105ead0) | ![Kapture 2024-08-05 at 17 50 33](https://github.com/user-attachments/assets/b6116120-9eba-4b25-bdd6-6d064f58f700) |



Fixes #6175 