### PR TITLE
kill rogue comma

### DIFF
--- a/editor/src/components/canvas/canvas-component-entry.tsx
+++ b/editor/src/components/canvas/canvas-component-entry.tsx
@@ -105,7 +105,6 @@ const CanvasComponentEntryInner = React.memo((props: CanvasComponentEntryProps) 
           />
         ) : null}
       </div>
-      ,
     </>
   )
 })


### PR DESCRIPTION
There was a comma floating on the canvas, now it's gone.

<img width="348" alt="Screenshot 2024-09-12 at 2 43 58 PM" src="https://github.com/user-attachments/assets/f7f5b8be-d377-438d-a6d8-db6a7eab93c0">
