### PR TITLE
disable tests that break because of Chrome 128 zoom

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
@@ -452,7 +452,8 @@ describe('Snapping guidelines for absolutely moved element', () => {
     ])
   })
 
-  it('should line up appropriately with a scale of 4', async () => {
+  // Disabled because of the zoom problems introduced by the Chrome 128 release
+  xit('should line up appropriately with a scale of 4', async () => {
     const renderResult = await getGuidelineRenderResult(4)
 
     expect(await getGuidelineDimensions(renderResult, 'guideline-0')).toEqual({

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.browser2.tsx
@@ -2455,7 +2455,9 @@ export var storyboard = (
         expect(span.clientWidth).toEqual(88)
         expect(isBetween(span.clientHeight, 37, 39)).toBe(true)
       })
-      it('does not resize text elements past their intrinsic size when zoomed in', async () => {
+
+      // Disabled because of the zoom problems introduced by the Chrome 128 release
+      xit('does not resize text elements past their intrinsic size when zoomed in', async () => {
         const renderResult = await renderTestEditorWithCode(
           formatTestProjectCode(`
           import * as React from 'react'

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.spec.browser2.tsx
@@ -60,7 +60,8 @@ describe('grid rearrange move strategy', () => {
     })
   })
 
-  it('can rearrange elements on a grid (zoom in)', async () => {
+  // Disabled because of the zoom problems introduced by the Chrome 128 release
+  xit('can rearrange elements on a grid (zoom in)', async () => {
     const editor = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')
 
     const testId = 'aaa'


### PR DESCRIPTION
Disable the tests that were broken by the `zoom`-related changes in the Chrome 128 release https://developer.chrome.com/release-notes/128#standardized_css_zoom_property
