### PR TITLE
Handle Remix Config Errors

### DIFF
--- a/editor/src/components/canvas/controls/insert-mode/insert-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/insert-mode/insert-mode-hooks.tsx
@@ -7,6 +7,7 @@ import { useRefEditorState } from '../../../editor/store/store-hook'
 import type { MouseCallbacks } from '../select-mode/select-mode-hooks'
 import { useHighlightCallbacks } from '../select-mode/select-mode-hooks'
 import { property } from 'css-tree'
+import { defaultEither } from '../../../../core/shared/either'
 
 function useGetHighlightableViewsForInsertMode() {
   const storeRef = useRefEditorState((store) => {
@@ -18,7 +19,7 @@ function useGetHighlightableViewsForInsertMode() {
       openFile: store.editor.canvas.openFile?.filename ?? null,
       projectContents: store.editor.projectContents,
       nodeModules: store.editor.nodeModules.files,
-      remixRoutingTable: store.derived.remixData?.routingTable ?? null,
+      remixRoutingTable: defaultEither(null, store.derived.remixData)?.routingTable ?? null,
       resolve: resolveFn,
       propertyControlsInfo: store.editor.propertyControlsInfo,
     }

--- a/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
@@ -27,6 +27,7 @@ import { useUpdateRemixSceneRouteInLiveblocks } from '../../../../core/shared/mu
 import { MultiplayerWrapper } from '../../../../utils/multiplayer-wrapper'
 import { getIdOfScene } from '../comment-mode/comment-mode-hooks'
 import { optionalMap } from '../../../../core/shared/optional-utils'
+import { defaultEither } from '../../../../core/shared/either'
 
 export const RemixSceneLabelPathTestId = (path: ElementPath): string =>
   `${EP.toString(path)}-remix-scene-label-path`
@@ -58,7 +59,7 @@ export const RemixSceneLabelTestID = (path: ElementPath): string =>
 function useCurrentLocationMatchesRoutes(pathToRemixScene: ElementPath): boolean {
   const routes = useEditorState(
     Substores.derived,
-    (store) => store.derived.remixData?.routes ?? null,
+    (store) => defaultEither(null, store.derived.remixData)?.routes ?? null,
     'useCurrentLocationMatchesRoutes routes',
   )
   const [remixNavigationData] = useAtom(RemixNavigationAtom)

--- a/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
+++ b/editor/src/components/canvas/remix/remix-utils.spec.browser2.tsx
@@ -1,8 +1,10 @@
+import { defaultEither } from '../../../core/shared/either'
 import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
 import { StoryboardFilePath } from '../../editor/store/editor-state'
 import {
   CreateRemixDerivedDataRefsGLOBAL,
   REMIX_CONFIG_JS_PATH,
+  getDefaultedRemixRootDir,
   getRemixRootDir,
 } from '../../editor/store/remix-derived-data'
 import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
@@ -34,6 +36,13 @@ export var storyboard = (
 
 const remixConfigJsFromRemixDocs = `
 /** @type {import('@remix-run/dev').AppConfig} */
+module.exports = {
+  appDirectory: "src",
+};
+`
+const brokenRemixConfigJs = `
+/** @type {import('@remix-run/dev').AppConfig} */
+throw new Error('This is a broken remix config');
 module.exports = {
   appDirectory: "src",
 };
@@ -120,7 +129,10 @@ describe('Route manifest', () => {
     })
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
-    const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
+    const rootDir = getDefaultedRemixRootDir(
+      renderResult.getEditorState().editor.projectContents,
+      renderResult.getEditorState().editor.codeResultCache.curriedRequireFn,
+    )
     const rootFilePath =
       getRemixRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(
@@ -179,7 +191,10 @@ describe('Route manifest', () => {
     })
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
-    const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
+    const rootDir = getDefaultedRemixRootDir(
+      renderResult.getEditorState().editor.projectContents,
+      renderResult.getEditorState().editor.codeResultCache.curriedRequireFn,
+    )
     const rootFilePath =
       getRemixRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(
@@ -204,7 +219,10 @@ describe('Route manifest', () => {
     })
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
-    const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
+    const rootDir = getDefaultedRemixRootDir(
+      renderResult.getEditorState().editor.projectContents,
+      renderResult.getEditorState().editor.codeResultCache.curriedRequireFn,
+    )
     const rootFilePath =
       getRemixRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(
@@ -318,7 +336,10 @@ describe('Routes', () => {
     })
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
-    const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
+    const rootDir = getDefaultedRemixRootDir(
+      renderResult.getEditorState().editor.projectContents,
+      renderResult.getEditorState().editor.codeResultCache.curriedRequireFn,
+    )
     const rootFilePath =
       getRemixRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(
@@ -367,7 +388,7 @@ describe('Routes', () => {
 
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
-    const remixRoutes = renderResult.getEditorState().derived.remixData?.routes
+    const remixRoutes = defaultEither(null, renderResult.getEditorState().derived.remixData)?.routes
     expect(remixRoutes).toBeDefined()
 
     expect(remixRoutes).toHaveLength(1)
@@ -402,12 +423,23 @@ describe('Routes', () => {
 
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
-    const remixRoutes = renderResult.getEditorState().derived.remixData?.routes
+    const remixRoutes = defaultEither(null, renderResult.getEditorState().derived.remixData)?.routes
     expect(remixRoutes).toBeDefined()
 
     expect(remixRoutes).toHaveLength(1)
     expect(remixRoutes![0].id).toEqual('root')
     expect(remixRoutes![0].children).toHaveLength(1)
+  })
+  it('Handles a failure in the remix config', async () => {
+    const project = createModifiedProject({
+      [REMIX_CONFIG_JS_PATH]: brokenRemixConfigJs,
+      [StoryboardFilePath]: storyboardFileContent,
+      ['/src/root.js']: rootFileContentWithExportedStuff,
+      ['/src/routes/_index.js']: routeFileContent('Index route'),
+    })
+
+    const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
+    expect(renderResult.getEditorState().derived.remixData.type).toEqual('LEFT')
   })
   it('Parses different route dir', async () => {
     const project = createModifiedProject({
@@ -419,7 +451,7 @@ describe('Routes', () => {
 
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
-    const remixRoutes = renderResult.getEditorState().derived.remixData?.routes
+    const remixRoutes = defaultEither(null, renderResult.getEditorState().derived.remixData)?.routes
     expect(remixRoutes).toBeDefined()
 
     expect(remixRoutes).toHaveLength(1)
@@ -440,7 +472,10 @@ describe('Routes', () => {
     })
     const renderResult = await renderTestEditorWithModel(project, 'await-first-dom-report')
 
-    const rootDir = getRemixRootDir(renderResult.getEditorState().editor.projectContents)
+    const rootDir = getDefaultedRemixRootDir(
+      renderResult.getEditorState().editor.projectContents,
+      renderResult.getEditorState().editor.codeResultCache.curriedRequireFn,
+    )
     const rootFilePath =
       getRemixRootFile(rootDir, renderResult.getEditorState().editor.projectContents)?.path ?? ''
     const remixManifest = createRouteManifestFromProjectContents(

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -20,6 +20,7 @@ import {
   flatMapEither,
   foldEither,
   forEachRight,
+  isLeft,
   isRight,
   left,
   right,
@@ -505,18 +506,26 @@ export const UiJsxCanvas = React.memo<UiJsxCanvasPropsWithErrorCallback>((props)
 
   const [remixNavigationState] = useAtom(RemixNavigationAtom)
 
-  const getRemixPathValidationContext = (path: ElementPath): RemixValidPathsGenerationContext =>
-    remixDerivedDataRef.current == null
-      ? { type: 'inactive' }
-      : {
+  const getRemixPathValidationContext = (path: ElementPath): RemixValidPathsGenerationContext => {
+    if (isLeft(remixDerivedDataRef.current)) {
+      return { type: 'inactive' }
+    } else {
+      const remixData = remixDerivedDataRef.current.value
+      if (remixData == null) {
+        return { type: 'inactive' }
+      } else {
+        return {
           type: 'active',
-          routeModulesToRelativePaths: remixDerivedDataRef.current.routeModulesToRelativePaths,
+          routeModulesToRelativePaths: remixData.routeModulesToRelativePaths,
           currentlyRenderedRouteModules:
             matchRoutes(
-              remixDerivedDataRef.current.routes,
+              remixData.routes,
               remixNavigationState[EP.toString(path)]?.location ?? '/',
             )?.map((p) => p.route) ?? [],
         }
+      }
+    }
+  }
 
   const {
     StoryboardRootComponent,

--- a/editor/src/components/editor/actions/actions.spec.tsx
+++ b/editor/src/components/editor/actions/actions.spec.tsx
@@ -995,7 +995,7 @@ describe('SET_FOCUSED_ELEMENT', () => {
   it('prevents focusing a non-focusable element', () => {
     const project = complexDefaultProjectPreParsed()
     let editorState = editorModelFromPersistentModel(project, NO_OP)
-    const derivedState = deriveState(editorState, null, 'unpatched', () => null)
+    const derivedState = deriveState(editorState, null, 'unpatched', () => right(null))
     const pathToFocus = EP.fromString('storyboard-entity/scene-1-entity/app-entity:app-outer-div')
     const underlyingElement = forceNotNull(
       'Should be able to find this.',
@@ -1238,6 +1238,7 @@ describe('replaceFilePath', () => {
       '/src/app.js',
       '/src/app2.js',
       editorState.projectContents,
+      editorState.codeResultCache.curriedRequireFn,
     )
     if (replaceResults.type === 'SUCCESS') {
       expect(replaceResults.updatedFiles).toMatchInlineSnapshot(`

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -182,7 +182,7 @@ import {
 } from '../../canvas/canvas-utils'
 import type { SetFocus } from '../../common/actions'
 import { openMenu } from '../../context-menu-side-effect'
-import type { CodeResultCache } from '../../custom-code/code-file'
+import type { CodeResultCache, CurriedUtopiaRequireFn } from '../../custom-code/code-file'
 import {
   codeCacheToBuildResult,
   generateCodeResultCache,
@@ -618,7 +618,7 @@ import {
 import type { FixUIDsState } from '../../../core/workers/parser-printer/uid-fix'
 import { fixTopLevelElementsUIDs } from '../../../core/workers/parser-printer/uid-fix'
 import { nextSelectedTab } from '../../navigator/left-pane/left-pane-utils'
-import { getRemixRootDir } from '../store/remix-derived-data'
+import { getDefaultedRemixRootDir, getRemixRootDir } from '../store/remix-derived-data'
 import { isReplaceKeepChildrenAndStyleTarget } from '../../navigator/navigator-item/component-picker-context-menu'
 import { canCondenseJSXElementChild } from '../../../utils/can-condense'
 import { getNavigatorTargetsFromEditorState } from '../../navigator/navigator-utils'
@@ -1328,6 +1328,7 @@ export function replaceFilePath(
   oldPath: string,
   newPath: string,
   projectContentsTree: ProjectContentTreeRoot,
+  curriedRequireFn: CurriedUtopiaRequireFn,
 ): ReplaceFilePathResult {
   // FIXME: Reimplement this in a way that doesn't require converting to and from `ProjectContents`.
   const projectContents = treeToContents(projectContentsTree)
@@ -1338,7 +1339,7 @@ export function replaceFilePath(
   }
   let updatedFiles: Array<{ oldPath: string; newPath: string }> = []
 
-  const remixRootDir = getRemixRootDir(projectContentsTree)
+  const remixRootDir = getDefaultedRemixRootDir(projectContentsTree, curriedRequireFn)
 
   let renamedOptionalPrefix = false
   Utils.fastForEach(Object.keys(projectContents), (filename) => {
@@ -6488,6 +6489,7 @@ function updateFilePath(
     params.oldPath,
     params.newPath,
     editor.projectContents,
+    editor.codeResultCache.curriedRequireFn,
   )
   if (replaceFilePathResults.type === 'FAILURE') {
     const toastAction = showToast(notice(replaceFilePathResults.errorMessage, 'ERROR', true))

--- a/editor/src/components/editor/history.spec.ts
+++ b/editor/src/components/editor/history.spec.ts
@@ -1,6 +1,7 @@
 import { add, baseAssetPromise, init, redo, undo } from './history'
 import { createEditorState, deriveState } from './store/editor-state'
 import { updateAssetFileName } from './server'
+import { right } from '../../core/shared/either'
 
 jest.mock('./server')
 
@@ -15,7 +16,7 @@ describe('history', () => {
         ...createEditorState(() => {}),
         id: 'testproject',
       }
-      const derivedState = deriveState(editorState, null, 'unpatched', () => null)
+      const derivedState = deriveState(editorState, null, 'unpatched', () => right(null))
       const stateHistory = init(editorState, derivedState)
       const updatedStateHistory = add(stateHistory, editorState, derivedState, [
         { filenameChangedFrom: 'thing.jpg', filenameChangedTo: 'otherthing.jpg' },
@@ -35,7 +36,7 @@ describe('history', () => {
         ...createEditorState(() => {}),
         id: 'testproject',
       }
-      const derivedState = deriveState(editorState, null, 'unpatched', () => null)
+      const derivedState = deriveState(editorState, null, 'unpatched', () => right(null))
       const stateHistory = init(editorState, derivedState)
       const updatedStateHistory = add(stateHistory, editorState, derivedState, [
         { filenameChangedFrom: 'thing.jpg', filenameChangedTo: 'otherthing.jpg' },
@@ -57,7 +58,7 @@ describe('history', () => {
         ...createEditorState(() => {}),
         id: 'testproject',
       }
-      const derivedState = deriveState(editorState, null, 'unpatched', () => null)
+      const derivedState = deriveState(editorState, null, 'unpatched', () => right(null))
       const stateHistory = init(editorState, derivedState)
       const updatedStateHistory = add(stateHistory, editorState, derivedState, [
         { filenameChangedFrom: 'thing.jpg', filenameChangedTo: 'otherthing.jpg' },

--- a/editor/src/components/editor/remix-navigation-bar.tsx
+++ b/editor/src/components/editor/remix-navigation-bar.tsx
@@ -17,7 +17,7 @@ import { matchPath, matchRoutes } from 'react-router'
 import { useDispatch } from './store/dispatch-context'
 import { showToast } from './actions/action-creators'
 import { notice } from '../common/notice'
-import { defaultEither } from '../../core/shared/either'
+import { defaultEither, foldEither } from '../../core/shared/either'
 import { getFeaturedRoutesFromPackageJSON } from '../../printer-parsers/html/external-resources-parser'
 
 export const RemixNavigationBarPathTestId = 'remix-navigation-bar-path'
@@ -41,7 +41,12 @@ export const RemixNavigationBar = React.memo(() => {
   const [activeRemixScene] = useAtom(ActiveRemixSceneAtom)
   const routes = useEditorState(
     Substores.derived,
-    (store) => store.derived.remixData?.routes ?? [],
+    (store) =>
+      foldEither(
+        () => [],
+        (remixData) => remixData?.routes ?? [],
+        store.derived.remixData,
+      ),
     'RemixNavigationBar routes',
   )
   const featuredRoutes = useEditorState(

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -191,6 +191,7 @@ import type { CommentFilterMode } from '../../inspector/sections/comment-section
 import type { Collaborator } from '../../../core/shared/multiplayer'
 import type { OnlineState } from '../online-status'
 import type { NavigatorRow } from '../../navigator/navigator-row'
+import type { FancyError } from 'src/core/shared/code-exec-utils'
 
 const ObjectPathImmutable: any = OPI
 
@@ -2429,7 +2430,7 @@ export interface DerivedState {
   elementWarnings: { [key: string]: ElementWarnings }
   projectContentsChecksums: FileChecksumsWithFile
   branchOriginContentsChecksums: FileChecksumsWithFile | null
-  remixData: RemixDerivedData | null
+  remixData: Either<FancyError, RemixDerivedData | null>
   filePathMappings: FilePathMappings
 }
 
@@ -2440,7 +2441,7 @@ function emptyDerivedState(editor: EditorState): DerivedState {
     elementWarnings: {},
     projectContentsChecksums: {},
     branchOriginContentsChecksums: {},
-    remixData: null,
+    remixData: right(null),
     filePathMappings: [],
   }
 }

--- a/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.spec.ts
@@ -63,6 +63,7 @@ import {
   unparsed,
 } from '../../../core/shared/project-file-types'
 import { regularNavigatorRow } from '../../navigator/navigator-row'
+import { right } from '../../../core/shared/either'
 
 describe('DerivedStateKeepDeepEquality', () => {
   const oldValue: DerivedState = {
@@ -93,7 +94,7 @@ describe('DerivedStateKeepDeepEquality', () => {
         ),
       },
     },
-    remixData: null,
+    remixData: right(null),
     filePathMappings: [],
   }
   const newSameValue: DerivedState = {
@@ -124,7 +125,7 @@ describe('DerivedStateKeepDeepEquality', () => {
         ),
       },
     },
-    remixData: null,
+    remixData: right(null),
     filePathMappings: [],
   }
   const newDifferentValue: DerivedState = {
@@ -155,7 +156,7 @@ describe('DerivedStateKeepDeepEquality', () => {
         ),
       },
     },
-    remixData: null,
+    remixData: right(null),
     filePathMappings: [],
   }
   it('same reference returns the same reference', () => {

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -965,7 +965,7 @@ export function DerivedStateKeepDeepEquality(): KeepDeepEqualityCall<DerivedStat
     (state) => state.branchOriginContentsChecksums,
     nullableDeepEquality(FileChecksumsWithFileKeepDeepEquality),
     (state) => state.remixData,
-    createCallWithTripleEquals(),
+    EitherKeepDeepEquality(createCallWithTripleEquals(), createCallWithTripleEquals()),
     (state) => state.filePathMappings,
     createCallWithShallowEquals(),
     (

--- a/editor/src/components/element-context-menu.tsx
+++ b/editor/src/components/element-context-menu.tsx
@@ -50,6 +50,7 @@ import { pointsEqual } from '../core/shared/math-utils'
 import { useDispatch } from './editor/store/dispatch-context'
 import { useCreateCallbackToShowComponentPicker } from './navigator/navigator-item/component-picker-context-menu'
 import { navigatorTargetsSelector, useGetNavigatorTargets } from './navigator/navigator-utils'
+import { foldEither } from '../core/shared/either'
 
 export type ElementContextMenuInstance =
   | 'context-menu-navigator'
@@ -192,7 +193,11 @@ function useCanvasContextMenuGetData(
       projectContents: store.editor.projectContents,
       filePathMappings: store.derived.filePathMappings,
       nodeModules: store.editor.nodeModules.files,
-      remixRoutingTable: store.derived.remixData?.routingTable ?? null,
+      remixRoutingTable: foldEither(
+        () => null,
+        (remixData) => remixData?.routingTable,
+        store.derived.remixData,
+      ),
       resolve: resolveFn,
       hiddenInstances: store.editor.hiddenInstances,
       scale: store.editor.canvas.scale,

--- a/editor/src/components/navigator/left-pane/pages-pane.tsx
+++ b/editor/src/components/navigator/left-pane/pages-pane.tsx
@@ -33,7 +33,7 @@ import {
   getFeaturedRoutesFromPackageJSON,
   getPageTemplatesFromPackageJSON,
 } from '../../../printer-parsers/html/external-resources-parser'
-import { defaultEither } from '../../../core/shared/either'
+import { defaultEither, foldEither } from '../../../core/shared/either'
 import { unless, when } from '../../../utils/react-conditionals'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import {
@@ -116,7 +116,14 @@ export const PagesPane = React.memo((props) => {
         }
         return result
       }
-      const routes = processRoutes(store.derived.remixData?.routes ?? [], '')
+      const routes = processRoutes(
+        foldEither(
+          () => [],
+          (remixData) => remixData?.routes ?? [],
+          store.derived.remixData,
+        ),
+        '',
+      )
       return routes
     },
     'PagesPane remixRoutes',


### PR DESCRIPTION
**Problem:**
Currently we have a simplistic way of executing the Remix config file which doesn't give it access to the project or any of the dependencies, so if the file uses those it just fails.

**Fix:**
The main fix was to use some of our existing logic for executing arbitrary code, so that the Remix config is run as close to any other project code as possible.

Additionally if an error occurs while running the config code it is recorded and displayed the same way as any other error is displayed on the canvas error overlay.

**Commit Details:**
- Refactored out `buildBaseExecutionScope` from the canvas code, so that it can be used when executing the Remix config.
- `DerivedState.remixData` is now an instance of `FancyError` or the remix derived data.
- Rewrote `getRemixRootDir` to have it execute the code similar to how any other code would be run. So that it can require dependencies and do anything like that it might need to.
- Added `getDefaultedRemixRootDir` to help with handling some cases that don't care about the error.
- `useReadOnlyRuntimeErrors` now pulls in the error from `remixData` if there is one.
- A few small fixes to handle the new type of `remixData`.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #6182
