### PR TITLE
Resize grid cell if the element is set to fill, resize the element otherwise

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
@@ -1,8 +1,8 @@
-import { styleStringInArray } from '../../../../utils/common-constants'
 import { getLayoutProperty } from '../../../../core/layout/getLayoutProperty'
 import type { PropsOrJSXAttributes } from '../../../../core/model/element-metadata-utils'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { foldEither, isLeft, right } from '../../../../core/shared/either'
+import * as EP from '../../../../core/shared/element-path'
 import type { ElementInstanceMetadata } from '../../../../core/shared/element-template'
 import { isJSXElement } from '../../../../core/shared/element-template'
 import type { CanvasPoint, CanvasRectangle } from '../../../../core/shared/math-utils'
@@ -11,7 +11,10 @@ import {
   isInfinityRectangle,
   offsetPoint,
 } from '../../../../core/shared/math-utils'
+import { styleStringInArray } from '../../../../utils/common-constants'
+import { trueUpGroupElementChanged } from '../../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../../inspector/common/property-path-hooks'
+import { isFixedHugFillModeApplied } from '../../../inspector/inspector-common'
 import type { EdgePosition } from '../../canvas-types'
 import { oppositeEdgePosition } from '../../canvas-types'
 import {
@@ -24,9 +27,12 @@ import {
   adjustCssLengthProperties,
   lengthPropertyToAdjust,
 } from '../../commands/adjust-css-length-command'
+import { pushIntendedBoundsAndUpdateGroups } from '../../commands/push-intended-bounds-and-update-groups-command'
+import { queueTrueUpElement } from '../../commands/queue-true-up-command'
 import { setCursorCommand } from '../../commands/set-cursor-command'
 import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rerender-command'
 import { updateHighlightedViews } from '../../commands/update-highlighted-views-command'
+import { controlsForGridPlaceholders } from '../../controls/grid-controls'
 import { ImmediateParentBounds } from '../../controls/parent-bounds'
 import { ImmediateParentOutlines } from '../../controls/parent-outlines'
 import { AbsoluteResizeControl } from '../../controls/select-mode/absolute-resize-control'
@@ -44,16 +50,13 @@ import {
 } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
 import { honoursPropsSize } from './absolute-utils'
+import { treatElementAsGroupLike } from './group-helpers'
 import {
   getLockedAspectRatio,
   isAnySelectedElementAspectRatioLocked,
   pickCursorFromEdgePosition,
   resizeBoundingBox,
 } from './resize-helpers'
-import { pushIntendedBoundsAndUpdateGroups } from '../../commands/push-intended-bounds-and-update-groups-command'
-import { queueTrueUpElement } from '../../commands/queue-true-up-command'
-import { treatElementAsGroupLike } from './group-helpers'
-import { trueUpGroupElementChanged } from '../../../editor/store/editor-state'
 
 export const BASIC_RESIZE_STRATEGY_ID = 'BASIC_RESIZE'
 
@@ -76,7 +79,11 @@ export function basicResizeStrategy(
   const elementDimensionsProps = metadata != null ? getElementDimensions(metadata) : null
   const elementParentBounds = metadata?.specialSizeMeasurements.immediateParentBounds ?? null
 
-  if (MetadataUtils.isGridCell(canvasState.startingMetadata, selectedElement)) {
+  const isGridCell = MetadataUtils.isGridCell(canvasState.startingMetadata, selectedElement)
+  if (
+    isGridCell &&
+    isFixedHugFillModeApplied(canvasState.startingMetadata, selectedElement, 'fill')
+  ) {
     return null
   }
 
@@ -113,6 +120,7 @@ export function basicResizeStrategy(
         key: 'parent-bounds-control',
         show: 'visible-only-while-active',
       }),
+      ...(isGridCell ? [controlsForGridPlaceholders(EP.parentPath(selectedElement))] : []),
     ],
     fitness:
       interactionSession != null &&

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
@@ -24,7 +24,7 @@ import type { InsertElementInsertionSubject } from '../../commands/insert-elemen
 import { insertElementInsertionSubject } from '../../commands/insert-element-insertion-subject'
 import { updateHighlightedViews } from '../../commands/update-highlighted-views-command'
 import { wildcardPatch } from '../../commands/wildcard-patch-command'
-import { GridControls } from '../../controls/grid-controls'
+import { controlsForGridPlaceholders } from '../../controls/grid-controls'
 import { canvasPointToWindowPoint } from '../../dom-lookup'
 import {
   getWrapperWithGeneratedUid,
@@ -153,15 +153,7 @@ const gridDrawToInsertStrategyInner =
         category: 'tools',
         type: 'pointer',
       },
-      controlsToRender: [
-        {
-          control: GridControls,
-          props: { targets: [targetParent] },
-          key: `draw-into-grid-strategy-controls`,
-          show: 'always-visible',
-          priority: 'bottom',
-        },
-      ],
+      controlsToRender: [controlsForGridPlaceholders(targetParent)],
       fitness: 5,
       apply: (strategyLifecycle) => {
         const newTargetCell = getGridCellUnderCursor(

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-keyboard-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-keyboard-strategy.ts
@@ -2,7 +2,7 @@ import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
 import type { GridPositionValue } from '../../../../core/shared/element-template'
 import { gridPositionValue } from '../../../../core/shared/element-template'
-import { GridControls, GridControlsKey } from '../../controls/grid-controls'
+import { controlsForGridPlaceholders } from '../../controls/grid-controls'
 import type {
   CanvasStrategy,
   CustomStrategyState,
@@ -77,15 +77,7 @@ export function gridRearrangeResizeKeyboardStrategy(
       category: 'modalities',
       type: 'reorder-large',
     },
-    controlsToRender: [
-      {
-        control: GridControls,
-        props: { targets: [parentGridPath] },
-        key: GridControlsKey(parentGridPath),
-        show: 'always-visible',
-        priority: 'bottom',
-      },
-    ],
+    controlsToRender: [controlsForGridPlaceholders(parentGridPath)],
     fitness: fitness(interactionSession),
     apply: () => {
       if (interactionSession == null || interactionSession.interactionData.type !== 'KEYBOARD') {

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-duplicate-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-duplicate-strategy.ts
@@ -7,7 +7,7 @@ import { setCursorCommand } from '../../commands/set-cursor-command'
 import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rerender-command'
 import { updateHighlightedViews } from '../../commands/update-highlighted-views-command'
 import { updateSelectedViews } from '../../commands/update-selected-views-command'
-import { GridControls, GridControlsKey } from '../../controls/grid-controls'
+import { controlsForGridPlaceholders } from '../../controls/grid-controls'
 import type { CanvasStrategyFactory } from '../canvas-strategies'
 import { onlyFitWhenDraggingThisControl } from '../canvas-strategies'
 import type { CustomStrategyState, InteractionCanvasState } from '../canvas-strategy-types'
@@ -49,15 +49,7 @@ export const gridRearrangeMoveDuplicateStrategy: CanvasStrategyFactory = (
       category: 'tools',
       type: 'pointer',
     },
-    controlsToRender: [
-      {
-        control: GridControls,
-        props: { targets: [EP.parentPath(selectedElement)] },
-        key: GridControlsKey(EP.parentPath(selectedElement)),
-        show: 'always-visible',
-        priority: 'bottom',
-      },
-    ],
+    controlsToRender: [controlsForGridPlaceholders(EP.parentPath(selectedElement))],
     fitness: onlyFitWhenDraggingThisControl(interactionSession, 'GRID_CELL_HANDLE', 3),
     apply: () => {
       if (

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.spec.browser2.tsx
@@ -5,7 +5,7 @@ import {
   offsetPoint,
   windowPoint,
 } from '../../../../core/shared/math-utils'
-import { selectComponentsForTest, wait } from '../../../../utils/utils.test-utils'
+import { selectComponentsForTest } from '../../../../utils/utils.test-utils'
 import CanvasActions from '../../canvas-actions'
 import { GridCellTestId } from '../../controls/grid-controls'
 import { mouseDragFromPointToPoint } from '../../event-helpers.test-utils'
@@ -117,6 +117,8 @@ export var storyboard = (
           gridTemplateRows: '1fr',
           gridColumn: 1,
           gridRow: 2,
+		  width: '100%',
+		  height: '100%',
         }}
       >
         <div

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
@@ -1,7 +1,7 @@
 import type { ElementPath } from 'utopia-shared/src/types'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
-import { GridControls, GridControlsKey } from '../../controls/grid-controls'
+import { controlsForGridPlaceholders } from '../../controls/grid-controls'
 import type {
   ElementInstanceMetadataMap,
   GridAutoOrTemplateBase,
@@ -409,14 +409,6 @@ function getStrategyToApply(
   return {
     type: 'GRID_REARRANGE',
     name: 'Rearrange Grid (Move)',
-    controlsToRender: [
-      {
-        control: GridControls,
-        props: { targets: [parentGridPath] },
-        key: GridControlsKey(parentGridPath),
-        show: 'always-visible',
-        priority: 'bottom',
-      },
-    ],
+    controlsToRender: [controlsForGridPlaceholders(parentGridPath)],
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategy.tsx
@@ -35,7 +35,7 @@ import type { CanvasRectangle, CanvasVector } from '../../../../core/shared/math
 import { canvasVector, isInfinityRectangle, offsetPoint } from '../../../../core/shared/math-utils'
 import { showGridControls } from '../../commands/show-grid-controls-command'
 import type { GridCellCoordinates } from '../../controls/grid-controls'
-import { GridControls } from '../../controls/grid-controls'
+import { controlsForGridPlaceholders } from '../../controls/grid-controls'
 import {
   gridPositionValue,
   type ElementInstanceMetadataMap,
@@ -137,13 +137,7 @@ export function controlsForGridReparent(reparentTarget: ReparentTarget): Control
       key: 'zero-size-control',
       show: 'visible-only-while-active',
     }),
-    {
-      control: GridControls,
-      props: { targets: [reparentTarget.newParent.intendedParentPath] },
-      key: `draw-into-grid-strategy-controls`,
-      show: 'always-visible',
-      priority: 'bottom',
-    },
+    controlsForGridPlaceholders(reparentTarget.newParent.intendedParentPath),
   ]
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
@@ -15,7 +15,6 @@ import type { EditorRenderResult } from '../../ui-jsx.test-utils'
 import { renderTestEditorWithCode } from '../../ui-jsx.test-utils'
 import type { GridResizeEdge } from '../interaction-state'
 import { gridCellTargetId } from './grid-helpers'
-import { wait } from '../../../../core/model/performance-scripts'
 
 async function runCellResizeTest(
   editor: EditorRenderResult,
@@ -46,6 +45,15 @@ async function runCellResizeTest(
 }
 
 describe('grid resize element strategy', () => {
+  it('cannot resize non-filling cells', async () => {
+    const editor = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')
+
+    await selectComponentsForTest(editor, [EP.fromString('sb/scene/grid/grid-child-not-filling')])
+
+    const resizeControl = editor.renderedDOM.queryByTestId(GridResizeEdgeTestId('column-end'))
+    expect(resizeControl).toBeNull()
+  })
+
   describe('column-end', () => {
     it('can enlarge element', async () => {
       const editor = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')
@@ -231,6 +239,8 @@ describe('grid resize element strategy', () => {
     expect(styleProp).toEqual([
       ['minHeight', 0],
       ['backgroundColor', '#db48f6'],
+      ['width', '100%'],
+      ['height', '100%'],
       ['gridColumnStart', 7],
       ['gridColumnEnd', 11],
       ['gridRow', 2],
@@ -272,6 +282,8 @@ export var storyboard = (
           gridTemplateRows: '1fr',
           gridColumn: 1,
           gridRow: 2,
+		  width: '100%',
+		  height: '100%',
         }}
       >
         <div
@@ -393,8 +405,11 @@ export var storyboard = (
             gridColumnStart: 1,
             gridRowStart: 3,
             backgroundColor: '#0074ff',
+			width: 25,
+			height: 30,
           }}
-          data-uid='ccc'
+          data-uid='grid-child-not-filling'
+		  data-testid='grid-child-not-filling'
         />
         <div
           style={{
@@ -404,6 +419,8 @@ export var storyboard = (
             gridColumnStart: 7,
             gridRowStart: 2,
             backgroundColor: '#db48f6',
+			width: '100%',
+			height: '100%',
           }}
           data-uid='ddd'
           data-testid='grid-child'
@@ -452,6 +469,8 @@ export var storyboard = (
             minHeight: 0,
             gridArea: '2 / 7 / 3 / 10',
             backgroundColor: '#db48f6',
+			width: '100%',
+			height: '100%',
           }}
           data-uid='ddd'
           data-testid='grid-child'

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -4,7 +4,8 @@ import type { GridElementProperties, GridPosition } from '../../../../core/share
 import { offsetPoint } from '../../../../core/shared/math-utils'
 import { assertNever } from '../../../../core/shared/utils'
 import { isCSSKeyword } from '../../../inspector/common/css-utils'
-import { GridControls, GridControlsKey, GridResizeControls } from '../../controls/grid-controls'
+import { isFixedHugFillModeApplied } from '../../../inspector/inspector-common'
+import { controlsForGridPlaceholders, GridResizeControls } from '../../controls/grid-controls'
 import { canvasPointToWindowPoint } from '../../dom-lookup'
 import type { CanvasStrategyFactory } from '../canvas-strategies'
 import { onlyFitWhenDraggingThisControl } from '../canvas-strategies'
@@ -37,6 +38,15 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
     return null
   }
 
+  const isFillContainer = isFixedHugFillModeApplied(
+    canvasState.startingMetadata,
+    selectedElement,
+    'fill',
+  )
+  if (!isFillContainer) {
+    return null
+  }
+
   const parentGridPath = EP.parentPath(selectedElement)
 
   return {
@@ -54,13 +64,7 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
         key: `grid-resize-controls-${EP.toString(selectedElement)}`,
         show: 'always-visible',
       },
-      {
-        control: GridControls,
-        props: { targets: [parentGridPath] },
-        key: GridControlsKey(parentGridPath),
-        show: 'always-visible',
-        priority: 'bottom',
-      },
+      controlsForGridPlaceholders(parentGridPath),
     ],
     fitness: onlyFitWhenDraggingThisControl(interactionSession, 'GRID_RESIZE_HANDLE', 1),
     apply: () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/rearrange-grid-swap-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/rearrange-grid-swap-strategy.ts
@@ -14,7 +14,7 @@ import { create } from '../../../../core/shared/property-path'
 import type { CanvasCommand } from '../../commands/commands'
 import { deleteProperties } from '../../commands/delete-properties-command'
 import { rearrangeChildren } from '../../commands/rearrange-children-command'
-import { GridControls, GridControlsKey } from '../../controls/grid-controls'
+import { controlsForGridPlaceholders } from '../../controls/grid-controls'
 import { recurseIntoChildrenOfMapOrFragment } from '../../gap-utils'
 import type { CanvasStrategyFactory } from '../canvas-strategies'
 import { onlyFitWhenDraggingThisControl } from '../canvas-strategies'
@@ -67,15 +67,7 @@ export const rearrangeGridSwapStrategy: CanvasStrategyFactory = (
       category: 'tools',
       type: 'pointer',
     },
-    controlsToRender: [
-      {
-        control: GridControls,
-        props: { targets: [parentGridPath] },
-        key: GridControlsKey(parentGridPath),
-        show: 'always-visible',
-        priority: 'bottom',
-      },
-    ],
+    controlsToRender: [controlsForGridPlaceholders(parentGridPath)],
     fitness: onlyFitWhenDraggingThisControl(interactionSession, 'GRID_CELL_HANDLE', 1),
     apply: () => {
       if (

--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.ts
@@ -9,8 +9,7 @@ import * as EP from '../../../../core/shared/element-path'
 import * as PP from '../../../../core/shared/property-path'
 import { setProperty } from '../../commands/set-property-command'
 import {
-  GridControls,
-  GridControlsKey,
+  controlsForGridPlaceholders,
   GridRowColumnResizingControls,
 } from '../../controls/grid-controls'
 import type { CanvasStrategyFactory } from '../canvas-strategies'
@@ -73,13 +72,7 @@ export const resizeGridStrategy: CanvasStrategyFactory = (
         show: 'always-visible',
         priority: 'top',
       },
-      {
-        control: GridControls,
-        props: { targets: [gridPath] },
-        key: GridControlsKey(gridPath),
-        show: 'always-visible',
-        priority: 'bottom',
-      },
+      controlsForGridPlaceholders(gridPath),
     ],
     fitness: onlyFitWhenDraggingThisControl(interactionSession, 'GRID_AXIS_HANDLE', 1),
     apply: () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
@@ -43,7 +43,7 @@ import { activeFrameTargetPath, setActiveFrames } from '../../commands/set-activ
 import type { GridGapControlProps } from '../../controls/select-mode/grid-gap-control'
 import { GridGapControl } from '../../controls/select-mode/grid-gap-control'
 import type { GridControlsProps } from '../../controls/grid-controls'
-import { GridControls } from '../../controls/grid-controls'
+import { controlsForGridPlaceholders } from '../../controls/grid-controls'
 
 const SetGridGapStrategyId = 'SET_GRID_GAP_STRATEGY'
 
@@ -142,15 +142,7 @@ export const setGridGapStrategy: CanvasStrategyFactory = (
 
   // when the drag is ongoing, keep showing the grid cells
   if (isDragOngoing(interactionSession)) {
-    controlsToRender.push(
-      controlWithProps({
-        control: GridControls,
-        props: { targets: [selectedElement] },
-        key: `set-grid-gap-strategy-controls`,
-        show: 'always-visible',
-        priority: 'bottom',
-      }),
-    )
+    controlsToRender.push(controlsForGridPlaceholders(selectedElement))
   }
 
   return {

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -51,6 +51,7 @@ import { useDispatch } from '../../editor/store/dispatch-context'
 import { Substores, useEditorState, useRefEditorState } from '../../editor/store/store-hook'
 import { useRollYourOwnFeatures } from '../../navigator/left-pane/roll-your-own-pane'
 import CanvasActions from '../canvas-actions'
+import type { ControlWithProps } from '../canvas-strategies/canvas-strategy-types'
 import { controlForStrategyMemoized } from '../canvas-strategies/canvas-strategy-types'
 import type {
   GridResizeEdge,
@@ -1700,3 +1701,13 @@ export function getGridPlaceholderDomElementFromCoordinates(params: {
 }
 
 const gridPlaceholderBorder = (color: string) => `2px solid ${color}`
+
+export function controlsForGridPlaceholders(gridPath: ElementPath): ControlWithProps<any> {
+  return {
+    control: GridControls,
+    props: { targets: [gridPath] },
+    key: GridControlsKey(gridPath),
+    show: 'always-visible',
+    priority: 'bottom',
+  }
+}


### PR DESCRIPTION
**Problem:**

Currently when a grid element is selected, it's only possible to resize it's _cell_.

**Fix:**

This PR expands the functionality in two ways:

1. if the selected element is set to fill on both width and height, show the _cell_ resize controls
2. otherwise, show the regular _element_ resize controls


https://github.com/user-attachments/assets/9e1ad8ac-0dae-43c2-b0f0-c282152e884b



Fixes #6348 
