### PR TITLE
Paste into grid

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
@@ -14,6 +14,7 @@ import { stripNulls, zip } from '../../../../core/shared/array-utils'
 import type { Either } from '../../../../core/shared/either'
 import { isLeft, left, right } from '../../../../core/shared/either'
 import * as EP from '../../../../core/shared/element-path'
+import * as PP from '../../../../core/shared/property-path'
 import type { ElementPathTrees } from '../../../../core/shared/element-path-tree'
 import type { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
 import {
@@ -53,6 +54,7 @@ import type { CanvasCommand } from '../../commands/commands'
 import { foldAndApplyCommandsInner } from '../../commands/commands'
 import { deleteElement } from '../../commands/delete-element-command'
 import { queueTrueUpElement } from '../../commands/queue-true-up-command'
+import { propertyToDelete, updateBulkProperties } from '../../commands/set-property-command'
 import { showToastCommand } from '../../commands/show-toast-command'
 import { updateFunctionCommand } from '../../commands/update-function-command'
 import { updateSelectedViews } from '../../commands/update-selected-views-command'
@@ -287,6 +289,13 @@ export function staticReparentAndUpdatePosition(
           target.parentPath.intendedParentPath,
         )
 
+  const isGrid = MetadataUtils.isGridLayoutedContainer(
+    MetadataUtils.findElementByElementPath(
+      editorStateContext.startingMetadata,
+      target.parentPath.intendedParentPath,
+    ),
+  )
+
   const commands = elementsToInsert.flatMap((elementToInsert) => {
     return [
       updateFunctionCommand('always', (editor, commandLifecycle) => {
@@ -317,22 +326,36 @@ export function staticReparentAndUpdatePosition(
           oldPathToNewPathMapping,
         )
 
-        const absolutePositioningCommands =
-          strategy === 'REPARENT_AS_STATIC'
-            ? []
-            : positionElementToCoordinatesCommands(
-                { oldPath: elementToInsert.elementPath, newPath: newPath },
-                pasteContext.originalAllElementProps,
-                {
-                  originalTargetMetadata:
-                    pasteContext.elementPasteWithMetadata.targetOriginalContextMetadata,
-                  originalPathTrees: pasteContext.targetOriginalPathTrees,
-                  currentMetadata: editor.jsxMetadata,
-                  currentPathTrees: editor.elementPathTree,
-                },
-                elementToInsert.intendedCoordinates,
-                oldPathToNewPathMapping,
-              )
+        function getAbsolutePositioningCommands(targetPath: ElementPath): Array<CanvasCommand> {
+          if (strategy === 'REPARENT_AS_STATIC') {
+            return []
+          } else if (isGrid) {
+            return [
+              updateBulkProperties('always', targetPath, [
+                propertyToDelete(PP.create('style', 'position')),
+                propertyToDelete(PP.create('style', 'top')),
+                propertyToDelete(PP.create('style', 'left')),
+                propertyToDelete(PP.create('style', 'bottom')),
+                propertyToDelete(PP.create('style', 'right')),
+              ]),
+            ]
+          } else {
+            return positionElementToCoordinatesCommands(
+              { oldPath: elementToInsert.elementPath, newPath: targetPath },
+              pasteContext.originalAllElementProps,
+              {
+                originalTargetMetadata:
+                  pasteContext.elementPasteWithMetadata.targetOriginalContextMetadata,
+                originalPathTrees: pasteContext.targetOriginalPathTrees,
+                currentMetadata: editor.jsxMetadata,
+                currentPathTrees: editor.elementPathTree,
+              },
+              elementToInsert.intendedCoordinates,
+              oldPathToNewPathMapping,
+            )
+          }
+        }
+        const absolutePositioningCommands = getAbsolutePositioningCommands(newPath)
 
         const propertyCommands = [...propertyChangeCommands, ...absolutePositioningCommands]
 

--- a/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
+++ b/editor/src/components/canvas/canvas-strategies/post-action-options/post-action-paste.ts
@@ -327,9 +327,7 @@ export function staticReparentAndUpdatePosition(
         )
 
         function getAbsolutePositioningCommands(targetPath: ElementPath): Array<CanvasCommand> {
-          if (strategy === 'REPARENT_AS_STATIC') {
-            return []
-          } else if (isGrid) {
+          if (isGrid) {
             return [
               updateBulkProperties('always', targetPath, [
                 propertyToDelete(PP.create('style', 'position')),
@@ -339,7 +337,7 @@ export function staticReparentAndUpdatePosition(
                 propertyToDelete(PP.create('style', 'right')),
               ]),
             ]
-          } else {
+          } else if (strategy === 'REPARENT_AS_ABSOLUTE') {
             return positionElementToCoordinatesCommands(
               { oldPath: elementToInsert.elementPath, newPath: targetPath },
               pasteContext.originalAllElementProps,
@@ -353,6 +351,8 @@ export function staticReparentAndUpdatePosition(
               elementToInsert.intendedCoordinates,
               oldPathToNewPathMapping,
             )
+          } else {
+            return []
           }
         }
         const absolutePositioningCommands = getAbsolutePositioningCommands(newPath)


### PR DESCRIPTION
**Problem:**

Pasting an element into a grid doesn't place the new element _into_ the grid's placement logic.

**Fix:**

If the target parent is a grid, remove flow properties from the pasted element, which will be then placed at the first valid coordinates following `auto` logic.

In the future we might revisit this with a bit more heuristics to determine "empty" cells to place the element into, but for now the current logic should be more than enough.

| Before | After |
|-------|----------|
| ![Kapture 2024-08-22 at 11 30 59](https://github.com/user-attachments/assets/16a4b479-6fa8-4962-8990-5fb1356d8537) | ![Kapture 2024-08-22 at 11 29 34](https://github.com/user-attachments/assets/f248cb1c-453d-4051-b2c0-30257c54ee2a) |


**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #6253

