### PR TITLE
fix(grid): show gaps and cells on gap resize

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
@@ -41,6 +41,7 @@ import type { InteractionSession } from '../interaction-state'
 import { colorTheme } from '../../../../uuiui'
 import { activeFrameTargetPath, setActiveFrames } from '../../commands/set-active-frames-command'
 import { GridGapControl } from '../../controls/select-mode/grid-gap-control'
+import { GridControls } from '../../controls/grid-controls'
 
 const SetGridGapStrategyId = 'SET_GRID_GAP_STRATEGY'
 
@@ -116,21 +117,30 @@ export const setGridGapStrategy: CanvasStrategyFactory = (
 
   const maybeIndicatorProps = gridGapValueIndicatorProps(interactionSession, gridGap)
 
-  const controlsToRender = optionalMap(
-    (props) => [
-      resizeControl,
-      controlWithProps({
-        control: FloatingIndicator,
-        props: {
-          ...props,
-          color: colorTheme.brandNeonPink.value,
-        },
-        key: 'padding-value-indicator-control',
-        show: 'visible-except-when-other-strategy-is-active',
-      }),
-    ],
-    maybeIndicatorProps,
-  ) ?? [resizeControl]
+  const controlsToRender = [
+    ...(optionalMap(
+      (props) => [
+        resizeControl,
+        controlWithProps({
+          control: FloatingIndicator,
+          props: {
+            ...props,
+            color: colorTheme.brandNeonPink.value,
+          },
+          key: 'padding-value-indicator-control',
+          show: 'visible-except-when-other-strategy-is-active',
+        }),
+      ],
+      maybeIndicatorProps,
+    ) ?? [resizeControl]),
+    {
+      control: GridControls,
+      props: { targets: [selectedElement] },
+      key: `draw-into-grid-strategy-controls`,
+      show: 'always-visible',
+      priority: 'bottom',
+    } as const,
+  ]
 
   return {
     id: SetGridGapStrategyId,

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
@@ -136,7 +136,7 @@ export const setGridGapStrategy: CanvasStrategyFactory = (
     {
       control: GridControls,
       props: { targets: [selectedElement] },
-      key: `draw-into-grid-strategy-controls`,
+      key: `set-grid-gap-strategy-controls`,
       show: 'always-visible',
       priority: 'bottom',
     } as const,

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
@@ -133,13 +133,18 @@ export const setGridGapStrategy: CanvasStrategyFactory = (
       ],
       maybeIndicatorProps,
     ) ?? [resizeControl]),
-    {
-      control: GridControls,
-      props: { targets: [selectedElement] },
-      key: `set-grid-gap-strategy-controls`,
-      show: 'always-visible',
-      priority: 'bottom',
-    } as const,
+    // when the drag is ongoing, keep showing the grid cells
+    ...(isDragOngoing(interactionSession)
+      ? ([
+          {
+            control: GridControls,
+            props: { targets: [selectedElement] },
+            key: `set-grid-gap-strategy-controls`,
+            show: 'always-visible',
+            priority: 'bottom',
+          },
+        ] as const)
+      : []),
   ]
 
   return {

--- a/editor/src/components/canvas/controls/select-mode/grid-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/grid-gap-control.tsx
@@ -26,7 +26,7 @@ import { isZeroSizedElement } from '../outline-utils'
 import { createArrayWithLength } from '../../../../core/shared/array-utils'
 import { useGridData } from '../grid-controls'
 
-interface GridGapControlProps {
+export interface GridGapControlProps {
   selectedElement: ElementPath
   updatedGapValueRow: CSSNumberWithRenderedValue | null
   updatedGapValueColumn: CSSNumberWithRenderedValue | null


### PR DESCRIPTION
**Problem:**
Today when changing grid gaps the grid cells (and gap handlers that rely on them) disappear:

<video src="https://github.com/user-attachments/assets/6a6a4e26-5aed-4b47-9a0d-1f2f945287c7"></video>

**Fix:**
Draw the cell placeholders explicitly when resizing the gaps (similar to reparent into grid).

<video src="https://github.com/user-attachments/assets/3e2a1cdd-d475-4e89-9735-b918a879a114"></video>

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode
