### PR TITLE
Allow setting the four-sides order for the split input control

### DIFF
--- a/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
+++ b/editor/src/components/inspector/sections/layout-section/layout-system-subsection/split-chained-number-input.tsx
@@ -129,6 +129,7 @@ export interface SplitChainedNumberInputProps<T> {
   values: SplitChainedNumberInputValues
   numberType: CSSNumberType
   eventHandler: SplitChainedNumberInputEventHandler
+  fourSidesOrder?: Array<SplitFourValueSide>
 }
 
 export type SplitChainedNumberInputEventHandler = (
@@ -160,6 +161,8 @@ export function getInitialMode(
 
 type CSSNumberOrNull = CSSNumber | null
 
+export type SplitFourValueSide = 'T' | 'R' | 'B' | 'L'
+
 export type FourValue =
   | { type: 'T'; value: CSSNumberOrNull }
   | { type: 'R'; value: CSSNumberOrNull }
@@ -174,7 +177,7 @@ export type SplitChainedEvent =
   | { type: 'four-value'; value: FourValue }
 
 export function splitChainedEventValueForProp(
-  prop: 'T' | 'R' | 'B' | 'L',
+  prop: SplitFourValueSide,
   e: SplitChainedEvent,
 ): CSSNumber | null {
   switch (e.type) {
@@ -456,7 +459,15 @@ const whenCSSNumber = (fn: (v: CSSNumber | null) => any) => (v: UnknownOrEmptyIn
 }
 
 export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInputProps<any>) => {
-  const { name, canvasControls, numberType, eventHandler, labels, values } = props
+  const {
+    name,
+    canvasControls,
+    numberType,
+    eventHandler,
+    labels,
+    values,
+    fourSidesOrder = ['T', 'R', 'L', 'B'],
+  } = props
 
   const setHoveredCanvasControls = useSetAtom(InspectorHoveredCanvasControls)
   const setFocusedCanvasControls = useSetAtom(InspectorFocusedCanvasControls)
@@ -600,8 +611,8 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
             },
           ]
         case 'per-side':
-          return [
-            {
+          const sides: Record<SplitFourValueSide, Omit<NumberInputProps, 'chained' | 'id'>> = {
+            T: {
               style: { width: '48%' },
               value: values.fourValue.top?.value,
               DEPRECATED_labelBelow: labels?.top ?? 'T',
@@ -619,7 +630,7 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
               },
               testId: `${name}-T`,
             },
-            {
+            R: {
               style: { width: '48%' },
               value: values.fourValue.right?.value,
               DEPRECATED_labelBelow: labels?.right ?? 'R',
@@ -637,7 +648,7 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
               },
               testId: `${name}-R`,
             },
-            {
+            L: {
               style: { width: '48%' },
               value: values.fourValue.left?.value,
               DEPRECATED_labelBelow: labels?.left ?? 'L',
@@ -655,7 +666,7 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
               },
               testId: `${name}-L`,
             },
-            {
+            B: {
               style: { width: '48%' },
               value: values.fourValue.bottom?.value,
               DEPRECATED_labelBelow: labels?.bottom ?? 'B',
@@ -673,7 +684,8 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
               },
               testId: `${name}-B`,
             },
-          ]
+          }
+          return fourSidesOrder.map((side) => sides[side])
         case null:
           return []
         default:
@@ -689,6 +701,7 @@ export const SplitChainedNumberInput = React.memo((props: SplitChainedNumberInpu
       eventHandler,
       props.mode,
       values,
+      fourSidesOrder,
     ])
 
   const tooltipTitle = React.useMemo(() => {

--- a/editor/src/components/inspector/sections/style-section/container-subsection/padding-row.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/padding-row.tsx
@@ -345,6 +345,7 @@ const PaddingControl = React.memo(() => {
       mode={modeToUse}
       onCycleMode={onCycleMode}
       values={values}
+      fourSidesOrder={['T', 'R', 'B', 'L']}
     />
   )
 })


### PR DESCRIPTION
**Problem:**
the order of the padding controls is incorrect, it follows the order of the border radius controls but should be a bit different.
this is the first part of #6140

**Fix:**
allow changing the order of the padding controls without changing the order of the border controls (passing it from outside)
![Image](https://github.com/user-attachments/assets/1a5b3abe-d710-4ee1-8a3c-615fb6b14133)

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode

Fixes #6220 that was extracted from #6140
