### PR TITLE
UI: remove icons from show/hide panel menu

### DIFF
--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -362,22 +362,12 @@ export const CanvasToolbar = React.memo(() => {
         id: 'navigator',
         label: 'Navigator',
         checked: navigatorVisible,
-        icon: (
-          <div style={{ transform: 'scale(0.8)' }}>
-            <LargerIcons.Navigator color='white' />
-          </div>
-        ),
         shortcut: keyToString(shortcutDetailsWithDefaults[TOGGLE_NAVIGATOR].shortcutKeys[0]),
         onSelect: () => dispatch([togglePanel('leftmenu')]),
       },
       {
         id: 'rightmenu',
         label: 'Inspector',
-        icon: (
-          <div style={{ transform: 'scale(0.8)' }}>
-            <LargerIcons.Inspector color='white' />
-          </div>
-        ),
         checked: inspectorVisible,
         shortcut: keyToString(shortcutDetailsWithDefaults[TOGGLE_INSPECTOR].shortcutKeys[0]),
         onSelect: () => dispatch([togglePanel('rightmenu')]),
@@ -385,11 +375,6 @@ export const CanvasToolbar = React.memo(() => {
       {
         id: 'code-editor',
         label: 'Code Editor',
-        icon: (
-          <div style={{ transform: 'scale(0.8)' }}>
-            <LargerIcons.Code color='white' />
-          </div>
-        ),
         checked: codeEditorVisible,
         shortcut: keyToString(
           shortcutDetailsWithDefaults[TOGGLE_CODE_EDITOR_SHORTCUT].shortcutKeys[0],


### PR DESCRIPTION
**Problem:**
The popup menu to show / hide panels (via the button in the top menu) was also using icons. However, these icons aren't used anywhere else, and make the menu harder to parse

**Fix:**
Remove the icons
<img width="169" alt="image" src="https://github.com/user-attachments/assets/9aafbf18-3b86-4e9d-9c22-6ef1746562f0">
(NB the menu also should be wider / have a wider gap between label and keyb shortcut, but that probably is a global setting)