### PR TITLE
Fix draw to insert into grid when zoomed in

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -368,13 +368,13 @@ export var storyboard = (
         .style
 
       expect({ gridRow, gridColumn, width, height, position, top, left }).toEqual({
-        gridColumn: '2',
+        gridColumn: '1',
         gridRow: '1',
-        height: '60px',
-        left: '83px',
+        height: '30px',
+        left: '125px',
         position: 'absolute',
-        top: '150px',
-        width: '40px',
+        top: '75px',
+        width: '20px',
       })
     })
   })

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
@@ -13,7 +13,9 @@ import {
   canvasVector,
   offsetPoint,
   roundRectangleToNearestWhole,
+  scaleVector,
   size,
+  windowPoint,
 } from '../../../../core/shared/math-utils'
 import { assertNever } from '../../../../core/shared/utils'
 import { EditorModes, type InsertionSubject } from '../../../editor/editor-modes'
@@ -335,8 +337,13 @@ function getOffsetFromGridCell(
     canvasState.canvasOffset,
   )
 
-  return canvasPoint({
-    x: mouseWindowPoint.x - cellWindowRectangle.x,
-    y: mouseWindowPoint.y - cellWindowRectangle.y,
-  })
+  const { x, y } = scaleVector(
+    windowPoint({
+      x: mouseWindowPoint.x - cellWindowRectangle.x,
+      y: mouseWindowPoint.y - cellWindowRectangle.y,
+    }),
+    1 / canvasState.scale,
+  )
+
+  return canvasPoint({ x, y })
 }


### PR DESCRIPTION
## Problem
Drawing into a grid doesn't draw to right place when the editor is zoomed in

## Fix
Update the drawing code to make it so and add tests