### PR TITLE
Don't show siblings control for grid cells

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.tsx
@@ -175,19 +175,24 @@ function convertToAbsoluteAndMoveStrategyFactory(setHuggingParentToFixed: SetHug
       }
     }
 
-    const autoLayoutSiblings = getAutoLayoutSiblings(
+    const autoLayoutSiblingsExceptGridCells = getAutoLayoutSiblings(
       canvasState.startingMetadata,
       canvasState.startingElementPathTree,
       originalTargets,
+    ).filter(
+      // don't show the siblings control for grid cells
+      (sibling) => !MetadataUtils.isGridCell(canvasState.startingMetadata, sibling.elementPath),
     )
-    const hasAutoLayoutSiblings = autoLayoutSiblings.length > 1
+
+    const showSiblingsControl = autoLayoutSiblingsExceptGridCells.length > 1
+
     const autoLayoutSiblingsBounds = getAutoLayoutSiblingsBounds(
       canvasState.startingMetadata,
       canvasState.startingElementPathTree,
       originalTargets,
     )
 
-    const autoLayoutSiblingsControl = hasAutoLayoutSiblings
+    const autoLayoutSiblingsControl = showSiblingsControl
       ? [
           controlWithProps({
             control: AutoLayoutSiblingsOutline,
@@ -200,7 +205,7 @@ function convertToAbsoluteAndMoveStrategyFactory(setHuggingParentToFixed: SetHug
 
     const fitness = getFitness(
       interactionSession,
-      hasAutoLayoutSiblings,
+      showSiblingsControl,
       autoLayoutSiblingsBounds,
       originalTargets.length > 1,
       isPositionRelative,


### PR DESCRIPTION
**Problem:**

The siblings control is too noisy for grid cells.

**Fix:**

Disable that control for grid cells.

| Before | After |
|-------|-----------|
| <img width="620" alt="Screenshot 2024-08-21 at 18 57 36" src="https://github.com/user-attachments/assets/e9578192-b12b-4697-9cec-d8abc41afa1a"> | <img width="620" alt="Screenshot 2024-08-21 at 18 57 04" src="https://github.com/user-attachments/assets/db8d5a1f-de36-413e-b318-3d0a1ca01adb"> |



Fixes #6251

