### PR TITLE
Drag To Move Strategy Improvement

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -93,6 +93,15 @@ export const drawToInsertMetaStrategy: MetaCanvasStrategy = (
     return []
   }
 
+  const insertionSubjects = getInsertionSubjectsFromInteractionTarget(canvasState.interactionTarget)
+  if (insertionSubjects.length != 1) {
+    return []
+  }
+  const insertionSubject = insertionSubjects[0]
+  if (insertionSubject.textEdit) {
+    return []
+  }
+
   const targetParent = findElementPathUnderInteractionPoint(canvasState, interactionSession)
 
   if (
@@ -103,11 +112,6 @@ export const drawToInsertMetaStrategy: MetaCanvasStrategy = (
     return stripNulls([
       gridDrawToInsertStrategy(canvasState, interactionSession, customStrategyState),
     ])
-  }
-
-  const insertionSubjects = getInsertionSubjectsFromInteractionTarget(canvasState.interactionTarget)
-  if (insertionSubjects.length != 1) {
-    return []
   }
 
   const pointOnCanvas =
@@ -211,7 +215,7 @@ export function drawToInsertStrategyFactory(
         show: 'visible-only-while-active',
       }),
     ], // Uses existing hooks in select-mode-hooks.tsx
-    fitness: !insertionSubject.textEdit && drawToInsertFitness(interactionSession) ? fitness : 0,
+    fitness: drawToInsertFitness(interactionSession) ? fitness : 0,
     apply: (strategyLifecycle) => {
       const rootPath = getRootPath(canvasState.startingMetadata)
       if (interactionSession != null) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-text-strategy.tsx
@@ -30,6 +30,15 @@ export const drawToInsertTextMetaStrategy: MetaCanvasStrategy = (
   interactionSession: InteractionSession | null,
   customStrategyState: CustomStrategyState,
 ): Array<CanvasStrategy> => {
+  const insertionSubjects = getInsertionSubjectsFromInteractionTarget(canvasState.interactionTarget)
+  if (insertionSubjects.length != 1) {
+    return []
+  }
+  const insertionSubject = insertionSubjects[0]
+  if (!insertionSubject.textEdit) {
+    return []
+  }
+
   const elementUnderCursor = findElementPathUnderInteractionPoint(canvasState, interactionSession)
   if (
     MetadataUtils.isGridLayoutedContainer(
@@ -50,17 +59,11 @@ export const drawToInsertTextMetaStrategy: MetaCanvasStrategy = (
   ) {
     return []
   }
-  const insertionSubjects = getInsertionSubjectsFromInteractionTarget(canvasState.interactionTarget)
-  if (insertionSubjects.length != 1) {
-    return []
-  }
 
   const pointOnCanvas =
     interactionSession.interactionData.type === 'DRAG'
       ? interactionSession.interactionData.originalDragStart
       : interactionSession.interactionData.point
-
-  const insertionSubject = insertionSubjects[0]
 
   return [
     {
@@ -69,7 +72,7 @@ export const drawToInsertTextMetaStrategy: MetaCanvasStrategy = (
       descriptiveLabel: 'Drawing To Insert Text',
       icon: { category: 'tools', type: 'pointer' },
       controlsToRender: [],
-      fitness: insertionSubject.textEdit && drawToInsertFitness(interactionSession) ? 1 : 0,
+      fitness: drawToInsertFitness(interactionSession) ? 1 : 0,
       apply: (s) => {
         if (interactionSession.interactionData.type !== 'DRAG') {
           return emptyStrategyApplicationResult

--- a/editor/src/components/canvas/canvas.ts
+++ b/editor/src/components/canvas/canvas.ts
@@ -128,6 +128,7 @@ function getFramesInCanvasContextUncached(
   })
 }
 
+// eslint-disable-next-line object-shorthand
 const Canvas = {
   parentsAndSiblings: [
     TargetSearchType.SelectedElements,


### PR DESCRIPTION
**Problem:**
The strategies take a little bit of time to run and run on every relevant interaction.

**Fix:**
Some of the logic for the two types of draw to insert metastrategies were rejigged to perform some fast checks much earlier which preclude the remainder of those strategies from being applicable.

**Commit Details:**
- Draw to insert metastrategy now checks insertion subjects and the `textEdit` value as early as possible as these are cheap compared to some subsequent checks.
- Draw to insert text metastrategy now checks insertion subjects and the `textEdit` value as early as possible as these are cheap compared to some subsequent checks.
- ESLint tweak to canvas.ts to make the `Canvas` object readable in anything that shows ESLint warnings.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
