### PR TITLE
Grid move: fallback to prevent flicker

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -134,12 +134,15 @@ export function runGridRearrangeMove(
     canvasOffset,
   )
 
-  const newTargetCell = getTargetCell(
+  const targetCellUnderMouse = getTargetCell(
     customState.targetCell,
     canvasScale,
     duplicating,
     mouseWindowPoint,
   )?.gridCellCoordinates
+
+  // if there's no cell target under the mouse, try using the last known cell
+  const newTargetCell = targetCellUnderMouse ?? customState.targetCell ?? null
 
   if (newTargetCell == null) {
     return {


### PR DESCRIPTION
**Problem:**

When moving a grid element, if the mouse goes over a non-grid-target area the element will temporarily jump back to its original position, creating effectively a flicker effect during the interaction.

**Fix:**

If the cell under the mouse is not found, instead of bailing try to fallback to the last known valid cell target instead.

| Before | After |
|----------|------------|
| ![Kapture 2024-08-08 at 15 34 38](https://github.com/user-attachments/assets/2114618c-2782-4b87-9aba-ad043d3ddda3) | ![Kapture 2024-08-08 at 15 34 04](https://github.com/user-attachments/assets/cd21df54-f311-46f1-8ee5-14fe6215fa46) |


Fixes #6209 
