### PR TITLE
Do not allow internals of unfocused components to block selection

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -27,10 +27,11 @@ import {
   clearHoveredViews,
 } from '../../../editor/actions/action-creators'
 import { cancelInsertModeActions } from '../../../editor/actions/meta-actions'
-import type {
-  EditorState,
-  EditorStorePatched,
-  LockedElements,
+import {
+  getAllFocusedPaths,
+  type EditorState,
+  type EditorStorePatched,
+  type LockedElements,
 } from '../../../editor/store/editor-state'
 import { Substores, useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import CanvasActions from '../../canvas-actions'
@@ -316,10 +317,10 @@ export function useFindValidTarget(): (
       elementPathTree: store.editor.elementPathTree,
       allElementProps: store.editor.allElementProps,
       lockedElements: store.editor.lockedElements,
-      focusedPaths:
-        store.editor.focusedElementPath != null
-          ? [store.editor.focusedElementPath, ...store.derived.autoFocusedPaths]
-          : store.derived.autoFocusedPaths,
+      focusedPaths: getAllFocusedPaths(
+        store.editor.focusedElementPath,
+        store.derived.autoFocusedPaths,
+      ),
     }
   })
 

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -313,10 +313,13 @@ export function useFindValidTarget(): (
       hiddenInstances: store.editor.hiddenInstances,
       canvasScale: store.editor.canvas.scale,
       canvasOffset: store.editor.canvas.realCanvasOffset,
-      focusedElementPath: store.editor.focusedElementPath,
       elementPathTree: store.editor.elementPathTree,
       allElementProps: store.editor.allElementProps,
       lockedElements: store.editor.lockedElements,
+      focusedPaths:
+        store.editor.focusedElementPath != null
+          ? [store.editor.focusedElementPath, ...store.derived.autoFocusedPaths]
+          : store.derived.autoFocusedPaths,
     }
   })
 
