### PR TITLE
fix(number-input): clamp mouse movements as well when value is clamped

### DIFF
--- a/editor/src/uuiui/inputs/number-input.spec.ts
+++ b/editor/src/uuiui/inputs/number-input.spec.ts
@@ -1,0 +1,21 @@
+import { calculateDragDirectionDelta } from './number-input'
+
+describe('number input', () => {
+  it('calculateDragDirectionDelta should be able to invert its results', () => {
+    const testCases = [
+      [5, 2],
+      [2, 5],
+      [-5.5, 2],
+      [-2, 5],
+      [0, 4],
+      [3.2, 1],
+      [-6, 3],
+      [-3, 6],
+    ]
+
+    testCases.forEach(([delta, scaling]) => {
+      const { result, inverse } = calculateDragDirectionDelta(delta, scaling)
+      expect(inverse(result)).toEqual(delta)
+    })
+  })
+})


### PR DESCRIPTION
**Problem:**
Today when scrubbing the value on mouse movement we still keep track of the original movement delta, causing an issue where it's hard to return after passing the thresholds

<video src="https://github.com/user-attachments/assets/4298be75-4449-45dd-a961-df89094300d7"></video>

**Fix:**
Keep track of the clamped mouse movement as well. This required adding a way to invert our `calculateDragDelta` function, in order to retrieve the "clamped" mouse movements after clamping the total value.

<video src="https://github.com/user-attachments/assets/d7005f59-b12b-46d8-9a3d-9fad3961e717"></video>

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode

Fixes #6299
