### PR TITLE
Execution Count Limiter

### DIFF
--- a/editor/src/components/canvas/dom-sampler.tsx
+++ b/editor/src/components/canvas/dom-sampler.tsx
@@ -42,8 +42,9 @@ import {
   getAttributesComingFromStyleSheets,
 } from './dom-walker'
 import type { UiJsxCanvasContextData } from './ui-jsx-canvas'
+import { limitExecutionCount } from '../../core/shared/execution-count'
 
-export function runDomSampler(options: {
+export function runDomSamplerUnchecked(options: {
   elementsToFocusOn: ElementsToRerender
   domWalkerAdditionalElementsToFocusOn: Array<ElementPath>
   scale: number
@@ -115,6 +116,13 @@ export function runDomSampler(options: {
 
   return result
 }
+
+const wrappedRunDomSamplerResult = limitExecutionCount(
+  { maximumExecutionCount: 2 },
+  runDomSamplerUnchecked,
+)
+export const runDomSampler = wrappedRunDomSamplerResult.wrappedFunction
+export const resetRunDomSamplerLimit = wrappedRunDomSamplerResult.resetCount
 
 function collectMetadataForPaths({
   canvasRootContainer,

--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -156,7 +156,7 @@ import {
 import { uniqBy } from '../../core/shared/array-utils'
 import { InitialOnlineState } from '../editor/online-status'
 import { RadixComponentsPortalId } from '../../uuiui/radix-components'
-import { runDomSampler } from './dom-sampler'
+import { resetRunDomSamplerLimit, runDomSampler } from './dom-sampler'
 import {
   ElementInstanceMetadataKeepDeepEquality,
   ElementInstanceMetadataMapKeepDeepEquality,
@@ -354,6 +354,7 @@ export async function renderTestEditorWithModel(
     waitForDispatchEntireUpdate = false,
     innerStrategiesToUse: Array<MetaCanvasStrategy> = strategiesToUse,
   ) => {
+    resetRunDomSamplerLimit()
     recordedActions.push(...actions)
     const originalEditorState = workingEditorState
     const result = editorDispatchActionRunner(

--- a/editor/src/core/shared/execution-count.spec.tsx
+++ b/editor/src/core/shared/execution-count.spec.tsx
@@ -1,0 +1,90 @@
+import type { LimitExecutionCountReset } from './execution-count'
+import { limitExecutionCount } from './execution-count'
+
+describe('limitExecutionCount', () => {
+  it('the wrapped function should retain its type', () => {
+    function putNumberOnString(str: string, num: number): string {
+      return `${str}-${num}`
+    }
+    const wrappedFunction = limitExecutionCount(
+      { maximumExecutionCount: 1 },
+      putNumberOnString,
+    ).wrappedFunction
+    expect(wrappedFunction('hello', 1)).toBe('hello-1')
+  })
+  it('should let a function be called the maximum number of times', () => {
+    const fn = jest.fn()
+    const { wrappedFunction } = limitExecutionCount({ maximumExecutionCount: 3 }, fn)
+    wrappedFunction()
+    wrappedFunction()
+    wrappedFunction()
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+  it('should let a function be called the maximum number of times, then reset and called the maximum number of times again', () => {
+    const fn = jest.fn()
+    const { wrappedFunction, resetCount } = limitExecutionCount({ maximumExecutionCount: 3 }, fn)
+    wrappedFunction()
+    wrappedFunction()
+    wrappedFunction()
+    expect(fn).toHaveBeenCalledTimes(3)
+    resetCount()
+    wrappedFunction()
+    wrappedFunction()
+    wrappedFunction()
+    expect(fn).toHaveBeenCalledTimes(6)
+  })
+  it('should let a function be called the maximum number of times, then reset via the reset array and called the maximum number of times again', () => {
+    const fn = jest.fn()
+    const resetArray: Array<LimitExecutionCountReset> = []
+    const { wrappedFunction } = limitExecutionCount(
+      { maximumExecutionCount: 3, addToResetArray: resetArray },
+      fn,
+    )
+    wrappedFunction()
+    wrappedFunction()
+    wrappedFunction()
+    expect(fn).toHaveBeenCalledTimes(3)
+    resetArray.forEach((reset) => reset())
+    wrappedFunction()
+    wrappedFunction()
+    wrappedFunction()
+    expect(fn).toHaveBeenCalledTimes(6)
+  })
+  it('should throw an exception if the function is called more than the maximum number of times', () => {
+    const fn = jest.fn()
+    const { wrappedFunction } = limitExecutionCount({ maximumExecutionCount: 2 }, fn)
+    wrappedFunction()
+    wrappedFunction()
+    expect(() => {
+      wrappedFunction()
+    }).toThrowErrorMatchingInlineSnapshot(`"Function exceeded maximum execution count of 2."`)
+  })
+  it('should throw an exception if the function is called more than the maximum number of times, after a reset', () => {
+    const fn = jest.fn()
+    const { wrappedFunction, resetCount } = limitExecutionCount({ maximumExecutionCount: 2 }, fn)
+    wrappedFunction()
+    wrappedFunction()
+    resetCount()
+    wrappedFunction()
+    wrappedFunction()
+    expect(() => {
+      wrappedFunction()
+    }).toThrowErrorMatchingInlineSnapshot(`"Function exceeded maximum execution count of 2."`)
+  })
+  it('should throw an exception if the function is called more than the maximum number of times, after a reset via the reset array', () => {
+    const fn = jest.fn()
+    const resetArray: Array<LimitExecutionCountReset> = []
+    const { wrappedFunction } = limitExecutionCount(
+      { maximumExecutionCount: 2, addToResetArray: resetArray },
+      fn,
+    )
+    wrappedFunction()
+    wrappedFunction()
+    resetArray.forEach((reset) => reset())
+    wrappedFunction()
+    wrappedFunction()
+    expect(() => {
+      wrappedFunction()
+    }).toThrowErrorMatchingInlineSnapshot(`"Function exceeded maximum execution count of 2."`)
+  })
+})

--- a/editor/src/core/shared/execution-count.tsx
+++ b/editor/src/core/shared/execution-count.tsx
@@ -1,0 +1,62 @@
+export type LimitExecutionCountReset = () => void
+
+export interface LimitExecutionCountOptions {
+  maximumExecutionCount: number
+  addToResetArray: Array<LimitExecutionCountReset> | null
+}
+
+export interface LimitExecutionCountState {
+  executionCount: number
+}
+
+export interface LimitExecutionCountResult<Args extends ReadonlyArray<unknown>, Result> {
+  wrappedFunction: (...args: Args) => Result
+  resetCount: LimitExecutionCountReset
+}
+
+const defaultOptions: LimitExecutionCountOptions = {
+  maximumExecutionCount: 1,
+  addToResetArray: null,
+}
+
+export function limitExecutionCount<Args extends ReadonlyArray<unknown>, Result>(
+  options: Partial<LimitExecutionCountOptions>,
+  fn: (...args: Args) => Result,
+): LimitExecutionCountResult<Args, Result> {
+  // Setup the default and specified options and state.
+  const fullySpecifiedOptions: LimitExecutionCountOptions = {
+    ...defaultOptions,
+    ...options,
+  }
+  let state: LimitExecutionCountState = {
+    executionCount: 0,
+  }
+
+  // Wrap the function supplied by the user.
+  const wrappedFunction = (...args: Args): Result => {
+    if (state.executionCount >= fullySpecifiedOptions.maximumExecutionCount) {
+      throw new Error(
+        `Function exceeded maximum execution count of ${fullySpecifiedOptions.maximumExecutionCount}.`,
+      )
+    }
+
+    state.executionCount += 1
+    return fn(...args)
+  }
+
+  // Create the function for resetting the count.
+  const resetCount = (): void => {
+    state.executionCount = 0
+  }
+
+  // Add into the reset array.
+  if (options.addToResetArray != null) {
+    options.addToResetArray.push(resetCount)
+  }
+
+  // Build the result.
+  return {
+    wrappedFunction: wrappedFunction,
+    resetCount: resetCount,
+  }
+}

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -136,7 +136,7 @@ import {
   traverseReadOnlyArray,
 } from '../core/shared/optics/optic-creators'
 import { keysEqualityExhaustive, shallowEqual } from '../core/shared/equality-utils'
-import { runDomSampler } from '../components/canvas/dom-sampler'
+import { resetRunDomSamplerLimit, runDomSampler } from '../components/canvas/dom-sampler'
 import { omitWithPredicate } from '../core/shared/object-utils'
 
 if (PROBABLY_ELECTRON) {
@@ -431,6 +431,7 @@ export class Editor {
   ): {
     entireUpdateFinished: Promise<any>
   } => {
+    resetRunDomSamplerLimit()
     const Measure = createPerformanceMeasure()
     Measure.logActions(dispatchedActions)
 


### PR DESCRIPTION
**Problem:**
Sometimes we want to ensure that a function does not run more than X number of times during a render or similar.

**Fix:**
Created a utility function that invisibly wraps around an existing function to provide an execution count limited version of it, along with a function to potentially reset the count.

**Commit Details:**
- Added `limitExecutionCount`, which can wrap around a function and prevent repeated execution with an exception being thrown.
- Wrapped `runDomSampler` with `limitExecutionCount`.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode