### PR TITLE
Ensure we're setting the cross-origin headers in the remix app

### DIFF
--- a/utopia-remix/app/root.tsx
+++ b/utopia-remix/app/root.tsx
@@ -43,7 +43,6 @@ export const rootLoader = loader
 export const headers: HeadersFunction = () => ({
   'cache-control': 'no-cache',
   'cross-origin-embedder-policy': 'require-corp',
-  'cross-origin-resource-policy': 'cross-origin',
 })
 
 export default function App() {

--- a/utopia-remix/app/root.tsx
+++ b/utopia-remix/app/root.tsx
@@ -42,6 +42,8 @@ export const rootLoader = loader
 
 export const headers: HeadersFunction = () => ({
   'cache-control': 'no-cache',
+  'cross-origin-embedder-policy': 'require-corp',
+  'cross-origin-resource-policy': 'cross-origin',
 })
 
 export default function App() {

--- a/utopia-remix/server.js
+++ b/utopia-remix/server.js
@@ -185,7 +185,10 @@ app.use('/v1/javascript/packager', proxy)
 app.use('/vscode', proxy)
 
 // other middlewares
-app.use(corsMiddleware)
+app.use((_req, res, next) => {
+  res.setHeader('cross-origin-resource-policy', 'cross-origin')
+  next()
+}, corsMiddleware)
 
 // static files
 app.use('/build', express.static('public/build', { immutable: true, maxAge: '1y' }))


### PR DESCRIPTION
**Problem:**
Sharing was broken because the dialog was blocked by our cross origin settings

**Fix:**
Ensure that the `cross-origin-embedder-policy` header is set on all regular requests, and that `cross-origin-resource-policy` is set on all requests (as this was required for assets in the /public folder)

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode