### PR TITLE
fix(inspector): queue inspector focus in a microtask to prevent flushSync

### DIFF
--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -341,7 +341,9 @@ export const Inspector = React.memo<InspectorProps>((props: InspectorProps) => {
   const onFocus = React.useCallback(
     (event: React.FocusEvent<HTMLElement>) => {
       if (focusedPanel !== 'inspector') {
-        dispatch([setFocus('inspector')], 'inspector')
+        queueMicrotask(() => {
+          dispatch([setFocus('inspector')], 'inspector')
+        })
       }
     },
     [dispatch, focusedPanel],


### PR DESCRIPTION
**Problem:**
Today triggering a dropdown from the inspector causes a `flushSync` error

<video src="https://github.com/user-attachments/assets/110f6556-689c-45de-ae64-414850e707c3"></video>

**Fix:**
Queue the `dispatch` in the inspector focus in a microtask to prevent this React error

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode
