### PR TITLE
fix(test): add a temp fix for hideAll flakiness

### DIFF
--- a/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
@@ -1282,7 +1282,7 @@ describe('The navigator component picker context menu', () => {
     )
 
     // a temp fix for `hideAll` flakiness
-    await wait(1000)
+    await wait(50)
 
     await mouseClickAtPoint(
       editor.renderedDOM.getByTestId('replace-element-button-sb/scene/flexrow/map/img~~~1'),
@@ -1387,7 +1387,7 @@ export var storyboard = (
     )
 
     // a temp fix for `hideAll` flakiness
-    await wait(1000)
+    await wait(50)
 
     await mouseClickAtPoint(
       editor.renderedDOM.getByTestId('replace-element-button-sb/scene/flexrow/conditional/img'),

--- a/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
+++ b/editor/src/components/navigator/navigator-item/run-in-shard-2-component-picker-context-menu.spec.browser2.tsx
@@ -1281,6 +1281,9 @@ describe('The navigator component picker context menu', () => {
       { x: 2, y: 2 },
     )
 
+    // a temp fix for `hideAll` flakiness
+    await wait(1000)
+
     await mouseClickAtPoint(
       editor.renderedDOM.getByTestId('replace-element-button-sb/scene/flexrow/map/img~~~1'),
       { x: 2, y: 2 },
@@ -1382,6 +1385,9 @@ export var storyboard = (
       ),
       { x: 2, y: 2 },
     )
+
+    // a temp fix for `hideAll` flakiness
+    await wait(1000)
 
     await mouseClickAtPoint(
       editor.renderedDOM.getByTestId('replace-element-button-sb/scene/flexrow/conditional/img'),


### PR DESCRIPTION
A temporary fix since in the test calling`hideAll` triggers hiding the context menu too late sometimes (after it is opened).
This is just to have the test to pass until we fix it.

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
-  [X] I could navigate to various routes in Preview mode
