### PR TITLE
fix(test): fix a flaky test for context menu

### DIFF
--- a/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
@@ -1286,7 +1286,8 @@ describe('The navigator component picker context menu', () => {
       { x: 2, y: 2 },
     )
 
-    await mouseClickAtPoint(editor.renderedDOM.getByText('div'), { x: 2, y: 2 })
+    const menuButton = await waitFor(() => editor.renderedDOM.getByText('div'))
+    await mouseClickAtPoint(menuButton, { x: 2, y: 2 })
 
     // the element inside the map has been changed to a `div`
     expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(`import * as React from 'react'


### PR DESCRIPTION
**Problem:**
selecting an item from the context menu can sometimes be flaky
<img width="1336" alt="image" src="https://github.com/user-attachments/assets/3b82d0ce-5a4a-48ae-9104-7188e73bbb65">

**Fix:**
Using a similar fix as here: https://github.com/concrete-utopia/utopia/blob/460ed2bc44e3451faae126c2e0df96259c11d24e/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx#L803-L804, waiting for the element

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode
