### PR TITLE
Continue following selection when the active file is a TS file

### DIFF
--- a/utopia-vscode-extension/src/extension.ts
+++ b/utopia-vscode-extension/src/extension.ts
@@ -646,7 +646,8 @@ function shouldFollowSelectionWithActiveFile() {
     filePath.endsWith('.js') ||
     filePath.endsWith('.jsx') ||
     filePath.endsWith('.cjs') ||
-    filePath.endsWith('.mjs')
+    filePath.endsWith('.mjs') ||
+    filePath.endsWith('.ts')
   const isComponentDescriptor = filePath.startsWith('/utopia/') && filePath.endsWith('.utopia.js')
   return isJs && !isComponentDescriptor
 }


### PR DESCRIPTION
**Problem:**
Now that you can `cmd`+click to jump to the definition of a symbol in code, it's easy to end up in a `.d.ts` file. #5259 restricted code selection following to only code files, but was missing `.ts` files since we don't support TS.

**Fix:**
Include the `.ts` file extension in `shouldFollowSelectionWithActiveFile`

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode