### PR TITLE
Fix disappearing navigator after code editing in remix projects

### DIFF
--- a/editor/src/components/canvas/dom-sampler.tsx
+++ b/editor/src/components/canvas/dom-sampler.tsx
@@ -135,11 +135,18 @@ function collectMetadataForPaths({
   )
 
   pathsToCollect.forEach((staticPath) => {
-    const dynamicPaths = spyPaths.filter((spyPath) =>
-      EP.pathsEqual(EP.makeLastPartOfPathStatic(EP.fromString(spyPath)), staticPath),
+    const dynamicPaths = [
+      ...spyPaths.filter((spyPath) =>
+        EP.pathsEqual(EP.makeLastPartOfPathStatic(EP.fromString(spyPath)), staticPath),
+      ),
+    ]
+    const pathsFromMetadataNotInSpyPaths = Object.keys(metadataToUpdate_MUTATE).filter(
+      (metadataPath) => !spyPaths.includes(metadataPath),
     )
 
-    dynamicPaths.forEach((pathString) => {
+    const allPathsToCheck = [...dynamicPaths, ...pathsFromMetadataNotInSpyPaths]
+
+    allPathsToCheck.forEach((pathString) => {
       const path = EP.fromString(pathString)
       const domMetadata = collectMetadataForElementPath(
         path,
@@ -151,6 +158,11 @@ function collectMetadataForPaths({
       )
 
       const spyMetadata = spyCollector.current.spyValues.metadata[EP.toString(path)]
+      if (spyMetadata == null && domMetadata == null) {
+        delete metadataToUpdate_MUTATE[EP.toString(path)]
+        return
+      }
+
       if (spyMetadata == null) {
         // if the element is missing from the spyMetadata, we bail out. this is the same behavior as the old reconstructJSXMetadata implementation
         return

--- a/editor/src/components/canvas/dom-sampler.tsx
+++ b/editor/src/components/canvas/dom-sampler.tsx
@@ -79,37 +79,25 @@ export function runDomSampler(options: {
     }
   }
 
-  let result: { metadata: ElementInstanceMetadataMap; tree: ElementPathTrees }
-  if (elementsToCollect == 'rerender-all-elements') {
-    result = collectMetadataForPaths({
-      metadataToUpdate_MUTATE: {},
-      canvasRootContainer: canvasRootContainer,
-      pathsToCollect: validPaths,
-      validPaths: validPaths,
-      scale: options.scale,
-      selectedViews: options.selectedViews,
-      spyCollector: options.spyCollector,
-      spyPaths: spyPaths,
-      elementCanvasRectangleCache: elementCanvasRectangleCache,
-    })
-  } else {
-    result = collectMetadataForPaths({
-      metadataToUpdate_MUTATE: { ...options.metadataToUpdate }, // shallow cloning this object so we can mutate it
-      canvasRootContainer: canvasRootContainer,
-      pathsToCollect: validPaths.filter((vp) =>
-        elementsToCollect.some((e) => {
-          const staticElement = EP.makeLastPartOfPathStatic(e)
-          return EP.pathsEqual(staticElement, vp) || EP.isParentOf(staticElement, vp)
-        }),
-      ),
-      validPaths: validPaths,
-      scale: options.scale,
-      selectedViews: options.selectedViews,
-      spyCollector: options.spyCollector,
-      spyPaths: spyPaths,
-      elementCanvasRectangleCache: elementCanvasRectangleCache,
-    })
-  }
+  const result = collectMetadataForPaths({
+    metadataToUpdate_MUTATE: { ...options.metadataToUpdate }, // shallow cloning this object so we can mutate it
+    canvasRootContainer: canvasRootContainer,
+    pathsToCollect: validPaths,
+    validPaths:
+      elementsToCollect == 'rerender-all-elements'
+        ? validPaths
+        : validPaths.filter((vp) =>
+            elementsToCollect.some((e) => {
+              const staticElement = EP.makeLastPartOfPathStatic(e)
+              return EP.pathsEqual(staticElement, vp) || EP.isParentOf(staticElement, vp)
+            }),
+          ),
+    scale: options.scale,
+    selectedViews: options.selectedViews,
+    spyCollector: options.spyCollector,
+    spyPaths: spyPaths,
+    elementCanvasRectangleCache: elementCanvasRectangleCache,
+  })
 
   return result
 }


### PR DESCRIPTION
**Problem:**
See https://github.com/concrete-utopia/utopia/issues/6314

**Root cause:**
This bug is connected to the new dom sampler, and only affects Remix projects.
This is what is happening:
1. You fix the error in vscode
2. After an UPDATE_FROM_WORKER action the project changes and the dom sampler runs. However, rendering of the Remix project can be async, and only the content outside of Remix is rendering immediately, so the spy collector only has data for those elements.
3. After this we can see that some valid navigator content is blinking up for a second.
4. Remix content is rendering and that triggers the mutation/resize observers which call a runDomWalker action (see this PR: https://github.com/concrete-utopia/utopia/pull/5838 , up-to-date metadata in remix projects rely on these observers, because there is no dispatch which runs after all remix rendering is ready).
5. Dom sampler is running again _from scratch_, but now only the Remix content is rendering, and nothing else outside of it! So there is no spy data for the storyboard, for the Outlet, etc, for anything outside of the Remix content.
6. The navigator will not render anything if it can not build a navigator item tree from the root element, and the metadata now misses that (and only includes elements from the Remix content).

**Fix:**
I believe the problem is that
1. The dom sampler starts from scratch in `rerender-all-elements` mode, so does not keep any of the previous metadata
2. We only create metadata for elements which have spy data
3. We don't necessarily have spy data for all valid elements when the dom walker was triggered by a remix render

Solution:
Let's keep the previous metadata in `rerender-all-elements` mode too. Can it happen that we keep stale metadata in this case? Since we delete all metadata for elements which are not in the valid paths list (see `pruneInvalidPathsFromMetadata_MUTATE`), I don't see how it could cause a problem. When an element is really rerendered, it is going to have spy data, so we are going to replace its metadata. When there is no spy metadata, but the element is still in valid paths, the metadata collected earlier should still be valid.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/6314