@@ -335,6 +338,7 @@ export function useFindValidTarget(): (
         elementPathTree,
         allElementProps,
         lockedElements,
+        focusedPaths,
       } = storeRef.current
       const validElementMouseOver: ElementPath | null = (() => {
         if (preferAlreadySelected === 'prefer-selected') {
@@ -349,6 +353,7 @@ export function useFindValidTarget(): (
             elementPathTree,
             allElementProps,
             lockedElements,
+            focusedPaths,
           )
         }
         const newSelection = getValidTargetAtPoint(
@@ -358,6 +363,7 @@ export function useFindValidTarget(): (
           canvasOffset,
           componentMetadata,
           lockedElements,
+          focusedPaths,
         )
         if (newSelection != null) {
           return newSelection
@@ -373,6 +379,7 @@ export function useFindValidTarget(): (
           elementPathTree,
           allElementProps,
           lockedElements,
+          focusedPaths,
         )
       })()
 

--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -1842,7 +1842,7 @@ const Foo = (props) => {
     // can't select props child because it is covered by the internal child and grandchild
     expect(renderResult.getEditorState().editor.selectedViews).toEqual([InternalGrandChild])
   })
-  it('In not locked the unfocused component with overlapping internals is selected instead of the props child', async () => {
+  it('In an unfocused component the internals always behave as locked (and the props child is selected not the overlapping internals)', async () => {
     const renderResult = await renderTestEditorWithCode(
       LockingTestProjectWithComponent,
       'await-first-dom-report',
@@ -1854,8 +1854,8 @@ const Foo = (props) => {
 
     await mouseClickAtPoint(canvasControlsLayer, propsChildCenter, { modifiers: cmdModifier })
 
-    // can't select props child because it is covered by the unlocked internals of the component
-    expect(renderResult.getEditorState().editor.selectedViews).toEqual([FooPath])
+    // can select props child even though it is covered by the unlocked internals of the component
+    expect(renderResult.getEditorState().editor.selectedViews).toEqual([PropsChildPath])
   })
 
   it('When the internal grandchild is locked, its internal parent is selected instead of the props child, because it is unlocked and covers props child', async () => {

--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -1825,7 +1825,7 @@ const Foo = (props) => {
     ['Foo_root_div', 'Foo_internal_child', 'Foo_internal_grandchild'],
   ])
 
-  it('In not locked case overlapping internal child is selected instead of the props child', async () => {
+  it('In a focused component, not locked overlapping internal child is selected instead of the props child', async () => {
     const renderResult = await renderTestEditorWithCode(
       LockingTestProjectWithComponent,
       'await-first-dom-report',
@@ -1842,7 +1842,7 @@ const Foo = (props) => {
     // can't select props child because it is covered by the internal child and grandchild
     expect(renderResult.getEditorState().editor.selectedViews).toEqual([InternalGrandChild])
   })
-  it('In an unfocused component the internals always behave as locked (and the props child is selected not the overlapping internals)', async () => {
+  it('In an unfocused component, the internals always behave as locked (and the props child is selected not the overlapping internals)', async () => {
     const renderResult = await renderTestEditorWithCode(
       LockingTestProjectWithComponent,
       'await-first-dom-report',

--- a/editor/src/components/canvas/controls/selection-area-helpers.ts
+++ b/editor/src/components/canvas/controls/selection-area-helpers.ts
@@ -61,6 +61,7 @@ export const filterUnderSelectionArea = (
   area: CanvasRectangle | null,
   selectedViews: ElementPath[],
   lockedElements: LockedElements,
+  focusedPaths: Array<ElementPath>,
 ): ElementPath[] => {
   if (area == null) {
     return []
@@ -127,6 +128,7 @@ export const filterUnderSelectionArea = (
           element.frame,
           element.selected,
           lockedElements,
+          focusedPaths,
         )
       }
       return true
@@ -172,6 +174,7 @@ function isElementIntersactionActuallyUnderAreaAndVisible(
   frame: CanvasRectangle | null,
   isSelected: boolean,
   lockedElements: LockedElements,
+  focusedPaths: Array<ElementPath>,
 ): boolean {
   if (area != null && frame != null && isFiniteRectangle(frame)) {
     const intersect = rectangleIntersection(area, frame)
@@ -196,6 +199,7 @@ function isElementIntersactionActuallyUnderAreaAndVisible(
       canvasOffset,
       jsxMetadata,
       lockedElements,
+      focusedPaths,
     ).some((other) => EP.pathsEqual(path, other))
     if (!pathActuallyUnderArea) {
       return false

--- a/editor/src/components/canvas/controls/selection-area-hooks.tsx
+++ b/editor/src/components/canvas/controls/selection-area-hooks.tsx
@@ -21,6 +21,7 @@ import {
   getSelectionAreaRenderedRect,
   isValidMouseEventForSelectionArea,
 } from './selection-area-helpers'
+import { getAllFocusedPaths } from '../../editor/store/editor-state'
 
 export function useSelectionArea(
   ref: React.MutableRefObject<HTMLDivElement | null>,
@@ -45,10 +46,10 @@ export function useSelectionArea(
       interactionSession: store.editor.canvas.interactionSession,
       keysPressed: store.editor.keysPressed,
       lockedElements: store.editor.lockedElements,
-      focusedPaths:
-        store.editor.focusedElementPath != null
-          ? [store.editor.focusedElementPath, ...store.derived.autoFocusedPaths]
-          : store.derived.autoFocusedPaths,
+      focusedPaths: getAllFocusedPaths(
+        store.editor.focusedElementPath,
+        store.derived.autoFocusedPaths,
+      ),
     }
   })
 

--- a/editor/src/components/canvas/controls/selection-area-hooks.tsx
+++ b/editor/src/components/canvas/controls/selection-area-hooks.tsx
@@ -45,6 +45,10 @@ export function useSelectionArea(
       interactionSession: store.editor.canvas.interactionSession,
       keysPressed: store.editor.keysPressed,
       lockedElements: store.editor.lockedElements,
+      focusedPaths:
+        store.editor.focusedElementPath != null
+          ? [store.editor.focusedElementPath, ...store.derived.autoFocusedPaths]
+          : store.derived.autoFocusedPaths,
     }
   })
 
@@ -95,6 +99,7 @@ export function useSelectionArea(
         area,
         localSelectedViews,
         storeRef.current.lockedElements,
+        storeRef.current.focusedPaths,
       )
     },
     [storeRef, localSelectedViews, getSelectableViews],

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -110,14 +110,14 @@ export function firstAncestorOrItselfWithValidElementPath(
   point: CanvasPoint,
   lockedElements: LockedElements,
   focusedPaths: Array<ElementPath>,
-): { path: ElementPath; locked: boolean } | null {
+): { path: ElementPath; originalIsUnselectable: boolean } | null {
   const staticAndDynamicTargetElementPaths = getStaticAndDynamicElementPathsForDomElement(target)
 
   if (staticAndDynamicTargetElementPaths.length === 0) {
     return null
   }
 
-  const isLocked = staticAndDynamicTargetElementPaths.every((p) => {
+  const originalIsUnselectable = staticAndDynamicTargetElementPaths.every((p) => {
     if (EP.containsPath(p.dynamic, lockedElements.simpleLock)) {
       return true
     }
@@ -233,7 +233,9 @@ export function firstAncestorOrItselfWithValidElementPath(
     }
   }
 
-  return resultPath == null ? null : { path: resultPath, locked: isLocked }
+  return resultPath == null
+    ? null
+    : { path: resultPath, originalIsUnselectable: originalIsUnselectable }
 }
 
 export function getValidTargetAtPoint(
@@ -331,7 +333,7 @@ function findFirstValidParentForSingleElementUncached(
     )
     if (p != null) {
       foundValidElementPath = p.path
-      if (!p.locked) {
+      if (!p.originalIsUnselectable) {
         break
       }
     }
@@ -474,7 +476,7 @@ function getSelectionOrFirstTargetAtPoint(
     )
     if (foundValidElementPath != null) {
       elementFromDOM = foundValidElementPath.path
-      if (!foundValidElementPath.locked) {
+      if (!foundValidElementPath.originalIsUnselectable) {
         break
       }
     }

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -109,6 +109,7 @@ export function firstAncestorOrItselfWithValidElementPath(
   metadata: ElementInstanceMetadataMap,
   point: CanvasPoint,
   lockedElements: LockedElements,
+  focusedPaths: Array<ElementPath>,
 ): { path: ElementPath; locked: boolean } | null {
   const staticAndDynamicTargetElementPaths = getStaticAndDynamicElementPathsForDomElement(target)
 
@@ -124,6 +125,13 @@ export function firstAncestorOrItselfWithValidElementPath(
       lockedElements.hierarchyLock.some((hierarchyLock) =>
         EP.isDescendantOfOrEqualTo(p.dynamic, hierarchyLock),
       )
+    ) {
+      return true
+    }
+    const containingComponent = EP.getContainingComponent(p.dynamic)
+    if (
+      containingComponent != null &&
+      !focusedPaths.some((c) => EP.pathsEqual(c, containingComponent))
     ) {
       return true
     }
@@ -233,6 +241,7 @@ export function getValidTargetAtPoint(
   canvasOffset: CanvasVector,
   metadata: ElementInstanceMetadataMap,
   lockedElements: LockedElements,
+  autofocusedPaths: Array<ElementPath>,
 ): ElementPath | null {
   if (point == null) {
     return null
@@ -251,6 +260,7 @@ export function getValidTargetAtPoint(
     metadata,
     pointOnCanvas,
     lockedElements,
+    autofocusedPaths,
   )
 }
 
@@ -261,6 +271,7 @@ export function getAllTargetsAtPoint(
   canvasOffset: CanvasVector,
   metadata: ElementInstanceMetadataMap,
   lockedElements: LockedElements,
+  focusedPaths: Array<ElementPath>,
 ): Array<ElementPath> {
   if (point == null) {
     return []
@@ -280,6 +291,7 @@ export function getAllTargetsAtPoint(
     metadata,
     pointOnCanvas,
     lockedElements,
+    focusedPaths,
   )
 }
 
@@ -294,6 +306,7 @@ function findFirstValidParentForSingleElementUncached(
   metadata: ElementInstanceMetadataMap,
   point: CanvasPoint,
   lockedElements: LockedElements,
+  autofocusedPaths: Array<ElementPath>,
 ) {
   const validPathsSet =
     validElementPathsForLookup == 'no-filter'
@@ -312,6 +325,7 @@ function findFirstValidParentForSingleElementUncached(
       metadata,
       point,
       lockedElements,
+      autofocusedPaths,
     )
     if (p != null) {
       foundValidElementPath = p.path
@@ -335,6 +349,7 @@ function findFirstValidParentsForAllElementsUncached(
   metadata: ElementInstanceMetadataMap,
   point: CanvasPoint,
   lockedElements: LockedElements,
+  focusedPaths: Array<ElementPath>,
 ): Array<ElementPath> {
   const validPathsSet =
     validElementPathsForLookup == 'no-filter'
@@ -351,6 +366,7 @@ function findFirstValidParentsForAllElementsUncached(
         metadata,
         point,
         lockedElements,
+        focusedPaths,
       )?.path
       if (foundValidElementPath != null) {
         return foundValidElementPath
@@ -373,6 +389,7 @@ export function getSelectionOrValidTargetAtPoint(
   elementPathTree: ElementPathTrees,
   allElementProps: AllElementProps,
   lockedElements: LockedElements,
+  focusedPaths: Array<ElementPath>,
 ): ElementPath | null {
   if (point == null) {
     return null
@@ -388,6 +405,7 @@ export function getSelectionOrValidTargetAtPoint(
     elementPathTree,
     allElementProps,
     lockedElements,
+    focusedPaths,
   )
   if (target === 'selection') {
     return selectedViews[0] ?? null
@@ -407,6 +425,7 @@ function getSelectionOrFirstTargetAtPoint(
   elementPathTree: ElementPathTrees,
   allElementProps: AllElementProps,
   lockedElements: LockedElements,
+  focusedPaths: Array<ElementPath>,
 ): 'selection' | ElementPath | null {
   if (point == null) {
     return null
@@ -449,6 +468,7 @@ function getSelectionOrFirstTargetAtPoint(
       componentMetadata,
       pointOnCanvas,
       lockedElements,
+      focusedPaths,
     )
     if (foundValidElementPath != null) {
       elementFromDOM = foundValidElementPath.path

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -243,7 +243,7 @@ export function getValidTargetAtPoint(
   canvasOffset: CanvasVector,
   metadata: ElementInstanceMetadataMap,
   lockedElements: LockedElements,
-  autofocusedPaths: Array<ElementPath>,
+  focusedPaths: Array<ElementPath>,
 ): ElementPath | null {
   if (point == null) {
     return null
@@ -262,7 +262,7 @@ export function getValidTargetAtPoint(
     metadata,
     pointOnCanvas,
     lockedElements,
-    autofocusedPaths,
+    focusedPaths,
   )
 }
 

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -128,6 +128,8 @@ export function firstAncestorOrItselfWithValidElementPath(
     ) {
       return true
     }
+
+    // when the containing component is not focused, we should consider the internals locked
     const containingComponent = EP.getContainingComponent(p.dynamic)
     if (
       !EP.isEmptyPath(containingComponent) &&

--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -130,7 +130,7 @@ export function firstAncestorOrItselfWithValidElementPath(
     }
     const containingComponent = EP.getContainingComponent(p.dynamic)
     if (
-      containingComponent != null &&
+      !EP.isEmptyPath(containingComponent) &&
       !focusedPaths.some((c) => EP.pathsEqual(c, containingComponent))
     ) {
       return true

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -301,6 +301,7 @@ export const EditorComponentInner = React.memo((props: EditorProps) => {
           event,
           editorStoreRef.current.editor,
           editorStoreRef.current.userState.loginState,
+          editorStoreRef.current.derived,
           editorStoreRef.current.projectServerState,
           metadataRef,
           navigatorTargetsRef,

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -106,7 +106,12 @@ import {
   COMMENT_SHORTCUT,
   CONVERT_TO_GRID_CONTAINER,
 } from './shortcut-definitions'
-import type { EditorState, LockedElements, NavigatorEntry } from './store/editor-state'
+import type {
+  DerivedState,
+  EditorState,
+  LockedElements,
+  NavigatorEntry,
+} from './store/editor-state'
 import { getOpenFile, RightMenuTab } from './store/editor-state'
 import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../utils/global-positions'
 import { pickColorWithEyeDropper } from '../canvas/canvas-utils'
@@ -354,6 +359,7 @@ export function handleKeyDown(
   event: KeyboardEvent,
   editor: EditorState,
   loginState: LoginState,
+  derived: DerivedState,
   projectServerState: ProjectServerState,
   metadataRef: { current: ElementInstanceMetadataMap },
   navigatorTargetsRef: { current: Array<NavigatorEntry> },
@@ -534,6 +540,9 @@ export function handleKeyDown(
             editor.canvas.realCanvasOffset,
             editor.jsxMetadata,
             editor.lockedElements,
+            editor.focusedElementPath != null
+              ? [editor.focusedElementPath, ...derived.autoFocusedPaths]
+              : derived.autoFocusedPaths,
           )
           const nextTarget = Canvas.getNextTarget(
             editor.jsxMetadata,

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -112,7 +112,7 @@ import type {
   LockedElements,
   NavigatorEntry,
 } from './store/editor-state'
-import { getOpenFile, RightMenuTab } from './store/editor-state'
+import { getAllFocusedPaths, getOpenFile, RightMenuTab } from './store/editor-state'
 import { CanvasMousePositionRaw, WindowMousePositionRaw } from '../../utils/global-positions'
 import { pickColorWithEyeDropper } from '../canvas/canvas-utils'
 import {
@@ -540,9 +540,7 @@ export function handleKeyDown(
             editor.canvas.realCanvasOffset,
             editor.jsxMetadata,
             editor.lockedElements,
-            editor.focusedElementPath != null
-              ? [editor.focusedElementPath, ...derived.autoFocusedPaths]
-              : derived.autoFocusedPaths,
+            getAllFocusedPaths(editor.focusedElementPath, derived.autoFocusedPaths),
           )
           const nextTarget = Canvas.getNextTarget(
             editor.jsxMetadata,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -3844,3 +3844,10 @@ export function getNewSceneName(editor: EditorState): string {
   // Fallback.
   return 'New Scene'
 }
+
+export function getAllFocusedPaths(
+  focusedElementPath: ElementPath | null,
+  autoFocusedPaths: Array<ElementPath>,
+): Array<ElementPath> {
+  return focusedElementPath != null ? [focusedElementPath, ...autoFocusedPaths] : autoFocusedPaths
+}

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -50,7 +50,6 @@ import { pointsEqual } from '../core/shared/math-utils'
 import { useDispatch } from './editor/store/dispatch-context'
 import { useCreateCallbackToShowComponentPicker } from './navigator/navigator-item/component-picker-context-menu'
 import { navigatorTargetsSelector, useGetNavigatorTargets } from './navigator/navigator-utils'
-import { auto } from '@twind/core'
 
 export type ElementContextMenuInstance =
   | 'context-menu-navigator'

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -50,6 +50,7 @@ import { pointsEqual } from '../core/shared/math-utils'
 import { useDispatch } from './editor/store/dispatch-context'
 import { useCreateCallbackToShowComponentPicker } from './navigator/navigator-item/component-picker-context-menu'
 import { navigatorTargetsSelector, useGetNavigatorTargets } from './navigator/navigator-utils'
+import { auto } from '@twind/core'
 
 export type ElementContextMenuInstance =
   | 'context-menu-navigator'
@@ -144,6 +145,7 @@ function useCanvasContextMenuItems(
                 data.canvasOffset,
                 data.jsxMetadata,
                 data.lockedElements,
+                data.autoFocusedPaths,
               )
               lastMousePosition = WindowMousePositionRaw
             }
@@ -203,6 +205,7 @@ function useCanvasContextMenuGetData(
       autoFocusedPaths: store.derived.autoFocusedPaths,
       propertyControlsInfo: store.editor.propertyControlsInfo,
       lockedElements: store.editor.lockedElements,
+      autofocusedPaths: store.derived.autoFocusedPaths,
     }
   })
   const navigatorTargetsRef = useRefEditorState(navigatorTargetsSelector)
@@ -232,6 +235,7 @@ function useCanvasContextMenuGetData(
       propertyControlsInfo: currentEditor.propertyControlsInfo,
       showComponentPicker: showComponentPicker,
       lockedElements: currentEditor.lockedElements,
+      autofocusedPaths: currentEditor.autoFocusedPaths,
     }
   }, [editorSliceRef, navigatorTargetsRef, contextMenuInstance, showComponentPicker])
 }


### PR DESCRIPTION
**Problem:**
Context for the issue:
https://github.com/concrete-utopia/utopia/issues/5964
This is a followup to https://github.com/concrete-utopia/utopia/pull/6158

The problem is described in detail in https://paper.dropbox.com/doc/Selecting-elements-behind-the-internals-of-a-component--CUe0YryzTscIUHWtRh8AkhOkAg-suXRgxCUQhvLKLjQTv16F

**Summary:**
Components sometimes render internal elements on top of renderable props. Typically our expectation is that we should be able to select the children from props.children on the canvas. Even if a component has some internals which cover those children, they should not block selection when the component is unfocused. Why? Because those internals are not selectable in an unfocused component. If you would like to edit the internals, you need to focus the component anyway.

The disadvantage of this solution is that it is hard to focus on a component in the canvas when its renderable props take up all of its bounds. To edit the component you need to focus it in the navigator, or using the context menu (and not with double click, which just selects a renderable prop).

**Fix:**
Check in dom-lookup if the found element from elementsFromPoint is an element from an unfocused component. If it is, treat it as if it was locked (and continue the algorithm described in https://github.com/concrete-utopia/utopia/pull/6158 )

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

**Possible followup task:**
Move autofocusedPaths out of derived state and make it a memoized function.

Fixes https://github.com/concrete-utopia/utopia/issues/5964
