### PR TITLE
chore(design) - add salt to inter font settings

### DIFF
--- a/editor/resources/editor/css/initial-load.css
+++ b/editor/resources/editor/css/initial-load.css
@@ -60,7 +60,7 @@ label {
     background-color: transparent;
     font-family: 'utopian-inter', 'sans-serif';
     font-size: 11px !important;
-    font-feature-settings: 'cv01', 'tnum', 'zero';
+    font-feature-settings: 'cv01', 'tnum', 'salt', 'zero';
     letter-spacing: 0.2px;
     line-height: 17px;
     overflow: hidden;


### PR DESCRIPTION
**Problem:**
Our threes didn't match between input and spans
Compare here: [default style](https://rsms.me/inter/lab) vs- [alternative style](https://rsms.me/inter/lab/?feat-salt=1)

![three](https://github.com/user-attachments/assets/c7939892-32c8-41aa-8f32-72aeaecafbed)


**Fix:**
- enabled `salt` (Inter font stylistic alternative character set) for `body` (already enabled for input)

**Result**
these two numbers match (they previously did not)
<img width="243" alt="image" src="https://github.com/user-attachments/assets/983231b7-eb49-4d80-a5ff-2cabe0f65018">

