### PR TITLE
increasing flaky test timeout to 15000

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -413,7 +413,8 @@ describe('Select Mode Clicking', () => {
     checkFocusedPath(renderResult, desiredPaths[2])
     checkSelectedPaths(renderResult, [desiredPaths[2]])
   })
-  it('Single click and five double clicks will focus a generated Card and select the Button inside', async () => {
+  it('Single click and five double clicks will focus a generated Card and select the Button inside', async function (this: Mocha.Context) {
+    this.timeout(15000)
     // prettier-ignore
     const desiredPaths = createConsecutivePaths(
       'sb' +                 // Skipped as it's the storyboard
@@ -795,7 +796,8 @@ describe('Select Mode Double Clicking With Fragments', () => {
     checkFocusedPath(renderResult, desiredPaths[2])
     checkSelectedPaths(renderResult, [desiredPaths[2]])
   })
-  it('Single click and five double clicks will focus a generated Card and select the Button inside', async () => {
+  it('Single click and five double clicks will focus a generated Card and select the Button inside', async function (this: Mocha.Context) {
+    this.timeout(15000)
     // prettier-ignore
     const desiredPaths = createConsecutivePaths(
       'sb' +                  // Skipped as it's the storyboard


### PR DESCRIPTION
**Problem:**
the test `Single click and five double clicks will focus a generated Card and select the Button inside` started timing out possibly because of performance reasons.

**Fix:**
For now, increase the timeout from 10,000 to 15,000 for this test

**Commit Details:**

- I used a this parameter to make typescript not complain
