### PR TITLE
Cache Or Avoid Normalisation Of Paths

### DIFF
--- a/editor/src/components/canvas/commands/adjust-css-length-command.ts
+++ b/editor/src/components/canvas/commands/adjust-css-length-command.ts
@@ -391,7 +391,7 @@ const FlexSizeProperties: Array<PropertyPath> = [
 function getConflictingPropertiesToDelete(
   parentFlexDirection: FlexDirection | null,
   propertyPath: PropertyPath,
-) {
+): Array<PropertyPath> {
   let propertiesToDelete: Array<PropertyPath> = []
 
   const parentFlexDimension =
@@ -439,11 +439,15 @@ export function deleteConflictingPropsForWidthHeight(
     propertyPath,
   )
 
-  const { editorStateWithChanges: editorStateWithPropsDeleted } = deleteValuesAtPath(
-    editorState,
-    target,
-    propertiesToDelete,
-  )
+  if (propertiesToDelete.length === 0) {
+    return editorState
+  } else {
+    const { editorStateWithChanges: editorStateWithPropsDeleted } = deleteValuesAtPath(
+      editorState,
+      target,
+      propertiesToDelete,
+    )
 
-  return editorStateWithPropsDeleted
+    return editorStateWithPropsDeleted
+  }
 }

--- a/editor/src/components/custom-code/code-file.spec.ts
+++ b/editor/src/components/custom-code/code-file.spec.ts
@@ -480,10 +480,6 @@ describe('normalisePathToUnderlyingTarget', () => {
     )
     expect(actualResult).toEqual(expectedResult)
   })
