### PR TITLE
Highlight hovered grid cell during draw-to-insert

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
@@ -183,6 +183,9 @@ const gridDrawToInsertStrategyInner =
               ...customStrategyState,
               grid: {
                 ...customStrategyState.grid,
+                // this is added here during the hover interaction so that
+                // `GridControls` can render the hover highlight based on the
+                // coordinates in `targetCellData`
                 targetCellData: newTargetCell ?? customStrategyState.grid.targetCellData,
               },
             },

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
@@ -164,21 +164,30 @@ const gridDrawToInsertStrategyInner =
       ],
       fitness: 5,
       apply: (strategyLifecycle) => {
-        if (strategyLifecycle === 'mid-interaction' && interactionData.type === 'HOVER') {
-          return strategyApplicationResult([
-            wildcardPatch('mid-interaction', {
-              selectedViews: { $set: [] },
-            }),
-            showGridControls('mid-interaction', targetParent),
-            updateHighlightedViews('mid-interaction', [targetParent]),
-          ])
-        }
-
         const newTargetCell = getGridCellUnderCursor(
           interactionData,
           canvasState,
           customStrategyState,
         )
+
+        if (strategyLifecycle === 'mid-interaction' && interactionData.type === 'HOVER') {
+          return strategyApplicationResult(
+            [
+              wildcardPatch('mid-interaction', {
+                selectedViews: { $set: [] },
+              }),
+              showGridControls('mid-interaction', targetParent),
+              updateHighlightedViews('mid-interaction', [targetParent]),
+            ],
+            {
+              ...customStrategyState,
+              grid: {
+                ...customStrategyState.grid,
+                targetCellData: newTargetCell ?? customStrategyState.grid.targetCellData,
+              },
+            },
+          )
+        }
 
         if (newTargetCell == null) {
           return emptyStrategyApplicationResult


### PR DESCRIPTION
## Problem
When the draw to insert strategy is active, the grid cell that the cursor is hovering over is not highlighted.

## Fix
Highlight the grid cell under the cursor on hover too.

### Context
It's not visible from the diff but the reason this works is that `GridControls` reads `GridCustomStrategyState.targetCellData` and renders that highlight indicator based on that [here](https://github.com/concrete-utopia/utopia/blob/d1b6a7ee2a3685ea34eb5468dc861603ac4509c8/editor/src/components/canvas/controls/grid-controls.tsx#L812-L816)