### PR TITLE
Send message to utopia when a file is saved in vs code

### DIFF
--- a/utopia-vscode-extension/src/utopia-fs.ts
+++ b/utopia-vscode-extension/src/utopia-fs.ts
@@ -50,7 +50,7 @@ import {
   isNotDirectoryError,
   pathIsFile,
 } from './in-mem-fs'
-import { appendToPath, dirname, vsCodeFileDelete } from 'utopia-vscode-common'
+import { appendToPath, dirname, vsCodeFileChange, vsCodeFileDelete } from 'utopia-vscode-common'
 import type { ProjectFile } from 'utopia-vscode-common'
 import { addSchemeToPath, allPathsUpToPath } from './path-utils'
 
@@ -219,6 +219,7 @@ export class UtopiaFSExtension
     const path = uri.path
     createDirectory(path)
     this.notifyFileCreated(path)
+    // TODO Add a message for when a directory is created / renamed
   }
 
   readFile(uri: Uri): Uint8Array {
@@ -243,6 +244,9 @@ export class UtopiaFSExtension
     } else {
       this.notifyFileCreated(path)
     }
+
+    const updatedFile = readFileAsUTF8(path)
+    commands.executeCommand('utopia.toUtopiaMessage', vsCodeFileChange(path, updatedFile))
   }
 
   ensureDirectoryExists(pathToEnsure: string) {


### PR DESCRIPTION
**Problem:**
When saving a file in the code editor it was still marked as unsaved in Utopia.

**Fix:**
This was just because we weren't informing Utopia that the file had been saved, so it was simply a case of sending the right message when the file is saved.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode
