### PR TITLE
keep track of set grid props

### DIFF
--- a/editor/src/components/inspector/add-remove-layout-system-control.tsx
+++ b/editor/src/components/inspector/add-remove-layout-system-control.tsx
@@ -19,6 +19,8 @@ import { DropdownMenu, regularDropdownMenuItem } from '../../uuiui/radix-compone
 import { stripNulls } from '../../core/shared/array-utils'
 import { layoutSystemSelector } from './flex-section'
 import { optionalMap } from '../../core/shared/optional-utils'
+import { useGridPropertiesSet } from './common/inspector-atoms'
+import { when } from '../../utils/react-conditionals'
 
 export const AddRemoveLayoutSystemControlTestId = (): string => 'AddRemoveLayoutSystemControlTestId'
 export const AddFlexLayoutOptionId = 'add-flex-layout'
@@ -136,6 +138,8 @@ export const AddRemoveLayoutSystemControl = React.memo<AddRemoveLayoutSystemCont
     }
   }
 
+  const numberOfGridPropsSet = useGridPropertiesSet().length
+
   return (
     <InspectorSectionHeader
       css={{
@@ -146,6 +150,7 @@ export const AddRemoveLayoutSystemControl = React.memo<AddRemoveLayoutSystemCont
           color: colorTheme.fg1.value,
           '--buttonContentOpacity': 1,
         },
+        alignItems: 'center',
       }}
     >
       <FlexRow
@@ -157,13 +162,27 @@ export const AddRemoveLayoutSystemControl = React.memo<AddRemoveLayoutSystemCont
       >
         <span style={{ textTransform: 'capitalize', fontSize: '11px' }}>{label()}</span>
       </FlexRow>
-      <div data-testid={AddRemoveLayoutSystemControlTestId()}>
-        <DropdownMenu
-          align='end'
-          items={addLayoutSystemMenuDropdownItems}
-          opener={addLayoutSystemOpenerButton}
-        />
-      </div>
+      <FlexRow>
+        {when(
+          numberOfGridPropsSet > 0,
+          <span
+            style={{
+              padding: 2,
+              backgroundColor: colorTheme.emphasizedBackground.value,
+              color: colorTheme.dynamicBlue.value,
+            }}
+          >
+            {`+${numberOfGridPropsSet}`}
+          </span>,
+        )}
+        <div data-testid={AddRemoveLayoutSystemControlTestId()}>
+          <DropdownMenu
+            align='end'
+            items={addLayoutSystemMenuDropdownItems}
+            opener={addLayoutSystemOpenerButton}
+          />
+        </div>
+      </FlexRow>
     </InspectorSectionHeader>
   )
 })

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -4516,6 +4516,8 @@ export interface ParsedCSSProperties {
   rowGap: CSSNumber
   columnGap: CSSNumber
   gridAutoFlow: GridAutoFlow | null
+  gridTemplateRows: string | null
+  gridTemplateColumns: string | null
 }
 
 export type ParsedCSSPropertiesKeys = keyof ParsedCSSProperties
@@ -4731,6 +4733,8 @@ export const cssEmptyValues: ParsedCSSProperties = {
     unit: null,
   },
   gridAutoFlow: null,
