### PR TITLE
disable flaky tests related to focusing elements

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx
@@ -416,7 +416,7 @@ describe('Select Mode Clicking', () => {
     checkFocusedPath(renderResult, desiredPaths[2])
     checkSelectedPaths(renderResult, [desiredPaths[2]])
   })
-  it('Single click and five double clicks will focus a generated Card and select the Button inside', async function (this: Mocha.Context) {
+  xit('Single click and five double clicks will focus a generated Card and select the Button inside', async function (this: Mocha.Context) {
     this.timeout(TimeoutForThisFile)
     // prettier-ignore
     const desiredPaths = createConsecutivePaths(
@@ -750,7 +750,7 @@ describe('Select Mode Double Clicking With Fragments', () => {
     checkSelectedPaths(renderResult, [desiredPaths[1]])
   })
 
-  it('Single click and three double clicks will focus a generated Card', async () => {
+  xit('Single click and three double clicks will focus a generated Card', async () => {
     // prettier-ignore
     const desiredPaths = createConsecutivePaths(
       'sb' +                  // Skipped as it's the storyboard


### PR DESCRIPTION
## Description

This PR disables the following flaky tests: 

https://github.com/concrete-utopia/utopia/blob/1eebfa60c17e988ddb29073aafd6c2c7c039780c/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx#L419

https://github.com/concrete-utopia/utopia/blob/1eebfa60c17e988ddb29073aafd6c2c7c039780c/editor/src/components/canvas/controls/select-mode/select-mode.spec.browser2.tsx#L753

Tracker issue: https://github.com/concrete-utopia/utopia/issues/6337
