### PR TITLE
Polish the grid column/row resize controls

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -79,6 +79,7 @@ import { useCanvasAnimation } from '../ui-jsx-canvas-renderer/animation-context'
 import { CanvasLabel } from './select-mode/controls-common'
 import { optionalMap } from '../../../core/shared/optional-utils'
 import type { Sides } from 'utopia-api/core'
+import { useMaybeHighlightElement } from './select-mode/select-mode-hooks'
 
 const CELL_ANIMATION_DURATION = 0.15 // seconds
 
@@ -195,6 +196,16 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
     [canvasOffset, dispatch, props.axis, props.dimensionIndex, scale],
   )
 
+  const { maybeClearHighlightsOnHoverEnd } = useMaybeHighlightElement()
+
+  const onMouseMove = React.useCallback(
+    (e: React.MouseEvent) => {
+      maybeClearHighlightsOnHoverEnd()
+      e.stopPropagation()
+    },
+    [maybeClearHighlightsOnHoverEnd],
+  )
+
   const labelId = `grid-${props.axis}-handle-${props.dimensionIndex}`
   const containerId = `${labelId}-container`
 
@@ -235,7 +246,7 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
           justifyContent: 'center',
           cursor: gridEdgeToCSSCursor(props.axis === 'column' ? 'column-start' : 'row-start'),
           fontSize: 8,
-          position: 'relative',
+          pointerEvents: 'initial',
         }}
         css={{
           opacity: resizing ? 1 : 0.5,
@@ -244,6 +255,7 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
           },
         }}
         onMouseDown={mouseDownHandler}
+        onMouseMove={onMouseMove}
       >
         {props.axis === 'row' ? '↕' : '↔'}
         {when(

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -212,13 +212,9 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
         display: 'flex',
         alignItems: props.axis === 'column' ? 'flex-start' : 'center',
         justifyContent: props.axis === 'column' ? 'center' : 'flex-start',
-        border: `1px solid ${resizing ? colorTheme.brandNeonPink.value : 'transparent'}`,
         height: props.axis === 'column' && resizing ? shadowSize : '100%',
         width: props.axis === 'row' && resizing ? shadowSize : '100%',
         position: 'relative',
-        ...(resizing
-          ? UtopiaStyles.backgrounds.stripedBackground(colorTheme.brandNeonPink60.value, scale)
-          : {}),
       }}
     >
       <div
@@ -267,6 +263,10 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
+            border: `1px solid ${resizing ? colorTheme.brandNeonPink.value : 'transparent'}`,
+            ...(resizing
+              ? UtopiaStyles.backgrounds.stripedBackground(colorTheme.brandNeonPink60.value, scale)
+              : {}),
           }}
         >
           <CanvasLabel

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -237,9 +237,7 @@ export const GridResizingControl = React.memo((props: GridResizingControlProps) 
           borderRadius: '100%',
           border: `1px solid ${colorTheme.border0.value}`,
           boxShadow: `${colorTheme.canvasControlsSizeBoxShadowColor50.value} 0px 0px
-              ${1 / scale}px, ${colorTheme.canvasControlsSizeBoxShadowColor20.value} 0px ${
-            1 / scale
-          }px ${2 / scale}px ${1 / scale}px`,
+              1px, ${colorTheme.canvasControlsSizeBoxShadowColor20.value} 0px 1px 2px 2px`,
           background: colorTheme.white.value,
           display: 'flex',
           alignItems: 'center',


### PR DESCRIPTION
## Description
This PR removes some visual glitches from the grid column/row resize controls:
- when the resize handle is being dragged, only the grid column/row is highlighted, not the grid column/row + the handle
- when a handle is hovered, elements under the handle aren't highlighted
- handle shadows are properly scaled

### Manual Tests:
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #[ticket_number] (<< pls delete this line if it's not relevant)
