### PR TITLE
DOM walker skips stylesheets that we cannot read

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -230,8 +230,8 @@ function lazyValue<T>(getter: () => T) {
 function getAttributesComingFromStyleSheets(element: HTMLElement): Set<string> {
   let appliedAttributes = new Set<string>()
   const sheets = document.styleSheets
-  try {
-    for (const i in sheets) {
+  for (const i in sheets) {
+    try {
       const sheet = sheets[i]
       const rules = sheet.rules ?? sheet.cssRules
       for (const r in rules) {
@@ -246,9 +246,11 @@ function getAttributesComingFromStyleSheets(element: HTMLElement): Set<string> {
           }
         }
       }
+    } catch (e) {
+      // ignore error, either JSDOM unit test related or we're trying to read one
+      // of the editor stylesheets from a CDN URL in a way that is blocked by our
+      // cross-origin policies
     }
-  } catch (e) {
-    // ignore error, probably JSDOM unit test related
   }
   return appliedAttributes
 }

--- a/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
+++ b/editor/src/components/inspector/common/inspector-end-to-end-tests.spec.browser2.tsx
@@ -1372,7 +1372,7 @@ describe('inspector tests with real metadata', () => {
       `"controlled"`,
     )
   })
-  xit('CSS props using numbers', async () => {
+  it('CSS props using numbers', async () => {
     const renderResult = await renderTestEditorWithCode(
       makeTestProjectCodeWithSnippetStyledComponents(`
         <div
@@ -1798,7 +1798,7 @@ describe('inspector tests with real metadata', () => {
     expect(widthControl.value).toBe('2')
   })
 
-  xit('Style is using css className', async () => {
+  it('Style is using css className', async () => {
     const renderResult = await renderTestEditorWithCode(
       Prettier.format(
         `
@@ -1914,7 +1914,7 @@ describe('inspector tests with real metadata', () => {
       `"detected-fromcss"`,
     )
   })
-  xit('Style is using css className, with default values', async () => {
+  it('Style is using css className, with default values', async () => {
     const renderResult = await renderTestEditorWithCode(
       Prettier.format(
         `


### PR DESCRIPTION
**Problem:**
The DOM walker attempts to check all stylesheets to find those affecting the currently selected element, but will silently fail if one cannot be read for whatever reason. In this case we were being bitten by the new cross-origin policies.

**Fix:**
Skip unreadable stylesheets.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
