### PR TITLE
Improve Selection Performance.

### DIFF
--- a/editor/src/core/shared/optics/optic-creators.ts
+++ b/editor/src/core/shared/optics/optic-creators.ts
@@ -112,6 +112,20 @@ export function traverseArray<A>(): Optic<Array<A>, A> {
   )
 }
 
+// Produces a traversal over a readonly array, presenting each value of the array.
+export function traverseReadOnlyArray<A>(): Optic<ReadonlyArray<A>, A> {
+  return makeOptic(
+    (s, f) => {
+      for (const a of s) {
+        f(a)
+      }
+    },
+    (s, modify) => {
+      return s.map(modify)
+    },
+  )
+}
+
 // Produces a traversal over the values of an object.
 export function objectValues<A>(): Optic<{ [key: string]: A }, A> {
   return makeOptic(


### PR DESCRIPTION
**Problem:**
In the sample project, selection is noticeably slow.

**Fix:**
This fix is entirely around improving `shouldRunDOMWalker`, which during the kind of selection reported was causing the DOM walker to run 4 times during a selection. It is now broken down into 3 parts:
- Checking various parts of the patched editor state.
- Checking various parts of the patched derived state.
- Determining if the `RUN_DOM_WALKER` action has been fired.

This has resulted in a reduction from about 1200ms to about 500ms for selection.

**Before:**
![Before](https://github.com/user-attachments/assets/4654dc13-b6de-4c0e-8b48-7918e9ddb5eb)

**After:**
![After](https://github.com/user-attachments/assets/b1dba760-366a-4b3c-8181-335a2cb74eff)

**Commit Details:**
- Added `actionActionsOptic` so that we can more easily walk the various actions.
- Added `traverseReadOnlyArray` because the typing works out that way.
- Revamped `shouldRunDOMWalker` because the current version results in the DOM walker running almost constantly.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #6149
