### PR TITLE
Fix isDescendantOf

### DIFF
--- a/editor/src/core/shared/element-path.spec.ts
+++ b/editor/src/core/shared/element-path.spec.ts
@@ -290,6 +290,14 @@ describe('isDescendantOf', () => {
     )
     chaiExpect(result).to.be.false
   })
+
+  it('returns false if they are siblings but one uid is a prefix of the other', () => {
+    const result = EP.isDescendantOf(
+      EP.elementPath([[BakedInStoryboardUID, 'scene-aaa'], ['X1']]),
+      EP.elementPath([[BakedInStoryboardUID, 'scene-aaa'], ['X']]),
+    )
+    chaiExpect(result).to.be.false
+  })
 })
 
 describe('replaceIfAncestor', () => {

--- a/editor/src/core/shared/element-path.ts
+++ b/editor/src/core/shared/element-path.ts
@@ -644,8 +644,12 @@ export function findAmongAncestorsOfPath<T>(
 export function isDescendantOf(target: ElementPath, maybeAncestor: ElementPath): boolean {
   const targetString = toString(target)
   const maybeAncestorString = toString(maybeAncestor)
-  // TODO FIX OMG this will return true for aaa/bbb vs aaa/bbb-1, which is a problem for user-written UIDs, especially common in tests
-  return targetString !== maybeAncestorString && targetString.startsWith(maybeAncestorString)
+  return (
+    targetString !== maybeAncestorString &&
+    targetString.startsWith(maybeAncestorString) &&
+    (targetString[maybeAncestorString.length] === SceneSeparator ||
+      targetString[maybeAncestorString.length] === ElementSeparator)
+  )
 }
 
 export function getAncestorsForLastPart(path: ElementPath): ElementPath[] {


### PR DESCRIPTION
**Problem:**
Another followup to the dom sampler PR (see comment https://github.com/concrete-utopia/utopia/pull/6240#discussion_r1740815404 )

EP.isDescendantOf does not check the element path representation, but uses String.startsWith on the stringified paths.
(This is an optimization, because startsWith is way faster than comparing the array of arrays of uids).
However, in cases when a uid is a prefix of a sibling uid this is going to return a false positive. 

**Fix:**
I kept the quick startsWith solution, and I just check whether the next character after the prefix is a `:` or a `/`. I added a unit test for this case.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

