### PR TITLE
fix(inspector): keep opener icon when dropdown is open

### DIFF
--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -500,12 +500,11 @@ function AxisDimensionControl({
     <div
       key={`col-${value}-${index}`}
       style={{ display: 'flex', alignItems: 'center', gap: 6 }}
-      className={isOpen ? 'openMenu' : ''}
       css={{
         [`& > .${axisDropdownMenuButton}`]: {
-          visibility: 'hidden',
+          visibility: isOpen ? 'visible' : 'hidden',
         },
-        ':hover, &.openMenu': {
+        ':hover': {
           [`& > .${axisDropdownMenuButton}`]: {
             visibility: 'visible',
           },

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -430,14 +430,14 @@ const TemplateDimensionControl = React.memo(
     )
 
     const openDropdown = React.useCallback(
-      () => (
+      (isOpen: boolean) => (
         <SquareButton
           data-testid={'openDropdown'}
           highlight
           onClick={NO_OP}
           style={{ width: 12, height: 22 }}
         >
-          <Icons.Threedots />
+          <Icons.Threedots color={isOpen ? 'subdued' : undefined} />
         </SquareButton>
       ),
       [],
@@ -457,58 +457,91 @@ const TemplateDimensionControl = React.memo(
             <Icons.Plus width={12} height={12} onClick={onAdd} />
           </SquareButton>
         </div>
-        {values.map((value, index) => {
-          const testId = `grid-dimension-${axis}-${index}`
-          return (
-            <div
-              key={`col-${value}-${index}`}
-              style={{ display: 'flex', alignItems: 'center', gap: 6 }}
-              css={{
-                [`& > .${axisDropdownMenuButton}`]: {
-                  visibility: 'hidden',
-                },
-                ':hover': {
-                  [`& > .${axisDropdownMenuButton}`]: {
-                    visibility: 'visible',
-                  },
-                },
-              }}
-            >
-              <div style={{ display: 'flex', alignItems: 'center', gap: 6, flex: 1 }}>
-                <Subdued
-                  style={{
-                    width: 40,
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                  }}
-                  title={value.areaName ?? undefined}
-                >
-                  {value.areaName ?? index + 1}
-                </Subdued>
-                <NumberOrKeywordControl
-                  style={{ flex: 1 }}
-                  testId={testId}
-                  value={value.value}
-                  keywords={gridDimensionDropdownKeywords}
-                  keywordTypeCheck={isValidGridDimensionKeyword}
-                  onSubmitValue={onUpdate(index)}
-                  controlStatus={
-                    isGridCSSKeyword(value) && value.value.value === 'auto' ? 'off' : undefined
-                  }
-                />
-              </div>
-              <SquareButton className={axisDropdownMenuButton}>
-                <DropdownMenu align='end' items={dropdownMenuItems(index)} opener={openDropdown} />
-              </SquareButton>
-            </div>
-          )
-        })}
+        {values.map((value, index) => (
+          <AxisDimensionControl
+            key={index}
+            value={value}
+            index={index}
+            axis={axis}
+            onUpdate={onUpdate}
+            items={dropdownMenuItems(index)}
+            opener={openDropdown}
+          />
+        ))}
       </div>
     )
   },
 )
 TemplateDimensionControl.displayName = 'TemplateDimensionControl'
+
+function AxisDimensionControl({
+  value,
+  index,
+  items,
+  axis,
+  onUpdate,
+  opener,
+}: {
+  value: GridDimension
+  index: number
+  items: DropdownMenuItem[]
+  axis: 'column' | 'row'
+  onUpdate: (
+    index: number,
+  ) => (value: UnknownOrEmptyInput<CSSNumber | CSSKeyword<ValidGridDimensionKeyword>>) => void
+  opener: (isOpen: boolean) => React.ReactElement
+}) {
+  const testId = `grid-dimension-${axis}-${index}`
+  const [isOpen, setIsOpen] = React.useState(false)
+  const onOpenChange = React.useCallback((isDropdownOpen: boolean) => {
+    setIsOpen(isDropdownOpen)
+  }, [])
+  return (
+    <div
+      key={`col-${value}-${index}`}
+      style={{ display: 'flex', alignItems: 'center', gap: 6 }}
+      className={isOpen ? 'openMenu' : ''}
+      css={{
+        [`& > .${axisDropdownMenuButton}`]: {
+          visibility: 'hidden',
+        },
+        ':hover, &.openMenu': {
+          [`& > .${axisDropdownMenuButton}`]: {
+            visibility: 'visible',
+          },
+        },
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, flex: 1 }}>
+        <Subdued
+          style={{
+            width: 40,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+          title={value.areaName ?? undefined}
+        >
+          {value.areaName ?? index + 1}
+        </Subdued>
+        <NumberOrKeywordControl
+          style={{ flex: 1 }}
+          testId={testId}
+          value={value.value}
+          keywords={gridDimensionDropdownKeywords}
+          keywordTypeCheck={isValidGridDimensionKeyword}
+          onSubmitValue={onUpdate(index)}
+          controlStatus={
+            isGridCSSKeyword(value) && value.value.value === 'auto' ? 'off' : undefined
+          }
+        />
+      </div>
+      <SquareButton className={axisDropdownMenuButton}>
+        <DropdownMenu align='end' items={items} opener={opener} onOpenChange={onOpenChange} />
+      </SquareButton>
+    </div>
+  )
+}
 
 function removeTemplateValueAtIndex(
   original: GridContainerProperties,


### PR DESCRIPTION
**Problem:**
When a grid dropdown is open, its icon disappears
![Image](https://github.com/user-attachments/assets/4ad07d9d-66ef-453b-bda7-e8157fc8d571)

**Fix:**
The icon will stay and have a subdued color when the dropdown is open

<video src="https://github.com/user-attachments/assets/aca01425-2f69-4cbe-890c-f75449d9b982"></video>

**Commit Details:** 
- pass the open state to the icon opener
- take the open state into consideration for visibility

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode

Fixes #6164
