### PR TITLE
More efficient collaborators listing

### DIFF
--- a/utopia-remix/app/models/project.server.spec.ts
+++ b/utopia-remix/app/models/project.server.spec.ts
@@ -419,15 +419,15 @@ describe('project model', () => {
       expect(got.projects[1].proj_id).toBe('four')
 
       expect(Object.keys(got.collaborators.byProjectId).length).toBe(2)
-      expect(Object.keys(got.collaborators.byProjectId)[0]).toBe('seven')
+      expect(got.collaborators.byProjectId).toHaveProperty('seven')
       expect(got.collaborators.byProjectId['seven'].length).toBe(2)
-      expect(got.collaborators.byProjectId['seven'][0]).toBe('bob')
-      expect(got.collaborators.byProjectId['seven'][1]).toBe('carol') // the owner is included implicitly!
-      expect(Object.keys(got.collaborators.byProjectId)[1]).toBe('four')
+      expect(got.collaborators.byProjectId['seven']).toContain('bob')
+      expect(got.collaborators.byProjectId['seven']).toContain('carol') // the owner is included implicitly!
+      expect(got.collaborators.byProjectId).toHaveProperty('four')
       expect(got.collaborators.byProjectId['four'].length).toBe(3)
-      expect(got.collaborators.byProjectId['four'][0]).toBe('bob')
-      expect(got.collaborators.byProjectId['four'][1]).toBe('carol')
-      expect(got.collaborators.byProjectId['four'][2]).toBe('alice') // the owner is included implicitly!
+      expect(got.collaborators.byProjectId['four']).toContain('bob')
+      expect(got.collaborators.byProjectId['four']).toContain('carol')
+      expect(got.collaborators.byProjectId['four']).toContain('alice') // the owner is included implicitly!
     })
   })
 

