### PR TITLE
Open storyboard file after git clone

### DIFF
--- a/editor/src/components/github/github-repository-clone-flow.tsx
+++ b/editor/src/components/github/github-repository-clone-flow.tsx
@@ -7,10 +7,19 @@ import invariant from '../../third-party/remix/invariant'
 import { useOnClickAuthenticateWithGithub } from '../../utils/github-auth-hooks'
 import { Dialog, FormButton } from '../../uuiui'
 import { isLoggedIn, type EditorDispatch } from '../editor/action-types'
-import { setGithubState, showToast, updateGithubData } from '../editor/actions/action-creators'
+import {
+  openCodeEditorFile,
+  setGithubState,
+  showToast,
+  updateGithubData,
+} from '../editor/actions/action-creators'
 import { useDispatch } from '../editor/store/dispatch-context'
 import type { GithubUser } from '../editor/store/editor-state'
-import { type EditorStorePatched, type GithubRepoWithBranch } from '../editor/store/editor-state'
+import {
+  StoryboardFilePath,
+  type EditorStorePatched,
+  type GithubRepoWithBranch,
+} from '../editor/store/editor-state'
 import { Substores, useEditorState, useRefEditorState } from '../editor/store/store-hook'
 import { onClickSignIn } from '../titlebar/title-bar'
 import { CloneParamKey } from '../editor/persistence/persistence-backend'
@@ -136,6 +145,7 @@ async function cloneGithubRepo(
   dispatch([
     setGithubState({ gitRepoToLoad: null }),
     updateGithubData({ publicRepositories: [repositoryEntry] }),
+    openCodeEditorFile(StoryboardFilePath, false),
   ])
 }
 

--- a/editor/src/core/vscode/vscode-bridge.ts
+++ b/editor/src/core/vscode/vscode-bridge.ts
@@ -100,7 +100,7 @@ let registeredHandlers: (messageEvent: MessageEvent) => void = NO_OP
 export function initVSCodeBridge(
   projectContents: ProjectContentTreeRoot,
   dispatch: (actions: Array<EditorAction>) => void,
-  openFilePath: string | null,
+  openFilePath: string,
 ) {
   let loadingScreenHidden = false
   let seenMessageListenersReadyMessage = false
@@ -123,11 +123,6 @@ export function initVSCodeBridge(
       messageEvent.source.postMessage(initProject(projectFiles, openFilePath), {
         targetOrigin: '*',
       })
-
-      if (openFilePath == null) {
-        loadingScreenHidden = true
-        dispatch([hideVSCodeLoadingScreen()])
-      }
     } else if (isVSCodeBridgeReady(data) && messageEvent.source != null) {
       // Store the source
       vscodeIFrame = messageEvent.source


### PR DESCRIPTION
**Problem:**
When creating a new project, or opening an existing project, we always attempt to open the storyboard file, but this doesn't happen with the URL based GitHub clone flow, meaning that the code editor will be initially empty after a clone if the user hasn't performed an action that would update the open file.

**Fix:**
Dispatch the `openCodeEditorFile` function after the GitHub flow, passing the storyboard file. The extension already checks for the existence of the file before attempting to open it, so if there is no storyboard file then nothing will happen.

I also noticed that the `openFilePath` passed to `initVSCodeBridge` was never `null`, so I removed the `| null` there (along with the inaccessible code path associated with it).

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
