### PR TITLE
Prevent insertion control flickering.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/interaction-state.ts
+++ b/editor/src/components/canvas/canvas-strategies/interaction-state.ts
@@ -134,6 +134,21 @@ export function interactionSession(
   }
 }
 
+export function interactionSessionIsActive(session: InteractionSession | null): boolean {
+  if (session == null) {
+    return false
+  } else {
+    switch (session.interactionData.type) {
+      case 'DRAG':
+        return session.interactionData.drag != null
+      case 'HOVER':
+        return true
+      case 'KEYBOARD':
+        return true
+    }
+  }
+}
+
 export type InteractionSessionWithoutMetadata = Omit<
   InteractionSession,
   'latestMetadata' | 'latestAllElementProps' | 'latestElementPathTree' | 'latestVariablesInScope'

--- a/editor/src/components/canvas/controls/insertion-plus-button.tsx
+++ b/editor/src/components/canvas/controls/insertion-plus-button.tsx
@@ -17,6 +17,7 @@ import {
   siblingAndPseudoPositions,
 } from '../canvas-strategies/strategies/reparent-helpers/reparent-strategy-sibling-position-helpers'
 import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
+import { interactionSessionIsActive } from '../canvas-strategies/interaction-state'
 
 export const InsertionButtonOffset = 10
 
@@ -36,8 +37,8 @@ export const InsertionControls: React.FunctionComponent = React.memo(
   (): React.ReactElement | null => {
     const isInteractionActive = useEditorState(
       Substores.canvas,
-      (store) => store.editor.canvas.interactionSession != null,
-      'DistanceGuidelineControl isInteractionActive',
+      (store) => interactionSessionIsActive(store.editor.canvas.interactionSession),
+      'InsertionControls isInteractionActive',
     )
     const selectedViews = useEditorState(
       Substores.selectedViews,


### PR DESCRIPTION
**Problem:**
Canvas controls can 'blink' because we hide them on mouse down, not on drag-threshold-exceeded.

**Cause:**
The insertion controls were just checking if the interaction session was a non-null value, but that doesn't necessarily mean (in the case of a drag) that the interaction session is actually active.

**Fix:**
Instead of checking if the interaction session is non-null, a new utility function `interactionSessionIsActive` does the introspection of the session necessary to determine if the session is active. Then for any other cases where this need arises that function can be utilised.

**Commit Details:**
- `InsertionControls` now use `interactionSessionIsActive` to check if the interaction session is actively doing something.
- Added `interactionSessionIsActive` utility function.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #6151