--- a/utopia-remix/app/models/project.server.spec.ts
+++ b/utopia-remix/app/models/project.server.spec.ts
@@ -409,7 +409,7 @@ describe('project model', () => {
     it('returns an empty list if there are no projects with user as a collaborator', async () => {
       const got = await listSharedWithMeProjectsAndCollaborators({ userId: 'alice' })
       expect(got.projects.length).toBe(0)
-      expect(Object.keys(got.collaborators).length).toBe(0)
+      expect(Object.keys(got.collaborators.byProjectId).length).toBe(0)
     })
 
     it('returns the projects and their collaborators for which the user is a collaborator, that are in the COLLABORATIVE state', async () => {
@@ -418,16 +418,16 @@ describe('project model', () => {
       expect(got.projects[0].proj_id).toBe('seven')
       expect(got.projects[1].proj_id).toBe('four')
 
-      expect(Object.keys(got.collaborators).length).toBe(2)
-      expect(Object.keys(got.collaborators)[0]).toBe('seven')
-      expect(got.collaborators['seven'].length).toBe(2)
-      expect(got.collaborators['seven'].map((c) => c.id)[0]).toBe('bob')
-      expect(got.collaborators['seven'].map((c) => c.id)[1]).toBe('carol') // the owner is included implicitly!
-      expect(Object.keys(got.collaborators)[1]).toBe('four')
-      expect(got.collaborators['four'].length).toBe(3)
-      expect(got.collaborators['four'].map((c) => c.id)[0]).toBe('bob')
-      expect(got.collaborators['four'].map((c) => c.id)[1]).toBe('carol')
-      expect(got.collaborators['four'].map((c) => c.id)[2]).toBe('alice') // the owner is included implicitly!
+      expect(Object.keys(got.collaborators.byProjectId).length).toBe(2)
+      expect(Object.keys(got.collaborators.byProjectId)[0]).toBe('seven')
+      expect(got.collaborators.byProjectId['seven'].length).toBe(2)
+      expect(got.collaborators.byProjectId['seven'][0]).toBe('bob')
+      expect(got.collaborators.byProjectId['seven'][1]).toBe('carol') // the owner is included implicitly!
+      expect(Object.keys(got.collaborators.byProjectId)[1]).toBe('four')
+      expect(got.collaborators.byProjectId['four'].length).toBe(3)
+      expect(got.collaborators.byProjectId['four'][0]).toBe('bob')
+      expect(got.collaborators.byProjectId['four'][1]).toBe('carol')
+      expect(got.collaborators.byProjectId['four'][2]).toBe('alice') // the owner is included implicitly!
     })
   })
 

--- a/utopia-remix/app/models/project.server.ts
+++ b/utopia-remix/app/models/project.server.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../db.server'
 import type {
-  CollaboratorsByProject,
+  Collaborators,
   GithubRepository,
   ProjectListing,
   ProjectMetadataForEditor,
@@ -15,6 +15,7 @@ import {
   type ProjectWithoutContentFromDB,
 } from '../types'
 import { ensure } from '../util/api.server'
+import { buildCollaboratorsFromProjects } from '../util/collaborators.server'
 import { Status } from '../util/statusCodes'
 import { selectUserDetailsForProjectCollaborator } from './projectCollaborators.server'
 
@@ -190,7 +191,7 @@ export async function listSharedWithMeProjectsAndCollaborators(params: {
   userId: string
 }): Promise<{
   projects: ProjectListing[]
-  collaborators: CollaboratorsByProject
+  collaborators: Collaborators
 }> {
   // 1. grab the projects for which the user is a collaborator, are not deleted, are
   // collaborative, and the user is not the owner.
@@ -223,23 +224,19 @@ export async function listSharedWithMeProjectsAndCollaborators(params: {
   })
 
   // 3. build the collaborators map
-  let collaboratorsByProject: CollaboratorsByProject = {}
+  let collaborators = buildCollaboratorsFromProjects(projects)
+
   for (const project of projects) {
-    const projectId = project.proj_id
-
-    collaboratorsByProject[projectId] = project.ProjectCollaborator.map(({ User }) =>
-      userToCollaborator(User),
-    )
-
     // the owner of a project should always appear in the list of collaborators, so
     // make sure to append it if it's missing
-    const collaboratorsIncludeOwner = collaboratorsByProject[projectId].some(
-      (collaborator) => collaborator.id === project.owner_id,
+    const collaboratorsIncludeOwner = collaborators.byProjectId[project.proj_id].some(
+      (collaborator) => collaborator === project.owner_id,
     )
     if (!collaboratorsIncludeOwner) {
       const owner = owners.find(({ user_id }) => user_id === project.owner_id)
       if (owner != null) {
-        collaboratorsByProject[projectId].push(userToCollaborator(owner))
+        collaborators.byProjectId[project.proj_id].push(owner.user_id)
+        collaborators.byUserId[owner.user_id] = userToCollaborator(owner)
       }
     }
   }
@@ -247,7 +244,7 @@ export async function listSharedWithMeProjectsAndCollaborators(params: {
   // 4. return both projects and collabs
   return {
     projects: projects,
-    collaborators: collaboratorsByProject,
+    collaborators: collaborators,
   }
 }
 

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -54,6 +54,7 @@ import { createProjectsStore, ProjectsContext, useProjectsStore } from '../store
 import { UserAvatar } from '../components/userAvatar'
 import { UserContextMenu } from '../components/user-context-menu'
 import { mergeCollaborators } from '../util/collaborators.server'
+import { mapDropNulls } from '../util/common'
 
 const SortOptions = ['title', 'dateCreated', 'dateModified'] as const
 export type SortCriteria = (typeof SortOptions)[number]
@@ -632,8 +633,14 @@ const Projects = React.memo(
     const scrollStyle = isAllProjects ? { overflow: 'initial' } : {}
 
     const getCollaboratorUsers = React.useCallback(
-      (projectId: string) => {
-        return collaborators.byProjectId[projectId].map((userId) => collaborators.byUserId[userId])
+      (projectId: string): Collaborator[] => {
+        const collaboratorIds = collaborators.byProjectId[projectId] ?? []
+        return mapDropNulls((collaboratorId) => {
+          if (!collaborators.byUserId.hasOwnProperty(collaboratorId)) {
+            return null
+          }
+          return collaborators.byUserId[collaboratorId]
+        }, collaboratorIds)
       },
       [collaborators],
     )

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -35,7 +35,7 @@ import { button } from '../styles/button.css'
 import { projectCards, projectRows, projectTemplate } from '../styles/projects.css'
 import { projectCategoryButton, userName } from '../styles/sidebarComponents.css'
 import { sprinkles } from '../styles/sprinkles.css'
-import type { Collaborator, CollaboratorsByProject, Operation, ProjectListing } from '../types'
+import type { Collaborator, Collaborators, Operation, ProjectListing } from '../types'
 import { AccessLevel, asAccessLevel, getOperationDescription } from '../types'
 import { requireUser } from '../util/api.server'
 import { assertNever } from '../util/assertNever'
@@ -53,6 +53,7 @@ import type { OperationWithKey } from '../stores/projectsStore'
 import { createProjectsStore, ProjectsContext, useProjectsStore } from '../stores/projectsStore'
 import { UserAvatar } from '../components/userAvatar'
 import { UserContextMenu } from '../components/user-context-menu'
+import { mergeCollaborators } from '../util/collaborators.server'
 
 const SortOptions = ['title', 'dateCreated', 'dateModified'] as const
 export type SortCriteria = (typeof SortOptions)[number]
@@ -116,7 +117,7 @@ export async function loader(args: LoaderFunctionArgs) {
     listSharedWithMeProjectsAndCollaborators({ userId: user.user_id }),
   ])
   const collaborators = await getCollaborators({
-    ids: [...projects, ...deletedProjects].map((p) => p.proj_id),
+    projectIds: [...projects, ...deletedProjects].map((p) => p.proj_id),
     userId: user.user_id,
   })
 
@@ -126,7 +127,7 @@ export async function loader(args: LoaderFunctionArgs) {
       projects: projects,
       deletedProjects: deletedProjects,
       projectsSharedWithMe: sharedWithMe.projects,
-      collaborators: { ...collaborators, ...sharedWithMe.collaborators },
+      collaborators: mergeCollaborators([collaborators, sharedWithMe.collaborators]),
     },
     { headers: { 'cache-control': 'no-cache' } },
   )
@@ -137,7 +138,7 @@ type LoaderData = {
   projects: ProjectListing[]
   deletedProjects: ProjectListing[]
   projectsSharedWithMe: ProjectListing[]
-  collaborators: CollaboratorsByProject
+  collaborators: Collaborators
 }
 
 const ProjectsPage = React.memo(() => {
@@ -613,13 +614,7 @@ const CategoryArchiveActions = React.memo(({ projects }: { projects: ProjectList
 CategoryArchiveActions.displayName = 'CategoryArchiveActions'
 
 const Projects = React.memo(
-  ({
-    projects,
-    collaborators,
-  }: {
-    projects: ProjectListing[]
-    collaborators: CollaboratorsByProject
-  }) => {
+  ({ projects, collaborators }: { projects: ProjectListing[]; collaborators: Collaborators }) => {
     const myUser = useProjectsStore((store) => store.myUser)
     const gridView = useProjectsStore((store) => store.gridView)
 
@@ -636,6 +631,13 @@ const Projects = React.memo(
     const isAllProjects = selectedCategory === 'allProjects'
     const scrollStyle = isAllProjects ? { overflow: 'initial' } : {}
 
+    const getCollaboratorUsers = React.useCallback(
+      (projectId: string) => {
+        return collaborators.byProjectId[projectId].map((userId) => collaborators.byUserId[userId])
+      },
+      [collaborators],
+    )
+
     return (
       <>
         {when(
@@ -649,7 +651,7 @@ const Projects = React.memo(
                 selected={project.proj_id === selectedProjectId}
                 /* eslint-disable-next-line react/jsx-no-bind */
                 onSelect={() => handleProjectSelect(project)}
-                collaborators={collaborators[project.proj_id]}
+                collaborators={getCollaboratorUsers(project.proj_id)}
               />
             ))}
           </div>,
@@ -665,7 +667,7 @@ const Projects = React.memo(
                 selected={project.proj_id === selectedProjectId}
                 /* eslint-disable-next-line react/jsx-no-bind */
                 onSelect={() => handleProjectSelect(project)}
-                collaborators={collaborators[project.proj_id]}
+                collaborators={getCollaboratorUsers(project.proj_id)}
               />
             ))}
           </div>,

--- a/utopia-remix/app/routes/projects.tsx
+++ b/utopia-remix/app/routes/projects.tsx
@@ -636,10 +636,7 @@ const Projects = React.memo(
       (projectId: string): Collaborator[] => {
         const collaboratorIds = collaborators.byProjectId[projectId] ?? []
         return mapDropNulls((collaboratorId) => {
-          if (!collaborators.byUserId.hasOwnProperty(collaboratorId)) {
-            return null
-          }
-          return collaborators.byUserId[collaboratorId]
+          return collaborators.byUserId[collaboratorId] ?? null
         }, collaboratorIds)
       },
       [collaborators],

--- a/utopia-remix/app/types.ts
+++ b/utopia-remix/app/types.ts
@@ -51,7 +51,17 @@ export interface Collaborator {
   avatar: string | null
 }
 
-export type CollaboratorsByProject = { [projectId: string]: Collaborator[] }
+export type Collaborators = {
+  byProjectId: { [projectId: string]: string[] }
+  byUserId: { [userId: string]: Collaborator }
+}
+
+export function emptyCollaborators(): Collaborators {
+  return {
+    byProjectId: {},
+    byUserId: {},
+  }
+}
 
 export function userToCollaborator(
   user: Pick<UserDetails, 'user_id' | 'name' | 'picture'>,

--- a/utopia-remix/app/util/collaborators.server.ts
+++ b/utopia-remix/app/util/collaborators.server.ts
@@ -1,0 +1,37 @@
+import type { UserDetails } from 'prisma-client'
+import { emptyCollaborators, userToCollaborator, type Collaborators } from '../types'
+
+export function buildCollaboratorsFromProjects(
+  projects: {
+    proj_id: string
+    ProjectCollaborator: {
+      User: UserDetails
+    }[]
+  }[],
+): Collaborators {
+  let result = emptyCollaborators()
+  for (const project of projects) {
+    result.byProjectId[project.proj_id] = project.ProjectCollaborator.map((c) => c.User.user_id)
+    for (const { User } of project.ProjectCollaborator) {
+      result.byUserId[User.user_id] = userToCollaborator(User)
+    }
+  }
+  return result
+}
+
+export function mergeCollaborators(list: Collaborators[]): Collaborators {
+  let merged = emptyCollaborators()
+  for (const collabs of list) {
+    merged = {
+      byUserId: {
+        ...merged.byUserId,
+        ...collabs.byUserId,
+      },
+      byProjectId: {
+        ...merged.byProjectId,
+        ...collabs.byProjectId,
+      },
+    }
+  }
+  return merged
+}

--- a/utopia-remix/app/util/common.ts
+++ b/utopia-remix/app/util/common.ts
@@ -29,3 +29,27 @@ export function urlToRelative(url: string): string {
   const parsed = new URL(url)
   return parsed.href.replace(parsed.origin, '')
 }
+
+// ported from editor/src/core/shared/utils.ts
+export function fastForEach<T>(a: readonly T[], fn: (t: T, index: number) => void): void {
+  for (var i = 0, len = a.length; i < len; i++) {
+    if (i in a) {
+      fn(a[i]!, i)
+    }
+  }
+}
+
+// ported from editor/src/core/shared/array-utils.ts
+export function mapDropNulls<T, U>(
+  fn: (t: T, i: number) => U | null | undefined,
+  a: ReadonlyArray<T>,
+): Array<U> {
+  let result: Array<U> = []
+  fastForEach(a, (t, i) => {
+    const u = fn(t, i)
+    if (u != null) {
+      result.push(u)
+    }
+  })
+  return result
+}


### PR DESCRIPTION
This is a follow up to https://github.com/concrete-utopia/utopia/pull/6003

**Problem:**

Getting project collaborators means returning a payload made of an array of extremely redundant collaborator details.

**Fix:**

Instead of returning something like
```ts
{
  project1: [ {id: "bob", name: "Bob", image: "..."}, {id: "alice", name: "Alice", image: "..."},
  project2: [ {id: "bob", name: "Bob", image: "..."}]
  ...
}
```

return a way more compact representation:
```ts
{
  byProjectId: {
    project1: ["bob", "alice"],
    project2: ["bob"]
  },
  byUserId: {
    bob: {id: "bob", name: "Bob", image: "..."},
    alice: {id: "alice", name: "Alice", image: "..."}
  }
}
```