-  it('gives an error when the element path is empty', () => {
-    const actualResult = normalisePathToUnderlyingTarget(projectContents, null)
-    expect(actualResult.type).toEqual('NORMALISE_PATH_ERROR')
-  })
   it('flags elements that can not be found', () => {
     const actualResult = normalisePathToUnderlyingTarget(
       projectContents,

--- a/editor/src/components/custom-code/code-file.ts
+++ b/editor/src/components/custom-code/code-file.ts
@@ -54,6 +54,7 @@ import type { EditorDispatch } from '../editor/action-types'
 import { StylingOptions } from 'utopia-api'
 import type { Emphasis, Focus, Icon, Styling } from 'utopia-api'
 import type { ComponentDescriptorBounds } from '../../core/property-controls/component-descriptor-parser'
+import { valueDependentCache } from '../../core/shared/memoize'
 
 type ModuleExportTypes = { [name: string]: ExportType }
 
@@ -472,11 +473,11 @@ export function normalisePathSuccessOrThrowError(
   }
 }
 
-export function normalisePathToUnderlyingTarget(
+export function normalisePathToUnderlyingTargetUncached(
   projectContents: ProjectContentTreeRoot,
-  elementPath: ElementPath | null,
+  elementPath: ElementPath,
 ): NormalisePathResult {
-  if (elementPath == null || EP.isEmptyPath(elementPath)) {
+  if (EP.isEmptyPath(elementPath)) {
     return normalisePathError('Empty element path')
   }
 
@@ -507,6 +508,11 @@ export function normalisePathToUnderlyingTarget(
     lastPartOfPath,
   )
 }
+
+export const normalisePathToUnderlyingTarget = valueDependentCache(
+  normalisePathToUnderlyingTargetUncached,
+  EP.toString,
+)
 
 export function findUnderlyingTargetComponentImplementationFromImportInfo(
   projectContents: ProjectContentTreeRoot,

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -3582,6 +3582,9 @@ export function modifyUnderlyingTarget(
     underlyingFilePath: string,
   ) => ParseSuccess = defaultModifyParseSuccess,
 ): EditorState {
+  if (target == null) {
+    throw new Error(`Target is null.`)
+  }
   const underlyingTarget = normalisePathToUnderlyingTarget(editor.projectContents, target)
   const targetSuccess = normalisePathSuccessOrThrowError(underlyingTarget)
 
@@ -3639,6 +3642,9 @@ export function modifyUnderlyingParseSuccessOnly(
     underlyingFilePath: string,
   ) => ParseSuccess = defaultModifyParseSuccess,
 ): EditorState {
+  if (target == null) {
+    throw new Error(`Target is null.`)
+  }
   const underlyingTarget = normalisePathToUnderlyingTarget(editor.projectContents, target)
   const targetSuccess = normalisePathSuccessOrThrowError(underlyingTarget)
 
@@ -3746,32 +3752,36 @@ export function withUnderlyingTarget<T>(
     underlyingDynamicTarget: ElementPath,
   ) => T,
 ): T {
-  const underlyingTarget = normalisePathToUnderlyingTarget(projectContents, target ?? null)
+  if (target == null) {
+    return defaultValue
+  } else {
+    const underlyingTarget = normalisePathToUnderlyingTarget(projectContents, target)
 
-  if (
-    underlyingTarget.type === 'NORMALISE_PATH_SUCCESS' &&
-    underlyingTarget.normalisedPath != null &&
-    underlyingTarget.normalisedDynamicPath != null
-  ) {
-    const parsed = underlyingTarget.textFile.fileContents.parsed
-    if (isParseSuccess(parsed)) {
-      const element = findJSXElementChildAtPath(
-        getUtopiaJSXComponentsFromSuccess(parsed),
-        underlyingTarget.normalisedPath,
-      )
-      if (element != null) {
-        return withTarget(
-          parsed,
-          element,
+    if (
+      underlyingTarget.type === 'NORMALISE_PATH_SUCCESS' &&
+      underlyingTarget.normalisedPath != null &&
+      underlyingTarget.normalisedDynamicPath != null
+    ) {
+      const parsed = underlyingTarget.textFile.fileContents.parsed
+      if (isParseSuccess(parsed)) {
+        const element = findJSXElementChildAtPath(
+          getUtopiaJSXComponentsFromSuccess(parsed),
           underlyingTarget.normalisedPath,
-          underlyingTarget.filePath,
-          underlyingTarget.normalisedDynamicPath,
         )
+        if (element != null) {
+          return withTarget(
+            parsed,
+            element,
+            underlyingTarget.normalisedPath,
+            underlyingTarget.filePath,
+            underlyingTarget.normalisedDynamicPath,
+          )
+        }
       }
     }
-  }
 
-  return defaultValue
+    return defaultValue
+  }
 }
 
 export function withUnderlyingTargetFromEditorState<T>(

--- a/editor/src/components/inspector/sections/component-section/component-section.tsx
+++ b/editor/src/components/inspector/sections/component-section/component-section.tsx
@@ -1491,7 +1491,7 @@ export const ComponentSectionInner = React.memo((props: ComponentSectionProps) =
     'ComponentInfoBox selectedViews',
   )
 
-  const target = safeIndex(selectedViews, 0) ?? null
+  const target = selectedViews.at(0) ?? EP.emptyElementPath
 
   const locationOfComponentInstance = useEditorState(
     Substores.projectContents,

--- a/editor/src/core/shared/memoize.ts
+++ b/editor/src/core/shared/memoize.ts
@@ -23,3 +23,30 @@ export function memoize<T extends Moizeable>(func: T, options?: Partial<Options<
   const memoizeOptions = getMemoizeOptions(options)
   return moize(func, memoizeOptions)
 }
+
+export function valueDependentCache<Value, Input, Result>(
+  fallback: (value: Value, input: Input) => Result,
+  inputToString: (input: Input) => string,
+): (value: Value, input: Input) => Result {
+  let cache: { [key: string]: Result } = {}
+  let lastSeenValue: Value | null = null
+  return (value: Value, input: Input) => {
+    const inputAsString = inputToString(input)
+    if (lastSeenValue == null || lastSeenValue !== value) {
+      // Either this is the first use of the function, or the value has changed.
+      lastSeenValue = value
+      const result = fallback(value, input)
+      cache = { [inputAsString]: result }
+      return result
+    } else {
+      // The value hasn't changed, so we can use the cache.
+      if (inputAsString in cache) {
+        return cache[inputAsString]
+      } else {
+        const result = fallback(value, input)
+        cache[inputAsString] = result
+        return result
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Problem:**
The function `normalisePathToUnderlyingTarget` is called quite a lot transitively by the strategies logic and often with the same values. But in general this function is triggered by pretty much anything the user does in the editor.

**Fix:**
Given that `normalisePathToUnderlyingTarget` relies on the project contents and an element path and the former changes in a stepwise fashion, we can cache based on that value so that when it changes we clear the cache with the cache being indexed by the element path. A utility function `valueDependentCache` was created which encapsulates this logic.

`valueDependentCache` was instrumented temporarily with a cache hit indicator which showed it hovering around 90% of calls being cache hits during a canvas interaction. When no changes were made to the project (like when the mouse is moved over the canvas) it rapidly shot to above 97%.

**Commit Details:**
- `deleteConflictingPropsForWidthHeight` now avoids calling `deleteValuesAtPath` if there is nothing to delete.
- Removed the null from the `elementPath` parameter of `normalisePathToUnderlyingTarget`.
- Added `valueDependentCache` utility function.
- Wrapped the original implementation of `normalisePathToUnderlyingTarget` with `valueDependentCache`

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode