### PR TITLE
fix(grid): remove unneeded child count check

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
@@ -75,10 +75,6 @@ export const setGridGapStrategy: CanvasStrategyFactory = (
     selectedElement,
   )
 
-  if (children.length < 2) {
-    return null
-  }
-
   const gridGap = maybeGridGapData(canvasState.startingMetadata, selectedElement)
   if (gridGap == null) {
     return null


### PR DESCRIPTION
**Problem:**
Grid gap controls are not shown when there are less than 2 children

**Fix:**
This is due to a previous check from when the gaps were between the elements and not the cells. Removed this check.

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode
