### PR TITLE
Rather than remove the VS Code sidebar, just hide it by default

### DIFF
--- a/vscode-build/vscode.patch
+++ b/vscode-build/vscode.patch
@@ -857,17 +857,28 @@ index 1d17e4c709e..00109563f5c 100644
 -	return { keyboardMapping, keyboardLayoutInfo };
 -}
 diff --git a/src/vs/workbench/browser/layout.ts b/src/vs/workbench/browser/layout.ts
-index b8232cb8490..0ce6a8e7002 100644
+index b8232cb8490..7663af49919 100644
 --- a/src/vs/workbench/browser/layout.ts
 +++ b/src/vs/workbench/browser/layout.ts
+@@ -600,7 +600,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
+ 	}
+ 
+ 	private initLayoutState(lifecycleService: ILifecycleService, fileService: IFileService): void {
+-		this.stateModel = new LayoutStateModel(this.storageService, this.configurationService, this.contextService, this.parent);
++		this.stateModel = new LayoutStateModel(this.storageService, this.configurationService, this.parent);
+ 		this.stateModel.load();
+ 
+ 		// Both editor and panel should not be hidden on startup
 @@ -1203,40 +1203,40 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
  
  		if (this.initialized) {
  			switch (part) {
 -				case Parts.TITLEBAR_PART:
 -					return this.workbenchGrid.isViewVisible(this.titleBarPartView);
--				case Parts.SIDEBAR_PART:
--					return !this.stateModel.getRuntimeValue(LayoutStateKeys.SIDEBAR_HIDDEN);
++				// case Parts.TITLEBAR_PART:
++				// 	return this.workbenchGrid.isViewVisible(this.titleBarPartView);
+ 				case Parts.SIDEBAR_PART:
+ 					return !this.stateModel.getRuntimeValue(LayoutStateKeys.SIDEBAR_HIDDEN);
 -				case Parts.PANEL_PART:
 -					return !this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_HIDDEN);
 -				case Parts.AUXILIARYBAR_PART:
@@ -876,10 +887,6 @@ index b8232cb8490..0ce6a8e7002 100644
 -					return !this.stateModel.getRuntimeValue(LayoutStateKeys.STATUSBAR_HIDDEN);
 -				case Parts.ACTIVITYBAR_PART:
 -					return !this.stateModel.getRuntimeValue(LayoutStateKeys.ACTIVITYBAR_HIDDEN);
-+				// case Parts.TITLEBAR_PART:
-+				// 	return this.workbenchGrid.isViewVisible(this.titleBarPartView);
-+				// case Parts.SIDEBAR_PART:
-+				// 	return !this.stateModel.getRuntimeValue(LayoutStateKeys.SIDEBAR_HIDDEN);
 +				// case Parts.PANEL_PART:
 +				// 	return !this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_HIDDEN);
 +				// case Parts.AUXILIARYBAR_PART:
@@ -902,8 +909,10 @@ index b8232cb8490..0ce6a8e7002 100644
  		switch (part) {
 -			case Parts.TITLEBAR_PART:
 -				return shouldShowCustomTitleBar(this.configurationService, mainWindow, this.state.runtime.menuBar.toggled, this.isZenModeActive());
--			case Parts.SIDEBAR_PART:
--				return !this.stateModel.getRuntimeValue(LayoutStateKeys.SIDEBAR_HIDDEN);
++			// case Parts.TITLEBAR_PART:
++			// 	return shouldShowCustomTitleBar(this.configurationService, mainWindow, this.state.runtime.menuBar.toggled, this.isZenModeActive());
+ 			case Parts.SIDEBAR_PART:
+ 				return !this.stateModel.getRuntimeValue(LayoutStateKeys.SIDEBAR_HIDDEN);
 -			case Parts.PANEL_PART:
 -				return !this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_HIDDEN);
 -			case Parts.AUXILIARYBAR_PART:
@@ -912,10 +921,6 @@ index b8232cb8490..0ce6a8e7002 100644
 -				return !this.stateModel.getRuntimeValue(LayoutStateKeys.STATUSBAR_HIDDEN);
 -			case Parts.ACTIVITYBAR_PART:
 -				return !this.stateModel.getRuntimeValue(LayoutStateKeys.ACTIVITYBAR_HIDDEN);
-+			// case Parts.TITLEBAR_PART:
-+			// 	return shouldShowCustomTitleBar(this.configurationService, mainWindow, this.state.runtime.menuBar.toggled, this.isZenModeActive());
-+			// case Parts.SIDEBAR_PART:
-+			// 	return !this.stateModel.getRuntimeValue(LayoutStateKeys.SIDEBAR_HIDDEN);
 +			// case Parts.PANEL_PART:
 +			// 	return !this.stateModel.getRuntimeValue(LayoutStateKeys.PANEL_HIDDEN);
 +			// case Parts.AUXILIARYBAR_PART:
@@ -936,6 +941,32 @@ index b8232cb8490..0ce6a8e7002 100644
  	}
  
  	private setZenModeActive(active: boolean) {
+@@ -2527,7 +2527,7 @@ const LayoutStateKeys = {
+ 
+ 	// Part Visibility
+ 	ACTIVITYBAR_HIDDEN: new RuntimeStateKey<boolean>('activityBar.hidden', StorageScope.WORKSPACE, StorageTarget.MACHINE, false, true),
+-	SIDEBAR_HIDDEN: new RuntimeStateKey<boolean>('sideBar.hidden', StorageScope.WORKSPACE, StorageTarget.MACHINE, false),
++	SIDEBAR_HIDDEN: new RuntimeStateKey<boolean>('sideBar.hidden', StorageScope.WORKSPACE, StorageTarget.MACHINE, true),
+ 	EDITOR_HIDDEN: new RuntimeStateKey<boolean>('editor.hidden', StorageScope.WORKSPACE, StorageTarget.MACHINE, false),
+ 	PANEL_HIDDEN: new RuntimeStateKey<boolean>('panel.hidden', StorageScope.WORKSPACE, StorageTarget.MACHINE, true),
+ 	AUXILIARYBAR_HIDDEN: new RuntimeStateKey<boolean>('auxiliaryBar.hidden', StorageScope.WORKSPACE, StorageTarget.MACHINE, true),
+@@ -2564,7 +2564,6 @@ class LayoutStateModel extends Disposable {
+ 	constructor(
+ 		private readonly storageService: IStorageService,
+ 		private readonly configurationService: IConfigurationService,
+-		private readonly contextService: IWorkspaceContextService,
+ 		private readonly container: HTMLElement
+ 	) {
+ 		super();
+@@ -2626,7 +2625,7 @@ class LayoutStateModel extends Disposable {
+ 		LayoutStateKeys.SIDEBAR_SIZE.defaultValue = Math.min(300, workbenchDimensions.width / 4);
+ 		LayoutStateKeys.AUXILIARYBAR_SIZE.defaultValue = Math.min(300, workbenchDimensions.width / 4);
+ 		LayoutStateKeys.PANEL_SIZE.defaultValue = (this.stateCache.get(LayoutStateKeys.PANEL_POSITION.name) ?? LayoutStateKeys.PANEL_POSITION.defaultValue) === Position.BOTTOM ? workbenchDimensions.height / 3 : workbenchDimensions.width / 4;
+-		LayoutStateKeys.SIDEBAR_HIDDEN.defaultValue = this.contextService.getWorkbenchState() === WorkbenchState.EMPTY;
++		LayoutStateKeys.SIDEBAR_HIDDEN.defaultValue = true;
+ 
+ 		// Apply all defaults
+ 		for (key in LayoutStateKeys) {
 diff --git a/src/vs/workbench/browser/workbench.contribution.ts b/src/vs/workbench/browser/workbench.contribution.ts
 index ae4d22c9eaa..e342fb223d8 100644
 --- a/src/vs/workbench/browser/workbench.contribution.ts


### PR DESCRIPTION
**Problem:**
We want to be able to use VS Code features that require the side bar, but don't want it to be shown by default.

**Fix:**
Rather than removing the side bar completely, we can instead just hide it by default. This means you can now use e.g. `cmd`+`f` for global search, or right click a symbol and "Find all references".

<img width="518" alt="image" src="https://github.com/user-attachments/assets/3b6e4f02-4b46-4610-b3bf-484bdbece307">

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
