### PR TITLE
Rerun the dom sampler when canvas root container is null

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -258,6 +258,9 @@ export interface DomWalkerMutableStateData {
   initComplete: boolean
   mutationObserver: MutationObserver
   resizeObserver: ResizeObserver
+  // dirty is set to true when after a dispatch resubscribeObservers could not run successfully. This happens whan the canvasRootContainer is null.
+  // It can happen in remix project that after this the project is rendered, but there are no observers to trigger the dom sampler.
+  dirty: boolean
 }
 
 export function createDomWalkerMutableState(
@@ -270,6 +273,7 @@ export function createDomWalkerMutableState(
     initComplete: true,
     mutationObserver: null as any,
     resizeObserver: null as any,
+    dirty: false,
   }
 
   const observers = initDomWalkerObservers(mutableData, editorStoreApi, dispatch)
@@ -290,6 +294,7 @@ function useDomWalkerMutableStateContext() {
 export function resubscribeObservers(domWalkerMutableState: {
   mutationObserver: MutationObserver
   resizeObserver: ResizeObserver
+  dirty: boolean
 }) {
   const canvasRootContainer = document.getElementById(CanvasContainerID)
   if (
@@ -302,6 +307,9 @@ export function resubscribeObservers(domWalkerMutableState: {
       domWalkerMutableState.resizeObserver.observe(elem)
     })
     domWalkerMutableState.mutationObserver.observe(canvasRootContainer, MutationObserverConfig)
+    domWalkerMutableState.dirty = false
+  } else {
+    domWalkerMutableState.dirty = true
   }
 }
 

--- a/editor/src/components/canvas/editor-dispatch-flow.tsx
+++ b/editor/src/components/canvas/editor-dispatch-flow.tsx
@@ -29,6 +29,7 @@ export function runDomSamplerAndSaveResults(
   domWalkerMutableState: {
     mutationObserver: MutationObserver
     resizeObserver: ResizeObserver
+    dirty: boolean
   },
   spyCollector: UiJsxCanvasContextData,
 ) {

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -482,7 +482,12 @@ export class Editor {
         })
       }
 
-      const runDomWalker = shouldRunDOMWalker(dispatchedActions, oldEditorState, this.storedState)
+      const runDomWalker = shouldRunDOMWalker(
+        dispatchedActions,
+        oldEditorState,
+        this.storedState,
+        this.domWalkerMutableState,
+      )
 
       // run the dom-walker
       if (runDomWalker) {
@@ -854,7 +859,12 @@ export function shouldRunDOMWalker(
   dispatchedActions: ReadonlyArray<EditorAction>,
   storeBefore: EditorStoreFull,
   storeAfter: EditorStoreFull,
+  domWalkerMutableState: DomWalkerMutableStateData,
 ): boolean {
+  if (domWalkerMutableState.dirty) {
+    return true
+  }
+
   const patchedEditorBefore = storeBefore.patchedEditor
   const patchedEditorAfter = storeAfter.patchedEditor
   const patchedEditorChanged =


### PR DESCRIPTION
**Problem:**
Describe the problem being addressed as succinctly as possible.

**Fix:**
Describe the fix you have made as succinctly as possible.

**Commit Details:** (< vv pls delete this section if's not relevant)

- Renamed `thing` to `otherThing`
- Removed `cake` from `fridge-contents.ts`
- Did [other things]

**Manual Tests:**
I hereby swear that:

- [ ] I opened a hydrogen project and it loaded
- [ ] I could navigate to various routes in Preview mode

Fixes #[ticket_number] (<< pls delete this line if it's not relevant)
