### PR TITLE
Fix CDN usage in webWorkerExtensionHost

### DIFF
--- a/editor/vite.config.js
+++ b/editor/vite.config.js
@@ -6,6 +6,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve'
 
 export default defineConfig(({ mode }) => {
   const isDevEnv = mode === 'development'
+  const baseDomain = isDevEnv ? 'http://cdn.localhost:8000' : ''
   return {
     plugins: [
       isDevEnv && react(),
@@ -13,8 +14,8 @@ export default defineConfig(({ mode }) => {
         data: {
           VITE: true,
           UTOPIA_SHA: process.env.REACT_APP_COMMIT_HASH,
-          UTOPIA_DOMAIN: isDevEnv ? 'http://localhost:8000' : '',
-          VSCODE_DOMAIN: '${window.location.origin}',
+          UTOPIA_DOMAIN: isDevEnv ? baseDomain : '',
+          VSCODE_DOMAIN: baseDomain === '' ? '${window.location.origin}' : baseDomain,
         },
       }),
     ],
@@ -37,6 +38,7 @@ export default defineConfig(({ mode }) => {
         host: 'localhost',
         port: 8088,
       },
+      cors: false, // This is being set by the server, leading to double values if we don't explicitly disable it
     },
     base: '/editor/',
     resolve: {
@@ -53,7 +55,7 @@ export default defineConfig(({ mode }) => {
       'process.env.GOOGLE_WEB_FONTS_KEY': `"${process.env.GOOGLE_WEB_FONTS_KEY}"`,
       'process.env.REACT_APP_COMMIT_HASH': `"${process.env.REACT_APP_COMMIT_HASH}"`,
       'process.env.HMR': mode === 'development' ? 'true' : 'false',
-      'process.env.UTOPIA_DOMAIN': isDevEnv ? '"http://localhost:8000"' : '""',
+      'process.env.UTOPIA_DOMAIN': isDevEnv ? `"${baseDomain}"` : '""',
       'process.env.UTOPIA_SHA': `"${process.env.REACT_APP_COMMIT_HASH}"`,
     },
     optimizeDeps: {

--- a/editor/webpack.config.js
+++ b/editor/webpack.config.js
@@ -51,7 +51,7 @@ const BaseDomain = isProd
   ? 'https://cdn.utopia.pizza'
   : isBranches
   ? 'https://cdn.utopia.fish'
-  : ''
+  : 'http://cdn.localhost:8000'
 const VSCodeBaseDomain = BaseDomain === '' ? '${window.location.origin}' : BaseDomain
 
 const htmlTemplateParameters = {

--- a/server/src/Utopia/Web/Executors/Development.hs
+++ b/server/src/Utopia/Web/Executors/Development.hs
@@ -133,7 +133,7 @@ localAuthCodeCheck "logmein" action = do
   pool <- fmap _projectPool ask
   metrics <- fmap _databaseMetrics ask
   portOfServer <- fmap _serverPort ask
-  let cdnRoot = "http://localhost:" <> show portOfServer
+  let cdnRoot = "http://cdn.localhost:" <> show portOfServer
   successfulAuthCheck metrics pool sessionStore action $ dummyUser cdnRoot
 localAuthCodeCheck _ action = do
   return $ action Nothing
@@ -172,7 +172,7 @@ innerServerExecutor (CheckAuthCode authCode action) = do
   pool <- fmap _projectPool ask
   metrics <- fmap _databaseMetrics ask
   portOfServer <- fmap _serverPort ask
-  let cdnRoot = "http://localhost:" <> show portOfServer
+  let cdnRoot = "http://cdn.localhost:" <> show portOfServer
   let codeCheck = maybe localAuthCodeCheck (auth0CodeCheck metrics pool sessionStore) auth0
   case authCode of
     "alice" -> successfulAuthCheck metrics pool sessionStore action (dummyUserAlice cdnRoot)
@@ -314,7 +314,7 @@ innerServerExecutor (GetSiteRoot action) = do
   return $ action siteRoot
 innerServerExecutor (GetCDNRoot action) = do
   portOfServer <- fmap _serverPort ask
-  let siteRoot = "http://localhost:" <> show portOfServer
+  let siteRoot = "http://cdn.localhost:" <> show portOfServer
   return $ action siteRoot
 innerServerExecutor (GetPathToServe defaultPathToServe possibleBranchName action) = do
   possibleDownloads <- fmap _branchDownloads ask

--- a/utopia-remix/app/env.server.ts
+++ b/utopia-remix/app/env.server.ts
@@ -49,7 +49,7 @@ export type BrowserEnvironmentType = {
 
 export const BrowserEnvironment: BrowserEnvironmentType = {
   EDITOR_URL: mustEnvOrLocalFallback('EDITOR_URL', 'http://localhost:8000'),
-  UTOPIA_CDN_URL: mustEnvOrLocalFallback('UTOPIA_CDN_URL', 'http://localhost:8000'),
+  UTOPIA_CDN_URL: mustEnvOrLocalFallback('UTOPIA_CDN_URL', 'http://cdn.localhost:8000'),
 }
 
 /**

--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -141,25 +141,8 @@ function didClose(path: string): DidClose {
 
 type SubscriptionWork = UpdateDirtyContentChange | DidChangeTextChange | WillSaveText | DidClose
 let pendingWork: Array<SubscriptionWork> = []
-let pendingWorkHandle: number
 
-function pushWorkToQueue(work: SubscriptionWork) {
-  pendingWork.push(work)
-
-  if (pendingWorkHandle != null) {
-    clearTimeout(pendingWorkHandle)
-  }
-
-  pendingWorkHandle = setTimeout(() => {
-    const minimisedWork = minimisePendingWork()
-    pendingWork = []
-    for (const innerWork of minimisedWork) {
-      doSubscriptionWork(innerWork)
-    }
-  }, 5)
-}
-
-function minimisePendingWork(): Array<SubscriptionWork> {
+function minimisePendingWork(): void {
   let newPendingWork: Array<SubscriptionWork> = []
   for (const workItem of pendingWork) {
     const latestWorkItem = newPendingWork[newPendingWork.length - 1]
@@ -178,7 +161,7 @@ function minimisePendingWork(): Array<SubscriptionWork> {
       newPendingWork.push(workItem)
     }
   }
-  return newPendingWork
+  pendingWork = newPendingWork
 }
 
 function doSubscriptionWork(work: SubscriptionWork) {
@@ -234,6 +217,22 @@ function doSubscriptionWork(work: SubscriptionWork) {
   }
 }
 
+const SUBSCRIPTION_POLLING_TIMEOUT = 100
+
+function runPendingSubscriptionChanges() {
+  minimisePendingWork()
+  for (const work of pendingWork) {
+    doSubscriptionWork(work)
+  }
+
+  pendingWork = []
+
+  // TODO should we still do it like this, or instead follow the pattern used by queueEvents?
+  setTimeout(runPendingSubscriptionChanges, SUBSCRIPTION_POLLING_TIMEOUT)
+}
+
+setTimeout(runPendingSubscriptionChanges, SUBSCRIPTION_POLLING_TIMEOUT)
+
 function watchForChangesFromVSCode(context: vscode.ExtensionContext, projectID: string) {
   function isUtopiaDocument(document: vscode.TextDocument): boolean {
     return document.uri.scheme === projectID
@@ -244,13 +243,13 @@ function watchForChangesFromVSCode(context: vscode.ExtensionContext, projectID: 
       if (isUtopiaDocument(event.document)) {
         const resource = event.document.uri
         const path = resource.path
-        pushWorkToQueue(didChangeTextChange(path, event))
+        pendingWork.push(didChangeTextChange(path, event))
       }
     }),
     vscode.workspace.onWillSaveTextDocument((event) => {
       if (isUtopiaDocument(event.document)) {
         const path = event.document.uri.path
-        pushWorkToQueue(willSaveText(path, event))
+        pendingWork.push(willSaveText(path, event))
         if (event.reason === vscode.TextDocumentSaveReason.Manual) {
           const formattedCode = applyPrettier(event.document.getText(), false).formatted
           event.waitUntil(Promise.resolve([new vscode.TextEdit(entireDocRange(), formattedCode)]))
@@ -260,13 +259,13 @@ function watchForChangesFromVSCode(context: vscode.ExtensionContext, projectID: 
     vscode.workspace.onDidCloseTextDocument((document) => {
       if (isUtopiaDocument(document)) {
         const path = document.uri.path
-        pushWorkToQueue(didClose(path))
+        pendingWork.push(didClose(path))
       }
     }),
     vscode.workspace.onDidOpenTextDocument((document) => {
       if (isUtopiaDocument(document)) {
         const path = document.uri.path
-        pushWorkToQueue(updateDirtyContentChange(path, document.uri))
+        pendingWork.push(updateDirtyContentChange(path, document.uri))
       }
     }),
   )
@@ -317,92 +316,6 @@ function sendMessageToUtopia(message: FromVSCodeToUtopiaMessage): void {
   vscode.commands.executeCommand('utopia.toUtopiaMessage', message)
 }
 
-function handleFromUtopiaToVSCodeMessage(
-  message: FromUtopiaToVSCodeMessage,
-  workspaceRootUri: vscode.Uri,
-  utopiaFS: UtopiaFSExtension,
-) {
-  switch (message.type) {
-    case 'INIT_PROJECT':
-      const { projectContents, openFilePath } = message
-      for (const projectFile of projectContents) {
-        utopiaFS.writeProjectFile(projectFile)
-        if (projectFile.type === 'PROJECT_TEXT_FILE' && projectFile.unsavedContent != null) {
-          updateDirtyContent(vscode.Uri.joinPath(workspaceRootUri, projectFile.filePath))
-        }
-      }
-      if (openFilePath != null) {
-        openFile(vscode.Uri.joinPath(workspaceRootUri, openFilePath))
-      } else {
-        sendMessageToUtopia(clearLoadingScreen())
-      }
-
-      sendMessageToUtopia(vsCodeReady()) // FIXME do we need both?
-      sendFullConfigToUtopia()
-      sendMessageToUtopia(vsCodeBridgeReady())
-      break
-    case 'WRITE_PROJECT_FILE':
-      const { projectFile } = message
-      utopiaFS.writeProjectFile(projectFile)
-      if (projectFile.type === 'PROJECT_TEXT_FILE') {
-        const fileUri = vscode.Uri.joinPath(workspaceRootUri, projectFile.filePath)
-        if (projectFile.unsavedContent == null) {
-          clearDirtyFlags(fileUri)
-        } else {
-          updateDirtyContent(fileUri)
-        }
-      }
-      break
-    case 'DELETE_PATH':
-      utopiaFS.silentDelete(message.fullPath, { recursive: message.recursive })
-      break
-    case 'ENSURE_DIRECTORY_EXISTS':
-      utopiaFS.ensureDirectoryExists(message.fullPath)
-      break
-    case 'OPEN_FILE':
-      if (message.bounds != null) {
-        revealRangeIfPossible(workspaceRootUri, {
-          ...message.bounds,
-          filePath: message.filePath,
-        })
-      } else {
-        openFile(vscode.Uri.joinPath(workspaceRootUri, message.filePath))
-      }
-      break
-    case 'UPDATE_DECORATIONS':
-      currentDecorations = message.decorations
-      updateDecorations(currentDecorations)
-      break
-    case 'SELECTED_ELEMENT_CHANGED':
-      const followSelectionEnabled = getFollowSelectionEnabledConfig()
-      const shouldFollowSelection =
-        followSelectionEnabled &&
-        (shouldFollowSelectionWithActiveFile() || message.forceNavigation === 'force-navigation')
-      if (shouldFollowSelection) {
-        currentSelection = message.boundsInFile
-        revealRangeIfPossible(workspaceRootUri, message.boundsInFile)
-      }
-      break
-    case 'GET_UTOPIA_VSCODE_CONFIG':
-      sendFullConfigToUtopia()
-      break
-    case 'SET_FOLLOW_SELECTION_CONFIG':
-      vscode.workspace
-        .getConfiguration()
-        .update(FollowSelectionConfigKey, message.enabled, vscode.ConfigurationTarget.Workspace)
-      break
-    case 'SET_VSCODE_THEME':
-      vscode.workspace.getConfiguration().update('workbench.colorTheme', message.theme, true)
-      break
-    case 'UTOPIA_READY':
-      sendMessageToUtopia(vsCodeReady())
-      break
-    default:
-      const _exhaustiveCheck: never = message
-      console.error(`Unhandled message type ${JSON.stringify(message)}`)
-  }
-}
-
 function initMessaging(
   context: vscode.ExtensionContext,
   workspaceRootUri: vscode.Uri,
@@ -411,8 +324,92 @@ function initMessaging(
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'utopia.toVSCodeMessage',
-      (message: FromUtopiaToVSCodeMessage) =>
-        handleFromUtopiaToVSCodeMessage(message, workspaceRootUri, utopiaFS),
+      (message: FromUtopiaToVSCodeMessage) => {
+        switch (message.type) {
+          case 'INIT_PROJECT':
+            const { projectContents, openFilePath } = message
+            for (const projectFile of projectContents) {
+              utopiaFS.writeProjectFile(projectFile)
+              if (projectFile.type === 'PROJECT_TEXT_FILE' && projectFile.unsavedContent != null) {
+                updateDirtyContent(vscode.Uri.joinPath(workspaceRootUri, projectFile.filePath))
+              }
+            }
+            if (openFilePath != null) {
+              openFile(vscode.Uri.joinPath(workspaceRootUri, openFilePath))
+            } else {
+              sendMessageToUtopia(clearLoadingScreen())
+            }
+
+            sendMessageToUtopia(vsCodeReady()) // FIXME do we need both?
+            sendFullConfigToUtopia()
+            sendMessageToUtopia(vsCodeBridgeReady())
+            break
+          case 'WRITE_PROJECT_FILE':
+            const { projectFile } = message
+            utopiaFS.writeProjectFile(projectFile)
+            if (projectFile.type === 'PROJECT_TEXT_FILE') {
+              const fileUri = vscode.Uri.joinPath(workspaceRootUri, projectFile.filePath)
+              if (projectFile.unsavedContent == null) {
+                clearDirtyFlags(fileUri)
+              } else {
+                updateDirtyContent(fileUri)
+              }
+            }
+            break
+          case 'DELETE_PATH':
+            utopiaFS.silentDelete(message.fullPath, { recursive: message.recursive })
+            break
+          case 'ENSURE_DIRECTORY_EXISTS':
+            utopiaFS.ensureDirectoryExists(message.fullPath)
+            break
+          case 'OPEN_FILE':
+            if (message.bounds != null) {
+              revealRangeIfPossible(workspaceRootUri, {
+                ...message.bounds,
+                filePath: message.filePath,
+              })
+            } else {
+              openFile(vscode.Uri.joinPath(workspaceRootUri, message.filePath))
+            }
+            break
+          case 'UPDATE_DECORATIONS':
+            currentDecorations = message.decorations
+            updateDecorations(currentDecorations)
+            break
+          case 'SELECTED_ELEMENT_CHANGED':
+            const followSelectionEnabled = getFollowSelectionEnabledConfig()
+            const shouldFollowSelection =
+              followSelectionEnabled &&
+              (shouldFollowSelectionWithActiveFile() ||
+                message.forceNavigation === 'force-navigation')
+            if (shouldFollowSelection) {
+              currentSelection = message.boundsInFile
+              revealRangeIfPossible(workspaceRootUri, message.boundsInFile)
+            }
+            break
+          case 'GET_UTOPIA_VSCODE_CONFIG':
+            sendFullConfigToUtopia()
+            break
+          case 'SET_FOLLOW_SELECTION_CONFIG':
+            vscode.workspace
+              .getConfiguration()
+              .update(
+                FollowSelectionConfigKey,
+                message.enabled,
+                vscode.ConfigurationTarget.Workspace,
+              )
+            break
+          case 'SET_VSCODE_THEME':
+            vscode.workspace.getConfiguration().update('workbench.colorTheme', message.theme, true)
+            break
+          case 'UTOPIA_READY':
+            sendMessageToUtopia(vsCodeReady())
+            break
+          default:
+            const _exhaustiveCheck: never = message
+            console.error(`Unhandled message type ${JSON.stringify(message)}`)
+        }
+      },
     ),
   )
 

--- a/vscode-build/vscode.patch
+++ b/vscode-build/vscode.patch
@@ -965,7 +965,7 @@ index ae4d22c9eaa..e342fb223d8 100644
  			},
  			'zenMode.restore': {
 diff --git a/src/vs/workbench/browser/workbench.ts b/src/vs/workbench/browser/workbench.ts
-index b0688133537..28862dfb4e8 100644
+index b0688133537..4353093fd5b 100644
 --- a/src/vs/workbench/browser/workbench.ts
 +++ b/src/vs/workbench/browser/workbench.ts
 @@ -50,6 +50,8 @@ import { AccessibilityProgressSignalScheduler } from 'vs/platform/accessibilityS
@@ -977,10 +977,16 @@ index b0688133537..28862dfb4e8 100644
  
  export interface IWorkbenchOptions {
  
-@@ -193,6 +195,19 @@ export class Workbench extends Layout {
+@@ -193,6 +195,37 @@ export class Workbench extends Layout {
  				this.restore(lifecycleService);
  			});
  
++			// Chain off of the previous one to ensure the ordering of changes is maintained.
++			// FIXME Do we still need this?
++			let applyProjectChangesCoordinator: Promise<void> = Promise.resolve()
++
++			let intervalID: number | null = null
++
 +			mainWindow.addEventListener('message', (messageEvent: MessageEvent) => {
 +				const { data } = messageEvent;
 +				if (isFromUtopiaToVSCodeMessage(data)) {
@@ -988,12 +994,24 @@ index b0688133537..28862dfb4e8 100644
 +					if (commandService == null) {
 +						console.error(`There is no command service`);
 +					} else {
-+						(commandService as ICommandService).executeCommand('utopia.toVSCodeMessage', data);
++						if (intervalID != null) {
++							window.clearInterval(intervalID)
++						}
++						applyProjectChangesCoordinator = applyProjectChangesCoordinator.then(async () => {
++							(commandService as ICommandService).executeCommand('utopia.toVSCodeMessage', data);
++						})
 +					}
 +				}
 +			});
 +
-+			window.top?.postMessage(messageListenersReady(), '*')
++			intervalID = window.setInterval(() => {
++				try {
++					window.top?.postMessage(messageListenersReady(), '*')
++				} catch (error) {
++					console.error('Error posting messageListenersReady', error)
++				}
++			}, 500)
++
  			return instantiationService;
  		} catch (error) {
  			onUnexpectedError(error);

--- a/vscode-build/vscode.patch
+++ b/vscode-build/vscode.patch
@@ -965,7 +965,7 @@ index ae4d22c9eaa..e342fb223d8 100644
  			},
  			'zenMode.restore': {
 diff --git a/src/vs/workbench/browser/workbench.ts b/src/vs/workbench/browser/workbench.ts
-index b0688133537..4353093fd5b 100644
+index b0688133537..28862dfb4e8 100644
 --- a/src/vs/workbench/browser/workbench.ts
 +++ b/src/vs/workbench/browser/workbench.ts
 @@ -50,6 +50,8 @@ import { AccessibilityProgressSignalScheduler } from 'vs/platform/accessibilityS
@@ -977,16 +977,10 @@ index b0688133537..4353093fd5b 100644
  
  export interface IWorkbenchOptions {
  
-@@ -193,6 +195,37 @@ export class Workbench extends Layout {
+@@ -193,6 +195,19 @@ export class Workbench extends Layout {
  				this.restore(lifecycleService);
  			});
  
-+			// Chain off of the previous one to ensure the ordering of changes is maintained.
-+			// FIXME Do we still need this?
-+			let applyProjectChangesCoordinator: Promise<void> = Promise.resolve()
-+
-+			let intervalID: number | null = null
-+
 +			mainWindow.addEventListener('message', (messageEvent: MessageEvent) => {
 +				const { data } = messageEvent;
 +				if (isFromUtopiaToVSCodeMessage(data)) {
@@ -994,24 +988,12 @@ index b0688133537..4353093fd5b 100644
 +					if (commandService == null) {
 +						console.error(`There is no command service`);
 +					} else {
-+						if (intervalID != null) {
-+							window.clearInterval(intervalID)
-+						}
-+						applyProjectChangesCoordinator = applyProjectChangesCoordinator.then(async () => {
-+							(commandService as ICommandService).executeCommand('utopia.toVSCodeMessage', data);
-+						})
++						(commandService as ICommandService).executeCommand('utopia.toVSCodeMessage', data);
 +					}
 +				}
 +			});
 +
-+			intervalID = window.setInterval(() => {
-+				try {
-+					window.top?.postMessage(messageListenersReady(), '*')
-+				} catch (error) {
-+					console.error('Error posting messageListenersReady', error)
-+				}
-+			}, 500)
-+
++			window.top?.postMessage(messageListenersReady(), '*')
  			return instantiationService;
  		} catch (error) {
  			onUnexpectedError(error);
@@ -1114,6 +1096,25 @@ index e1913359976..3834f2dde41 100644
  
  				this.builtinExtensionsPromises = bundledExtensions.map(async e => {
  					const id = getGalleryExtensionId(e.packageJSON.publisher, e.packageJSON.name);
+diff --git a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+index 0c8d2e27317..2d42580e17b 100644
+--- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
++++ b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+@@ -115,8 +115,13 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
+ 			console.warn(`The web worker extension host is started in a same-origin iframe!`);
+ 		}
+ 
++		// We want to use the cdn for loading all assets, but if we create this iframe using the cdn
++		// path then the cross origin settings prevent it from calling postmessage on its parent
+ 		const relativeExtensionHostIframeSrc = FileAccess.asBrowserUri(iframeModulePath);
+-		return `${relativeExtensionHostIframeSrc.toString(true)}${suffix}`;
++		const authority = relativeExtensionHostIframeSrc.authority;
++		const authorityWithoutCDN = authority.startsWith('cdn.') ? authority.slice(4) : authority;
++		const srcWithoutCDN = relativeExtensionHostIframeSrc.with({authority: authorityWithoutCDN});
++		return `${srcWithoutCDN.toString(true)}${suffix}`;
+ 	}
+ 
+ 	public async start(): Promise<IMessagePassingProtocol> {
 diff --git a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
 index 731a48bf5b0..b77097ce7c2 100644
 --- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts

--- a/website-next/components/common/env-vars.ts
+++ b/website-next/components/common/env-vars.ts
@@ -72,6 +72,8 @@ export const REFERENCE_EQUALITY_CHECK = false
 export const STATIC_BASE_URL: string =
   PRODUCTION_OR_STAGING_CONFIG && BARE_HOST !== 'localhost:8000'
     ? `https://cdn.${BARE_HOST}/`
+    : BARE_HOST.includes('localhost')
+    ? `http://cdn.${BARE_HOST}/`
     : `http://${BARE_HOST}/`
 
 export const FLOATING_PREVIEW_BASE_URL: string = SECONDARY_BASE_URL


### PR DESCRIPTION
**Problem:**
VS Code now uses an iframe for running the web workers used for hosting extensions. In staging we have VS Code use the CDN for loading everything by providing the CDN as part of the base URL that is used via its require function. That in turn meant that whilst VS Code was being run in an iframe with the regular utopia domain, the extensions host iframe was using cdn subdomain, which caused CORS issues.

**Fix:**
At the point where the iframe's URI is constructed we now strip the `cdn.` from it's authority.
Included in this PR are some changes to local dev to use `cdn.localhost` in all places where we would use the CDN subdomain, since it turns out you don't need to do anything to make that work. ~~Also I was in the process of tidying up some code after feedback from the previous PR, so I've included that rather than separating it into another PR.~~

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
