### PR TITLE
Reparenting sets the elements to re-render correctly.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
@@ -1,6 +1,7 @@
 import { canvasPoint } from '../../../../core/shared/math-utils'
 import type { EditorStatePatch } from '../../../editor/store/editor-state'
 import { foldAndApplyCommandsInner } from '../../commands/commands'
+import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rerender-command'
 import { updateFunctionCommand } from '../../commands/update-function-command'
 import { ParentBounds } from '../../controls/parent-bounds'
 import { ParentOutlines } from '../../controls/parent-outlines'
@@ -104,6 +105,10 @@ export function baseFlexReparentToAbsoluteStrategy(
               [
                 ...placeholderCommands.commands,
                 ...escapeHatchCommands,
+                setElementsToRerenderCommand([
+                  newParent.intendedParentPath,
+                  ...filteredSelectedElements,
+                ]),
                 updateFunctionCommand(
                   'always',
                   (editorState, commandLifecycle): Array<EditorStatePatch> => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategy.tsx
@@ -49,6 +49,7 @@ import type { ReparentTarget } from './reparent-helpers/reparent-strategy-helper
 import { getReparentOutcome, pathToReparent } from './reparent-utils'
 import { flattenSelection } from './shared-move-strategies-helpers'
 import type { GridCellCoordinates } from './grid-cell-bounds'
+import { setElementsToRerenderCommand } from '../../commands/set-elements-to-rerender-command'
 
 export function gridReparentStrategy(
   reparentTarget: ReparentTarget,
@@ -258,6 +259,7 @@ export function applyGridReparent(
             updateSelectedViews('always', newPaths),
             setCursorCommand(CSSCursor.Reparent),
             showGridControls('mid-interaction', reparentTarget.newParent.intendedParentPath),
+            setElementsToRerenderCommand(elementsToRerender),
           ],
           {
             elementsToRerender: elementsToRerender,


### PR DESCRIPTION
**Problem:**
When reparenting, sometimes the strategy is not invoking `setElementsToRerenderCommand`.

**Fix:**
I ran all the tests with some added instrumentation that captures any strategies that weren't including `setElementsToRerenderCommand` in their output commands. For any that weren't it was added.

**Commit Details:**
- `applyGridReparent` invokes `setElementsToRerenderCommand`.
- `baseFlexReparentToAbsoluteStrategy` invokes `setElementsToRerenderCommand`.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

Fixes #6260
