### PR TITLE
Fix test suite name

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
@@ -45,7 +45,7 @@ async function runCellResizeTest(
   )
 }
 
-describe('grid rearrange move strategy', () => {
+describe('grid resize element strategy', () => {
   describe('column-end', () => {
     it('can enlarge element', async () => {
       const editor = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')


### PR DESCRIPTION
## Problem
The name of the test suite for grid resizing didn't match the file name (and actually was the same as another test suite's name), which could lead to confusion and frustration

## Fix
Change its name to match the file it's in
