### PR TITLE
Update grid placeholders during resize

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
@@ -213,11 +213,17 @@ export function basicResizeStrategy(
             elementParentBounds?.height,
           )
 
+          const gridsToRerender = selectedElements
+            .filter((element) => MetadataUtils.isGridCell(canvasState.startingMetadata, element))
+            .map(EP.parentPath)
+
+          const elementsToRerender = [...selectedElements, ...gridsToRerender]
+
           return strategyApplicationResult([
             adjustCssLengthProperties('always', selectedElement, null, resizeProperties),
             updateHighlightedViews('mid-interaction', []),
             setCursorCommand(pickCursorFromEdgePosition(edgePosition)),
-            setElementsToRerenderCommand(selectedElements),
+            setElementsToRerenderCommand(elementsToRerender),
             pushIntendedBoundsAndUpdateGroups(
               [{ target: selectedElement, frame: resizedBounds }],
               'starting-metadata',


### PR DESCRIPTION
**Problem:**

The grid placeholders don't resize live while resizing a grid child (with fixed size).

**Fix:**

Rerender the grid during resize, so its computed template is picked up.

| Before | After |
|---------|----------|
| ![Kapture 2024-09-12 at 18 38 52](https://github.com/user-attachments/assets/ce491425-d5ae-4970-8997-967356610da9) | ![Kapture 2024-09-12 at 18 38 22](https://github.com/user-attachments/assets/978e0923-b9f6-414f-98cd-5a12add04948) |

Fixes #6359 
