### PR TITLE
Reparent out of grid

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.tsx
@@ -24,6 +24,7 @@ import type {
   CanvasStrategy,
   CustomStrategyState,
   InteractionCanvasState,
+  InteractionLifecycle,
 } from '../canvas-strategy-types'
 import {
   controlWithProps,
@@ -61,7 +62,6 @@ export function baseAbsoluteReparentStrategy(
       return null
     }
 
-    const dragInteractionData = interactionSession.interactionData // Why TypeScript?!
     const filteredSelectedElements = flattenSelection(selectedElements)
     const isApplicable = replaceFragmentLikePathsWithTheirChildrenRecursive(
       canvasState.startingMetadata,
@@ -90,26 +90,7 @@ export function baseAbsoluteReparentStrategy(
         category: 'modalities',
         type: 'reparent-large',
       },
-      controlsToRender: [
-        controlWithProps({
-          control: ParentOutlines,
-          props: { targetParent: reparentTarget.newParent.intendedParentPath },
-          key: 'parent-outlines-control',
-          show: 'visible-only-while-active',
-        }),
-        controlWithProps({
-          control: ParentBounds,
-          props: { targetParent: reparentTarget.newParent.intendedParentPath },
-          key: 'parent-bounds-control',
-          show: 'visible-only-while-active',
-        }),
-        controlWithProps({
-          control: ZeroSizedElementControls,
-          props: { showAllPossibleElements: true },
-          key: 'zero-size-control',
-          show: 'visible-only-while-active',
-        }),
-      ],
+      controlsToRender: controlsForAbsoluteReparent(reparentTarget),
       fitness: shouldKeepMovingDraggedGroupChildren(
         canvasState.startingMetadata,
         selectedElements,
@@ -117,100 +98,148 @@ export function baseAbsoluteReparentStrategy(
       )
         ? 1
         : fitness,
-      apply: (strategyLifecycle) => {
-        const { projectContents, nodeModules } = canvasState
-        const newParent = reparentTarget.newParent
-        return ifAllowedToReparent(
-          canvasState,
-          canvasState.startingMetadata,
-          filteredSelectedElements,
-          newParent.intendedParentPath,
-          () => {
-            if (dragInteractionData.drag == null) {
-              return emptyStrategyApplicationResult
-            }
-
-            const allowedToReparent = filteredSelectedElements.every((selectedElement) => {
-              return isAllowedToReparent(
-                canvasState.projectContents,
-                canvasState.startingMetadata,
-                selectedElement,
-                newParent.intendedParentPath,
-              )
-            })
-
-            if (reparentTarget.shouldReparent && allowedToReparent) {
-              const commands = mapDropNulls(
-                (selectedElement) =>
-                  createAbsoluteReparentAndOffsetCommands(
-                    selectedElement,
-                    newParent,
-                    null,
-                    canvasState.startingMetadata,
-                    canvasState.startingElementPathTree,
-                    canvasState.startingAllElementProps,
-                    canvasState.builtInDependencies,
-                    projectContents,
-                    nodeModules,
-                    'force-pins',
-                  ),
-                selectedElements,
-              )
-
-              let newPaths: Array<ElementPath> = []
-              let updatedTargetPaths: UpdatedPathMap = {}
-
-              commands.forEach((c) => {
-                newPaths.push(c.newPath)
-                updatedTargetPaths[EP.toString(c.oldPath)] = c.newPath
-              })
-
-              const moveCommands =
-                absoluteMoveStrategy(
-                  canvasState,
-                  {
-                    ...interactionSession,
-                    updatedTargetPaths: updatedTargetPaths,
-                  },
-                  { ...defaultCustomStrategyState(), action: 'reparent' },
-                )?.strategy.apply(strategyLifecycle).commands ?? []
-
-              const elementsToRerender = EP.uniqueElementPaths([
-                ...customStrategyState.elementsToRerender,
-                ...newPaths,
-                ...newPaths.map(EP.parentPath),
-                ...filteredSelectedElements.map(EP.parentPath),
-              ])
-              return strategyApplicationResult(
-                [
-                  ...moveCommands,
-                  ...commands.flatMap((c) => c.commands),
-                  updateSelectedViews('always', newPaths),
-                  setElementsToRerenderCommand(elementsToRerender),
-                  ...maybeAddContainLayout(
-                    canvasState.startingMetadata,
-                    canvasState.startingAllElementProps,
-                    canvasState.startingElementPathTree,
-                    newParent.intendedParentPath,
-                  ),
-                  setCursorCommand(CSSCursor.Reparent),
-                ],
-                {
-                  elementsToRerender,
-                },
-              )
-            } else {
-              const moveCommands =
-                absoluteMoveStrategy(canvasState, interactionSession, {
-                  ...defaultCustomStrategyState(),
-                  action: 'reparent',
-                })?.strategy.apply(strategyLifecycle).commands ?? []
-              return strategyApplicationResult(moveCommands)
-            }
-          },
-        )
-      },
+      apply: applyAbsoluteReparent(
+        canvasState,
+        interactionSession,
+        customStrategyState,
+        reparentTarget,
+        filteredSelectedElements,
+      ),
     }
+  }
+}
+
+export function controlsForAbsoluteReparent(reparentTarget: ReparentTarget) {
+  return [
+    controlWithProps({
+      control: ParentOutlines,
+      props: { targetParent: reparentTarget.newParent.intendedParentPath },
+      key: 'parent-outlines-control',
+      show: 'visible-only-while-active',
+    }),
+    controlWithProps({
+      control: ParentBounds,
+      props: { targetParent: reparentTarget.newParent.intendedParentPath },
+      key: 'parent-bounds-control',
+      show: 'visible-only-while-active',
+    }),
+    controlWithProps({
+      control: ZeroSizedElementControls,
+      props: { showAllPossibleElements: true },
+      key: 'zero-size-control',
+      show: 'visible-only-while-active',
+    }),
+  ]
+}
+
+export function applyAbsoluteReparent(
+  canvasState: InteractionCanvasState,
+  interactionSession: InteractionSession,
+  customStrategyState: CustomStrategyState,
+  reparentTarget: ReparentTarget,
+  selectedElements: ElementPath[],
+) {
+  return (strategyLifecycle: InteractionLifecycle) => {
+    if (
+      selectedElements.length === 0 ||
+      interactionSession == null ||
+      interactionSession.interactionData.type !== 'DRAG'
+    ) {
+      return emptyStrategyApplicationResult
+    }
+    const dragInteractionData = interactionSession.interactionData
+
+    const { projectContents, nodeModules } = canvasState
+    const newParent = reparentTarget.newParent
+    return ifAllowedToReparent(
+      canvasState,
+      canvasState.startingMetadata,
+      selectedElements,
+      newParent.intendedParentPath,
+      () => {
+        if (dragInteractionData.drag == null) {
+          return emptyStrategyApplicationResult
+        }
+
+        const allowedToReparent = selectedElements.every((selectedElement) => {
+          return isAllowedToReparent(
+            canvasState.projectContents,
+            canvasState.startingMetadata,
+            selectedElement,
+            newParent.intendedParentPath,
+          )
+        })
+
+        if (reparentTarget.shouldReparent && allowedToReparent) {
+          const commands = mapDropNulls(
+            (selectedElement) =>
+              createAbsoluteReparentAndOffsetCommands(
+                selectedElement,
+                newParent,
+                null,
+                canvasState.startingMetadata,
+                canvasState.startingElementPathTree,
+                canvasState.startingAllElementProps,
+                canvasState.builtInDependencies,
+                projectContents,
+                nodeModules,
+                'force-pins',
+              ),
+            selectedElements,
+          )
+
+          let newPaths: Array<ElementPath> = []
+          let updatedTargetPaths: UpdatedPathMap = {}
+
+          commands.forEach((c) => {
+            newPaths.push(c.newPath)
+            updatedTargetPaths[EP.toString(c.oldPath)] = c.newPath
+          })
+
+          const moveCommands =
+            absoluteMoveStrategy(
+              canvasState,
+              {
+                ...interactionSession,
+                updatedTargetPaths: updatedTargetPaths,
+              },
+              { ...defaultCustomStrategyState(), action: 'reparent' },
+            )?.strategy.apply(strategyLifecycle).commands ?? []
+
+          const elementsToRerender = EP.uniqueElementPaths([
+            ...customStrategyState.elementsToRerender,
+            ...newPaths,
+            ...newPaths.map(EP.parentPath),
+            ...selectedElements.map(EP.parentPath),
+          ])
+          return strategyApplicationResult(
+            [
+              ...moveCommands,
+              ...commands.flatMap((c) => c.commands),
+              updateSelectedViews('always', newPaths),
+              setElementsToRerenderCommand(elementsToRerender),
+              ...maybeAddContainLayout(
+                canvasState.startingMetadata,
+                canvasState.startingAllElementProps,
+                canvasState.startingElementPathTree,
+                newParent.intendedParentPath,
+              ),
+              setCursorCommand(CSSCursor.Reparent),
+            ],
+            {
+              elementsToRerender,
+            },
+          )
+        } else {
+          const moveCommands =
+            absoluteMoveStrategy(canvasState, interactionSession, {
+              ...defaultCustomStrategyState(),
+              action: 'reparent',
+            })?.strategy.apply(strategyLifecycle).commands ?? []
+          return strategyApplicationResult(moveCommands)
+        }
+      },
+    )
   }
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
@@ -240,19 +240,18 @@ function getCommandsAndPatchForReparent(
   }
   const result = applyReparent()
 
-  let commands = [...result.commands]
+  let commands: CanvasCommand[] = []
   if (strategy.strategy === 'REPARENT_AS_ABSOLUTE') {
     const frame = MetadataUtils.getFrameOrZeroRect(targetElement, canvasState.startingMetadata)
-    const top = frame.y + interactionData.drag.y
-    const left = frame.x + interactionData.drag.x
     commands.push(
       updateBulkProperties('always', targetElement, [
         propertyToSet(PP.create('style', 'position'), 'absolute'),
-        propertyToSet(PP.create('style', 'top'), top),
-        propertyToSet(PP.create('style', 'left'), left),
+        propertyToSet(PP.create('style', 'top'), frame.y + interactionData.drag.y),
+        propertyToSet(PP.create('style', 'left'), frame.x + interactionData.drag.x),
       ]),
     )
   }
+  commands.push(...result.commands)
 
   return {
     commands: commands,

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
@@ -315,7 +315,7 @@ type StrategyToApply =
       name: string
     }
   | {
-      type: 'GRID_REARRANGE' | 'REPARENT'
+      type: 'REPARENT'
       controlsToRender: ControlWithProps<any>[]
       name: string
       strategy: FindReparentStrategyResult

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
@@ -16,14 +16,29 @@ import {
 } from '../../commands/set-property-command'
 import type { CanvasStrategyFactory } from '../canvas-strategies'
 import { onlyFitWhenDraggingThisControl } from '../canvas-strategies'
-import type { CustomStrategyState, InteractionCanvasState } from '../canvas-strategy-types'
+import type {
+  ControlWithProps,
+  CustomStrategyState,
+  CustomStrategyStatePatch,
+  InteractionCanvasState,
+  InteractionLifecycle,
+} from '../canvas-strategy-types'
 import {
   getTargetPathsFromInteractionTarget,
   emptyStrategyApplicationResult,
   strategyApplicationResult,
 } from '../canvas-strategy-types'
-import type { InteractionSession } from '../interaction-state'
+import type { DragInteractionData, InteractionSession } from '../interaction-state'
 import { runGridRearrangeMove } from './grid-helpers'
+import type { CanvasRectangle } from '../../../../core/shared/math-utils'
+import { isInfinityRectangle, offsetPoint } from '../../../../core/shared/math-utils'
+import { findReparentStrategies } from './reparent-helpers/reparent-strategy-helpers'
+import { applyAbsoluteReparent, controlsForAbsoluteReparent } from './absolute-reparent-strategy'
+import type { CanvasCommand } from '../../commands/commands'
+import { applyStaticReparent, controlsForStaticReparent } from './reparent-as-static-strategy'
+import type { FindReparentStrategyResult } from './reparent-helpers/reparent-strategy-parent-lookup'
+import { applyGridReparent, controlsForGridReparent } from './grid-reparent-strategy'
+import { assertNever } from '../../../../core/shared/utils'
 
 export const gridRearrangeMoveStrategy: CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -48,59 +63,45 @@ export const gridRearrangeMoveStrategy: CanvasStrategyFactory = (
   }
 
   const parentGridPath = EP.parentPath(selectedElement)
+  const gridFrame = MetadataUtils.findElementByElementPath(
+    canvasState.startingMetadata,
+    parentGridPath,
+  )?.globalFrame
+  if (gridFrame == null || isInfinityRectangle(gridFrame)) {
+    return null
+  }
 
   const initialTemplates = getGridTemplates(canvasState.startingMetadata, parentGridPath)
   if (initialTemplates == null) {
     return null
   }
 
+  const strategyToApply = getStrategyToApply(
+    canvasState,
+    interactionSession.interactionData,
+    parentGridPath,
+  )
+  if (strategyToApply == null) {
+    return null
+  }
+
   return {
     id: 'rearrange-grid-move-strategy',
-    name: 'Rearrange Grid (Move)',
-    descriptiveLabel: 'Rearrange Grid (Move)',
+    name: strategyToApply.name,
+    descriptiveLabel: strategyToApply.name,
     icon: {
       category: 'tools',
       type: 'pointer',
     },
-    controlsToRender: [
-      {
-        control: GridControls,
-        props: { targets: [parentGridPath] },
-        key: GridControlsKey(parentGridPath),
-        show: 'always-visible',
-        priority: 'bottom',
-      },
-    ],
+    controlsToRender: strategyToApply.controlsToRender,
     fitness: onlyFitWhenDraggingThisControl(interactionSession, 'GRID_CELL_HANDLE', 2),
-    apply: () => {
+    apply: (strategyLifecycle) => {
       if (
         interactionSession == null ||
         interactionSession.interactionData.type !== 'DRAG' ||
         interactionSession.interactionData.drag == null ||
         interactionSession.activeControl.type !== 'GRID_CELL_HANDLE'
       ) {
-        return emptyStrategyApplicationResult
-      }
-
-      const targetElement = selectedElement
-
-      const {
-        commands: moveCommands,
-        targetCell: targetGridCell,
-        draggingFromCell,
-        originalRootCell,
-        targetRootCell,
-      } = runGridRearrangeMove(
-        targetElement,
-        selectedElement,
-        canvasState.startingMetadata,
-        interactionSession.interactionData,
-        canvasState.scale,
-        canvasState.canvasOffset,
-        customState.grid,
-        false,
-      )
-      if (moveCommands.length === 0) {
         return emptyStrategyApplicationResult
       }
 
@@ -127,18 +128,125 @@ export const gridRearrangeMoveStrategy: CanvasStrategyFactory = (
         ),
       ]
 
+      const { commands, patch } =
+        strategyToApply.type === 'GRID_REARRANGE'
+          ? getCommandsAndPatchForGridRearrange(
+              canvasState,
+              interactionSession.interactionData,
+              customState,
+              selectedElement,
+            )
+          : getCommandsAndPatchForReparent(
+              strategyToApply.strategy,
+              canvasState,
+              interactionSession.interactionData,
+              interactionSession,
+              customState,
+              selectedElement,
+              strategyLifecycle,
+              gridFrame,
+            )
+
+      if (commands.length === 0) {
+        return emptyStrategyApplicationResult
+      }
+
       return strategyApplicationResult(
-        [...moveCommands, ...midInteractionCommands, ...onCompleteCommands],
-        {
-          grid: {
-            targetCell: targetGridCell,
-            draggingFromCell: draggingFromCell,
-            originalRootCell: originalRootCell,
-            currentRootCell: targetRootCell,
-          },
-        },
+        [...midInteractionCommands, ...onCompleteCommands, ...commands],
+        patch,
       )
     },
+  }
+}
+
+function getCommandsAndPatchForGridRearrange(
+  canvasState: InteractionCanvasState,
+  interactionData: DragInteractionData,
+  customState: CustomStrategyState,
+  selectedElement: ElementPath,
+): { commands: CanvasCommand[]; patch: CustomStrategyStatePatch } {
+  if (interactionData.drag == null) {
+    return { commands: [], patch: {} }
+  }
+
+  const {
+    commands,
+    targetCell: targetGridCell,
+    draggingFromCell,
+    originalRootCell,
+    targetRootCell,
+  } = runGridRearrangeMove(
+    selectedElement,
+    selectedElement,
+    canvasState.startingMetadata,
+    interactionData,
+    canvasState.scale,
+    canvasState.canvasOffset,
+    customState.grid,
+    false,
+  )
+
+  return {
+    commands: commands,
+    patch: {
+      grid: {
+        targetCell: targetGridCell,
+        draggingFromCell: draggingFromCell,
+        originalRootCell: originalRootCell,
+        currentRootCell: targetRootCell,
+      },
+    },
+  }
+}
+
+function getCommandsAndPatchForReparent(
+  strategy: FindReparentStrategyResult,
+  canvasState: InteractionCanvasState,
+  interactionData: DragInteractionData,
+  interactionSession: InteractionSession,
+  customState: CustomStrategyState,
+  targetElement: ElementPath,
+  strategyLifecycle: InteractionLifecycle,
+  gridFrame: CanvasRectangle,
+): { commands: CanvasCommand[]; patch: CustomStrategyStatePatch } {
+  if (interactionData.drag == null) {
+    return { commands: [], patch: {} }
+  }
+  const frame = MetadataUtils.getFrameOrZeroRect(targetElement, canvasState.startingMetadata)
+
+  const top = frame.y + interactionData.drag.y
+  const left = frame.x + interactionData.drag.x
+
+  const reparent =
+    strategy.strategy === 'REPARENT_INTO_GRID'
+      ? applyGridReparent(
+          canvasState,
+          interactionData,
+          customState,
+          strategy.target,
+          [targetElement],
+          gridFrame,
+        )()
+      : strategy.strategy === 'REPARENT_AS_ABSOLUTE'
+      ? applyAbsoluteReparent(canvasState, interactionSession, customState, strategy.target, [
+          targetElement,
+        ])(strategyLifecycle)
+      : applyStaticReparent(canvasState, interactionSession, customState, strategy.target)
+
+  return {
+    commands: [
+      ...(strategy.strategy === 'REPARENT_AS_ABSOLUTE'
+        ? [
+            updateBulkProperties('always', targetElement, [
+              propertyToSet(PP.create('style', 'position'), 'absolute'),
+              propertyToSet(PP.create('style', 'top'), top),
+              propertyToSet(PP.create('style', 'left'), left),
+            ]),
+          ]
+        : []),
+      ...reparent.commands,
+    ],
+    patch: reparent.customStatePatch,
   }
 }
 
@@ -197,5 +305,82 @@ function getGridTemplates(jsxMetadata: ElementInstanceMetadataMap, gridPath: Ele
       columns: templateColsFromProps,
       rows: templateRowsFromProps,
     },
+  }
+}
+
+type StrategyToApply =
+  | {
+      type: 'GRID_REARRANGE'
+      controlsToRender: ControlWithProps<any>[]
+      name: string
+    }
+  | {
+      type: 'GRID_REARRANGE' | 'REPARENT'
+      controlsToRender: ControlWithProps<any>[]
+      name: string
+      strategy: FindReparentStrategyResult
+    }
+
+function getStrategyToApply(
+  canvasState: InteractionCanvasState,
+  interactionData: DragInteractionData,
+  parentGridPath: ElementPath,
+): StrategyToApply | null {
+  if (interactionData.drag == null) {
+    return null
+  }
+
+  const shouldReparent = interactionData.modifiers.cmd
+  if (shouldReparent) {
+    const pointOnCanvas = offsetPoint(interactionData.originalDragStart, interactionData.drag)
+    const reparentStrategies = findReparentStrategies(
+      canvasState,
+      true,
+      pointOnCanvas,
+      'allow-smaller-parent',
+    )
+
+    const strategy = reparentStrategies[0]
+    if (strategy != null) {
+      switch (strategy.strategy) {
+        case 'REPARENT_AS_ABSOLUTE':
+          return {
+            type: 'REPARENT',
+            name: 'Reparent (Abs)',
+            controlsToRender: controlsForAbsoluteReparent(strategy.target),
+            strategy: strategy,
+          }
+        case 'REPARENT_AS_STATIC':
+          return {
+            type: 'REPARENT',
+            name: 'Reparent (Flex)',
+            controlsToRender: controlsForStaticReparent(strategy.target),
+            strategy: strategy,
+          }
+        case 'REPARENT_INTO_GRID':
+          return {
+            type: 'REPARENT',
+            name: 'Reparent (Grid)',
+            controlsToRender: controlsForGridReparent(strategy.target),
+            strategy: strategy,
+          }
+        default:
+          assertNever(strategy.strategy)
+      }
+    }
+  }
+
+  return {
+    type: 'GRID_REARRANGE',
+    name: 'Rearrange Grid (Move)',
+    controlsToRender: [
+      {
+        control: GridControls,
+        props: { targets: [parentGridPath] },
+        key: GridControlsKey(parentGridPath),
+        show: 'always-visible',
+        priority: 'bottom',
+      },
+    ],
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/rearrange-grid-swap-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/rearrange-grid-swap-strategy.ts
@@ -38,7 +38,8 @@ export const rearrangeGridSwapStrategy: CanvasStrategyFactory = (
     interactionSession.interactionData.type !== 'DRAG' ||
     interactionSession.interactionData.drag == null ||
     interactionSession.activeControl.type !== 'GRID_CELL_HANDLE' ||
-    interactionSession.interactionData.modifiers.alt
+    interactionSession.interactionData.modifiers.alt ||
+    interactionSession.interactionData.modifiers.cmd
   ) {
     return null
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reparent-as-static-strategy.tsx
@@ -66,38 +66,7 @@ export function baseReparentAsStaticStrategy(
 
     return {
       ...getDescriptivePropertiesOfReparentToStaticStrategy(targetLayout),
-      controlsToRender: [
-        controlWithProps({
-          control: ParentOutlines,
-          props: { targetParent: reparentTarget.newParent.intendedParentPath },
-          key: 'parent-outlines-control',
-          show: 'visible-only-while-active',
-        }),
-        controlWithProps({
-          control: ParentBounds,
-          props: { targetParent: reparentTarget.newParent.intendedParentPath },
-          key: 'parent-bounds-control',
-          show: 'visible-only-while-active',
-        }),
-        controlWithProps({
-          control: FlexReparentTargetIndicator,
-          props: {},
-          key: 'flex-reparent-target-indicator',
-          show: 'visible-only-while-active',
-        }),
-        controlWithProps({
-          control: ZeroSizedElementControls,
-          props: { showAllPossibleElements: true },
-          key: 'zero-size-control',
-          show: 'visible-only-while-active',
-        }),
-        controlWithProps({
-          control: StaticReparentTargetOutlineIndicator,
-          props: {},
-          key: 'parent-outline-highlight',
-          show: 'visible-only-while-active',
-        }),
-      ],
+      controlsToRender: controlsForStaticReparent(reparentTarget),
       fitness: shouldKeepMovingDraggedGroupChildren(
         canvasState.startingMetadata,
         selectedElements,
@@ -115,6 +84,41 @@ export function baseReparentAsStaticStrategy(
       },
     }
   }
+}
+
+export function controlsForStaticReparent(reparentTarget: ReparentTarget) {
+  return [
+    controlWithProps({
+      control: ParentOutlines,
+      props: { targetParent: reparentTarget.newParent.intendedParentPath },
+      key: 'parent-outlines-control',
+      show: 'visible-only-while-active',
+    }),
+    controlWithProps({
+      control: ParentBounds,
+      props: { targetParent: reparentTarget.newParent.intendedParentPath },
+      key: 'parent-bounds-control',
+      show: 'visible-only-while-active',
+    }),
+    controlWithProps({
+      control: FlexReparentTargetIndicator,
+      props: {},
+      key: 'flex-reparent-target-indicator',
+      show: 'visible-only-while-active',
+    }),
+    controlWithProps({
+      control: ZeroSizedElementControls,
+      props: { showAllPossibleElements: true },
+      key: 'zero-size-control',
+      show: 'visible-only-while-active',
+    }),
+    controlWithProps({
+      control: StaticReparentTargetOutlineIndicator,
+      props: {},
+      key: 'parent-outline-highlight',
+      show: 'visible-only-while-active',
+    }),
+  ]
 }
 
 function getDescriptivePropertiesOfReparentToStaticStrategy(
@@ -146,7 +150,7 @@ function getDescriptivePropertiesOfReparentToStaticStrategy(
   }
 }
 
-function applyStaticReparent(
+export function applyStaticReparent(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession,
   customStrategyState: CustomStrategyState,

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -486,7 +486,7 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
       store.editor.canvas.interactionSession != null &&
       store.editor.canvas.interactionSession.activeControl.type === 'GRID_CELL_HANDLE' &&
       store.editor.canvas.interactionSession?.interactionData.type === 'DRAG' &&
-      !store.editor.canvas.interactionSession?.interactionData.modifiers.cmd &&
+      store.editor.canvas.interactionSession?.interactionData.modifiers.cmd !== true &&
       store.editor.canvas.interactionSession?.interactionData.drag != null
         ? store.editor.canvas.interactionSession.activeControl.id
         : null,

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -486,6 +486,7 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
       store.editor.canvas.interactionSession != null &&
       store.editor.canvas.interactionSession.activeControl.type === 'GRID_CELL_HANDLE' &&
       store.editor.canvas.interactionSession?.interactionData.type === 'DRAG' &&
+      !store.editor.canvas.interactionSession?.interactionData.modifiers.cmd &&
       store.editor.canvas.interactionSession?.interactionData.drag != null
         ? store.editor.canvas.interactionSession.activeControl.id
         : null,


### PR DESCRIPTION
**Problem:**

It's currently not possible to reparent out of a grid.

**Fix:**

Allow reparenting out of a grid while holding `cmd`, like all other reparenting scenarios.

https://github.com/user-attachments/assets/df75b0ee-5098-4cba-b66c-507697cf03c0

**Notes:**
The grid rearrange strategy now needs to act as a sort of meta strat, because 1) it needs a custom mouse drag handling (due to the grid placeholder controls) and 2) cells don't have positioning props so absolute reparenting needs some massaging in order to work

Fixes #6263 
