### PR TITLE
Fragment support in lists

### DIFF
--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -43,6 +43,7 @@ import {
   isJSExpressionOtherJavaScript,
   isJSXMapExpression,
   isJSXTextBlock,
+  getJSXElementLikeNameAsString,
 } from '../../core/shared/element-template'
 import {
   guaranteeUniqueUids,
@@ -1843,7 +1844,7 @@ function getValidElementPathsFromElement(
     const isScene = isSceneElement(element, filePath, projectContents)
     const isSceneWithOneChild = isScene && element.children.length === 1
 
-    const name = isJSXElement(element) ? getJSXElementNameAsString(element.name) : 'Fragment'
+    const name = getJSXElementLikeNameAsString(element)
     const lastElementPathPart = EP.lastElementPathForPath(path)
     const matchingFocusedPathPart =
       focusedElementPath == null || lastElementPathPart == null

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -27,8 +27,6 @@ import type {
 import {
   isJSXElement,
   jsExpressionValue,
-  getJSXElementNameAsString,
-  isJSExpressionMapOrOtherJavaScript,
   isUtopiaJSXComponent,
   emptyComments,
   jsxElementName,
@@ -39,7 +37,6 @@ import {
   isJSIdentifier,
   isJSPropertyAccess,
   isJSElementAccess,
-  isJSExpression,
   isJSExpressionOtherJavaScript,
   isJSXMapExpression,
   isJSXTextBlock,

--- a/editor/src/components/canvas/dom-sampler.spec.browser2.tsx
+++ b/editor/src/components/canvas/dom-sampler.spec.browser2.tsx
@@ -100,9 +100,18 @@ export var Playground = ({ style }) => {
         "sb/pg-sc/pg:aaa/bbb/266/ccc~~~1/ddd",
         "sb/pg-sc/pg:aaa/bbb/266/ccc~~~2/ddd",
         "sb/pg-sc/pg:aaa/bbb/266/ccc~~~3/ddd",
-        "sb/pg-sc/pg:aaa/bbb/6cc",
+        "sb/pg-sc/pg:aaa/bbb/7f0",
+        "sb/pg-sc/pg:aaa/bbb/7f0/486~~~1",
+        "sb/pg-sc/pg:aaa/bbb/7f0/486~~~2",
+        "sb/pg-sc/pg:aaa/bbb/7f0/486~~~3",
+        "sb/pg-sc/pg:aaa/bbb/7f0/486~~~1/yyy",
+        "sb/pg-sc/pg:aaa/bbb/7f0/486~~~2/yyy",
+        "sb/pg-sc/pg:aaa/bbb/7f0/486~~~3/yyy",
+        "sb/pg-sc/pg:aaa/bbb/7f0/486~~~1/zzz",
+        "sb/pg-sc/pg:aaa/bbb/7f0/486~~~2/zzz",
+        "sb/pg-sc/pg:aaa/bbb/7f0/486~~~3/zzz",
       ]
-    `, // TODO before merge isn't the fragment children missing from here?
+    `,
     )
   })
 

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-element-renderer-utils.tsx
@@ -6,7 +6,7 @@ import {
   UTOPIA_INSTANCE_PATH,
   UTOPIA_UID_KEY,
 } from '../../../core/model/utopia-constants'
-import { forEachRight } from '../../../core/shared/either'
+import { type Either, forEachRight, left } from '../../../core/shared/either'
 import type {
   JSXElementChild,
   JSXElement,
@@ -16,6 +16,7 @@ import type {
   JSIdentifier,
   JSPropertyAccess,
   JSElementAccess,
+  JSXAttributes,
 } from '../../../core/shared/element-template'
 import {
   isJSXElement,
@@ -108,30 +109,34 @@ export function createLookupRender(
   renderLimit: number | null,
   valuesInScopeFromParameters: Array<string>,
   assignedToProp: string | null,
-): (element: JSXElement, scope: MapLike<any>) => React.ReactChild | null {
+): (element: JSXElementLike, scope: MapLike<any>) => React.ReactChild | null {
   let index = 0
 
-  return (element: JSXElement, scope: MapLike<any>): React.ReactChild | null => {
+  return (element: JSXElementLike, scope: MapLike<any>): React.ReactChild | null => {
     index++
     if (renderLimit != null && index > renderLimit) {
       return null
     }
     const innerUID = getUtopiaID(element)
     const generatedUID = EP.createIndexedUid(innerUID, index)
-    const withGeneratedUID = setJSXValueAtPath(
-      element.props,
-      PP.create('data-uid'),
-      jsExpressionValue(generatedUID, emptyComments),
-    )
+    const withGeneratedUID: Either<string, JSXAttributes> = isJSXElement(element)
+      ? setJSXValueAtPath(
+          element.props,
+          PP.create('data-uid'),
+          jsExpressionValue(generatedUID, emptyComments),
+        )
+      : left('fragment')
 
     const innerPath = optionalMap((path) => EP.appendToPath(path, generatedUID), elementPath)
 
     let augmentedInnerElement = element
     forEachRight(withGeneratedUID, (attrs) => {
-      augmentedInnerElement = {
-        ...augmentedInnerElement,
-        props: attrs,
-      }
+      augmentedInnerElement = isJSXElement(augmentedInnerElement)
+        ? {
+            ...augmentedInnerElement,
+            props: attrs,
+          }
+        : augmentedInnerElement
     })
 
     let innerVariablesInScope: VariableData = {
@@ -170,9 +175,11 @@ function monkeyUidProp(uid: string | undefined, propsToUpdate: MapLike<any>): Ma
   return monkeyedProps
 }
 
-function NoOpLookupRender(element: JSXElement, scope: MapLike<any>): React.ReactChild {
+function NoOpLookupRender(element: JSXElementLike, scope: MapLike<any>): React.ReactChild {
   throw new Error(
-    `Utopia Error: createLookupRender was not used properly for element: ${element.name.baseVariable}`,
+    `Utopia Error: createLookupRender was not used properly for  ${
+      isJSXElement(element) ? `element: ${element.name.baseVariable}` : 'fragment'
+    }`,
   )
 }
 
@@ -946,7 +953,7 @@ function displayNoneElement(props: any): any {
 export function utopiaCanvasJSXLookup(
   elementsWithin: ElementsWithin,
   executionScope: MapLike<any>,
-  render: (element: JSXElement, inScope: MapLike<any>) => React.ReactChild | null,
+  render: (element: JSXElementLike, inScope: MapLike<any>) => React.ReactChild | null,
 ): (uid: string, inScope: MapLike<any>) => React.ReactChild | null {
   return (uid, inScope) => {
     const element = elementsWithin[uid]

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -635,7 +635,7 @@ import type { OnlineState } from '../online-status'
 import { onlineState } from '../online-status'
 import type { NavigatorRow } from '../../navigator/navigator-row'
 import { condensedNavigatorRow, regularNavigatorRow } from '../../navigator/navigator-row'
-import type { SimpleFunctionWrap, FunctionWrap } from 'utopia-shared/src/types'
+import type { SimpleFunctionWrap, FunctionWrap, JSXElementLike } from 'utopia-shared/src/types'
 import { simpleFunctionWrap, isSimpleFunctionWrap } from 'utopia-shared/src/types'
 import type {
   ComponentDescriptorBounds,
@@ -1438,8 +1438,33 @@ export function JSXElementWithoutUIDKeepDeepEquality(): KeepDeepEqualityCall<JSX
   )
 }
 
+export const JSXFragmentKeepDeepEquality: KeepDeepEqualityCall<JSXFragment> = combine3EqualityCalls(
+  (fragment) => fragment.children,
+  JSXElementChildArrayKeepDeepEquality,
+  (fragment) => fragment.uid,
+  StringKeepDeepEquality,
+  (fragment) => fragment.longForm,
+  BooleanKeepDeepEquality,
+  (children, uid, longForm) => {
+    return {
+      type: 'JSX_FRAGMENT',
+      children: children,
+      uid: uid,
+      longForm: longForm,
+    }
+  },
+)
+
+export function JSXElementLikeKeepDeepEquality(): KeepDeepEqualityCall<JSXElementLike> {
+  return unionDeepEquality(
+    JSXElementKeepDeepEquality,
+    JSXFragmentKeepDeepEquality,
+    isJSXElement,
+    isJSXFragment,
+  )
+}
 export function ElementsWithinKeepDeepEqualityCall(): KeepDeepEqualityCall<ElementsWithin> {
-  return objectDeepEquality(JSXElementKeepDeepEquality)
+  return objectDeepEquality(JSXElementLikeKeepDeepEquality())
 }
 
 export function ArbitraryJSBlockKeepDeepEquality(): KeepDeepEqualityCall<ArbitraryJSBlock> {
@@ -1708,23 +1733,6 @@ export const JSXTextBlockKeepDeepEquality: KeepDeepEqualityCall<JSXTextBlock> =
       }
     },
   )
-
-export const JSXFragmentKeepDeepEquality: KeepDeepEqualityCall<JSXFragment> = combine3EqualityCalls(
-  (fragment) => fragment.children,
-  JSXElementChildArrayKeepDeepEquality,
-  (fragment) => fragment.uid,
-  StringKeepDeepEquality,
-  (fragment) => fragment.longForm,
-  BooleanKeepDeepEquality,
-  (children, uid, longForm) => {
-    return {
-      type: 'JSX_FRAGMENT',
-      children: children,
-      uid: uid,
-      longForm: longForm,
-    }
-  },
-)
 
 export const JSXConditionalExpressionKeepDeepEquality: KeepDeepEqualityCall<JSXConditionalExpression> =
   combine6EqualityCalls(

--- a/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-arbitrary-elements.spec.tsx
@@ -112,7 +112,9 @@ export var ${BakedInStoryboardVariableName} = (props) => {
             if (isJSExpressionOtherJavaScript(firstChild)) {
               const elementWithin =
                 firstChild.elementsWithin[Object.keys(firstChild.elementsWithin)[0]]
-              expect(getJSXAttribute(elementWithin.props, 'data-uid')).not.toBeNull()
+              if (isJSXElement(elementWithin)) {
+                expect(getJSXAttribute(elementWithin.props, 'data-uid')).not.toBeNull()
+              }
             } else {
               throw new Error('First child is not an arbitrary block of code.')
             }
@@ -202,14 +204,16 @@ export var ${BakedInStoryboardVariableName} = (props) => {
           const firstChild = view.children[0]
           if (isJSExpressionOtherJavaScript(firstChild)) {
             const elementWithin = firstChild.elementsWithin['bbb']
-            const newAttributes = setJSXValueAtPath(
-              elementWithin.props,
-              PP.create('style'),
-              jsExpressionValue({ left: 20, top: 300 }, emptyComments),
-            )
-            forEachRight(newAttributes, (updated) => {
-              elementWithin.props = updated
-            })
+            if (isJSXElement(elementWithin)) {
+              const newAttributes = setJSXValueAtPath(
+                elementWithin.props,
+                PP.create('style'),
+                jsExpressionValue({ left: 20, top: 300 }, emptyComments),
+              )
+              forEachRight(newAttributes, (updated) => {
+                elementWithin.props = updated
+              })
+            }
           }
         }
       }
@@ -288,14 +292,16 @@ export var ${BakedInStoryboardVariableName} = (props) => {
             .find((prop) => prop.key === 'thing')
           if (jsxProp != null && isJSExpressionOtherJavaScript(jsxProp.value)) {
             const elementWithin = jsxProp.value.elementsWithin['bbb']
-            const newAttributes = setJSXValueAtPath(
-              elementWithin.props,
-              PP.create('style'),
-              jsExpressionValue({ left: 20, top: 300 }, emptyComments),
-            )
-            forEachRight(newAttributes, (updated) => {
-              elementWithin.props = updated
-            })
+            if (isJSXElement(elementWithin)) {
+              const newAttributes = setJSXValueAtPath(
+                elementWithin.props,
+                PP.create('style'),
+                jsExpressionValue({ left: 20, top: 300 }, emptyComments),
+              )
+              forEachRight(newAttributes, (updated) => {
+                elementWithin.props = updated
+              })
+            }
           }
         }
       }

--- a/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-parsing.ts
@@ -1122,7 +1122,7 @@ function parseOtherJavaScript<T extends { uid: string }>(
         // Be conservative with this for the moment.
         if (success.value.length === 1) {
           const firstChild = success.value[0]
-          if (isJSXElement(firstChild.value)) {
+          if (isJSXElementLike(firstChild.value)) {
             const uid = getUtopiaIDFromJSXElement(firstChild.value)
             parsedElementsWithin.push({
               uid: uid,

--- a/editor/src/core/workers/parser-printer/parser-printer-transpiling.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-transpiling.ts
@@ -6,10 +6,12 @@ import ReactTransformPlugin from 'babel-plugin-transform-react-jsx'
 import type { SourceNode } from 'source-map'
 import type { Either } from '../../shared/either'
 import { isRight, left, right } from '../../shared/either'
-import type { JSXElement } from '../../shared/element-template'
+import type { JSXElement, JSXElementLike } from '../../shared/element-template'
 import {
   getDefinedElsewhereFromElement,
+  getJSXElementLikeNameAsString,
   getJSXElementNameAsString,
+  isJSXElement,
 } from '../../shared/element-template'
 import { getUtopiaIDFromJSXElement } from '../../shared/uid-utils'
 import { fastForEach } from '../../shared/utils'
@@ -144,7 +146,7 @@ function babelRewriteJSExpressionCode(
 } {
   function transformForElementWithin(
     path: BabelTraverse.NodePath<BabelTypes.JSXElement>,
-    elementWithin: JSXElement,
+    elementWithin: JSXElementLike,
     uid: string,
   ): void {
     if (insertCanvasRenderCall) {
@@ -279,7 +281,7 @@ function babelRewriteJSExpressionCode(
     const foundElementWithin =
       foundByLocation ??
       elementsWithin.find((e) => {
-        return tagName === getJSXElementNameAsString(e.element.name)
+        return tagName === getJSXElementLikeNameAsString(e.element)
       })
 
     if (foundElementWithin != null) {

--- a/editor/src/core/workers/parser-printer/parser-printer-uids.spec.tsx
+++ b/editor/src/core/workers/parser-printer/parser-printer-uids.spec.tsx
@@ -370,57 +370,59 @@ export var app = (props) => {
               if (isJSExpressionOtherJavaScript(firstChild)) {
                 const firstKey = Object.keys(firstChild.elementsWithin)[0]
                 const firstElementWithin = firstChild.elementsWithin[firstKey]
-                const updatedAttributes = jsxAttributesFromMap({
-                  style: jsExpressionValue(
-                    {
-                      backgroundColor: 'red',
-                      position: 'absolute',
-                      left: 0,
-                      top: 0,
-                      width: 100,
-                      height: 200,
-                    },
-                    emptyComments,
-                  ),
-                })
-                const updatedElementsWithin = {
-                  [firstKey]: jsxElement(
-                    firstElementWithin.name,
-                    firstKey,
-                    updatedAttributes,
-                    firstElementWithin.children,
-                  ),
+                if (isJSXElement(firstElementWithin)) {
+                  const updatedAttributes = jsxAttributesFromMap({
+                    style: jsExpressionValue(
+                      {
+                        backgroundColor: 'red',
+                        position: 'absolute',
+                        left: 0,
+                        top: 0,
+                        width: 100,
+                        height: 200,
+                      },
+                      emptyComments,
+                    ),
+                  })
+                  const updatedElementsWithin = {
+                    [firstKey]: jsxElement(
+                      firstElementWithin.name,
+                      firstKey,
+                      updatedAttributes,
+                      firstElementWithin.children,
+                    ),
+                  }
+                  const updatedFirstChild = jsExpressionOtherJavaScript(
+                    isJSExpressionOtherJavaScript(firstChild) ? firstChild.params : [],
+                    firstChild.originalJavascript,
+                    firstChild.javascriptWithUIDs,
+                    firstChild.transpiledJavascript,
+                    firstChild.definedElsewhere,
+                    firstChild.sourceMap,
+                    updatedElementsWithin,
+                    firstChild.comments,
+                  )
+                  const updatedRootElement = jsxElement(
+                    rootElement.name,
+                    rootElement.uid,
+                    rootElement.props,
+                    [updatedFirstChild],
+                  )
+                  const updatedComponent = utopiaJSXComponent(
+                    tle.name,
+                    tle.isFunction,
+                    tle.declarationSyntax,
+                    tle.blockOrExpression,
+                    tle.functionWrapping,
+                    tle.params,
+                    tle.propsUsed,
+                    updatedRootElement,
+                    tle.arbitraryJSBlock,
+                    tle.usedInReactDOMRender,
+                    tle.returnStatementComments,
+                  )
+                  return updatedComponent
                 }
-                const updatedFirstChild = jsExpressionOtherJavaScript(
-                  isJSExpressionOtherJavaScript(firstChild) ? firstChild.params : [],
-                  firstChild.originalJavascript,
-                  firstChild.javascriptWithUIDs,
-                  firstChild.transpiledJavascript,
-                  firstChild.definedElsewhere,
-                  firstChild.sourceMap,
-                  updatedElementsWithin,
-                  firstChild.comments,
-                )
-                const updatedRootElement = jsxElement(
-                  rootElement.name,
-                  rootElement.uid,
-                  rootElement.props,
-                  [updatedFirstChild],
-                )
-                const updatedComponent = utopiaJSXComponent(
-                  tle.name,
-                  tle.isFunction,
-                  tle.declarationSyntax,
-                  tle.blockOrExpression,
-                  tle.functionWrapping,
-                  tle.params,
-                  tle.propsUsed,
-                  updatedRootElement,
-                  tle.arbitraryJSBlock,
-                  tle.usedInReactDOMRender,
-                  tle.returnStatementComments,
-                )
-                return updatedComponent
               }
             }
           }

--- a/editor/src/core/workers/parser-printer/parser-printer-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-utils.ts
@@ -1,5 +1,5 @@
 import * as TS from 'typescript-for-the-editor'
-import type { JSXElement } from '../../shared/element-template'
+import type { JSXElement, JSXElementLike } from '../../shared/element-template'
 import { TopLevelElement, UtopiaJSXComponent } from '../../shared/element-template'
 import { fixUtopiaElement, UIDMappings, WithUIDMappings } from '../../shared/uid-utils'
 import { fastForEach } from '../../shared/utils'
@@ -135,7 +135,7 @@ export function prependToSourceString(
 
 interface ElementWithinInPosition {
   uid: string
-  element: JSXElement
+  element: JSXElementLike
   startLine: number
   startColumn: number
 }

--- a/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer.test-utils.ts
@@ -37,6 +37,7 @@ import type {
   JSXConditionalExpression,
   JSXFragment,
   ElementsWithin,
+  JSXElementLike,
 } from '../../shared/element-template'
 import {
   arbitraryJSBlock,
@@ -336,6 +337,25 @@ export function simplifyJSXElementAttributes(element: JSXElement): JSXElement {
   }
 }
 
+export function simplifyJSXFragmentAttributes(element: JSXFragment): JSXFragment {
+  const updatedChildren = element.children.map(simplifyJSXElementChildAttributes)
+  return {
+    ...element,
+    children: updatedChildren,
+  }
+}
+
+export function simplifyJSXElementLikeAttributes(element: JSXElementLike): JSXElementLike {
+  switch (element.type) {
+    case 'JSX_ELEMENT':
+      return simplifyJSXElementAttributes(element)
+    case 'JSX_FRAGMENT':
+      return simplifyJSXFragmentAttributes(element)
+    default:
+      assertNever(element)
+  }
+}
+
 export function simplifyJSXElementChildAttributes(element: JSXElementChild): JSXElementChild {
   switch (element.type) {
     case 'JSX_ELEMENT':
@@ -374,7 +394,7 @@ export function simplifyJSXElementChildAttributes(element: JSXElementChild): JSX
 }
 
 export function simplifyElementsWithinAttributes(elementsWithin: ElementsWithin): ElementsWithin {
-  return objectMap((element) => simplifyJSXElementAttributes(element), elementsWithin)
+  return objectMap(simplifyJSXElementLikeAttributes, elementsWithin)
 }
 
 export function simplifyArbitraryJSBlockAttributes(block: ArbitraryJSBlock): ArbitraryJSBlock {

--- a/editor/src/core/workers/parser-printer/uid-fix.ts
+++ b/editor/src/core/workers/parser-printer/uid-fix.ts
@@ -756,9 +756,7 @@ export function fixJSXFragmentUIDs(
   newElement: JSXFragment,
   fixUIDsState: FixUIDsState,
 ): JSXFragment {
-  // If this is a `JSXElement`, then work through the common fields.
-  // Do this _before_ potentially updating the `data-uid` prop, so that it does
-  // not cause any issues with the uid clashing.
+  // since we don't process props for fragments, we don't have a data-uid prop to update
   let fixedChildren: Array<JSXElementChild>
   if (oldElement != null && isJSXFragment(oldElement)) {
     fixedChildren = fixJSXElementChildArray(oldElement.children, newElement.children, fixUIDsState)

--- a/utopia-shared/src/types/element-template.ts
+++ b/utopia-shared/src/types/element-template.ts
@@ -229,7 +229,7 @@ export type JSXFragmentWithoutUID = Omit<JSXFragment, 'uid'>
 
 export type JSXMapExpressionWithoutUID = Omit<JSXMapExpression, 'uid'>
 
-export type ElementsWithin = { [uid: string]: JSXElement }
+export type ElementsWithin = { [uid: string]: JSXElementLike }
 
 export interface WithElementsWithin {
   elementsWithin: ElementsWithin


### PR DESCRIPTION
**Problem:**
When you have a list which returns fragments, the fragments and their descendants don't have metadata (and they don't appear in the navigator):

<img width="803" alt="image" src="https://github.com/user-attachments/assets/cf968e6a-592b-4bc6-b73a-78d623e1a66d">


**Fix:**
The problem is that fragments can not appear in ElementsWithin:

<img width="574" alt="image" src="https://github.com/user-attachments/assets/c879605f-8399-45f2-8785-7edf457e149f">

The fix is to change the type ElementsWithin to contain JSXElementLike values.

**Notes:**

We don't store the props of fragments, so all the data-uid processing parts don't work for fragments. Moreover, we actually lose any props provided to fragments, even though it is possible to give props to longform fragments.

Potential followup tasks
- [ ] Do we need to extend ElementsWithin to JSXElementChild? What I see e.g. is that embedded lists are merged into a single long list, which may be connected the incorrect elementsWithin of the outer list (because it should contain the inner list itself)
<img width="736" alt="image" src="https://github.com/user-attachments/assets/1d3cabb8-8582-411e-9fa6-ffa3dd1b6786">

- [ ] Rethink the decision that JSXFragment is a separate type from JSXElement, or at least give longform JSXFragments props. With our current solution data-uid attribute of fragments can not work well.
- [ ] There is another suspicious part that JSExpression-s can not be fragments neither. Check if this causes any problems or not
- [ ] Render props can only be JSXElements too, extend that to JSXElementChild

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/5763
