### PR TITLE
fixing a handful of setElementsToRerenderCommand

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.tsx
@@ -127,7 +127,7 @@ export function absoluteDuplicateStrategy(
           [
             ...duplicateCommands,
             ...maybeAddContainLayoutCommand(commonParentPath),
-            setElementsToRerenderCommand([...selectedElements, ...newPaths]),
+            setElementsToRerenderCommand([commonParentPath, ...selectedElements, ...newPaths]),
             updateSelectedViews('always', selectedElements),
             updateFunctionCommand('always', (editorState, commandLifecycle) =>
               runMoveStrategy(

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-reorder-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-reorder-strategy.ts
@@ -86,9 +86,14 @@ export function keyboardReorderStrategy(
         const result = unpatchedIndex + keyboardResult
         const newIndex = Math.min(Math.max(0, result), siblings.length - 1)
 
+        const siblingsAndParent = siblings.concat(EP.parentPath(target))
+
         if (newIndex === unpatchedIndex) {
           return strategyApplicationResult(
-            [updateHighlightedViews('mid-interaction', []), setElementsToRerenderCommand(siblings)],
+            [
+              updateHighlightedViews('mid-interaction', []),
+              setElementsToRerenderCommand(siblingsAndParent),
+            ],
             {
               lastReorderIdx: newIndex,
             },
@@ -97,7 +102,7 @@ export function keyboardReorderStrategy(
           return strategyApplicationResult(
             [
               reorderElement('always', target, absolute(newIndex)),
-              setElementsToRerenderCommand(siblings),
+              setElementsToRerenderCommand(siblingsAndParent),
               updateHighlightedViews('mid-interaction', []),
             ],
             {

--- a/editor/src/components/canvas/canvas-strategies/strategies/reorder-slider-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reorder-slider-strategy.tsx
@@ -78,6 +78,8 @@ export function reorderSliderStategy(
       ) {
         const siblingsOfTarget = siblings.map((element) => element.elementPath)
 
+        const siblingsAndParent = siblingsOfTarget.concat(EP.parentPath(target))
+
         if (!isReorderAllowed(siblingsOfTarget)) {
           return strategyApplicationResult(
             [setCursorCommand(CSSCursor.NotPermitted)],
@@ -101,7 +103,7 @@ export function reorderSliderStategy(
           return strategyApplicationResult(
             [
               reorderElement('always', target, absolute(newIndex)),
-              setElementsToRerenderCommand(siblingsOfTarget),
+              setElementsToRerenderCommand(siblingsAndParent),
               updateHighlightedViews('mid-interaction', []),
               setCursorCommand(CSSCursor.ResizeEW),
             ],

--- a/editor/src/components/canvas/canvas-strategies/strategies/reorder-utils.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/reorder-utils.ts
@@ -58,6 +58,8 @@ export function applyReorderCommon(
       target,
     ).map((element) => element.elementPath)
 
+    const siblingsAndParent = siblings.concat(EP.parentPath(target))
+
     if (!isReorderAllowed(siblings)) {
       return strategyApplicationResult([setCursorCommand(CSSCursor.NotPermitted)], {}, 'failure')
     }
@@ -99,7 +101,7 @@ export function applyReorderCommon(
             { action: 'reorder', target: activeFrameTargetRect(targetFrame), source: sourceFrame },
           ]),
           updateHighlightedViews('mid-interaction', []),
-          setElementsToRerenderCommand(siblings),
+          setElementsToRerenderCommand(siblingsAndParent),
           setCursorCommand(CSSCursor.Move),
         ],
         {
@@ -113,7 +115,7 @@ export function applyReorderCommon(
             { action: 'reorder', target: activeFrameTargetRect(targetFrame), source: sourceFrame },
           ]),
           reorderElement('always', target, absolute(newResultOrLastIndex)),
-          setElementsToRerenderCommand(siblings),
+          setElementsToRerenderCommand(siblingsAndParent),
           updateHighlightedViews('mid-interaction', []),
           setCursorCommand(CSSCursor.Move),
         ],


### PR DESCRIPTION
**Problem:**
In the upcoming dom-walker refactor PR the dom-sampler will only collect metadata for `ElementsToRerender` and their children. In testing we realized that on `master` some behavior was hinging on the dom-walker also collecting metadata for siblings and parent.

**Fix:**
Go through all uses of `setElementsToRerenderCommand` and make sure the parent and siblings are included in the relevant strategies.
