### PR TITLE
Fix subscribing mutation/resize observers during a build error

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -25,7 +25,11 @@ import type {
 } from './ui-jsx-canvas'
 import { DomWalkerInvalidatePathsCtxAtom, UiJsxCanvas, pickUiJsxCanvasProps } from './ui-jsx-canvas'
 
-interface CanvasComponentEntryProps {}
+export const CanvasContainerOuterId = 'canvas-container-outer'
+
+interface CanvasComponentEntryProps {
+  shouldRenderCanvas: boolean
+}
 
 export const CanvasComponentEntry = React.memo((props: CanvasComponentEntryProps) => {
   const canvasStore = React.useContext(CanvasStateContext)
@@ -85,7 +89,7 @@ const CanvasComponentEntryInner = React.memo((props: CanvasComponentEntryProps) 
     <>
       {when(canvasProps == null, <CanvasLoadingScreen />)}
       <div
-        id='canvas-container-outer'
+        id={CanvasContainerOuterId}
         ref={containerRef}
         style={{
           position: 'absolute',
@@ -93,14 +97,15 @@ const CanvasComponentEntryInner = React.memo((props: CanvasComponentEntryProps) 
           transform: 'translate3d(0px, 0px, 0px)',
         }}
       >
-        {canvasProps == null ? null : (
+        {props.shouldRenderCanvas && canvasProps != null ? (
           <CanvasInner
             canvasProps={canvasProps}
             onRuntimeError={onRuntimeError}
             localClearRuntimeErrors={localClearRuntimeErrors}
           />
-        )}
+        ) : null}
       </div>
+      ,
     </>
   )
 })

--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -88,17 +88,16 @@ export const CanvasWrapperComponent = React.memo(() => {
         // ^ prevents Monaco from pushing the inspector out
       }}
     >
-      {fatalErrors.length === 0 && !safeMode ? (
-        <EditorCanvas
-          userState={userState}
-          editor={editorState}
-          derived={derivedState}
-          model={createCanvasModelKILLME(editorState, derivedState)}
-          builtinDependencies={builtinDependencies}
-          updateCanvasSize={updateCanvasSize}
-          dispatch={dispatch}
-        />
-      ) : null}
+      <EditorCanvas
+        userState={userState}
+        editor={editorState}
+        derived={derivedState}
+        model={createCanvasModelKILLME(editorState, derivedState)}
+        builtinDependencies={builtinDependencies}
+        updateCanvasSize={updateCanvasSize}
+        dispatch={dispatch}
+        shouldRenderCanvas={fatalErrors.length === 0 && !safeMode}
+      />
 
       <FlexRow
         style={{

--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -19,8 +19,6 @@ import { Substores, useEditorState } from '../editor/store/store-hook'
 import { shouldShowErrorOverlay } from './canvas-utils'
 import { FloatingPostActionMenu } from './controls/select-mode/post-action-menu'
 
-export const CanvasWrapperComponentId = 'canvas-wrapper-component'
-
 export const CanvasWrapperComponent = React.memo(() => {
   const dispatch = useDispatch()
   const { editorState, derivedState, userState } = useEditorState(
@@ -76,7 +74,6 @@ export const CanvasWrapperComponent = React.memo(() => {
 
   return (
     <FlexColumn
-      id={CanvasWrapperComponentId}
       className='CanvasWrapperComponent'
       style={{
         position: 'relative',

--- a/editor/src/components/canvas/canvas-wrapper-component.tsx
+++ b/editor/src/components/canvas/canvas-wrapper-component.tsx
@@ -19,6 +19,8 @@ import { Substores, useEditorState } from '../editor/store/store-hook'
 import { shouldShowErrorOverlay } from './canvas-utils'
 import { FloatingPostActionMenu } from './controls/select-mode/post-action-menu'
 
+export const CanvasWrapperComponentId = 'canvas-wrapper-component'
+
 export const CanvasWrapperComponent = React.memo(() => {
   const dispatch = useDispatch()
   const { editorState, derivedState, userState } = useEditorState(
@@ -74,6 +76,7 @@ export const CanvasWrapperComponent = React.memo(() => {
 
   return (
     <FlexColumn
+      id={CanvasWrapperComponentId}
       className='CanvasWrapperComponent'
       style={{
         position: 'relative',

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -295,11 +295,11 @@ export function resubscribeObservers(domWalkerMutableState: {
   let rootElementId = CanvasContainerID
   let rootElement = document.getElementById(rootElementId)
 
-  // if (rootElement == null) {
-  //   // when there is a build error the canvas root container is not rendered, so we attach the observers to the canvas wrapper component
-  //   rootElementId = CanvasWrapperComponentId
-  //   rootElement = document.getElementById(rootElementId)
-  // }
+  if (rootElement == null) {
+    // when there is a build error the canvas root container is not rendered, so we attach the observers to the canvas wrapper component
+    rootElementId = CanvasWrapperComponentId
+    rootElement = document.getElementById(rootElementId)
+  }
 
   if (
     ObserversAvailable &&

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -299,6 +299,8 @@ export function resubscribeObservers(domWalkerMutableState: {
     domWalkerMutableState.resizeObserver != null &&
     domWalkerMutableState.mutationObserver != null
   ) {
+    domWalkerMutableState.resizeObserver.disconnect()
+    domWalkerMutableState.mutationObserver.disconnect()
     document.querySelectorAll(`#${CanvasContainerOuterId} *`).forEach((elem) => {
       domWalkerMutableState.resizeObserver.observe(elem)
     })

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -295,11 +295,11 @@ export function resubscribeObservers(domWalkerMutableState: {
   let rootElementId = CanvasContainerID
   let rootElement = document.getElementById(rootElementId)
 
-  if (rootElement == null) {
-    // when there is a build error the canvas root container is not rendered, so we attach the observers to the canvas wrapper component
-    rootElementId = CanvasWrapperComponentId
-    rootElement = document.getElementById(rootElementId)
-  }
+  // if (rootElement == null) {
+  //   // when there is a build error the canvas root container is not rendered, so we attach the observers to the canvas wrapper component
+  //   rootElementId = CanvasWrapperComponentId
+  //   rootElement = document.getElementById(rootElementId)
+  // }
 
   if (
     ObserversAvailable &&

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -72,6 +72,7 @@ import { pick } from '../../core/shared/object-utils'
 import { getFlexAlignment, getFlexJustifyContent, MaxContent } from '../inspector/inspector-common'
 import type { EditorDispatch } from '../editor/action-types'
 import { runDOMWalker } from '../editor/actions/action-creators'
+import { CanvasWrapperComponentId } from './canvas-wrapper-component'
 
 export const ResizeObserver =
   window.ResizeObserver ?? ResizeObserverSyntheticDefault.default ?? ResizeObserverSyntheticDefault
@@ -291,17 +292,17 @@ export function resubscribeObservers(domWalkerMutableState: {
   mutationObserver: MutationObserver
   resizeObserver: ResizeObserver
 }) {
-  const canvasRootContainer = document.getElementById(CanvasContainerID)
+  const canvasWrapperComponent = document.getElementById(CanvasWrapperComponentId)
   if (
     ObserversAvailable &&
-    canvasRootContainer != null &&
+    canvasWrapperComponent != null &&
     domWalkerMutableState.resizeObserver != null &&
     domWalkerMutableState.mutationObserver != null
   ) {
-    document.querySelectorAll(`#${CanvasContainerID} *`).forEach((elem) => {
+    document.querySelectorAll(`#${CanvasWrapperComponentId} *`).forEach((elem) => {
       domWalkerMutableState.resizeObserver.observe(elem)
     })
-    domWalkerMutableState.mutationObserver.observe(canvasRootContainer, MutationObserverConfig)
+    domWalkerMutableState.mutationObserver.observe(canvasWrapperComponent, MutationObserverConfig)
   }
 }
 

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -59,7 +59,7 @@ import {
 } from '../inspector/common/css-utils'
 import { camelCaseToDashed } from '../../core/shared/string-utils'
 import type { UtopiaStoreAPI } from '../editor/store/store-hook'
-import { UTOPIA_SCENE_ID_KEY } from '../../core/model/utopia-constants'
+import { UTOPIA_SCENE_ID_KEY, UTOPIA_UID_KEY } from '../../core/model/utopia-constants'
 import { emptySet } from '../../core/shared/set-utils'
 import type { PathWithString } from '../../core/shared/uid-utils'
 import { getDeepestPathOnDomElement, getPathStringsOnDomElement } from '../../core/shared/uid-utils'
@@ -299,9 +299,7 @@ export function resubscribeObservers(domWalkerMutableState: {
     domWalkerMutableState.resizeObserver != null &&
     domWalkerMutableState.mutationObserver != null
   ) {
-    domWalkerMutableState.resizeObserver.disconnect()
-    domWalkerMutableState.mutationObserver.disconnect()
-    document.querySelectorAll(`#${CanvasContainerOuterId} *`).forEach((elem) => {
+    document.querySelectorAll(`#${CanvasContainerOuterId} [${UTOPIA_UID_KEY}]`).forEach((elem) => {
       domWalkerMutableState.resizeObserver.observe(elem)
     })
     domWalkerMutableState.mutationObserver.observe(canvasRootContainer, MutationObserverConfig)

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -292,17 +292,25 @@ export function resubscribeObservers(domWalkerMutableState: {
   mutationObserver: MutationObserver
   resizeObserver: ResizeObserver
 }) {
-  const canvasWrapperComponent = document.getElementById(CanvasWrapperComponentId)
+  let rootElementId = CanvasContainerID
+  let rootElement = document.getElementById(rootElementId)
+
+  if (rootElement == null) {
+    // when there is a build error the canvas root container is not rendered, so we attach the observers to the canvas wrapper component
+    rootElementId = CanvasWrapperComponentId
+    rootElement = document.getElementById(rootElementId)
+  }
+
   if (
     ObserversAvailable &&
-    canvasWrapperComponent != null &&
+    rootElement != null &&
     domWalkerMutableState.resizeObserver != null &&
     domWalkerMutableState.mutationObserver != null
   ) {
-    document.querySelectorAll(`#${CanvasWrapperComponentId} *`).forEach((elem) => {
+    document.querySelectorAll(`#${rootElementId} *`).forEach((elem) => {
       domWalkerMutableState.resizeObserver.observe(elem)
     })
-    domWalkerMutableState.mutationObserver.observe(canvasWrapperComponent, MutationObserverConfig)
+    domWalkerMutableState.mutationObserver.observe(rootElement, MutationObserverConfig)
   }
 }
 

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -73,6 +73,7 @@ import { getFlexAlignment, getFlexJustifyContent, MaxContent } from '../inspecto
 import type { EditorDispatch } from '../editor/action-types'
 import { runDOMWalker } from '../editor/actions/action-creators'
 import { CanvasWrapperComponentId } from './canvas-wrapper-component'
+import { CanvasContainerOuterId } from './canvas-component-entry'
 
 export const ResizeObserver =
   window.ResizeObserver ?? ResizeObserverSyntheticDefault.default ?? ResizeObserverSyntheticDefault
@@ -292,25 +293,21 @@ export function resubscribeObservers(domWalkerMutableState: {
   mutationObserver: MutationObserver
   resizeObserver: ResizeObserver
 }) {
-  let rootElementId = CanvasContainerID
-  let rootElement = document.getElementById(rootElementId)
-
-  if (rootElement == null) {
-    // when there is a build error the canvas root container is not rendered, so we attach the observers to the canvas wrapper component
-    rootElementId = CanvasWrapperComponentId
-    rootElement = document.getElementById(rootElementId)
-  }
+  const canvasContainerOuterElement = document.getElementById(CanvasContainerOuterId)
 
   if (
     ObserversAvailable &&
-    rootElement != null &&
+    canvasContainerOuterElement != null &&
     domWalkerMutableState.resizeObserver != null &&
     domWalkerMutableState.mutationObserver != null
   ) {
-    document.querySelectorAll(`#${rootElementId} *`).forEach((elem) => {
+    document.querySelectorAll(`#${CanvasContainerOuterId} *`).forEach((elem) => {
       domWalkerMutableState.resizeObserver.observe(elem)
     })
-    domWalkerMutableState.mutationObserver.observe(rootElement, MutationObserverConfig)
+    domWalkerMutableState.mutationObserver.observe(
+      canvasContainerOuterElement,
+      MutationObserverConfig,
+    )
   }
 }
 

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -60,7 +60,6 @@ import {
 import { camelCaseToDashed } from '../../core/shared/string-utils'
 import type { UtopiaStoreAPI } from '../editor/store/store-hook'
 import { UTOPIA_SCENE_ID_KEY } from '../../core/model/utopia-constants'
-import { CanvasContainerID } from './canvas-types'
 import { emptySet } from '../../core/shared/set-utils'
 import type { PathWithString } from '../../core/shared/uid-utils'
 import { getDeepestPathOnDomElement, getPathStringsOnDomElement } from '../../core/shared/uid-utils'
@@ -72,7 +71,6 @@ import { pick } from '../../core/shared/object-utils'
 import { getFlexAlignment, getFlexJustifyContent, MaxContent } from '../inspector/inspector-common'
 import type { EditorDispatch } from '../editor/action-types'
 import { runDOMWalker } from '../editor/actions/action-creators'
-import { CanvasWrapperComponentId } from './canvas-wrapper-component'
 import { CanvasContainerOuterId } from './canvas-component-entry'
 
 export const ResizeObserver =
@@ -293,21 +291,18 @@ export function resubscribeObservers(domWalkerMutableState: {
   mutationObserver: MutationObserver
   resizeObserver: ResizeObserver
 }) {
-  const canvasContainerOuterElement = document.getElementById(CanvasContainerOuterId)
+  const canvasRootContainer = document.getElementById(CanvasContainerOuterId)
 
   if (
     ObserversAvailable &&
-    canvasContainerOuterElement != null &&
+    canvasRootContainer != null &&
     domWalkerMutableState.resizeObserver != null &&
     domWalkerMutableState.mutationObserver != null
   ) {
     document.querySelectorAll(`#${CanvasContainerOuterId} *`).forEach((elem) => {
       domWalkerMutableState.resizeObserver.observe(elem)
     })
-    domWalkerMutableState.mutationObserver.observe(
-      canvasContainerOuterElement,
-      MutationObserverConfig,
-    )
+    domWalkerMutableState.mutationObserver.observe(canvasRootContainer, MutationObserverConfig)
   }
 }
 

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -306,6 +306,8 @@ export function optOutFromCheckFileTimestamps() {
   })
 }
 
+let prevDomWalkerMutableState: DomWalkerMutableStateData | null = null
+
 export async function renderTestEditorWithModel(
   rawModel: PersistentModel,
   awaitFirstDomReport: 'await-first-dom-report' | 'dont-await-first-dom-report',
@@ -600,7 +602,10 @@ export async function renderTestEditorWithModel(
     patchedStoreFromFullStore(initialEditorStore, 'canvas-store'),
   )
 
+  prevDomWalkerMutableState?.resizeObserver.disconnect()
+  prevDomWalkerMutableState?.mutationObserver.disconnect()
   const domWalkerMutableState = createDomWalkerMutableState(canvasStoreHook, asyncTestDispatch)
+  prevDomWalkerMutableState = domWalkerMutableState
 
   const lowPriorityStoreHook: UtopiaStoreAPI = createStoresAndState(
     patchedStoreFromFullStore(initialEditorStore, 'low-priority-store'),

--- a/editor/src/templates/editor-canvas.tsx
+++ b/editor/src/templates/editor-canvas.tsx
@@ -695,6 +695,7 @@ interface EditorCanvasProps {
   builtinDependencies: BuiltInDependencies
   dispatch: EditorDispatch
   updateCanvasSize: (newValueOrUpdater: Size | ((oldValue: Size) => Size)) => void
+  shouldRenderCanvas: boolean
 }
 
 export class EditorCanvas extends React.Component<EditorCanvasProps> {
@@ -855,6 +856,10 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
     // we round the offset here, so all layers, the canvas, and controls use the same rounded value for positioning
     // instead of letting Chrome do it, because that results in funky artifacts (e.g. while scrolling, the layers don't "jump" pixels at the same time)
 
+    if (!this.props.shouldRenderCanvas) {
+      return <CanvasComponentEntry shouldRenderCanvas={false} />
+    }
+
     const nodeConnectorsDiv = createNodeConnectorsDiv(
       this.props.model.canvasOffset,
       this.props.model.scale,
@@ -871,10 +876,9 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
 
     const canvasIsLive = isLiveMode(this.props.editor.mode)
 
-    const canvasControls = React.createElement(NewCanvasControls, {
-      windowToCanvasPosition: this.getPosition,
-      cursor,
-    })
+    const canvasControls = (
+      <NewCanvasControls windowToCanvasPosition={this.getPosition} cursor={cursor} />
+    )
 
     const canvasLiveEditingStyle = canvasIsLive
       ? UtopiaStyles.canvas.live
@@ -1070,9 +1074,9 @@ export class EditorCanvas extends React.Component<EditorCanvasProps> {
         },
       },
       nodeConnectorsDiv,
-      React.createElement(CanvasComponentEntry, {}),
+      <CanvasComponentEntry shouldRenderCanvas={true} />,
       canvasControls,
-      React.createElement(CursorComponent, {}),
+      <CursorComponent />,
       <EditorCommon mouseDown={this.handleMouseDown} />,
     )
   }


### PR DESCRIPTION
**Problem:**
Followup to https://github.com/concrete-utopia/utopia/pull/6326
In a Remix project it can happen that in the dispatch flow we don't have the results of the rendering in the dom yet. It can even happen, that after a build error is fixed, we still don't have the canvas root container in the dom.
That is a critical issue, because we attach the mutation/resize observers to the canvas root container element, so when we don't have that we can subscribe them, so the dom sample is not going to run when the rendering is finished.

**Fix:**
I needed an element, which is an ancestor of the canvas root container and
1 is always rendered
2 does not contain canvas controls or other content
I choose canvas-container-outer, but I needed to modify its ancestors so it is always rendered, even when there is a build error.
To make sure we don't observe unnecessary elements, I filtered the query for the resize observer to only include elements with the `data-uid` attribute.

I needed to update the tests to make sure the observers from the previous domwalkermutablestate don't continue to fire when there is a change, because the outer canvas container can stay persistent between test runs.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes https://github.com/concrete-utopia/utopia/issues/6345