### PR TITLE
x for grids

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -10,9 +10,9 @@ import type { InsertionSubject } from '../../editor/editor-modes'
 import type { AllElementProps } from '../../editor/store/editor-state'
 import type { CanvasCommand } from '../commands/commands'
 import type { ActiveFrameAction } from '../commands/set-active-frames-command'
-import type { GridCellCoordinates } from '../controls/grid-controls'
 import type { StrategyApplicationStatus } from './interaction-state'
 import type { TargetGridCellData } from './strategies/grid-helpers'
+import type { GridCellCoordinates } from './strategies/grid-cell-bounds'
 
 // TODO: fill this in, maybe make it an ADT for different strategies
 export interface CustomStrategyState {

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-cell-bounds.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-cell-bounds.ts
@@ -1,0 +1,139 @@
+import type { ElementPath } from 'utopia-shared/src/types'
+import type { ElementInstanceMetadata } from '../../../../core/shared/element-template'
+import type { CanvasVector, WindowPoint, WindowRectangle } from '../../../../core/shared/math-utils'
+import {
+  isInfinityRectangle,
+  offsetPoint,
+  rectContainsPoint,
+  windowPoint,
+  windowRectangle,
+} from '../../../../core/shared/math-utils'
+import { canvasPointToWindowPoint } from '../../dom-lookup'
+import * as EP from '../../../../core/shared/element-path'
+
+export type GridCellCoordinates = { row: number; column: number }
+
+export function gridCellCoordinates(row: number, column: number): GridCellCoordinates {
+  return { row: row, column: column }
+}
+
+const gridCellTargetIdPrefix = 'grid-cell-target-'
+
+export function gridCellTargetId(
+  gridElementPath: ElementPath,
+  row: number,
+  column: number,
+): string {
+  return gridCellTargetIdPrefix + `${EP.toString(gridElementPath)}-${row}-${column}`
+}
+
+export function getGridCellUnderMouse(mousePoint: WindowPoint) {
+  return getGridCellAtPoint(mousePoint, false)
+}
+
+export function getGridCellUnderMouseRecursive(mousePoint: WindowPoint) {
+  return getGridCellAtPoint(mousePoint, true)
+}
+
+function isGridCellTargetId(id: string): boolean {
+  return id.startsWith(gridCellTargetIdPrefix)
+}
+
+export function getGridCellAtPoint(
+  point: WindowPoint,
+  duplicating: boolean,
+): { id: string; coordinates: GridCellCoordinates; cellWindowRectangle: WindowRectangle } | null {
+  function maybeRecursivelyFindCellAtPoint(
+    elements: Element[],
+  ): { element: Element; cellWindowRectangle: WindowRectangle } | null {
+    // If this used during duplication, the canvas controls will be in the way and we need to traverse the children too.
+    for (const element of elements) {
+      if (isGridCellTargetId(element.id)) {
+        const domRect = element.getBoundingClientRect()
+        const windowRect = windowRectangle(domRect)
+        if (rectContainsPoint(windowRect, point)) {
+          return { element: element, cellWindowRectangle: windowRect }
+        }
+      }
+
+      if (duplicating) {
+        const child = maybeRecursivelyFindCellAtPoint(Array.from(element.children))
+        if (child != null) {
+          return child
+        }
+      }
+    }
+
+    return null
+  }
+
+  const cellUnderMouse = maybeRecursivelyFindCellAtPoint(
+    document.elementsFromPoint(point.x, point.y),
+  )
+  if (cellUnderMouse == null) {
+    return null
+  }
+
+  const { element, cellWindowRectangle } = cellUnderMouse
+  const row = element.getAttribute('data-grid-row')
+  const column = element.getAttribute('data-grid-column')
+
+  return {
+    id: element.id,
+    cellWindowRectangle: cellWindowRectangle,
+    coordinates: gridCellCoordinates(
+      row == null ? 0 : parseInt(row),
+      column == null ? 0 : parseInt(column),
+    ),
+  }
+}
+
+const GRID_BOUNDS_TOLERANCE = 5 // px
+
+export function getGridCellBoundsFromCanvas(
+  cell: ElementInstanceMetadata,
+  canvasScale: number,
+  canvasOffset: CanvasVector,
+) {
+  const cellFrame = cell.globalFrame
+  if (cellFrame == null || isInfinityRectangle(cellFrame)) {
+    return null
+  }
+
+  const canvasFrameWidth = cellFrame.width * canvasScale
+  const canvasFrameHeight = cellFrame.height * canvasScale
+
+  const cellOriginPoint = offsetPoint(
+    canvasPointToWindowPoint(cellFrame, canvasScale, canvasOffset),
+    windowPoint({ x: GRID_BOUNDS_TOLERANCE, y: GRID_BOUNDS_TOLERANCE }),
+  )
+  const cellOrigin = getGridCellAtPoint(cellOriginPoint, true)
+  if (cellOrigin == null) {
+    return null
+  }
+
+  const cellEndPoint = offsetPoint(
+    cellOriginPoint,
+    windowPoint({
+      x: canvasFrameWidth - GRID_BOUNDS_TOLERANCE,
+      y: canvasFrameHeight - GRID_BOUNDS_TOLERANCE,
+    }),
+  )
+  const cellEnd = getGridCellAtPoint(cellEndPoint, true)
+  if (cellEnd == null) {
+    return null
+  }
+
+  const cellOriginCoords = cellOrigin.coordinates
+  const cellEndCoords = cellEnd.coordinates
+
+  const cellWidth = cellEndCoords.column - cellOriginCoords.column + 1
+  const cellHeight = cellEndCoords.row - cellOriginCoords.row + 1
+
+  return {
+    column: cellOriginCoords.column,
+    row: cellOriginCoords.row,
+    width: cellWidth,
+    height: cellHeight,
+  }
+}

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -13,10 +13,8 @@ import {
   canvasPoint,
   isInfinityRectangle,
   offsetPoint,
-  rectContainsPoint,
   scaleVector,
   windowPoint,
-  windowRectangle,
   windowVector,
   type WindowPoint,
 } from '../../../../core/shared/math-utils'
@@ -26,83 +24,16 @@ import { setProperty } from '../../commands/set-property-command'
 import { canvasPointToWindowPoint } from '../../dom-lookup'
 import type { DragInteractionData } from '../interaction-state'
 import type { GridCustomStrategyState, InteractionCanvasState } from '../canvas-strategy-types'
-import type { GridCellCoordinates } from '../../controls/grid-controls'
-import { gridCellCoordinates } from '../../controls/grid-controls'
 import * as EP from '../../../../core/shared/element-path'
 import { deleteProperties } from '../../commands/delete-properties-command'
 import { cssNumber, isCSSKeyword } from '../../../inspector/common/css-utils'
 import { setCssLengthProperty } from '../../commands/set-css-length-command'
-
-export function getGridCellUnderMouse(mousePoint: WindowPoint) {
-  return getGridCellAtPoint(mousePoint, false)
-}
-
-function getGridCellUnderMouseRecursive(mousePoint: WindowPoint) {
-  return getGridCellAtPoint(mousePoint, true)
-}
-
-const gridCellTargetIdPrefix = 'grid-cell-target-'
-
-export function gridCellTargetId(
-  gridElementPath: ElementPath,
-  row: number,
-  column: number,
-): string {
-  return gridCellTargetIdPrefix + `${EP.toString(gridElementPath)}-${row}-${column}`
-}
-
-function isGridCellTargetId(id: string): boolean {
-  return id.startsWith(gridCellTargetIdPrefix)
-}
-
-export function getGridCellAtPoint(
-  point: WindowPoint,
-  duplicating: boolean,
-): { id: string; coordinates: GridCellCoordinates; cellWindowRectangle: WindowRectangle } | null {
-  function maybeRecursivelyFindCellAtPoint(
-    elements: Element[],
-  ): { element: Element; cellWindowRectangle: WindowRectangle } | null {
-    // If this used during duplication, the canvas controls will be in the way and we need to traverse the children too.
-    for (const element of elements) {
-      if (isGridCellTargetId(element.id)) {
-        const domRect = element.getBoundingClientRect()
-        const windowRect = windowRectangle(domRect)
-        if (rectContainsPoint(windowRect, point)) {
-          return { element: element, cellWindowRectangle: windowRect }
-        }
-      }
-
-      if (duplicating) {
-        const child = maybeRecursivelyFindCellAtPoint(Array.from(element.children))
-        if (child != null) {
-          return child
-        }
-      }
-    }
-
-    return null
-  }
-
-  const cellUnderMouse = maybeRecursivelyFindCellAtPoint(
-    document.elementsFromPoint(point.x, point.y),
-  )
-  if (cellUnderMouse == null) {
-    return null
-  }
-
-  const { element, cellWindowRectangle } = cellUnderMouse
-  const row = element.getAttribute('data-grid-row')
-  const column = element.getAttribute('data-grid-column')
-
-  return {
-    id: element.id,
-    cellWindowRectangle: cellWindowRectangle,
-    coordinates: gridCellCoordinates(
-      row == null ? 0 : parseInt(row),
-      column == null ? 0 : parseInt(column),
-    ),
-  }
-}
+import type { GridCellCoordinates } from './grid-cell-bounds'
+import {
+  getGridCellUnderMouse,
+  getGridCellUnderMouseRecursive,
+  gridCellCoordinates,
+} from './grid-cell-bounds'
 
 export function runGridRearrangeMove(
   targetElement: ElementPath,
@@ -500,54 +431,4 @@ function gridChildAbsoluteMoveCommands(
       null,
     ),
   ]
-}
-
-const GRID_BOUNDS_TOLERANCE = 5 // px
-
-export function getGridCellBoundsFromCanvas(
-  cell: ElementInstanceMetadata,
-  canvasScale: number,
-  canvasOffset: CanvasVector,
-) {
-  const cellFrame = cell.globalFrame
-  if (cellFrame == null || isInfinityRectangle(cellFrame)) {
-    return null
-  }
-
-  const canvasFrameWidth = cellFrame.width * canvasScale
-  const canvasFrameHeight = cellFrame.height * canvasScale
-
-  const cellOriginPoint = offsetPoint(
-    canvasPointToWindowPoint(cellFrame, canvasScale, canvasOffset),
-    windowPoint({ x: GRID_BOUNDS_TOLERANCE, y: GRID_BOUNDS_TOLERANCE }),
-  )
-  const cellOrigin = getGridCellAtPoint(cellOriginPoint, true)
-  if (cellOrigin == null) {
-    return null
-  }
-
-  const cellEndPoint = offsetPoint(
-    cellOriginPoint,
-    windowPoint({
-      x: canvasFrameWidth - GRID_BOUNDS_TOLERANCE,
-      y: canvasFrameHeight - GRID_BOUNDS_TOLERANCE,
-    }),
-  )
-  const cellEnd = getGridCellAtPoint(cellEndPoint, true)
-  if (cellEnd == null) {
-    return null
-  }
-
-  const cellOriginCoords = cellOrigin.coordinates
-  const cellEndCoords = cellEnd.coordinates
-
-  const cellWidth = cellEndCoords.column - cellOriginCoords.column + 1
-  const cellHeight = cellEndCoords.row - cellOriginCoords.row + 1
-
-  return {
-    column: cellOriginCoords.column,
-    row: cellOriginCoords.row,
-    width: cellWidth,
-    height: cellHeight,
-  }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-keyboard-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-keyboard-strategy.ts
@@ -14,7 +14,8 @@ import {
   strategyApplicationResult,
 } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
-import { getGridCellBoundsFromCanvas, setGridPropsCommands } from './grid-helpers'
+import { setGridPropsCommands } from './grid-helpers'
+import { getGridCellBoundsFromCanvas } from './grid-cell-bounds'
 import { accumulatePresses } from './shared-keyboard-strategy-helpers'
 
 export function gridRearrangeResizeKeyboardStrategy(

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.spec.browser2.tsx
@@ -11,7 +11,7 @@ import { GridCellTestId } from '../../controls/grid-controls'
 import { mouseDragFromPointToPoint } from '../../event-helpers.test-utils'
 import type { EditorRenderResult } from '../../ui-jsx.test-utils'
 import { renderTestEditorWithCode } from '../../ui-jsx.test-utils'
-import { gridCellTargetId } from './grid-helpers'
+import { gridCellTargetId } from './grid-cell-bounds'
 
 describe('grid rearrange move strategy', () => {
   it('can rearrange elements on a grid', async () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategy.tsx
@@ -34,7 +34,6 @@ import { flattenSelection } from './shared-move-strategies-helpers'
 import type { CanvasRectangle, CanvasVector } from '../../../../core/shared/math-utils'
 import { canvasVector, isInfinityRectangle, offsetPoint } from '../../../../core/shared/math-utils'
 import { showGridControls } from '../../commands/show-grid-controls-command'
-import type { GridCellCoordinates } from '../../controls/grid-controls'
 import { GridControls } from '../../controls/grid-controls'
 import {
   gridPositionValue,
@@ -49,6 +48,7 @@ import { removeAbsolutePositioningProps } from './reparent-helpers/reparent-prop
 import { canvasPointToWindowPoint } from '../../dom-lookup'
 import type { TargetGridCellData } from './grid-helpers'
 import { getTargetCell, setGridPropsCommands } from './grid-helpers'
+import type { GridCellCoordinates } from './grid-cell-bounds'
 
 export function gridReparentStrategy(
   reparentTarget: ReparentTarget,

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
@@ -14,8 +14,7 @@ import { mouseDragFromPointToPoint } from '../../event-helpers.test-utils'
 import type { EditorRenderResult } from '../../ui-jsx.test-utils'
 import { renderTestEditorWithCode } from '../../ui-jsx.test-utils'
 import type { GridResizeEdge } from '../interaction-state'
-import { gridCellTargetId } from './grid-helpers'
-import { wait } from '../../../../core/model/performance-scripts'
+import { gridCellTargetId } from './grid-cell-bounds'
 
 async function runCellResizeTest(
   editor: EditorRenderResult,

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -15,8 +15,9 @@ import {
   strategyApplicationResult,
 } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
+import { getGridCellUnderMouse } from './grid-cell-bounds'
 import type { TargetGridCellData } from './grid-helpers'
-import { getGridCellUnderMouse, setGridPropsCommands } from './grid-helpers'
+import { setGridPropsCommands } from './grid-helpers'
 
 export const gridResizeElementStrategy: CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -62,7 +62,6 @@ import {
 import { windowToCanvasCoordinates } from '../dom-lookup'
 import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
 import { useColorTheme, UtopiaStyles } from '../../../uuiui'
-import { gridCellTargetId } from '../canvas-strategies/strategies/grid-helpers'
 import { resizeBoundingBoxFromSide } from '../canvas-strategies/strategies/resize-helpers'
 import type { EdgePosition } from '../canvas-types'
 import {
@@ -78,16 +77,12 @@ import { optionalMap } from '../../../core/shared/optional-utils'
 import type { Sides } from 'utopia-api/core'
 import type { Axis } from '../gap-utils'
 import { useMaybeHighlightElement } from './select-mode/select-mode-hooks'
+import type { GridCellCoordinates } from '../canvas-strategies/strategies/grid-cell-bounds'
+import { gridCellTargetId } from '../canvas-strategies/strategies/grid-cell-bounds'
 
 const CELL_ANIMATION_DURATION = 0.15 // seconds
 
 export const GridCellTestId = (elementPath: ElementPath) => `grid-cell-${EP.toString(elementPath)}`
-
-export type GridCellCoordinates = { row: number; column: number }
-
-export function gridCellCoordinates(row: number, column: number): GridCellCoordinates {
-  return { row: row, column: column }
-}
 
 function getCellsCount(template: GridAutoOrTemplateBase | null): number {
   if (template == null) {

--- a/editor/src/components/editor/global-shortcuts.tsx
+++ b/editor/src/components/editor/global-shortcuts.tsx
@@ -963,6 +963,7 @@ export function handleKeyDown(
           editor.allElementProps,
           editor.elementPathTree,
           editor.selectedViews,
+          { scale: editor.canvas.scale, offset: editor.canvas.realCanvasOffset },
         )
 
         if (commands.length === 0) {

--- a/editor/src/components/editor/shortcuts.spec.browser2.tsx
+++ b/editor/src/components/editor/shortcuts.spec.browser2.tsx
@@ -259,6 +259,187 @@ describe('shortcuts', () => {
         canvasRectangle({ x: 186, y: 34, width: 94, height: 55 }),
       )
     })
+
+    describe('inside grid', () => {
+      it('can place element spanning a single cell into the grid and take it out', async () => {
+        const editor = await renderTestEditorWithCode(
+          `import { Scene, Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <Scene
+      id='playground-scene'
+      commentId='playground-scene'
+      style={{
+        width: 620,
+        height: 548,
+        position: 'absolute',
+        left: 212,
+        top: 103,
+      }}
+      data-label='Playground'
+      data-uid='scene'
+    >
+      <div
+      data-uid='grid'
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: 527,
+          height: 461,
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr 1fr 1fr 1fr',
+          gridTemplateRows: '1fr 1fr 1fr 1fr 1fr',
+          contain: 'layout',
+          gridGap: 2,
+          position: 'absolute',
+          left: 46,
+          top: 43,
+        }}
+      >
+        <div
+        data-uid='child'
+        data-testid='child'
+          style={{
+            backgroundColor: '#0162ff',
+            position: 'absolute',
+            left: 13,
+            top: 19,
+            width: 74,
+            height: 59,
+            gridColumn: 3,
+            gridRow: 3,
+          }}
+        />
+      </div>
+    </Scene>
+  </Storyboard>
+)
+`,
+          'await-first-dom-report',
+        )
+
+        await selectComponentsForTest(editor, [EP.fromString('sb/scene/grid/child')])
+        await pressKey('x')
+
+        {
+          const { position, gridRow, gridColumn, width, height } =
+            editor.renderedDOM.getByTestId('child').style
+          expect({ position, gridRow, gridColumn, width, height }).toEqual({
+            gridColumn: '3',
+            gridRow: '3',
+            height: '',
+            position: '',
+            width: '',
+          })
+        }
+
+        await pressKey('x') // convert it back to absolute
+
+        {
+          const { position, gridRow, gridColumn, width, height, top, left } =
+            editor.renderedDOM.getByTestId('child').style
+          expect({ position, gridRow, gridColumn, width, height, top, left }).toEqual({
+            gridColumn: '3',
+            gridRow: '3',
+            height: '90.5px',
+            left: '0px',
+            position: 'absolute',
+            top: '0px',
+            width: '104px',
+          })
+        }
+      })
+
+      it('can place element spanning multiple grid cells into the grid and take it out', async () => {
+        const editor = await renderTestEditorWithCode(
+          `import { Scene, Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <Scene
+      id='playground-scene'
+      commentId='playground-scene'
+      style={{
+        width: 620,
+        height: 548,
+        position: 'absolute',
+        left: 212,
+        top: 103,
+      }}
+      data-label='Playground'
+      data-uid='scene'
+    >
+      <div
+      data-uid='grid'
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: 527,
+          height: 461,
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr 1fr 1fr 1fr',
+          gridTemplateRows: '1fr 1fr 1fr 1fr 1fr',
+          contain: 'layout',
+          gridGap: 2,
+          position: 'absolute',
+          left: 46,
+          top: 43,
+        }}
+      >
+        <div
+        data-uid='child'
+        data-testid='child'
+          style={{
+            position: 'absolute',
+            left: 29,
+            top: 34,
+            width: 237,
+            height: 121,
+            gridColumn: 2,
+            gridRow: 2,
+            backgroundImage:
+              'linear-gradient(44deg, #BE3B5E 0%, #309212 100%)',
+          }}
+        />
+      </div>
+    </Scene>
+  </Storyboard>
+)
+`,
+          'await-first-dom-report',
+        )
+
+        await selectComponentsForTest(editor, [EP.fromString('sb/scene/grid/child')])
+        await pressKey('x')
+
+        {
+          const { position, gridRow, gridColumn, width, height } =
+            editor.renderedDOM.getByTestId('child').style
+          expect({ position, gridRow, gridColumn, width, height }).toEqual({
+            gridColumn: '2 / 5',
+            gridRow: '2 / 4',
+            height: '',
+            position: '',
+            width: '',
+          })
+        }
+
+        await pressKey('x') // convert it back to absolute
+
+        {
+          const { position, gridRow, gridColumn, width, height, top, left } =
+            editor.renderedDOM.getByTestId('child').style
+          expect({ position, gridRow, gridColumn, width, height, top, left }).toEqual({
+            gridColumn: '2',
+            gridRow: '2',
+            height: '183px',
+            left: '0px',
+            position: 'absolute',
+            top: '0px',
+            width: '315.5px',
+          })
+        }
+      })
+    })
   })
 
   describe('jump to parent', () => {

--- a/editor/src/components/editor/shortcuts.spec.browser2.tsx
+++ b/editor/src/components/editor/shortcuts.spec.browser2.tsx
@@ -439,6 +439,77 @@ export var storyboard = (
           })
         }
       })
+
+      it('can place element with no grid positioning props set', async () => {
+        const editor = await renderTestEditorWithCode(
+          `import { Scene, Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <Scene
+      id='playground-scene'
+      commentId='playground-scene'
+      style={{
+        width: 620,
+        height: 548,
+        position: 'absolute',
+        left: 212,
+        top: 103,
+      }}
+      data-label='Playground'
+      data-uid='scene'
+    >
+      <div
+        data-uid='grid'
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: 527,
+          height: 461,
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr 1fr 1fr 1fr',
+          gridTemplateRows: '1fr 1fr 1fr 1fr 1fr',
+          contain: 'layout',
+          gridGap: 2,
+          position: 'absolute',
+          left: 46,
+          top: 43,
+        }}
+      >
+        <div
+          data-uid='child'
+          data-testid='child'
+          style={{
+            backgroundColor: '#0162ff',
+            position: 'absolute',
+            left: 113,
+            top: 119,
+            width: 174,
+            height: 119,
+          }}
+        />
+      </div>
+    </Scene>
+  </Storyboard>
+)
+`,
+          'await-first-dom-report',
+        )
+
+        await selectComponentsForTest(editor, [EP.fromString('sb/scene/grid/child')])
+        await pressKey('x')
+
+        {
+          const { position, gridRow, gridColumn, width, height } =
+            editor.renderedDOM.getByTestId('child').style
+          expect({ position, gridRow, gridColumn, width, height }).toEqual({
+            gridColumn: '2 / 4',
+            gridRow: '2 / 4',
+            height: '',
+            position: '',
+            width: '',
+          })
+        }
+      })
     })
   })
 

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -1418,19 +1418,26 @@ export function isHuggingParent(element: ElementInstanceMetadata, property: 'wid
   return element.specialSizeMeasurements.computedHugProperty[property] != null
 }
 
+interface ContainedGridPositioning {
+  type: 'contained'
+  gridRow: number
+  gridColumn: number
+}
+
+interface SpanningGridPositioning {
+  type: 'span'
+  gridRowStart: number
+  gridRowEnd: number
+  gridColumnStart: number
+  gridColumnEnd: number
+}
+
+type DetectedGridPositioning = ContainedGridPositioning | SpanningGridPositioning
+
 function getGridElementBounds(
   cell: ElementInstanceMetadata,
   canvasContext: { scale: number; offset: CanvasVector },
-):
-  | null
-  | { type: 'contained'; gridRow: number; gridColumn: number }
-  | {
-      type: 'span'
-      gridRowStart: number
-      gridRowEnd: number
-      gridColumnStart: number
-      gridColumnEnd: number
-    } {
+): DetectedGridPositioning | null {
   const initialCellBounds = getGridCellBoundsFromCanvas(
     cell,
     canvasContext.scale,

--- a/editor/src/components/inspector/inspector-common.ts
+++ b/editor/src/components/inspector/inspector-common.ts
@@ -34,7 +34,12 @@ import { optionalMap } from '../../core/shared/optional-utils'
 import type { CSSProperties } from 'react'
 import type { CanvasCommand } from '../canvas/commands/commands'
 import { deleteProperties } from '../canvas/commands/delete-properties-command'
-import { setProperty } from '../canvas/commands/set-property-command'
+import {
+  propertyToDelete,
+  propertyToSet,
+  setProperty,
+  updateBulkProperties,
+} from '../canvas/commands/set-property-command'
 import { addContainLayoutIfNeeded } from '../canvas/commands/add-contain-layout-if-needed-command'
 import {
   setCssLengthProperty,
@@ -1491,13 +1496,11 @@ function gridChildAbsolutePositionConversionCommands(
 
     return [
       ...nukeAllAbsolutePositioningPropsCommands(elementPath),
-      deleteProperties('always', elementPath, gridElementProps),
-      ...gridPositioningProps.map(({ prop, value }) =>
-        setProperty('always', elementPath, prop, value),
-      ),
-      deleteProperties('always', elementPath, [
-        PP.create('style', 'width'),
-        PP.create('style', 'height'),
+      updateBulkProperties('always', elementPath, [
+        propertyToDelete(PP.create('style', 'width')),
+        propertyToDelete(PP.create('style', 'height')),
+        ...gridElementProps.map(propertyToDelete),
+        ...gridPositioningProps.map(({ prop, value }) => propertyToSet(prop, value)),
       ]),
     ]
   }
@@ -1511,23 +1514,13 @@ function gridChildAbsolutePositionConversionCommands(
 
   return [
     ...sizeToVisualDimensions(jsxMetadata, elementPathTree, elementPath),
-    deleteProperties('always', elementPath, gridElementProps),
-    setProperty('always', elementPath, PP.create('style', 'gridRow'), row),
-    setProperty('always', elementPath, PP.create('style', 'gridColumn'), column),
-    setProperty('always', elementPath, PP.create('style', 'position'), 'absolute'),
-    setCssLengthProperty(
-      'always',
-      elementPath,
-      PP.create('style', 'top'),
-      { type: 'EXPLICIT_CSS_NUMBER', value: cssNumber(0) },
-      null,
-    ),
-    setCssLengthProperty(
-      'always',
-      elementPath,
-      PP.create('style', 'left'),
-      { type: 'EXPLICIT_CSS_NUMBER', value: cssNumber(0) },
-      null,
-    ),
+    updateBulkProperties('always', elementPath, [
+      ...gridElementProps.map(propertyToDelete),
+      propertyToSet(PP.create('style', 'gridRow'), row),
+      propertyToSet(PP.create('style', 'gridColumn'), column),
+      propertyToSet(PP.create('style', 'position'), 'absolute'),
+      propertyToSet(PP.create('style', 'top'), 0),
+      propertyToSet(PP.create('style', 'left'), 0),
+    ]),
   ]
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/7627f89e-c87b-4246-9ac5-1f70ca4e254d

## Problem
The x shortcut isn't aware of grids

## Fix
Special case grid elements in the x shortcut.

### How it works
If an element is a grid child and it's absolute positioned (for example after a reparent or drawing), pressing x removes the `position: absolute`, absolute positioning prop, and any explicit width/height props on the element, and sets `gridRow`/`gridColumn`/`gridRowStart`/gridRowEnd`/`gridColumnStart`/gridColumnEnd` in way that snaps the element into the grid cells it occupies.

When an element is a non-position-absolute grid child, and x is pressed, `position: absolute` is set, the element is sized to its visual dimensions with `width`/`height`, and `top: 0` / `left: 0` is added. Making it possible to absolute resize the element after this is left to a follow-up PR. 

### Details
- Due to a circular dependency, a lot of grid cell related code was factored out into `grid-cell-utils.ts`

