### PR TITLE
Update Radix Context Menu paddings

### DIFF
--- a/editor/src/uuiui/radix-components.tsx
+++ b/editor/src/uuiui/radix-components.tsx
@@ -11,7 +11,7 @@ import { when } from '../utils/react-conditionals'
 
 const RadixItemContainer = styled(RadixDropdownMenu.Item, {
   minWidth: 128,
-  padding: '4px 8px',
+  padding: '4px 6px',
   display: 'flex',
   gap: 12,
   justifyContent: 'space-between',
@@ -26,7 +26,7 @@ const RadixItemContainer = styled(RadixDropdownMenu.Item, {
 })
 
 const RadixDropdownContent = styled(RadixDropdownMenu.Content, {
-  padding: '6px 8px',
+  padding: 4,
   flexDirection: 'column',
   backgroundColor: colorTheme.contextMenuBackground.value,
   borderRadius: 6,


### PR DESCRIPTION
Some small padding adjustments to the radix context menus, that should apply to all of them going forward

| Before  | After |
| ------------- | ------------- |
| <img width="189" alt="Screenshot 2024-08-05 at 12 22 52 PM" src="https://github.com/user-attachments/assets/229834a3-a339-46d0-89a2-0b2096f25123"> | <img width="181" alt="Screenshot 2024-08-05 at 12 21 16 PM" src="https://github.com/user-attachments/assets/59643355-4ae1-4e19-b819-ce816a0416ed"> |


**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode 
