### PR TITLE
NumberOrKeyword control for grid placement

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -26,6 +26,7 @@ import type { GridCellCoordinates } from '../../controls/grid-controls'
 import { gridCellCoordinates } from '../../controls/grid-controls'
 import * as EP from '../../../../core/shared/element-path'
 import { deleteProperties } from '../../commands/delete-properties-command'
+import { isCSSKeyword } from '../../../inspector/common/css-utils'
 
 export function getGridCellUnderMouse(mousePoint: WindowPoint, canvasScale: number) {
   return getGridCellAtPoint(mousePoint, canvasScale, false)
@@ -222,8 +223,8 @@ export function gridPositionToValue(p: GridPosition | null | undefined): string 
   if (p == null) {
     return null
   }
-  if (p === 'auto') {
-    return 'auto'
+  if (isCSSKeyword(p)) {
+    return p.value
   }
 
   return p.numericalPosition
@@ -343,7 +344,7 @@ function getElementGridProperties(
   // get the grid fixtures (start and end for column and row) from the element metadata
   function getGridProperty(field: keyof GridElementProperties, fallback: number) {
     const propValue = element.specialSizeMeasurements.elementGridProperties[field]
-    if (propValue == null || propValue === 'auto') {
+    if (propValue == null || isCSSKeyword(propValue)) {
       return fallback
     }
     return propValue.numericalPosition ?? fallback

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -3,6 +3,7 @@ import * as EP from '../../../../core/shared/element-path'
 import type { GridElementProperties, GridPosition } from '../../../../core/shared/element-template'
 import { offsetPoint } from '../../../../core/shared/math-utils'
 import { assertNever } from '../../../../core/shared/utils'
+import { isCSSKeyword } from '../../../inspector/common/css-utils'
 import { GridControls, GridResizeControls } from '../../controls/grid-controls'
 import { canvasPointToWindowPoint } from '../../dom-lookup'
 import type { CanvasStrategyFactory } from '../canvas-strategies'
@@ -157,10 +158,10 @@ function orderedGridPositions({
 } {
   if (
     start == null ||
-    start === 'auto' ||
+    isCSSKeyword(start) ||
     start.numericalPosition == null ||
     end == null ||
-    end === 'auto' ||
+    isCSSKeyword(end) ||
     end.numericalPosition == null
   ) {
     return { start, end }

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -8,6 +8,7 @@ import React from 'react'
 import type { ElementPath } from 'utopia-shared/src/types'
 import type { GridDimension } from '../../../components/inspector/common/css-utils'
 import {
+  isCSSKeyword,
   printGridAutoOrTemplateBase,
   printGridCSSNumber,
 } from '../../../components/inspector/common/css-utils'
@@ -521,13 +522,13 @@ export const GridControls = controlForStrategyMemoized(() => {
           column:
             columnFromProps == null
               ? countedColumn
-              : columnFromProps === 'auto'
+              : isCSSKeyword(columnFromProps)
               ? countedColumn
               : columnFromProps.numericalPosition ?? countedColumn,
           row:
             rowFromProps == null
               ? countedRow
-              : rowFromProps === 'auto'
+              : isCSSKeyword(rowFromProps)
               ? countedRow
               : rowFromProps.numericalPosition ?? countedRow,
           index: index,

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -69,6 +69,7 @@ import {
   parseGridPosition,
   parseGridRange,
   parseGridAutoOrTemplateBase,
+  isCSSKeyword,
 } from '../inspector/common/css-utils'
 import { camelCaseToDashed } from '../../core/shared/string-utils'
 import type { UtopiaStoreAPI } from '../editor/store/store-hook'
@@ -1116,7 +1117,7 @@ function getGridElementProperties(
     ) ??
     null
   const adjustedColumnEnd =
-    gridColumnEnd === 'auto' && gridColumn?.end != null ? gridColumn.end : gridColumnEnd
+    isCSSKeyword(gridColumnEnd) && gridColumn?.end != null ? gridColumn.end : gridColumnEnd
 
   const gridRow = defaultEither(null, parseGridRange(container, 'row', elementStyle.gridRow))
   const gridRowStart =
@@ -1139,7 +1140,7 @@ function getGridElementProperties(
       parseGridPosition(container, 'row', 'end', gridRow?.end ?? null, elementStyle.gridRowEnd),
     ) ??
     null
-  const adjustedRowEnd = gridRowEnd === 'auto' && gridRow?.end != null ? gridRow.end : gridRowEnd
+  const adjustedRowEnd = isCSSKeyword(gridRowEnd) && gridRow?.end != null ? gridRow.end : gridRowEnd
 
   const result = gridElementProperties(
     gridColumnStart,

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -567,6 +567,7 @@ import {
   fontSettings,
   gridCSSKeyword,
   gridCSSNumber,
+  isCSSKeyword,
   isGridCSSKeyword,
   isGridCSSNumber,
 } from '../../inspector/common/css-utils'
@@ -2051,14 +2052,14 @@ export const GridPositionKeepDeepEquality: KeepDeepEqualityCall<GridPosition> = 
   oldValue,
   newValue,
 ) => {
-  if (typeof oldValue === 'string') {
-    if (typeof newValue === 'string') {
+  if (isCSSKeyword(oldValue)) {
+    if (isCSSKeyword(newValue)) {
       return createCallWithTripleEquals<GridPosition>()(oldValue, newValue)
     } else {
       return keepDeepEqualityResult(newValue, false)
     }
   } else {
-    if (typeof newValue === 'string') {
+    if (isCSSKeyword(newValue)) {
       return keepDeepEqualityResult(newValue, false)
     } else {
       return GridPositionValueKeepDeepEquality(oldValue, newValue)

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -953,7 +953,7 @@ export function parseGridPosition(
   input: unknown,
 ): Either<string, GridPosition> {
   if (input === 'auto') {
-    return right('auto')
+    return right(cssKeyword('auto'))
   } else if (typeof input === 'string') {
     const referenceTemplate =
       axis === 'row' ? container.gridTemplateRows : container.gridTemplateColumns
@@ -964,7 +964,7 @@ export function parseGridPosition(
         if (
           edge === 'end' &&
           shorthand != null &&
-          shorthand !== 'auto' &&
+          !isCSSKeyword(shorthand) &&
           shorthand.numericalPosition === value.numericalPosition
         ) {
           value.numericalPosition = (value.numericalPosition ?? 0) + 1
@@ -997,7 +997,7 @@ export function parseGridRange(
       const startParsed = parseGridPosition(container, axis, 'start', null, input)
       return mapEither((start) => {
         const end =
-          start !== 'auto' && start.numericalPosition != null
+          !isCSSKeyword(start) && start.numericalPosition != null
             ? gridPositionValue(start.numericalPosition + 1)
             : null
         return gridRange(start, end)

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -275,7 +275,7 @@ const TemplateDimensionControl = React.memo(
 
           function needsAdjusting(pos: GridPosition | null, bound: number) {
             return pos != null &&
-              pos !== 'auto' &&
+              !isCSSKeyword(pos) &&
               pos.numericalPosition != null &&
               pos.numericalPosition >= bound
               ? pos.numericalPosition

--- a/editor/src/components/inspector/sections/style-section/container-subsection/grid-cell-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/grid-cell-subsection.tsx
@@ -429,7 +429,8 @@ function getWidthOrHeight(props: GridElementProperties, dimension: 'width' | 'he
 
 function getLabelsFromTemplate(gridTemplate: GridContainerProperties) {
   const getAxisLabels = (axis: 'gridTemplateColumns' | 'gridTemplateRows') => {
-    if (gridTemplate[axis]?.type !== 'DIMENSIONS') {
+    const template = gridTemplate[axis]
+    if (template?.type !== 'DIMENSIONS') {
       return []
     }
     return mapDropNulls((d, index) => {
@@ -437,7 +438,7 @@ function getLabelsFromTemplate(gridTemplate: GridContainerProperties) {
         return null
       }
       return { areaName: d.areaName, position: index + 1 }
-    }, gridTemplate[axis].dimensions)
+    }, template.dimensions)
   }
   const columnLabels = getAxisLabels('gridTemplateColumns')
 

--- a/editor/src/components/inspector/sections/style-section/container-subsection/grid-cell-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/grid-cell-subsection.tsx
@@ -215,6 +215,20 @@ const DimensionsControls = React.memo(
       [dispatch, cell, gridTemplate, width, height, columnLabels, rowLabels],
     )
 
+    const columnStartValue = React.useMemo(() => {
+      return getValueWithAlias(
+        cell.specialSizeMeasurements.elementGridProperties.gridColumnStart,
+        columnLabels,
+      )
+    }, [cell, columnLabels])
+
+    const rowStartValue = React.useMemo(() => {
+      return getValueWithAlias(
+        cell.specialSizeMeasurements.elementGridProperties.gridRowStart,
+        rowLabels,
+      )
+    }, [cell, rowLabels])
+
     return (
       <>
         <UIGridRow padded variant='|--80px--|<--------1fr-------->'>
@@ -223,10 +237,8 @@ const DimensionsControls = React.memo(
             <NumberOrKeywordControl
               testId='input-position-column-start'
               onSubmitValue={onSubmitPosition('gridColumnStart')}
-              value={
-                getValue(cell.specialSizeMeasurements.elementGridProperties.gridColumnStart) ??
-                cssKeyword('auto')
-              }
+              value={columnStartValue.value}
+              valueAlias={columnStartValue.alias}
               keywords={keywordsForPosition(columnLabels.map((l) => l.areaName))}
               keywordTypeCheck={isValidGridPositionKeyword(columnLabels.map((l) => l.areaName))}
               labelInner={{
@@ -238,10 +250,8 @@ const DimensionsControls = React.memo(
             <NumberOrKeywordControl
               testId='input-position-row-start'
               onSubmitValue={onSubmitPosition('gridRowStart')}
-              value={
-                getValue(cell.specialSizeMeasurements.elementGridProperties.gridRowStart) ??
-                cssKeyword('auto')
-              }
+              value={rowStartValue.value}
+              valueAlias={rowStartValue.alias}
               keywords={keywordsForPosition(rowLabels.map((l) => l.areaName))}
               keywordTypeCheck={isValidGridPositionKeyword(rowLabels.map((l) => l.areaName))}
               labelInner={{
@@ -333,16 +343,42 @@ const BoundariesControls = React.memo(
       [dispatch, cell, gridTemplate, columnLabels, rowLabels],
     )
 
+    const columnStartValue = React.useMemo(() => {
+      return getValueWithAlias(
+        cell.specialSizeMeasurements.elementGridProperties.gridColumnStart,
+        columnLabels,
+      )
+    }, [cell, columnLabels])
+
+    const columnEndValue = React.useMemo(() => {
+      return getValueWithAlias(
+        cell.specialSizeMeasurements.elementGridProperties.gridColumnEnd,
+        columnLabels,
+      )
+    }, [cell, columnLabels])
+
+    const rowStartValue = React.useMemo(() => {
+      return getValueWithAlias(
+        cell.specialSizeMeasurements.elementGridProperties.gridRowStart,
+        rowLabels,
+      )
+    }, [cell, rowLabels])
+
+    const rowEndValue = React.useMemo(() => {
+      return getValueWithAlias(
+        cell.specialSizeMeasurements.elementGridProperties.gridRowEnd,
+        rowLabels,
+      )
+    }, [cell, rowLabels])
+
     return (
       <>
         <UIGridRow padded variant='|--80px--|<--------1fr-------->'>
           <div>Start</div>
           <FlexRow style={{ gap: 4 }}>
             <NumberOrKeywordControl
-              value={
-                getValue(cell.specialSizeMeasurements.elementGridProperties.gridColumnStart) ??
-                cssKeyword('auto')
-              }
+              value={columnStartValue.value}
+              valueAlias={columnStartValue.alias}
               testId='grid-cell-column-start'
               onSubmitValue={onSubmitPosition('gridColumnStart')}
               labelInner={{
@@ -354,10 +390,8 @@ const BoundariesControls = React.memo(
               keywordTypeCheck={isValidGridPositionKeyword(columnLabels.map((l) => l.areaName))}
             />
             <NumberOrKeywordControl
-              value={
-                getValue(cell.specialSizeMeasurements.elementGridProperties.gridRowStart) ??
-                cssKeyword('auto')
-              }
+              value={rowStartValue.value}
+              valueAlias={rowStartValue.alias}
               testId='grid-cell-row-start'
               onSubmitValue={onSubmitPosition('gridRowStart')}
               labelInner={{
@@ -374,10 +408,8 @@ const BoundariesControls = React.memo(
           <div>End</div>
           <FlexRow style={{ gap: 4 }}>
             <NumberOrKeywordControl
-              value={
-                getValue(cell.specialSizeMeasurements.elementGridProperties.gridColumnEnd) ??
-                cssKeyword('auto')
-              }
+              value={columnEndValue.value}
+              valueAlias={columnEndValue.alias}
               testId='grid-cell-column-end'
               onSubmitValue={onSubmitPosition('gridColumnEnd')}
               labelInner={{
@@ -389,10 +421,8 @@ const BoundariesControls = React.memo(
               keywordTypeCheck={isValidGridPositionKeyword(columnLabels.map((l) => l.areaName))}
             />
             <NumberOrKeywordControl
-              value={
-                getValue(cell.specialSizeMeasurements.elementGridProperties.gridRowEnd) ??
-                cssKeyword('auto')
-              }
+              value={rowEndValue.value}
+              valueAlias={rowEndValue.alias}
               testId='grid-cell-row-end'
               onSubmitValue={onSubmitPosition('gridRowEnd')}
               labelInner={{
@@ -473,4 +503,16 @@ function maybeValueFromAreaName(
     return gridPositionValue(areaMatch.position)
   }
   return null
+}
+
+function getValueWithAlias(
+  position: GridPosition | null,
+  labels: { areaName: string; position: number }[],
+) {
+  const value = getValue(position) ?? cssKeyword('auto')
+  if (isCSSKeyword(value)) {
+    return { value: value }
+  }
+  const areaName = labels.find((l) => l.position === value.value)
+  return { value: value, alias: areaName?.areaName }
 }

--- a/editor/src/components/inspector/sections/style-section/container-subsection/grid-cell-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/grid-cell-subsection.tsx
@@ -6,6 +6,7 @@ import type {
   ElementInstanceMetadata,
   GridContainerProperties,
   GridElementProperties,
+  GridPositionValue,
   ValidGridPositionKeyword,
 } from '../../../../../core/shared/element-template'
 import {
@@ -151,24 +152,16 @@ const DimensionsControls = React.memo(
             ? gridPositionValue(e.value)
             : cssKeyword(e.value)
 
-          let newValues = {
-            ...cell.specialSizeMeasurements.elementGridProperties,
+          const maybeAreaValue = maybeValueFromAreaName(
+            value,
+            dimension === 'gridColumnStart' || dimension === 'width' ? columnLabels : rowLabels,
+          )
+          if (maybeAreaValue != null) {
+            value = maybeAreaValue
           }
 
-          if (isCSSKeyword(value)) {
-            if (dimension === 'gridColumnStart' || dimension === 'width') {
-              const keyword = value
-              const areaMatch = columnLabels.find((l) => l.areaName === keyword.value)
-              if (areaMatch != null) {
-                value = gridPositionValue(areaMatch.position)
-              }
-            } else {
-              const keyword = value
-              const areaMatch = rowLabels.find((l) => l.areaName === keyword.value)
-              if (areaMatch != null) {
-                value = gridPositionValue(areaMatch.position)
-              }
-            }
+          let newValues = {
+            ...cell.specialSizeMeasurements.elementGridProperties,
           }
 
           switch (dimension) {
@@ -319,20 +312,14 @@ const BoundariesControls = React.memo(
             ? gridPositionValue(e.value)
             : cssKeyword(e.value)
 
-          if (isCSSKeyword(value)) {
-            if (dimension === 'gridColumnStart' || dimension === 'gridColumnEnd') {
-              const keyword = value
-              const areaMatch = columnLabels.find((l) => l.areaName === keyword.value)
-              if (areaMatch != null) {
-                value = gridPositionValue(areaMatch.position)
-              }
-            } else {
-              const keyword = value
-              const areaMatch = rowLabels.find((l) => l.areaName === keyword.value)
-              if (areaMatch != null) {
-                value = gridPositionValue(areaMatch.position)
-              }
-            }
+          const maybeAreaValue = maybeValueFromAreaName(
+            value,
+            dimension === 'gridColumnStart' || dimension === 'gridColumnEnd'
+              ? columnLabels
+              : rowLabels,
+          )
+          if (maybeAreaValue != null) {
+            value = maybeAreaValue
           }
 
           const newValues = {
@@ -471,4 +458,18 @@ function keywordsForPosition(labels: string[]) {
     )
   }
   return items
+}
+
+function maybeValueFromAreaName(
+  value: GridPosition,
+  labels: { areaName: string; position: number }[],
+): GridPositionValue | null {
+  if (!isCSSKeyword(value)) {
+    return null
+  }
+  const areaMatch = labels.find((l) => l.areaName === value.value)
+  if (areaMatch != null) {
+    return gridPositionValue(areaMatch.position)
+  }
+  return null
 }

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -22,6 +22,7 @@ import { assertNever, fastForEach, unknownObjectProperty } from './utils'
 import { addAllUniquely, mapDropNulls } from './array-utils'
 import { objectMap } from './object-utils'
 import type {
+  CSSKeyword,
   CSSPosition,
   FlexDirection,
   GridDimension,
@@ -2570,7 +2571,23 @@ export function gridPositionValue(numericalPosition: number | null): GridPositio
   }
 }
 
-export type GridPosition = GridPositionValue | 'auto'
+export const validGridPositionKeywords = ['auto']
+
+export type ValidGridPositionKeyword = string // using <string> because valid keywords are also area names we cannot know in advance
+
+export type GridPosition = GridPositionValue | CSSKeyword<ValidGridPositionKeyword>
+
+export const isValidGridPositionKeyword =
+  (labels: string[]) =>
+  (u: unknown): u is ValidGridPositionKeyword => {
+    if (u == null || typeof u !== 'string') {
+      return false
+    }
+    if (validGridPositionKeywords.includes(u)) {
+      return true
+    }
+    return labels.includes(u)
+  }
 
 export interface GridRange {
   start: GridPosition

--- a/editor/src/uuiui/inputs/new-number-or-keyword-input.tsx
+++ b/editor/src/uuiui/inputs/new-number-or-keyword-input.tsx
@@ -22,14 +22,15 @@ import type {
 } from '../../components/inspector/controls/control'
 import { isRight } from '../../core/shared/either'
 import { StringInput } from './string-input'
+import { Icn, type IcnProps } from '../icn'
 
 export interface NumberOrKeywordInputProps<T extends string> extends InspectorControlProps {
   value: CSSNumber | CSSKeyword<T>
   onSubmitValue: OnSubmitValueOrUnknownOrEmpty<CSSNumber | CSSKeyword<T>>
   validKeywords: Array<CSSKeyword<T>>
-  labelBelowStyle?: React.CSSProperties
   incrementalControls?: boolean
   showBorder?: boolean
+  labelInner?: string | IcnProps
 }
 
 export function NumberOrKeywordInput<T extends string>(props: NumberOrKeywordInputProps<T>) {
@@ -57,18 +58,37 @@ export function NumberOrKeywordInput<T extends string>(props: NumberOrKeywordInp
   )
 
   return (
-    <StringInput
-      style={props.style}
-      showBorder={props.showBorder}
-      className={props.className}
-      id={props.id}
-      controlStatus={props.controlStatus}
-      DEPRECATED_labelBelow={props.DEPRECATED_labelBelow}
-      value={stringValue}
-      onChange={onChange}
-      onSubmitValue={onSubmitValue}
-      testId={props.testId}
-    />
+    <div style={{ position: 'relative' }}>
+      <div
+        style={{
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          bottom: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {typeof props.labelInner === 'object' && 'type' in props.labelInner ? (
+          <Icn {...props.labelInner} />
+        ) : (
+          props.labelInner
+        )}
+      </div>
+      <StringInput
+        innerStyle={{ paddingLeft: props.labelInner != null ? 15 : 0 }}
+        style={props.style}
+        showBorder={props.showBorder}
+        className={props.className}
+        id={props.id}
+        controlStatus={props.controlStatus}
+        value={stringValue}
+        onChange={onChange}
+        onSubmitValue={onSubmitValue}
+        testId={props.testId}
+      />
+    </div>
   )
 }
 

--- a/editor/src/uuiui/inputs/number-or-keyword-control.tsx
+++ b/editor/src/uuiui/inputs/number-or-keyword-control.tsx
@@ -17,6 +17,7 @@ import { isCSSNumber } from '../../components/inspector/common/css-utils'
 import { NO_OP } from '../../core/shared/utils'
 import type { ControlStatus } from '../../uuiui-deps'
 import type { IcnProps } from '../icn'
+import { mapDropNulls } from '../../core/shared/array-utils'
 
 export type KeywordForControl<T extends string> =
   | { label: string; value: CSSKeyword<T> }
@@ -112,7 +113,9 @@ export function NumberOrKeywordControl<T extends string>(props: NumberOrKeywordC
         showBorder={hover || dropdownOpen}
         onSubmitValue={onSubmitValue}
         incrementalControls={false}
-        validKeywords={props.keywords.filter((k) => k !== 'separator').map((k) => k.value)}
+        validKeywords={mapDropNulls((k) => (k !== 'separator' ? k : null), props.keywords).map(
+          (k) => k.value,
+        )}
         style={{ flex: 1 }}
         controlStatus={hover || dropdownOpen ? 'detected' : props.controlStatus}
         labelInner={props.labelInner}

--- a/editor/src/uuiui/inputs/number-or-keyword-control.tsx
+++ b/editor/src/uuiui/inputs/number-or-keyword-control.tsx
@@ -95,6 +95,10 @@ export function NumberOrKeywordControl<T extends string>(props: NumberOrKeywordC
     return items
   }, [props.value, props.keywords, onSubmitValue, props.controlStatus])
 
+  const keywordsWithoutSeparators = React.useMemo(() => {
+    return mapDropNulls((k) => (k !== 'separator' ? k : null), props.keywords).map((k) => k.value)
+  }, [props.keywords])
+
   return (
     <div
       style={{
@@ -113,9 +117,7 @@ export function NumberOrKeywordControl<T extends string>(props: NumberOrKeywordC
         showBorder={hover || dropdownOpen}
         onSubmitValue={onSubmitValue}
         incrementalControls={false}
-        validKeywords={mapDropNulls((k) => (k !== 'separator' ? k : null), props.keywords).map(
-          (k) => k.value,
-        )}
+        validKeywords={keywordsWithoutSeparators}
         style={{ flex: 1 }}
         controlStatus={hover || dropdownOpen ? 'detected' : props.controlStatus}
         labelInner={props.labelInner}

--- a/editor/src/uuiui/inputs/number-or-keyword-control.tsx
+++ b/editor/src/uuiui/inputs/number-or-keyword-control.tsx
@@ -16,15 +16,21 @@ import type {
 import { isCSSNumber } from '../../components/inspector/common/css-utils'
 import { NO_OP } from '../../core/shared/utils'
 import type { ControlStatus } from '../../uuiui-deps'
+import type { IcnProps } from '../icn'
+
+export type KeywordForControl<T extends string> =
+  | { label: string; value: CSSKeyword<T> }
+  | 'separator'
 
 type NumberOrKeywordControlProps<T extends string> = {
   testId: string
   style?: CSSProperties
   onSubmitValue: (value: UnknownOrEmptyInput<CSSNumber | CSSKeyword<T>>) => void
   value: CSSNumber | CSSKeyword<T>
-  keywords: Array<{ label: string; value: CSSKeyword<T> }>
+  keywords: Array<KeywordForControl<T>>
   keywordTypeCheck: (keyword: unknown) => keyword is T
   controlStatus?: ControlStatus
+  labelInner?: string | IcnProps
 }
 
 export function NumberOrKeywordControl<T extends string>(props: NumberOrKeywordControlProps<T>) {
@@ -67,11 +73,16 @@ export function NumberOrKeywordControl<T extends string>(props: NumberOrKeywordC
           disabled: true,
           onSelect: NO_OP,
         }),
-        separatorDropdownMenuItem('dropdown-separator'),
       )
     }
+    if (props.keywords.length > 0) {
+      items.push(separatorDropdownMenuItem('dropdown-separator'))
+    }
     items.push(
-      ...props.keywords.map((keyword): DropdownMenuItem => {
+      ...props.keywords.map((keyword, idx): DropdownMenuItem => {
+        if (keyword === 'separator') {
+          return separatorDropdownMenuItem(`keyword-separator-${idx}`)
+        }
         return regularDropdownMenuItem({
           id: `dropdown-label-${keyword.value.value}`,
           icon: <div style={{ width: 16, height: 16 }} />,
@@ -101,9 +112,10 @@ export function NumberOrKeywordControl<T extends string>(props: NumberOrKeywordC
         showBorder={hover || dropdownOpen}
         onSubmitValue={onSubmitValue}
         incrementalControls={false}
-        validKeywords={props.keywords.map((k) => k.value)}
+        validKeywords={props.keywords.filter((k) => k !== 'separator').map((k) => k.value)}
         style={{ flex: 1 }}
         controlStatus={hover || dropdownOpen ? 'detected' : props.controlStatus}
+        labelInner={props.labelInner}
       />
       <div
         style={{

--- a/editor/src/uuiui/inputs/number-or-keyword-control.tsx
+++ b/editor/src/uuiui/inputs/number-or-keyword-control.tsx
@@ -28,6 +28,7 @@ type NumberOrKeywordControlProps<T extends string> = {
   style?: CSSProperties
   onSubmitValue: (value: UnknownOrEmptyInput<CSSNumber | CSSKeyword<T>>) => void
   value: CSSNumber | CSSKeyword<T>
+  valueAlias?: string
   keywords: Array<KeywordForControl<T>>
   keywordTypeCheck: (keyword: unknown) => keyword is T
   controlStatus?: ControlStatus
@@ -70,7 +71,9 @@ export function NumberOrKeywordControl<T extends string>(props: NumberOrKeywordC
         regularDropdownMenuItem({
           id: 'dropdown-input-value',
           icon: <Icons.Checkmark color='white' width={16} height={16} />,
-          label: `${props.value.value}${isCSSNumber(props.value) ? props.value.unit ?? '' : ''}`,
+          label: `${props.value.value}${isCSSNumber(props.value) ? props.value.unit ?? '' : ''}${
+            props.valueAlias != null ? ` (${props.valueAlias})` : ''
+          }`,
           disabled: true,
           onSelect: NO_OP,
         }),
@@ -93,7 +96,7 @@ export function NumberOrKeywordControl<T extends string>(props: NumberOrKeywordC
       }),
     )
     return items
-  }, [props.value, props.keywords, onSubmitValue, props.controlStatus])
+  }, [props.value, props.keywords, onSubmitValue, props.controlStatus, props.valueAlias])
 
   const keywordsWithoutSeparators = React.useMemo(() => {
     return mapDropNulls((k) => (k !== 'separator' ? k : null), props.keywords).map((k) => k.value)

--- a/editor/src/uuiui/inputs/string-input.tsx
+++ b/editor/src/uuiui/inputs/string-input.tsx
@@ -33,6 +33,7 @@ export interface StringInputProps
   onEscape?: () => void
   pasteHandler?: boolean
   showBorder?: boolean
+  innerStyle?: React.CSSProperties
 }
 
 export const StringInput = React.memo(
@@ -41,6 +42,7 @@ export const StringInput = React.memo(
       {
         controlStatus = 'simple',
         style,
+        innerStyle,
         focusOnMount = false,
         includeBoxShadow = true,
         placeholder: initialPlaceHolder,
@@ -95,6 +97,7 @@ export const StringInput = React.memo(
         >
           <div
             className='string-input-container'
+            style={innerStyle}
             css={{
               borderRadius: 2,
               color: controlStyles.mainColor,


### PR DESCRIPTION
**Problem:**

The grid placement subsection inputs for positioning should use the new dropdown keyword/number combo input and offer area names and keywords as possible choices.

**Fix:**

1. Extend the `NumberOrKeywordControl` to support icons
2. Extend the `NumberOrKeywordControl` to support inner separators
3. Extend the grid position representation so it supports keywords
4. Use the new controls in the section, and make it offer `auto` and any pertinent area names as dropdown options


https://github.com/user-attachments/assets/37715424-2289-4440-aa1c-1dc7156cfe3a



Fixes #6180 
