### PR TITLE
Easier grid drag animation

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -134,7 +134,6 @@ function getLabelForAxis(
   return gridCSSNumberToLabel(defaultEither(fromDOM, fromPropsAtIndex))
 }
 
-const SHADOW_SNAP_ANIMATION = 'shadow-snap'
 const GRID_RESIZE_HANDLE_CONTAINER_SIZE = 30 // px
 const GRID_RESIZE_HANDLE_SIZE = 15 // px
 
@@ -648,7 +647,7 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
     return maybeGridFrame
   }, [gridPath, metadataRef])
 
-  useSnapAnimation({
+  useCellAnimation({
     disabled: anyTargetAbsolute,
     targetRootCell: targetRootCell,
     controls: controls,
@@ -946,15 +945,6 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
         interactionData?.drag != null &&
         hoveringStart != null ? (
           <motion.div
-            initial={'normal'}
-            variants={{
-              normal: { scale: 1 },
-              [SHADOW_SNAP_ANIMATION]: {
-                scale: [1, 1.4, 1],
-                transition: { duration: 0.15, type: 'tween' },
-              },
-            }}
-            animate={controls}
             style={{
               pointerEvents: 'none',
               position: 'absolute',
@@ -977,7 +967,7 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
   )
 })
 
-function useSnapAnimation(params: {
+function useCellAnimation(params: {
   disabled: boolean
   gridPath: ElementPath | null
   shadowFrame: CanvasRectangle | null
@@ -985,7 +975,6 @@ function useSnapAnimation(params: {
   controls: AnimationControls
 }) {
   const { gridPath, targetRootCell, controls, shadowFrame, disabled } = params
-  const features = useRollYourOwnFeatures()
 
   const [lastTargetRootCellId, setLastTargetRootCellId] = React.useState(targetRootCell)
   const [lastSnapPoint, setLastSnapPoint] = React.useState<CanvasPoint | null>(shadowFrame)
@@ -1048,12 +1037,12 @@ function useSnapAnimation(params: {
             x: [moveFromPoint.x - snapPoint.x, 0],
             y: [moveFromPoint.y - snapPoint.y, 0],
           },
-          { duration: CELL_ANIMATION_DURATION },
+          {
+            duration: CELL_ANIMATION_DURATION,
+            type: 'tween',
+            ease: 'easeInOut',
+          },
         )
-
-        if (features.Grid.animateShadowSnap) {
-          void controls.start(SHADOW_SNAP_ANIMATION)
-        }
       }
     }
     setLastSnapPoint(snapPoint)
@@ -1061,7 +1050,6 @@ function useSnapAnimation(params: {
   }, [
     targetRootCell,
     controls,
-    features.Grid.animateShadowSnap,
     lastSnapPoint,
     snapPoint,
     animate,

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -36,6 +36,7 @@ import type { ResolveFn } from '../../custom-code/code-file'
 import { useColorTheme } from '../../../uuiui'
 import {
   isDragInteractionActive,
+  isGridDragInteractionActive,
   pickSelectionEnabled,
   useMaybeHighlightElement,
   useSelectAndHover,
@@ -71,10 +72,8 @@ import { useSelectionArea } from './selection-area-hooks'
 import { RemixSceneLabelControl } from './select-mode/remix-scene-label'
 import { NO_OP } from '../../../core/shared/utils'
 import { useIsMyProject } from '../../editor/store/collaborative-editing'
-import { useStatus } from '../../../../liveblocks.config'
 import { MultiplayerWrapper } from '../../../utils/multiplayer-wrapper'
 import { MultiplayerPresence } from '../multiplayer-presence'
-import { isFeatureEnabled } from '../../../utils/feature-switches'
 
 export const CanvasControlsContainerID = 'new-canvas-controls-container'
 
@@ -170,7 +169,7 @@ export const NewCanvasControls = React.memo((props: NewCanvasControlsProps) => {
     canDrop: () => true,
   }
 
-  const [_, drop] = useDrop(dropSpec)
+  const [, drop] = useDrop(dropSpec)
 
   const forwardedRef = React.useCallback(
     (node: ConnectableElement) => {
@@ -295,6 +294,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
     keysPressed,
     componentMetadata,
     dragInteractionActive,
+    gridDragInteractionActive,
     selectionEnabled,
     textEditor,
     editorMode,
@@ -313,6 +313,7 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
         keysPressed: store.editor.keysPressed,
         componentMetadata: getMetadata(store.editor),
         dragInteractionActive: isDragInteractionActive(store.editor),
+        gridDragInteractionActive: isGridDragInteractionActive(store.editor),
         selectionEnabled: pickSelectionEnabled(store.editor.canvas, store.editor.keysPressed),
         editorMode: store.editor.mode,
         textEditor: store.editor.canvas.textEditor,
@@ -555,7 +556,10 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
           <>
             {renderHighlightControls()}
             {unless(dragInteractionActive, <LayoutParentControl />)}
-            <MultiSelectOutlineControl localSelectedElements={localSelectedViews} />
+            {unless(
+              gridDragInteractionActive,
+              <MultiSelectOutlineControl localSelectedElements={localSelectedViews} />,
+            )}
             <ZeroSizedElementControls.control showAllPossibleElements={false} />
 
             {when(

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -1,21 +1,13 @@
 import React from 'react'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
-import { mapArrayToDictionary, mapDropNulls, uniqBy } from '../../../../core/shared/array-utils'
+import { uniqBy } from '../../../../core/shared/array-utils'
 import type { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
 import type { WindowPoint } from '../../../../core/shared/math-utils'
-import {
-  boundingRectangleArray,
-  CanvasPoint,
-  distance,
-  isInfinityRectangle,
-  point,
-  windowPoint,
-} from '../../../../core/shared/math-utils'
+import { point, windowPoint } from '../../../../core/shared/math-utils'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import * as EP from '../../../../core/shared/element-path'
-import { NO_OP, assertNever, fastForEach } from '../../../../core/shared/utils'
+import { assertNever } from '../../../../core/shared/utils'
 import type { KeysPressed } from '../../../../utils/keyboard'
-import Keyboard, { isDigit } from '../../../../utils/keyboard'
 import Utils from '../../../../utils/utils'
 import {
   clearHighlightedViews,
@@ -49,14 +41,12 @@ import {
 import { Modifier } from '../../../../utils/modifiers'
 import { pathsEqual } from '../../../../core/shared/element-path'
 import type { EditorAction } from '../../../../components/editor/action-types'
-import { EditorDispatch } from '../../../../components/editor/action-types'
-import { EditorModes, isInsertMode, isSelectModeWithArea } from '../../../editor/editor-modes'
+import { isInsertMode, isSelectModeWithArea } from '../../../editor/editor-modes'
 import {
   scheduleTextEditForNextFrame,
   useTextEditModeSelectAndHover,
 } from '../text-edit-mode/text-edit-mode-hooks'
 import { useDispatch } from '../../../editor/store/dispatch-context'
-import { isFeatureEnabled } from '../../../../utils/feature-switches'
 import { useSetAtom } from 'jotai'
 import type { CanvasControlWithProps } from '../../../inspector/common/inspector-atoms'
 import {
@@ -71,6 +61,13 @@ import { useFollowModeSelectAndHover } from '../follow-mode/follow-mode-hooks'
 
 export function isDragInteractionActive(editorState: EditorState): boolean {
   return editorState.canvas.interactionSession?.interactionData.type === 'DRAG'
+}
+
+export function isGridDragInteractionActive(editorState: EditorState): boolean {
+  return (
+    editorState.canvas.interactionSession?.interactionData.type === 'DRAG' &&
+    editorState.canvas.interactionSession.activeControl.type === 'GRID_CELL_HANDLE'
+  )
 }
 
 export function pickSelectionEnabled(

--- a/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
+++ b/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
@@ -14,7 +14,6 @@ type GridFeatures = {
   dragVerbatim: boolean
   dragMagnetic: boolean
   dragRatio: boolean
-  animateShadowSnap: boolean
   dotgrid: boolean
   shadow: boolean
   activeGridColor: string
@@ -37,7 +36,6 @@ const defaultRollYourOwnFeatures: RollYourOwnFeatures = {
     dragVerbatim: false,
     dragMagnetic: false,
     dragRatio: true,
-    animateShadowSnap: false,
     dotgrid: true,
     shadow: true,
     activeGridColor: '#0099ff77',


### PR DESCRIPTION
**Problem:**

The grid drag animation is a bit jaggy.

**Fix:**

1. Disable the element outline during the grid drag interaction
2. Make the animation use a more explicit tween definition
3. Remove unused/legacy experiment for a dedicated the snap animation

![Kapture 2024-09-05 at 17 18 20](https://github.com/user-attachments/assets/f1992e51-9052-4ad6-9b01-503c6d183728)

**Note: the GIF does not make this justice, it should be smooth 60 fps IRL.**

Fixes #6320 
