### PR TITLE
decouple dom-walker from canvas re-render

### DIFF
--- a/editor/src/components/editor/store/store-hook.ts
+++ b/editor/src/components/editor/store/store-hook.ts
@@ -2,7 +2,7 @@ import React from 'react'
 import type { EqualityChecker, Mutate, StoreApi, UseBoundStore } from 'zustand'
 import create from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
-import { shallowEqual } from '../../../core/shared/equality-utils'
+import { keysEquality, shallowEqual } from '../../../core/shared/equality-utils'
 import { objectMap } from '../../../core/shared/object-utils'
 import {
   MultiplayerSubstateKeepDeepEquality,
@@ -367,11 +367,4 @@ function tailoredEqualFunctions<K extends keyof Substates>(
   key: K,
 ) {
   return SubstateEqualityFns[key](oldEditorStore, editorStore)
-}
-
-function keyEquality<T>(key: keyof T, a: T, b: T): boolean {
-  return a[key] === b[key]
-}
-function keysEquality<T>(keys: ReadonlyArray<keyof T>, a: T, b: T): boolean {
-  return keys.every((key) => keyEquality(key, a, b))
 }

--- a/editor/src/core/shared/equality-utils.ts
+++ b/editor/src/core/shared/equality-utils.ts
@@ -71,3 +71,27 @@ export function keepReferenceIfShallowEqual<T>(original: T, maybeNew: T) {
     return maybeNew
   }
 }
+
+function keyEquality<T>(key: keyof T, a: T, b: T): boolean {
+  return a[key] === b[key]
+}
+
+export function keysEquality<T>(keys: ReadonlyArray<keyof T>, a: T, b: T): boolean {
+  return keys.every((key) => keyEquality(key, a, b))
+}
+
+type AtLeastOne<T> = [T, ...T[]]
+
+export const keysEqualityExhaustive =
+  <O extends { [key: string]: any }>() =>
+  <L1 extends AtLeastOne<keyof O>, L2 extends Array<Exclude<keyof O, L1[number]>>>(options: {
+    include: L1
+    exclude: L2 extends any
+      ? Exclude<keyof O, L1[number] | L2[number]> extends never
+        ? L2
+        : Exclude<keyof O, L1[number] | L2[number]>[]
+      : never
+  }) =>
+  (a: O, b: O): boolean => {
+    return keysEquality(options.include, a, b)
+  }

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -459,13 +459,13 @@ export class Editor {
 
       const reactRouterErrorPreviouslyLogged = hasReactRouterErrorBeenLogged()
 
-      const shouldRerender =
+      const shouldUpdateCanvasStore =
         !dispatchResult.nothingChanged &&
         !anyCodeAhead(dispatchResult.unpatchedEditor.projectContents)
 
       const updateId = canvasUpdateId++
-      if (shouldRerender) {
-        // TODO: not running this if nothing has changed in the result might give another performance benefit
+      if (shouldUpdateCanvasStore) {
+        // this will re-render the canvas root and potentially the canvas contents itself
         Measure.taskTime(`update canvas ${updateId}`, () => {
           const currentElementsToRender = fixElementsToRerender(
             this.storedState.patchedEditor.canvas.elementsToRerender,

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -457,10 +457,9 @@ export class Editor {
 
       const reactRouterErrorPreviouslyLogged = hasReactRouterErrorBeenLogged()
 
-      const runDomWalker = shouldRunDOMWalker(dispatchedActions, oldEditorState, this.storedState)
-
       const shouldRerender =
-        runDomWalker && !anyCodeAhead(dispatchResult.unpatchedEditor.projectContents)
+        !dispatchResult.nothingChanged &&
+        !anyCodeAhead(dispatchResult.unpatchedEditor.projectContents)
 
       const updateId = canvasUpdateId++
       if (shouldRerender) {
@@ -479,8 +478,10 @@ export class Editor {
         })
       }
 
+      const runDomWalker = shouldRunDOMWalker(dispatchedActions, oldEditorState, this.storedState)
+
       // run the dom-walker
-      if (shouldRerender || runDomWalker) {
+      if (runDomWalker) {
         const domWalkerDispatchResult = runDomWalkerAndSaveResults(
           this.boundDispatch,
           this.domWalkerMutableState,

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -47,6 +47,7 @@ import type {
   PersistentModel,
   ElementsToRerender,
   GithubRepoWithBranch,
+  EditorState,
 } from '../components/editor/store/editor-state'
 import {
   createEditorState,
@@ -134,6 +135,7 @@ import {
   traverseArray,
   traverseReadOnlyArray,
 } from '../core/shared/optics/optic-creators'
+import { keysEqualityExhaustive } from '../core/shared/equality-utils'
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()
@@ -846,7 +848,32 @@ export function shouldRunDOMWalker(
     patchedEditorBefore.nodeModules !== patchedEditorAfter.nodeModules ||
     patchedEditorBefore.selectedViews !== patchedEditorAfter.selectedViews ||
     patchedEditorBefore.focusedElementPath !== patchedEditorAfter.focusedElementPath ||
-    patchedEditorBefore.canvas !== patchedEditorAfter.canvas
+    !keysEqualityExhaustive<EditorState['canvas']>()({
+      include: [
+        'base64Blobs',
+        'canvasContentInvalidateCount',
+        'domWalkerAdditionalElementsToUpdate',
+        'domWalkerInvalidateCount',
+        'elementsToRerender',
+        'mountCount',
+        'scale',
+        'transientProperties',
+      ],
+      exclude: [
+        'controls',
+        'cursor',
+        'duplicationState',
+        'interactionSession',
+        'openFile',
+        'realCanvasOffset',
+        'resizeOptions',
+        'roundedCanvasOffset',
+        'scrollAnimation',
+        'selectionControlsVisible',
+        'snappingThreshold',
+        'textEditor',
+      ],
+    })(patchedEditorBefore.canvas, patchedEditorAfter.canvas)
 
   const patchedDerivedBefore = storeBefore.patchedDerived
   const patchedDerivedAfter = storeAfter.patchedDerived


### PR DESCRIPTION
**Problem:**
Today dom-walker runs when the canvas re-renders. But instead we want to be able to sometimes re-render the canvas and not run the dom-walker (when we scroll the canvas, for example), and sometimes we want to re-run the dom-walker but not re-render the canvas (when a `RUN_DOM_WALKER` action is dispatched)

**Fix:**
- Decouple `shouldRerender` and `runDomWalker`.
- Revert `shouldRerender` to how it was a few months ago: if anything in the dispatch result changes, re-render the canvas subtree. the Canvas code has enough internal memoization to be resilient
- `shouldRunDOMWalker` instead of checking the full EditorState.canvas, just checks a few important keys from it, most importantly, it does NOT check the scroll offset.
- We want to be able to check a few keys of an object but ensure that we provided an exhaustive list of what to check and what to deliberately ignore – because otherwise we may silently fail to check important new keys! To achieve this, I added a new `keysEqualityExhaustive` that uses some typescript dark magic.

**Warning**
These changes were made in the parts of the dispatch which is not testable by any of our test suites. (Something we should address in the future), so please help in being vigilant and looking for potential performance regressions this change might cause!