### PR TITLE
Only deduplicate canvas controls if their keys match

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -619,7 +619,7 @@ export function useGetApplicableStrategyControls(): Array<ControlWithProps<unkno
       applicableControls = addAllUniquelyBy(
         applicableControls,
         strategyControls,
-        (l, r) => l.control === r.control,
+        (l, r) => l.control === r.control && l.key === r.key,
       )
     }
     // Special case controls.


### PR DESCRIPTION
## Problem
The canvas control deduplication logic only takes into account the control components. This can be problematic we want to render multiple instances of the same component (for example, multiple grid controls in https://github.com/concrete-utopia/utopia/pull/6203). With the current code, only one of each type of control is kept.

## Fix
When the uniqueness check is performed, take into account both the control component and the key supplied with the control. This way, multiple instances of the same control component can be rendered (provided their keys are unique, which for example can be done by including the strategy name and/or a selected element path in the key)