+  gridTemplateRows: null,
+  gridTemplateColumns: null,
 }
 
 type CSSParsers = {
@@ -4806,6 +4810,8 @@ export const cssParsers: CSSParsers = {
   rowGap: parseCSSLengthPercent,
   columnGap: parseCSSLengthPercent,
   gridAutoFlow: parseGridAutoFlowValue,
+  gridTemplateColumns: parseString,
+  gridTemplateRows: parseString,
 }
 
 type CSSPrinters = {
@@ -4883,6 +4889,8 @@ const cssPrinters: CSSPrinters = {
   rowGap: printCSSNumberAsAttributeValue('px'),
   columnGap: printCSSNumberAsAttributeValue('px'),
   gridAutoFlow: jsxAttributeValueWithNoComments,
+  gridTemplateColumns: jsxAttributeValueWithNoComments,
+  gridTemplateRows: jsxAttributeValueWithNoComments,
 }
 
 export interface UtopianElementProperties {
@@ -5326,6 +5334,13 @@ function parseGridAutoFlowValue(value: unknown): Either<string, GridAutoFlow> {
   return right(maybeParsedValue)
 }
 
+function parseStringOrNull(value: unknown): Either<string, string | null> {
+  if (typeof value !== 'string') {
+    return left('Value is not a string')
+  }
+  return right(value)
+}
+
 // hmmmm
 type PrintedValue = JSExpression
 
@@ -5614,6 +5629,8 @@ export const trivialDefaultValues: ParsedPropertiesWithNonTrivial = {
     unit: 'px',
   },
   gridAutoFlow: null,
+  gridTemplateColumns: null,
+  gridTemplateRows: null,
 }
 
 export function isTrivialDefaultValue(

--- a/editor/src/components/inspector/common/inspector-atoms.ts
+++ b/editor/src/components/inspector/common/inspector-atoms.ts
@@ -1,4 +1,5 @@
-import { atom } from 'jotai'
+import { atom, useAtom, useSetAtom } from 'jotai'
+import React from 'react'
 
 export const InspectorWidthAtom = atom<'regular' | 'wide'>('regular')
 
@@ -10,3 +11,25 @@ export interface CanvasControlWithProps<P> {
 
 export const InspectorHoveredCanvasControls = atom<Array<CanvasControlWithProps<any>>>([])
 export const InspectorFocusedCanvasControls = atom<Array<CanvasControlWithProps<any>>>([])
+
+type GridProperty = keyof React.CSSProperties // coarse grained
+
+const GridPropertiesSetAtom = atom<GridProperty[]>([])
+
+export function useGridPropertiesSet() {
+  const [gridPropsSet] = useAtom(GridPropertiesSetAtom)
+  return gridPropsSet
+}
+
+export function useSetGridProperty(property: GridProperty, isSet: boolean) {
+  const setGridProperties = useSetAtom(GridPropertiesSetAtom)
+  React.useEffect(() => {
+    setGridProperties((props) => {
+      if (isSet && !props.includes(property)) {
+        return [...props, property]
+      } else {
+        return props.filter((p) => p !== property)
+      }
+    })
+  }, [isSet, property, setGridProperties])
+}

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -88,6 +88,7 @@ import { NumberOrKeywordControl } from '../../uuiui/inputs/number-or-keyword-con
 import { optionalMap } from '../../core/shared/optional-utils'
 import { cssNumberEqual } from '../canvas/controls/select-mode/controls-common'
 import type { EditorAction } from '../editor/action-types'
+import { useSetGridProperty } from './common/inspector-atoms'
 
 const axisDropdownMenuButton = 'axisDropdownMenuButton'
 
@@ -442,6 +443,16 @@ const TemplateDimensionControl = React.memo(
       [],
     )
 
+    const prop: keyof React.CSSProperties =
+      axis === 'column'
+        ? 'gridTemplateColumns'
+        : axis === 'row'
+        ? 'gridTemplateRows'
+        : assertNever(axis)
+
+    const { propertyStatus } = useInspectorLayoutInfo(prop)
+    useSetGridProperty(prop, propertyStatus.set)
+
     return (
       <div
         style={{
@@ -672,6 +683,10 @@ const GapRowColumnControl = React.memo(() => {
   const columnGap = useInspectorLayoutInfo('columnGap')
   const rowGap = useInspectorLayoutInfo('rowGap')
 
+  useSetGridProperty('gap', gap.propertyStatus.set)
+  useSetGridProperty('columnGap', columnGap.propertyStatus.set)
+  useSetGridProperty('rowGap', rowGap.propertyStatus.set)
+
   const [controlSplitState, setControlSplitState] = React.useState<GridGapControlSplitState>(
     cssNumberEqual(columnGap.value, rowGap.value) ? 'unified' : 'split',
   )
@@ -892,7 +907,9 @@ const AutoFlowControl = React.memo(() => {
     'AutoFlowControl gridAutoFlowValue',
   )
 
-  const { controlStatus } = useInspectorStyleInfo('gridAutoFlow')
+  const { controlStatus, propertyStatus } = useInspectorStyleInfo('gridAutoFlow')
+
+  useSetGridProperty('gridAutoFlow', propertyStatus.set)
 
   const currentValue = React.useMemo(
     () =>

--- a/editor/src/core/layout/layout-helpers-new.ts
+++ b/editor/src/core/layout/layout-helpers-new.ts
@@ -108,6 +108,8 @@ export type StyleLayoutProp =
   | 'zIndex'
   | 'rowGap'
   | 'columnGap'
+  | 'gridTemplateRows'
+  | 'gridTemplateColumns'
 
 export function framePointForPinnedProp(pinnedProp: LayoutPinnedProp): FramePoint {
   switch (pinnedProp) {


### PR DESCRIPTION
Depends on https://github.com/concrete-utopia/utopia/pull/6191

## Description
This PR adds a utility hook that makes it possible for inspector control section to record whether the component(s) they are setting are set. 


### Manual Tests
I hereby swear that:

- [ ] I opened a hydrogen project and it loaded
- [ ] I could navigate to various routes in Preview mode