### PR TITLE
Improve performance of createRemixDerivedData.

### DIFF
--- a/editor/src/components/assets.ts
+++ b/editor/src/components/assets.ts
@@ -22,7 +22,7 @@ import { emptySet } from '../core/shared/set-utils'
 import { sha1 } from 'sha.js'
 import type { GithubFileChanges, TreeConflicts } from '../core/shared/github/helpers'
 import type { FileChecksumsWithFile } from './editor/store/editor-state'
-import { memoize } from '../core/shared/memoize'
+import { memoize, valueDependentCache } from '../core/shared/memoize'
 import { makeOptic, type Optic } from '../core/shared/optics/optics'
 import type {
   AssetFileWithFileName,
@@ -567,7 +567,12 @@ export function getContentsTreeFromElements(
   }
 }
 
-export function getProjectFileByFilePath(
+export const getProjectFileByFilePath = valueDependentCache(
+  getProjectFileByFilePathUncached,
+  (path) => path,
+)
+
+export function getProjectFileByFilePathUncached(
   tree: ProjectContentTreeRoot,
   path: string,
 ): ProjectFile | null {

--- a/editor/src/core/model/element-template-utils.ts
+++ b/editor/src/core/model/element-template-utils.ts
@@ -1601,9 +1601,13 @@ function findAmongJSXElementChildren(
   condition: (e: JSXElementChild) => boolean,
   children: JSXElementChild[],
 ): Array<ElementPathPart> {
-  return children.flatMap((child) =>
-    findPathToJSXElementChild(condition, child).map((path) => [parentUid, ...path]),
-  )
+  let result: Array<ElementPathPart> = []
+  for (const child of children) {
+    for (const path of findPathToJSXElementChild(condition, child)) {
+      result.push([parentUid, ...path])
+    }
+  }
+  return result
 }
 
 export function findPathToJSXElementChild(

--- a/editor/src/core/model/project-file-utils.ts
+++ b/editor/src/core/model/project-file-utils.ts
@@ -179,13 +179,10 @@ export function isRemixOutletAgainstImports(element: JSXElementChild, imports: I
     return false
   }
 
-  if (PP.depth(element.name.propertyPath) === 0) {
-    for (const fromWithin of remix.importedFromWithin) {
-      if (fromWithin.alias === element.name.baseVariable && fromWithin.name === 'Outlet') {
-        return true
-      }
+  for (const fromWithin of remix.importedFromWithin) {
+    if (fromWithin.alias === element.name.baseVariable && fromWithin.name === 'Outlet') {
+      return true
     }
-    return false
   }
 
   return (
@@ -900,10 +897,8 @@ export function fileExportsFunctionWithName(
     return false
   }
 
-  return (
-    file.fileContents.parsed.exportsDetail.find(
-      (v) => isExportFunction(v) && v.functionName === componentName,
-    ) != null
+  return file.fileContents.parsed.exportsDetail.some(
+    (v) => isExportFunction(v) && v.functionName === componentName,
   )
 }
 


### PR DESCRIPTION
**Problem:**
In a Remix project `createRemixDerivedData` is called constantly during any updates and takes 2-3ms.

**Fix:**
This ended up being a lot of small changes as there was no-one big change needed but a little bit of wastage in a few places.

**Result:**
The changes within this PR have resulted in `createRemixDerivedData` taking around 0.5-1ms the vast majority of the time.

**Commit Details:**
- Wrapped `getProjectFileByFilePath` in `valueDependentCache`.
- Removed an unnecessary lambda from `createRouteManifestFromProjectContents`.
- Rewrote `patchRemixRoutes` so that it doesn't need to build an object to process the contents.
- Made a very slight tweak to `getRouteModulesWithPaths`.
- Refactored `findAmongJSXElementChildren` to avoid some unnecessary intermediate arrays.
- Small tweak to remove an unnecessary conditional from `isRemixOutletAgainstImports`.
- Changed a `find` to a `some` in `fileExportsFunctionWithName`.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
