### PR TITLE
Remove grid rearrange adaptive opacity

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -23,12 +23,8 @@ import {
 import type { CanvasPoint, CanvasRectangle } from '../../../core/shared/math-utils'
 import {
   canvasPoint,
-  distance,
-  getRectCenter,
   isFiniteRectangle,
   isInfinityRectangle,
-  offsetPoint,
-  pointDifference,
   pointsEqual,
   scaleRect,
   windowPoint,
@@ -687,37 +683,6 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
 
   // NOTE: this stuff is meant to be temporary, until we settle on the set of interaction pieces we like.
   // After that, we should get rid of this.
-  const shadowOpacity = React.useMemo(() => {
-    if (shadow == null || initialShadowFrame == null || interactionData == null) {
-      return 0
-    } else if (!features.Grid.adaptiveOpacity) {
-      return features.Grid.opacityBaseline
-    } else if (features.Grid.dragLockedToCenter) {
-      return Math.min(
-        (0.2 * distance(getRectCenter(shadow.globalFrame), mouseCanvasPosition)) /
-          Math.min(shadow.globalFrame.height, shadow.globalFrame.width) +
-          0.05,
-        features.Grid.opacityBaseline,
-      )
-    } else {
-      return Math.min(
-        (0.2 *
-          distance(
-            offsetPoint(
-              interactionData.dragStart,
-              pointDifference(initialShadowFrame, shadow.globalFrame),
-            ),
-            mouseCanvasPosition,
-          )) /
-          Math.min(shadow.globalFrame.height, shadow.globalFrame.width) +
-          0.05,
-        features.Grid.opacityBaseline,
-      )
-    }
-  }, [features, shadow, initialShadowFrame, interactionData, mouseCanvasPosition])
-
-  // NOTE: this stuff is meant to be temporary, until we settle on the set of interaction pieces we like.
-  // After that, we should get rid of this.
   const shadowPosition = React.useMemo(() => {
     const drag = interactionData?.drag
     const dragStart = interactionData?.dragStart
@@ -735,13 +700,6 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
     const getCoord = (axis: 'x' | 'y', dimension: 'width' | 'height') => {
       if (features.Grid.dragVerbatim) {
         return initialShadowFrame[axis] + drag[axis]
-      } else if (features.Grid.dragLockedToCenter) {
-        return (
-          shadow.globalFrame[axis] +
-          drag[axis] -
-          (shadow.globalFrame[axis] - dragStart[axis]) -
-          shadow.globalFrame[dimension] / 2
-        )
       } else if (features.Grid.dragMagnetic) {
         return shadow.globalFrame[axis] + (mouseCanvasPosition[axis] - hoveringStart.point[axis])
       } else if (features.Grid.dragRatio) {
@@ -1007,7 +965,7 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
                   ? `${shadow.borderRadius.top}px ${shadow.borderRadius.right}px ${shadow.borderRadius.bottom}px ${shadow.borderRadius.left}px`
                   : 0,
               backgroundColor: 'black',
-              opacity: shadowOpacity,
+              opacity: features.Grid.shadowOpacity,
               border: '1px solid white',
               top: shadowPosition?.y,
               left: shadowPosition?.x,

--- a/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
+++ b/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
@@ -11,18 +11,16 @@ const sections = ['Grid'] as const
 type Section = (typeof sections)[number]
 
 type GridFeatures = {
-  dragLockedToCenter: boolean
   dragVerbatim: boolean
   dragMagnetic: boolean
   dragRatio: boolean
   animateShadowSnap: boolean
   dotgrid: boolean
   shadow: boolean
-  adaptiveOpacity: boolean
   activeGridColor: string
   dotgridColor: string
   inactiveGridColor: string
-  opacityBaseline: number
+  shadowOpacity: number
   activeGridBackground: string
 }
 
@@ -36,19 +34,17 @@ type RollYourOwnFeatures = {
 
 const defaultRollYourOwnFeatures: RollYourOwnFeatures = {
   Grid: {
-    dragLockedToCenter: false,
     dragVerbatim: false,
     dragMagnetic: false,
     dragRatio: true,
     animateShadowSnap: false,
     dotgrid: true,
     shadow: true,
-    adaptiveOpacity: true,
     activeGridColor: '#0099ff77',
     activeGridBackground: colorTheme.primary10.value,
     dotgridColor: '#0099ffaa',
     inactiveGridColor: '#00000033',
-    opacityBaseline: 0.25,
+    shadowOpacity: 0.05,
   },
 }
 

--- a/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
+++ b/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
@@ -44,7 +44,7 @@ const defaultRollYourOwnFeatures: RollYourOwnFeatures = {
     activeGridBackground: colorTheme.primary10.value,
     dotgridColor: '#0099ffaa',
     inactiveGridColor: '#00000033',
-    shadowOpacity: 0.05,
+    shadowOpacity: 0.1,
   },
 }
 


### PR DESCRIPTION
**Problem:**

The adaptive opacity of the grid rearrange shadow is confusing and worth binning.

**Fix:**

Remove the related adaptive opacity stuff and use a (still configurable via the RYO panel) opacity of `0.1` which feels adequate.

| Before | After |
|---------|-----------|
| ![Kapture 2024-09-05 at 16 22 25](https://github.com/user-attachments/assets/2655f233-0a58-4524-a23c-a92ff2a20832) | ![Kapture 2024-09-05 at 16 21 16](https://github.com/user-attachments/assets/3083b8e6-3fdd-4552-8bd2-89aaf7661ed8) |

Fixes #6318 
