### PR TITLE
fix(canvas): short delay when hovering grid gaps

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/grid-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/grid-gap-control.tsx
@@ -34,6 +34,7 @@ interface GridGapControlProps {
 
 export const GridGapControlTestId = 'grid-gap-control'
 export const GridGapControlHandleTestId = 'grid-gap-control-handle'
+const GridGapHandlersBackgroundHoverDelay = 350
 
 export const GridGapControl = controlForStrategyMemoized<GridGapControlProps>((props) => {
   const { selectedElement, updatedGapValueRow, updatedGapValueColumn } = props
@@ -51,9 +52,12 @@ export const GridGapControl = controlForStrategyMemoized<GridGapControlProps>((p
   const [rowBackgroundShown, setRowBackgroundShown] = React.useState<boolean>(false)
   const [columnBackgroundShown, setColumnBackgroundShown] = React.useState<boolean>(false)
 
-  const [rowControlHoverStart, rowControlHoverEnd] = useHoverWithDelay(0, setRowBackgroundShown)
+  const [rowControlHoverStart, rowControlHoverEnd] = useHoverWithDelay(
+    GridGapHandlersBackgroundHoverDelay,
+    setRowBackgroundShown,
+  )
   const [columnControlHoverStart, columnControlHoverEnd] = useHoverWithDelay(
-    0,
+    GridGapHandlersBackgroundHoverDelay,
     setColumnBackgroundShown,
   )
 


### PR DESCRIPTION
**Problem:**
When a grid has several rows and columns, the grid gap hover indicator can be hoverwhelming (📷 ruggi)
<video src="https://github.com/user-attachments/assets/f5dc2149-4654-4909-b26e-cd7b3c29e069"></video>


**Fix:**
Add a small delay so that the hover background will not appear immeditately
<video src="https://github.com/user-attachments/assets/804ea535-da10-4b6d-b5a6-e1b04283c86a"></video>


**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode
