### PR TITLE
Minor optimizations in getComponentDescriptorForTarget

### DIFF
--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -170,6 +170,10 @@ function getComponentDescriptorForTargetInner(
       underlyingFilePath: string,
     ) => {
       if (isJSXElement(element)) {
+        if (isIntrinsicElement(element.name)) {
+          return null
+        }
+
         const importedFrom = importedFromWhere(
           filePathMappings,
           underlyingFilePath,
@@ -180,11 +184,7 @@ function getComponentDescriptorForTargetInner(
 
         let filenameForLookup: string | null = null
         if (importedFrom == null) {
-          if (isIntrinsicElement(element.name)) {
-            return null
-          } else {
-            filenameForLookup = underlyingFilePath.replace(/\.(js|jsx|ts|tsx)$/, '')
-          }
+          filenameForLookup = underlyingFilePath.replace(/\.(js|jsx|ts|tsx)$/, '')
         } else {
           filenameForLookup = importedFrom.filePath
         }

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -27,6 +27,7 @@ import { getFilePathMappings } from '../model/project-file-utils'
 import { valueDependentCache } from '../shared/memoize'
 import * as EP from '../shared/element-path'
 import { shallowEqual } from '../shared/equality-utils'
+import { stripExtension } from '../../components/custom-code/custom-code-utils'
 
 export function propertyControlsForComponentInFile(
   componentName: string,
@@ -148,8 +149,6 @@ export const getComponentDescriptorForTarget = valueDependentCache(
   },
 )
 
-const FileExtRegExp = /\.(js|jsx|ts|tsx)$/
-
 function getComponentDescriptorForTargetInner(
   {
     projectContents,
@@ -186,7 +185,7 @@ function getComponentDescriptorForTargetInner(
 
         let filenameForLookup: string | null = null
         if (importedFrom == null) {
-          filenameForLookup = underlyingFilePath.replace(FileExtRegExp, '')
+          filenameForLookup = stripExtension(underlyingFilePath)
         } else {
           filenameForLookup = importedFrom.filePath
         }
@@ -218,7 +217,7 @@ function getComponentDescriptorForTargetInner(
           )
 
           const trimmedPath = absolutePath.includes('/')
-            ? absolutePath.replace(FileExtRegExp, '')
+            ? stripExtension(absolutePath)
             : absolutePath
 
           return propertyControlsInfo[trimmedPath]?.[nameAsString]

--- a/editor/src/core/property-controls/property-controls-utils.ts
+++ b/editor/src/core/property-controls/property-controls-utils.ts
@@ -148,6 +148,8 @@ export const getComponentDescriptorForTarget = valueDependentCache(
   },
 )
 
+const FileExtRegExp = /\.(js|jsx|ts|tsx)$/
+
 function getComponentDescriptorForTargetInner(
   {
     projectContents,
@@ -184,7 +186,7 @@ function getComponentDescriptorForTargetInner(
 
         let filenameForLookup: string | null = null
         if (importedFrom == null) {
-          filenameForLookup = underlyingFilePath.replace(/\.(js|jsx|ts|tsx)$/, '')
+          filenameForLookup = underlyingFilePath.replace(FileExtRegExp, '')
         } else {
           filenameForLookup = importedFrom.filePath
         }
@@ -216,7 +218,7 @@ function getComponentDescriptorForTargetInner(
           )
 
           const trimmedPath = absolutePath.includes('/')
-            ? absolutePath.replace(/\.(js|jsx|ts|tsx)$/, '')
+            ? absolutePath.replace(FileExtRegExp, '')
             : absolutePath
 
           return propertyControlsInfo[trimmedPath]?.[nameAsString]


### PR DESCRIPTION
**Problem:**
1. Let's early return for intrinsic elements, which are not component instances, so no reason to search for component descriptors at all.
2. Let's remove the regex replaces which remove file extensions and replace them with `stripExtension` function calls, which are significantly faster.
3. 
**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

