### PR TITLE
Only follow selection in the code editor when the selection has actually changed

### DIFF
--- a/editor/src/components/editor/store/vscode-changes.ts
+++ b/editor/src/components/editor/store/vscode-changes.ts
@@ -201,19 +201,9 @@ export function shouldIncludeSelectedElementChanges(
   oldEditorState: EditorState,
   newEditorState: EditorState,
 ): boolean {
-  const oldHighlightBounds = getHighlightBoundsForElementPaths(
-    oldEditorState.selectedViews,
-    oldEditorState,
-  )
-  const newHighlightBounds = getHighlightBoundsForElementPaths(
-    newEditorState.selectedViews,
-    newEditorState,
-  )
   return (
-    !(
-      EP.arrayOfPathsEqual(oldEditorState.selectedViews, newEditorState.selectedViews) &&
-      shallowEqual(oldHighlightBounds, newHighlightBounds)
-    ) && newEditorState.selectedViews.length > 0
+    !EP.arrayOfPathsEqual(oldEditorState.selectedViews, newEditorState.selectedViews) &&
+    newEditorState.selectedViews.length > 0
   )
 }
 


### PR DESCRIPTION
**Problem:**
If the user changes code file but doesn't change selection, and then makes a change to the currently selected element via the canvas or inspector, the code editor will jump back to the current selection.

**Fix:**
Previously we would update the cursor's position in the code editor if the selection had changed _or_ if the highlight bounds of the selected element had changed. I've removed the second part of that condition so that now we only update the cursor's position if the selection has changed. Note that we're still updating the code decorations via a separate message to VS Code, so that part was already decoupled from this.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #6113
