### PR TITLE
fix(parse): add variables altered inside a code to the scope

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-scope-utils.ts
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-scope-utils.ts
@@ -24,7 +24,11 @@ export function runBlockUpdatingScope(
   if (result.type === 'ARBITRARY_BLOCK_RAN_TO_END') {
     const definedWithinWithValues: MapLike<any> = {}
     const definedWithinVariableData: VariableData = {}
-    for (const within of block.definedWithin) {
+    const alteredWithin = [
+      ...block.definedWithin,
+      ...block.definedElsewhere.filter((variable) => variable in result.scope),
+    ]
+    for (const within of alteredWithin) {
       currentScope[within] = result.scope[within]
       definedWithinWithValues[within] = result.scope[within]
       if (elementPath != null) {

--- a/editor/src/core/workers/parser-printer/parser-printer-transpiling.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-transpiling.ts
@@ -389,7 +389,13 @@ function rewriteBlockToCaptureEarlyReturns(source: string): () => {
           let identifiersToReturn: Array<string> = []
 
           function handleNodeAddingIdentifiers(nodeToProcess: BabelTypes.Node): void {
-            if (BabelTypes.isVariableDeclaration(nodeToProcess)) {
+            if (
+              BabelTypes.isExpressionStatement(nodeToProcess) &&
+              BabelTypes.isAssignmentExpression(nodeToProcess.expression) &&
+              BabelTypes.isIdentifier(nodeToProcess.expression.left)
+            ) {
+              identifiersToReturn.push(nodeToProcess.expression.left.name)
+            } else if (BabelTypes.isVariableDeclaration(nodeToProcess)) {
               for (const declaration of nodeToProcess.declarations) {
                 handleNodeAddingIdentifiers(declaration.id)
               }


### PR DESCRIPTION
**Problem:**
Today code blocks that re-assign variables defined elsewhere are not updating the variables, since we only take into consideration variable declarations. For example this code will throw an error on our canvas:
```tsx
const Foo = ({ prop }) => {
  prop = { title: 'test' }
  return <div>{prop.title}</div>
}
```

**Fix:**
1. Treat re-assigned variables inside arbitrary code as identifiers that need to be returned to update the scope. More specifically - this PR adds them to the `utopiaCanvasBlockRanToEnd` call that runs in the end of every code block.
2. In addition - in the `runBlockUpdatingScope` function where we actually update the scope - don't filter them out (currently it only takes `definedWithin` into consideration, so this PR adds any re-assigned variables that were defined elsewhere). 

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode

Fixes #5762
