### PR TITLE
Fallback to rendered px number when there is no explicit css value

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-border-radius-strategy.tsx
@@ -54,6 +54,7 @@ import {
   canShowCanvasPropControl,
   cssNumberEqual,
   cssNumberWithRenderedValue,
+  fallbackEmptyValue,
   measurementBasedOnOtherMeasurement,
   precisionFromModifiers,
   shouldShowControls,
@@ -507,12 +508,6 @@ function updateBorderRadiusFn(
   }
 }
 
-function borderRadiusSidesAllEqual(sides: BorderRadiusSides<CSSNumberWithRenderedValue>): boolean {
-  return allElemsEqual([sides.bl, sides.br, sides.tl, sides.tr], (l, r) =>
-    cssNumberEqual(l.value, r.value),
-  )
-}
-
 function setBorderRadiusStrategyRunResult(
   data: BorderRadiusData<CSSNumberWithRenderedValue>,
   borderRadiusAdjustData: BorderRadiusAdjustData | null,
@@ -541,7 +536,7 @@ function setBorderRadiusStrategyRunResult(
 
     return {
       commands: setLonghandStylePropertyCommand(
-        mapBorderRadiusSides((v) => v.value, updatedBorderRadiusSides),
+        mapBorderRadiusSides((v) => fallbackEmptyValue(v), updatedBorderRadiusSides),
       ),
       updatedBorderRadius: updatedBorderRadiusSides,
     }
@@ -553,7 +548,9 @@ function setBorderRadiusStrategyRunResult(
   )
 
   return {
-    commands: setShorthandStylePropertyCommand(printCSSNumber(allUpdated.tl.value, null)),
+    commands: setShorthandStylePropertyCommand(
+      printCSSNumber(fallbackEmptyValue(allUpdated.tl), null),
+    ),
     updatedBorderRadius: allUpdated,
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
@@ -17,6 +17,7 @@ import { setCursorCommand } from '../../commands/set-cursor-command'
 import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rerender-command'
 import { setProperty } from '../../commands/set-property-command'
 import {
+  fallbackEmptyValue,
   indicatorMessage,
   offsetMeasurementByDelta,
   precisionFromModifiers,
@@ -181,7 +182,7 @@ export const setFlexGapStrategy: CanvasStrategyFactory = (
           'always',
           selectedElement,
           StyleGapProp,
-          printCSSNumber(updatedFlexGapMeasurement.value, null),
+          printCSSNumber(fallbackEmptyValue(updatedFlexGapMeasurement), null),
         ),
         setCursorCommand(cursorFromFlexDirection(flexGap.direction)),
         setElementsToRerenderCommand([...selectedElements, ...children.map((c) => c.elementPath)]),

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -59,6 +59,7 @@ import type {
 } from '../../controls/select-mode/controls-common'
 import {
   canShowCanvasPropControl,
+  fallbackEmptyValue,
   indicatorMessage,
   offsetMeasurementByDelta,
   shouldShowControls,
@@ -215,7 +216,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
           if (value == null || value.renderedValuePx < 0) {
             return []
           }
-          return [[p, printCssNumberWithDefaultUnit(value.value, 'px')]]
+          return [[p, printCssNumberWithDefaultUnit(fallbackEmptyValue(value), 'px')]]
         },
       )
 

--- a/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
@@ -40,7 +40,7 @@ import { useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 import { isZeroSizedElement } from '../outline-utils'
 import type { CSSNumberWithRenderedValue } from './controls-common'
-import { CanvasLabel } from './controls-common'
+import { CanvasLabel, fallbackEmptyValue } from './controls-common'
 
 export const CircularHandleTestId = (corner: BorderRadiusCorner): string =>
   `circular-handle-${corner}`
@@ -229,7 +229,7 @@ const CircularHandle = React.memo((props: CircularHandleProp) => {
             }}
           >
             <CanvasLabel
-              value={`${printCSSNumber(borderRadius.value, null)}`}
+              value={`${printCSSNumber(fallbackEmptyValue(borderRadius), null)}`}
               scale={scale}
               color={colorTheme.brandNeonPink.value}
               textColor={colorTheme.white.value}

--- a/editor/src/components/canvas/controls/select-mode/controls-common.spec.ts
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.spec.ts
@@ -1,11 +1,11 @@
 import { cssNumberWithRenderedValue, fallbackEmptyValue } from './controls-common'
-import { cssNumber, emptyCssNumber } from '../../../../components/inspector/common/css-utils'
+import { cssNumber } from '../../../../components/inspector/common/css-utils'
 describe('empty css value', () => {
   const renderedValuePx = 16
   const tests = [
     {
       title: 'should fallback to rendered px in case of an empty value',
-      cssNumber: emptyCssNumber(),
+      cssNumber: null,
       expected: { value: 16, unit: 'px' },
     },
     {

--- a/editor/src/components/canvas/controls/select-mode/controls-common.spec.ts
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.spec.ts
@@ -6,17 +6,17 @@ describe('empty css value', () => {
     {
       title: 'should fallback to rendered px in case of an empty value',
       cssNumber: emptyCssNumber(),
-      expected: { value: { value: 16, unit: 'px' }, renderedValuePx: renderedValuePx },
+      expected: { value: 16, unit: 'px' },
     },
     {
       title: 'shouldnt fallback to rendered px in case of a non-empty value',
       cssNumber: cssNumber(1, 'em'),
-      expected: { value: { value: 1, unit: 'em' }, renderedValuePx: renderedValuePx },
+      expected: { value: 1, unit: 'em' },
     },
     {
       title: 'shouldnt fallback to rendered px in case of a zero value',
       cssNumber: cssNumber(0),
-      expected: { value: { value: 0, unit: null }, renderedValuePx: renderedValuePx },
+      expected: { value: 0, unit: null },
     },
   ]
 

--- a/editor/src/components/canvas/controls/select-mode/controls-common.spec.ts
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.spec.ts
@@ -1,0 +1,30 @@
+import { cssNumberWithRenderedValue, fallbackEmptyValue } from './controls-common'
+import { cssNumber, emptyCssNumber } from '../../../../components/inspector/common/css-utils'
+describe('empty css value', () => {
+  const renderedValuePx = 16
+  const tests = [
+    {
+      title: 'should fallback to rendered px in case of an empty value',
+      cssNumber: emptyCssNumber(),
+      expected: { value: { value: 16, unit: 'px' }, renderedValuePx: renderedValuePx },
+    },
+    {
+      title: 'shouldnt fallback to rendered px in case of a non-empty value',
+      cssNumber: cssNumber(1, 'em'),
+      expected: { value: { value: 1, unit: 'em' }, renderedValuePx: renderedValuePx },
+    },
+    {
+      title: 'shouldnt fallback to rendered px in case of a zero value',
+      cssNumber: cssNumber(0),
+      expected: { value: { value: 0, unit: null }, renderedValuePx: renderedValuePx },
+    },
+  ]
+
+  tests.forEach((test) => {
+    it(`${test.title}`, () => {
+      expect(
+        fallbackEmptyValue(cssNumberWithRenderedValue(test.cssNumber, renderedValuePx)),
+      ).toEqual(test.expected)
+    })
+  })
+})

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -7,7 +7,7 @@ import type { Modifiers } from '../../../../utils/modifiers'
 import type { ProjectContentTreeRoot } from '../../../assets'
 import { colorTheme } from '../../../../uuiui'
 import type { CSSNumber, CSSNumberUnit } from '../../../inspector/common/css-utils'
-import { printCSSNumber } from '../../../inspector/common/css-utils'
+import { cssNumber, printCSSNumber } from '../../../inspector/common/css-utils'
 import { elementHasOnlyTextChildren } from '../../canvas-utils'
 import type { ElementPathTrees } from '../../../../core/shared/element-path-tree'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
@@ -27,7 +27,7 @@ export const unitlessCSSNumberWithRenderedValue = (
   renderedValuePx: number,
 ): CSSNumberWithRenderedValue => ({
   value: { value: renderedValuePx, unit: null },
-  renderedValuePx,
+  renderedValuePx: renderedValuePx,
 })
 
 export const cssNumberWithRenderedValue = (
@@ -69,6 +69,8 @@ export function measurementBasedOnOtherMeasurement(
     precision,
   )
 
+  const baseValue = fallbackEmptyValue(base)
+
   if (base.renderedValuePx === 0) {
     return {
       renderedValuePx: desiredRenderedValueWithPrecision,
@@ -76,9 +78,9 @@ export function measurementBasedOnOtherMeasurement(
     }
   }
 
-  const pixelsPerUnit = base.value.value / base.renderedValuePx
+  const pixelsPerUnit = baseValue.value / base.renderedValuePx
   const desiredValueInUnits = valueWithUnitAppropriatePrecision(
-    base.value.unit,
+    baseValue.unit,
     desiredRenderedValue * pixelsPerUnit,
     precision,
   )
@@ -86,7 +88,7 @@ export function measurementBasedOnOtherMeasurement(
   return {
     renderedValuePx: desiredRenderedValueWithPrecision,
     value: {
-      unit: base.value.unit,
+      unit: baseValue.unit,
       value: desiredValueInUnits,
     },
   }
@@ -292,4 +294,11 @@ export function shouldShowControls(
   }
 
   return true
+}
+
+export function fallbackEmptyValue(numberWithRenderedValue: CSSNumberWithRenderedValue): CSSNumber {
+  if (!numberWithRenderedValue.value.emptyValue) {
+    return numberWithRenderedValue.value
+  }
+  return cssNumber(numberWithRenderedValue.renderedValuePx, 'px')
 }

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -297,8 +297,7 @@ export function shouldShowControls(
 }
 
 export function fallbackEmptyValue(numberWithRenderedValue: CSSNumberWithRenderedValue): CSSNumber {
-  if (!numberWithRenderedValue.value.emptyValue) {
-    return numberWithRenderedValue.value
-  }
-  return cssNumber(numberWithRenderedValue.renderedValuePx, 'px')
+  return numberWithRenderedValue.value.emptyValue
+    ? cssNumber(numberWithRenderedValue.renderedValuePx, 'px')
+    : numberWithRenderedValue.value
 }

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -19,7 +19,7 @@ import type { PropertyControlsInfo } from '../../../custom-code/code-file'
 export const Emdash: string = '\u2014'
 
 export interface CSSNumberWithRenderedValue {
-  value: CSSNumber
+  value: CSSNumber | null
   renderedValuePx: number
 }
 
@@ -31,7 +31,7 @@ export const unitlessCSSNumberWithRenderedValue = (
 })
 
 export const cssNumberWithRenderedValue = (
-  value: CSSNumber,
+  value: CSSNumber | null,
   renderedValuePx: number,
 ): CSSNumberWithRenderedValue => ({ value, renderedValuePx })
 
@@ -188,7 +188,8 @@ export function indicatorMessage(
   value: CSSNumberWithRenderedValue,
 ): string | number {
   if (isOverThreshold) {
-    return printCSSNumber(value.value, value.value.unit)
+    const valueOrRendered = fallbackEmptyValue(value)
+    return printCSSNumber(valueOrRendered, valueOrRendered.unit)
   }
 
   return Emdash // emdash
@@ -297,7 +298,7 @@ export function shouldShowControls(
 }
 
 export function fallbackEmptyValue(numberWithRenderedValue: CSSNumberWithRenderedValue): CSSNumber {
-  return numberWithRenderedValue.value.emptyValue == true
+  return numberWithRenderedValue.value == null
     ? cssNumber(numberWithRenderedValue.renderedValuePx, 'px')
     : numberWithRenderedValue.value
 }

--- a/editor/src/components/canvas/controls/select-mode/controls-common.tsx
+++ b/editor/src/components/canvas/controls/select-mode/controls-common.tsx
@@ -297,7 +297,7 @@ export function shouldShowControls(
 }
 
 export function fallbackEmptyValue(numberWithRenderedValue: CSSNumberWithRenderedValue): CSSNumber {
-  return numberWithRenderedValue.value.emptyValue
+  return numberWithRenderedValue.value.emptyValue == true
     ? cssNumber(numberWithRenderedValue.renderedValuePx, 'px')
     : numberWithRenderedValue.value
 }

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
@@ -30,7 +30,7 @@ import {
 } from '../../gap-utils'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 import type { CSSNumberWithRenderedValue } from './controls-common'
-import { CanvasLabel, PillHandle, useHoverWithDelay } from './controls-common'
+import { CanvasLabel, fallbackEmptyValue, PillHandle, useHoverWithDelay } from './controls-common'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../../core/shared/array-utils'
 import {
@@ -201,6 +201,7 @@ export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((p
       <div data-testid={FlexGapControlTestId} style={{ pointerEvents: 'none' }}>
         {controlBounds.map(({ bounds, path: p }) => {
           const path = EP.toString(p)
+          const valueToShow = fallbackEmptyValue(flexGapValue)
           return (
             <GapControlSegment
               key={path}
@@ -216,7 +217,7 @@ export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((p
               scale={scale}
               backgroundShown={backgroundShown}
               isDragging={isDragging}
-              gapValue={flexGapValue.value}
+              gapValue={valueToShow}
               justifyContent={justifyContent}
               alignItems={alignItems}
             />

--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -40,7 +40,7 @@ import { useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 import { isZeroSizedElement } from '../outline-utils'
 import type { CSSNumberWithRenderedValue } from './controls-common'
-import { CanvasLabel, PillHandle, useHoverWithDelay } from './controls-common'
+import { CanvasLabel, fallbackEmptyValue, PillHandle, useHoverWithDelay } from './controls-common'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../../core/shared/array-utils'
 
@@ -288,7 +288,7 @@ const PaddingResizeControlI = React.memo((props: ResizeContolProps) => {
             }}
           >
             <CanvasLabel
-              value={printCSSNumber(props.paddingValue.value, 'px')}
+              value={printCSSNumber(fallbackEmptyValue(props.paddingValue), 'px')}
               scale={scale}
               color={color}
               textColor={colorTheme.white.value}

--- a/editor/src/components/canvas/gap-utils.ts
+++ b/editor/src/components/canvas/gap-utils.ts
@@ -14,7 +14,6 @@ import { assertNever } from '../../core/shared/utils'
 import { CSSCursor } from './canvas-types'
 import type { CSSNumberWithRenderedValue } from './controls/select-mode/controls-common'
 import type { CSSNumber, FlexDirection } from '../inspector/common/css-utils'
-import { emptyCssNumber } from '../inspector/common/css-utils'
 import type { Sides } from 'utopia-api/core'
 import { sides } from 'utopia-api/core'
 import { styleStringInArray } from '../../utils/common-constants'
@@ -189,7 +188,7 @@ export function maybeFlexGapData(
   return {
     value: {
       renderedValuePx: gap,
-      value: gapFromProps ?? emptyCssNumber(),
+      value: gapFromProps ?? null,
     },
     direction: flexDirection,
   }

--- a/editor/src/components/canvas/gap-utils.ts
+++ b/editor/src/components/canvas/gap-utils.ts
@@ -14,7 +14,7 @@ import { assertNever } from '../../core/shared/utils'
 import { CSSCursor } from './canvas-types'
 import type { CSSNumberWithRenderedValue } from './controls/select-mode/controls-common'
 import type { CSSNumber, FlexDirection } from '../inspector/common/css-utils'
-import { cssNumber } from '../inspector/common/css-utils'
+import { emptyCssNumber } from '../inspector/common/css-utils'
 import type { Sides } from 'utopia-api/core'
 import { sides } from 'utopia-api/core'
 import { styleStringInArray } from '../../utils/common-constants'
@@ -187,7 +187,10 @@ export function maybeFlexGapData(
   const flexDirection = element.specialSizeMeasurements.flexDirection ?? 'row'
 
   return {
-    value: { renderedValuePx: gap, value: gapFromProps ?? cssNumber(0) },
+    value: {
+      renderedValuePx: gap,
+      value: gapFromProps ?? emptyCssNumber(),
+    },
     direction: flexDirection,
   }
 }

--- a/editor/src/components/canvas/padding-utils.tsx
+++ b/editor/src/components/canvas/padding-utils.tsx
@@ -18,6 +18,7 @@ import type {
 } from './controls/select-mode/controls-common'
 import {
   cssNumberWithRenderedValue,
+  fallbackEmptyValue,
   offsetMeasurementByDelta,
   unitlessCSSNumberWithRenderedValue,
 } from './controls/select-mode/controls-common'
@@ -201,10 +202,10 @@ export function offsetPaddingByEdge(
 
 export function paddingToPaddingString(padding: CSSPaddingMeasurements): string {
   return [
-    printCssNumberWithDefaultUnit(padding.paddingTop.value, 'px'),
-    printCssNumberWithDefaultUnit(padding.paddingRight.value, 'px'),
-    printCssNumberWithDefaultUnit(padding.paddingBottom.value, 'px'),
-    printCssNumberWithDefaultUnit(padding.paddingLeft.value, 'px'),
+    printCssNumberWithDefaultUnit(fallbackEmptyValue(padding.paddingTop), 'px'),
+    printCssNumberWithDefaultUnit(fallbackEmptyValue(padding.paddingRight), 'px'),
+    printCssNumberWithDefaultUnit(fallbackEmptyValue(padding.paddingBottom), 'px'),
+    printCssNumberWithDefaultUnit(fallbackEmptyValue(padding.paddingLeft), 'px'),
   ].join(' ')
 }
 

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -578,10 +578,13 @@ const CSSNumberUnits: Array<CSSNumberUnit> = [
   '%',
 ]
 
-export interface CSSNumber {
+export type CSSNumber = {
   value: number
   unit: CSSNumberUnit | null
+  emptyValue?: boolean
 }
+
+export type EmptyCssNumber = CSSNumber & { emptyValue: true }
 
 export type GridCSSNumberUnit = LengthUnit | ResolutionUnit | PercentUnit | 'fr'
 const GridCSSNumberUnits: Array<GridCSSNumberUnit> = [...LengthUnits, ...ResolutionUnits, '%', 'fr']
@@ -638,6 +641,10 @@ export function printGridCSSNumber(dim: GridDimension): string {
 
 export function cssNumber(value: number, unit: CSSNumberUnit | null = null): CSSNumber {
   return { value, unit }
+}
+
+export function emptyCssNumber(): EmptyCssNumber {
+  return { value: 0, unit: null, emptyValue: true }
 }
 
 export function isCSSNumber(value: unknown): value is CSSNumber {

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -578,10 +578,9 @@ const CSSNumberUnits: Array<CSSNumberUnit> = [
   '%',
 ]
 
-export type CSSNumber = {
+export interface CSSNumber {
   value: number
   unit: CSSNumberUnit | null
-  emptyValue?: boolean
 }
 
 export type GridCSSNumberUnit = LengthUnit | ResolutionUnit | PercentUnit | 'fr'

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -584,8 +584,6 @@ export type CSSNumber = {
   emptyValue?: boolean
 }
 
-export type EmptyCssNumber = CSSNumber & { emptyValue: true }
-
 export type GridCSSNumberUnit = LengthUnit | ResolutionUnit | PercentUnit | 'fr'
 const GridCSSNumberUnits: Array<GridCSSNumberUnit> = [...LengthUnits, ...ResolutionUnits, '%', 'fr']
 
@@ -641,10 +639,6 @@ export function printGridCSSNumber(dim: GridDimension): string {
 
 export function cssNumber(value: number, unit: CSSNumberUnit | null = null): CSSNumber {
   return { value, unit }
-}
-
-export function emptyCssNumber(): EmptyCssNumber {
-  return { value: 0, unit: null, emptyValue: true }
 }
 
 export function isCSSNumber(value: unknown): value is CSSNumber {


### PR DESCRIPTION
**Problem:**
When a gap css value is assigned using a global class, we read the rendered value correctly in the inspector, but not in the inline handles.
This causes the issue where the value is displayed as 0, and changing the value first collapses it to 0 as well.

<video src="https://github.com/user-attachments/assets/0a8b873a-b509-4e71-9e72-1b7b12d39179"></video>

**Fix:**
Making the value nullable (and not just CssNumber) - and falling back to the rendered px prop in that case.
this was added to distinguish this from an actual `0` value.

<video src="https://github.com/user-attachments/assets/d822bf4e-1d7b-4484-939f-14656139c991"></video>

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode

Fixes #6162
