### PR TITLE
Fix owner badge position while loading

### DIFF
--- a/editor/src/components/user-bar.tsx
+++ b/editor/src/components/user-bar.tsx
@@ -11,7 +11,6 @@ import {
   getConnectionById,
   useCollaborators,
   useConnections,
-  useMyUserAndPresence,
 } from '../core/commenting/comment-hooks'
 import type { FollowTarget, MultiplayerColor } from '../core/shared/multiplayer'
 import {
@@ -93,6 +92,7 @@ const SinglePlayerUserBar = React.memo(() => {
     <FlexRow
       onClick={handleCopyToClipboard}
       css={{
+        position: 'relative',
         background: colorTheme.primary30.value,
         borderRadius: 24,
         height: 24,


### PR DESCRIPTION
**Problem:**

The owner badge is shown in a really bad place for the single player user bar which is displayed while loading the editor/LB.

https://github.com/user-attachments/assets/b3922933-7cd6-444b-b1d2-a95b9aa4e38b


**Fix:**

Make the bar itself use `position: relative`.

_Note: we could also just remove the owner badge at all from single user bar, but I kept it for now to not change anything functionally._