### PR TITLE
Follow up tasks to the dom sampler PR

### DIFF
--- a/editor/src/components/canvas/dom-lookup.ts
+++ b/editor/src/components/canvas/dom-lookup.ts
@@ -27,6 +27,7 @@ import Utils from '../../utils/utils'
 import { memoize } from '../../core/shared/memoize'
 import type { ElementPathTrees } from '../../core/shared/element-path-tree'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
+import { UTOPIA_VALID_PATHS } from '../../core/model/utopia-constants'
 
 type FindParentSceneValidPathsCache = Map<Element, Array<ElementPath> | null>
 
@@ -36,7 +37,7 @@ export function findParentSceneValidPaths(
 ): Array<ElementPath> | null {
   const cacheResult = mutableCache.get(target)
   if (cacheResult === undefined) {
-    const validPaths = getDOMAttribute(target, 'data-utopia-valid-paths')
+    const validPaths = getDOMAttribute(target, UTOPIA_VALID_PATHS)
     if (validPaths != null) {
       const result = validPaths.split(' ').map(EP.fromString)
       mutableCache.set(target, result)

--- a/editor/src/components/canvas/dom-sampler.tsx
+++ b/editor/src/components/canvas/dom-sampler.tsx
@@ -152,7 +152,6 @@ function collectMetadataForPaths({
         selectedViews,
         scale,
         containerRect,
-        spyCollector,
       )
 
       const spyMetadata = spyCollector.current.spyValues.metadata[EP.toString(path)]
@@ -204,7 +203,6 @@ function collectMetadataForElementPath(
   selectedViews: Array<ElementPath>,
   scale: number,
   containerRect: CanvasPoint,
-  spyCollector: UiJsxCanvasContextData,
 ): DomElementMetadata | null {
   if (EP.isStoryboardPath(path)) {
     return createFakeMetadataForCanvasRoot(path)

--- a/editor/src/components/canvas/dom-sampler.tsx
+++ b/editor/src/components/canvas/dom-sampler.tsx
@@ -139,53 +139,52 @@ function collectMetadataForPaths({
     'nearest-half',
   )
 
-  const dynamicPathsToCollect: Array<ElementPath> = pathsToCollect
-    .flatMap((staticPath) => {
-      return spyPaths.filter((spyPath) =>
-        EP.pathsEqual(EP.makeLastPartOfPathStatic(EP.fromString(spyPath)), staticPath),
-      )
-    })
-    .map(EP.fromString)
-
-  dynamicPathsToCollect.forEach((path) => {
-    const domMetadata = collectMetadataForElementPath(
-      path,
-      validPaths,
-      selectedViews,
-      scale,
-      containerRect,
-      spyCollector,
-    )
-
-    const spyMetadata = spyCollector.current.spyValues.metadata[EP.toString(path)]
-    if (spyMetadata == null) {
-      // if the element is missing from the spyMetadata, we bail out. this is the same behavior as the old reconstructJSXMetadata implementation
-      return
-    }
-
-    if (domMetadata == null) {
-      metadataToUpdate_MUTATE[EP.toString(path)] = {
-        ...spyMetadata,
+  pathsToCollect.forEach((staticPath) => {
+    spyPaths.forEach((spyPath) => {
+      const path = EP.fromString(spyPath)
+      if (!EP.pathsEqual(EP.makeLastPartOfPathStatic(path), staticPath)) {
+        return
       }
-      return
-    }
 
-    let jsxElement = alternativeEither(spyMetadata.element, domMetadata.element)
+      const domMetadata = collectMetadataForElementPath(
+        path,
+        validPaths,
+        selectedViews,
+        scale,
+        containerRect,
+        spyCollector,
+      )
 
-    // TODO avoid temporary object creation
-    const elementInstanceMetadata: ElementInstanceMetadata = {
-      ...domMetadata,
-      element: jsxElement,
-      elementPath: spyMetadata.elementPath,
-      componentInstance: spyMetadata.componentInstance,
-      isEmotionOrStyledComponent: spyMetadata.isEmotionOrStyledComponent,
-      label: spyMetadata.label,
-      importInfo: spyMetadata.importInfo,
-      assignedToProp: spyMetadata.assignedToProp,
-      conditionValue: spyMetadata.conditionValue,
-      earlyReturn: spyMetadata.earlyReturn,
-    }
-    metadataToUpdate_MUTATE[EP.toString(spyMetadata.elementPath)] = elementInstanceMetadata
+      const spyMetadata = spyCollector.current.spyValues.metadata[EP.toString(path)]
+      if (spyMetadata == null) {
+        // if the element is missing from the spyMetadata, we bail out. this is the same behavior as the old reconstructJSXMetadata implementation
+        return
+      }
+
+      if (domMetadata == null) {
+        metadataToUpdate_MUTATE[EP.toString(path)] = {
+          ...spyMetadata,
+        }
+        return
+      }
+
+      let jsxElement = alternativeEither(spyMetadata.element, domMetadata.element)
+
+      // TODO avoid temporary object creation
+      const elementInstanceMetadata: ElementInstanceMetadata = {
+        ...domMetadata,
+        element: jsxElement,
+        elementPath: spyMetadata.elementPath,
+        componentInstance: spyMetadata.componentInstance,
+        isEmotionOrStyledComponent: spyMetadata.isEmotionOrStyledComponent,
+        label: spyMetadata.label,
+        importInfo: spyMetadata.importInfo,
+        assignedToProp: spyMetadata.assignedToProp,
+        conditionValue: spyMetadata.conditionValue,
+        earlyReturn: spyMetadata.earlyReturn,
+      }
+      metadataToUpdate_MUTATE[EP.toString(spyMetadata.elementPath)] = elementInstanceMetadata
+    })
   })
 
   const finalMetadata = [

--- a/editor/src/components/canvas/dom-sampler.tsx
+++ b/editor/src/components/canvas/dom-sampler.tsx
@@ -157,21 +157,16 @@ function collectMetadataForPaths({
       spyCollector,
     )
 
-    if (domMetadata == null) {
-      // if we couldn't find any dom elements for the path, we must scan through all the spy elements to find a fallback with a potentially dynamic path
-      const spyElem = spyCollector.current.spyValues.metadata[EP.toString(path)]
-      if (spyElem != null) {
-        metadataToUpdate_MUTATE[EP.toString(path)] = {
-          ...spyElem,
-        }
-      }
-      return // we couldn't find a fallback spy element, so we bail out
-    }
-
-    const validDynamicPath = path
-    const spyMetadata = spyCollector.current.spyValues.metadata[EP.toString(validDynamicPath)]
+    const spyMetadata = spyCollector.current.spyValues.metadata[EP.toString(path)]
     if (spyMetadata == null) {
       // if the element is missing from the spyMetadata, we bail out. this is the same behavior as the old reconstructJSXMetadata implementation
+      return
+    }
+
+    if (domMetadata == null) {
+      metadataToUpdate_MUTATE[EP.toString(path)] = {
+        ...spyMetadata,
+      }
       return
     }
 

--- a/editor/src/components/canvas/dom-sampler.tsx
+++ b/editor/src/components/canvas/dom-sampler.tsx
@@ -140,12 +140,12 @@ function collectMetadataForPaths({
   )
 
   pathsToCollect.forEach((staticPath) => {
-    spyPaths.forEach((spyPath) => {
-      const path = EP.fromString(spyPath)
-      if (!EP.pathsEqual(EP.makeLastPartOfPathStatic(path), staticPath)) {
-        return
-      }
+    const dynamicPaths = spyPaths.filter((spyPath) =>
+      EP.pathsEqual(EP.makeLastPartOfPathStatic(EP.fromString(spyPath)), staticPath),
+    )
 
+    dynamicPaths.forEach((pathString) => {
+      const path = EP.fromString(pathString)
       const domMetadata = collectMetadataForElementPath(
         path,
         validPaths,

--- a/editor/src/components/canvas/dom-sampler.tsx
+++ b/editor/src/components/canvas/dom-sampler.tsx
@@ -8,7 +8,7 @@ import {
   fillMissingDataFromAncestors,
   MetadataUtils,
 } from '../../core/model/element-metadata-utils'
-import { UTOPIA_PATH_KEY } from '../../core/model/utopia-constants'
+import { UTOPIA_PATH_KEY, UTOPIA_VALID_PATHS } from '../../core/model/utopia-constants'
 import { allElemsEqual, mapDropNulls, pluck } from '../../core/shared/array-utils'
 import { getCanvasRectangleFromElement } from '../../core/shared/dom-utils'
 import { alternativeEither, left } from '../../core/shared/either'
@@ -387,7 +387,7 @@ function createFakeMetadataForCanvasRoot(canvasRootPath: ElementPath): DomElemen
 function getValidPathsFromCanvasContainer(canvasRootContainer: HTMLElement): Array<ElementPath> {
   const validPaths: Array<ElementPath> | null = optionalMap(
     (paths) => paths.split(' ').map(EP.fromString),
-    canvasRootContainer.getAttribute('data-utopia-valid-paths'),
+    canvasRootContainer.getAttribute(UTOPIA_VALID_PATHS),
   )
 
   if (validPaths == null) {

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -80,6 +80,7 @@ import {
   UTOPIA_DO_NOT_TRAVERSE_KEY,
   UTOPIA_PATH_KEY,
   UTOPIA_SCENE_ID_KEY,
+  UTOPIA_VALID_PATHS,
 } from '../../core/model/utopia-constants'
 
 import { PERFORMANCE_MARKS_ALLOWED } from '../../common/env-vars'
@@ -648,7 +649,7 @@ export function runDomWalker({
 
     const validPaths: Array<ElementPath> | null = optionalMap(
       (paths) => paths.split(' ').map(EP.fromString),
-      canvasRootContainer.getAttribute('data-utopia-valid-paths'),
+      canvasRootContainer.getAttribute(UTOPIA_VALID_PATHS),
     )
 
     if (validPaths == null) {

--- a/editor/src/core/model/utopia-constants.ts
+++ b/editor/src/core/model/utopia-constants.ts
@@ -6,6 +6,7 @@ export const UTOPIA_SCENE_ID_KEY = 'data-utopia-scene-id'
 export const UTOPIA_UID_PARENTS_KEY = 'data-utopia-parents'
 export const UTOPIA_UID_ORIGINAL_PARENTS_KEY = 'data-utopia-original-parents'
 export const UTOPIA_INSTANCE_PATH = 'data-utopia-instance-path'
+export const UTOPIA_VALID_PATHS = 'data-utopia-valid-paths'
 
 export const UtopiaKeys: Array<string> = [
   UTOPIA_UID_KEY,


### PR DESCRIPTION
**Problem:**
I addressed a few comments on the original dom sampler PR:
https://github.com/concrete-utopia/utopia/pull/6240#discussion_r1738990534
https://github.com/concrete-utopia/utopia/pull/6240#discussion_r1740786401
https://github.com/concrete-utopia/utopia/pull/6240#discussion_r1738978368

**Fix:**
- Extracted UTOPIA_VALID_PATHS constant to remove magic strings
- Simplified logic in dom sampler to handle null domMetadata and/or spyMetadata
- Replaces flatMap and forEach with a bigger forEach to reduce array allocations.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
