### PR TITLE
Cleaning up some error messages from the VS Code work

### DIFF
--- a/server/src/Utopia/Web/Endpoints.hs
+++ b/server/src/Utopia/Web/Endpoints.hs
@@ -214,9 +214,9 @@ vsCodePathsToPreload = [
         ("extensions.js", VSCodeJS),
         ("vscode/vs/code/browser/workbench/workbench.js", VSCodeJS),
         ("vscode/vs/loader.js", VSCodeJS),
-        ("vscode/vs/workbench/workbench.web.api.css", VSCodeCSS),
-        ("vscode/vs/workbench/workbench.web.api.js", VSCodeJS),
-        ("vscode/vs/workbench/workbench.web.api.nls.js", VSCodeJS)
+        ("vscode/vs/workbench/workbench.web.main.css", VSCodeCSS),
+        ("vscode/vs/workbench/workbench.web.main.js", VSCodeJS),
+        ("vscode/vs/workbench/workbench.web.main.nls.js", VSCodeJS)
         ]
 
 vscodePreloadTypeToPreloadAs :: VSCodePreloadType -> Text

--- a/vscode-build/vscode.patch
+++ b/vscode-build/vscode.patch
@@ -57,6 +57,33 @@ index 9e26dfeeb6e..00000000000
 @@ -1 +0,0 @@
 -{}
 \ No newline at end of file
+diff --git a/extensions/typescript-language-features/web/src/typingsInstaller/typingsInstaller.ts b/extensions/typescript-language-features/web/src/typingsInstaller/typingsInstaller.ts
+index 7c40993d6df..53e614142ea 100644
+--- a/extensions/typescript-language-features/web/src/typingsInstaller/typingsInstaller.ts
++++ b/extensions/typescript-language-features/web/src/typingsInstaller/typingsInstaller.ts
+@@ -62,7 +62,8 @@ export class WebTypingsInstallerClient implements ts.server.ITypingsInstaller {
+ 	 * TypingsInstaller internals.
+ 	 */
+ 	private async handleResponse(response: InstallerResponse): Promise<void> {
+-		switch (response.kind) {
++		const responseKind = response.kind
++		switch (responseKind) {
+ 			case 'action::packageInstalled':
+ 			case 'action::invalidate':
+ 			case 'action::set':
+@@ -70,10 +71,11 @@ export class WebTypingsInstallerClient implements ts.server.ITypingsInstaller {
+ 				break;
+ 			case 'event::beginInstallTypes':
+ 			case 'event::endInstallTypes':
++				case 'action::watchTypingLocations':
+ 				// Don't care.
+ 				break;
+ 			default:
+-				throw new Error(`unexpected response: ${response}`);
++				throw new Error(`unexpected response: ${responseKind}`);
+ 		}
+ 	}
+ 
 diff --git a/package.json b/package.json
 index 2103fe1fe1a..92954953615 100644
 --- a/package.json


### PR DESCRIPTION
**Problem:**
The console was becoming noisy with some error messages from the VS Code work.

![image](https://github.com/user-attachments/assets/709ec83e-f0e3-4510-95dd-f6bf3d702236)
![image](https://github.com/user-attachments/assets/7158107e-1b31-4af3-ba13-d70edc6a3b69)

**Fix:**
The errors in the first screenshot are because VS Code was missing the `'action::watchTypingLocations'` response from the TS Server, which has been fixed on their latest `main` branch, but hasn't been released yet (https://github.com/microsoft/vscode/blob/6ab1a1e4fefffb25fe15ed33dcf5ae6322043b40/extensions/typescript-language-features/web/src/typingsInstaller/typingsInstaller.ts#L64-L80)

The errors from the second screenshot are because the `workbench.web.api.*` assets had been changed to `workbench.web.main.*`, but that change hadn't been applied to the list of assets to preload which are injected by our Haskell server.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
