### PR TITLE
fix(grid): move controls when changing content placement

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -375,6 +375,8 @@ export type GridData = {
   gridTemplateColumnsFromProps: GridAutoOrTemplateBase | null
   gridTemplateRowsFromProps: GridAutoOrTemplateBase | null
   gap: number | null
+  justifyContent: string | null
+  alignContent: string | null
   rowGap: number | null
   columnGap: number | null
   padding: Sides
@@ -432,6 +434,8 @@ export function useGridData(elementPaths: ElementPath[]): GridData[] {
           gap: gap,
           rowGap: rowGap,
           columnGap: columnGap,
+          justifyContent: targetGridContainer.specialSizeMeasurements.justifyContent,
+          alignContent: targetGridContainer.specialSizeMeasurements.alignContent,
           padding: padding,
           rows: rows,
           columns: columns,
@@ -767,6 +771,8 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
             border: `1px solid ${
               activelyDraggingOrResizingCell != null ? colorTheme.primary.value : 'transparent'
             }`,
+            justifyContent: grid.justifyContent ?? 'initial',
+            alignContent: grid.alignContent ?? 'initial',
             pointerEvents: 'none',
             padding:
               grid.padding == null

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -680,6 +680,7 @@ function getSpecialMeasurements(
   const parentTextDirection = eitherToMaybe(parseDirection(parentElementStyle?.direction, null))
 
   const justifyContent = getFlexJustifyContent(elementStyle.justifyContent)
+  const alignContent = getFlexAlignment(elementStyle.alignContent)
   const alignItems = getFlexAlignment(elementStyle.alignItems)
 
   const margin = applicative4Either(
@@ -876,6 +877,7 @@ function getSpecialMeasurements(
     gap,
     flexDirection,
     justifyContent,
+    alignContent,
     alignItems,
     element.localName,
     childrenCount,

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -2810,6 +2810,7 @@ export interface SpecialSizeMeasurements {
   gap: number | null
   flexDirection: FlexDirection | null
   justifyContent: FlexJustifyContent | null
+  alignContent: FlexAlignment | null
   alignItems: FlexAlignment | null
   htmlElementName: string
   renderedChildrenCount: number
@@ -2859,6 +2860,7 @@ export function specialSizeMeasurements(
   gap: number | null,
   flexDirection: FlexDirection | null,
   justifyContent: FlexJustifyContent | null,
+  alignContent: FlexAlignment | null,
   alignItems: FlexAlignment | null,
   htmlElementName: string,
   renderedChildrenCount: number,
@@ -2909,6 +2911,7 @@ export function specialSizeMeasurements(
     gap,
     flexDirection,
     justifyContent,
+    alignContent,
     alignItems,
     htmlElementName,
     renderedChildrenCount,
@@ -2959,6 +2962,7 @@ export const emptySpecialSizeMeasurements = specialSizeMeasurements(
   0,
   sides(undefined, undefined, undefined, undefined),
   false,
+  null,
   null,
   null,
   null,


### PR DESCRIPTION
**Problem:**
Today the grid controls placeholder don't move when changing `content` placement
![10-45-psczv-wnkpg](https://github.com/user-attachments/assets/ea5d2623-0705-4337-8aa2-6d0139addec8)
 

**Fix:**
Copy `justifyContent` and `alignContent` props to the grid placeholder as well.

<video src="https://github.com/user-attachments/assets/0e8dfd6e-f6ca-4b46-bd83-89b2472d03a8"></video>

**Note:**
We should discuss how we can avoid these kinds of issues in the future - where there might be a future grid style prop that will not be copied to the grid control

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode
