### PR TITLE
Grids: don't use absolute for click to insert

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-strategy.spec.browser2.tsx
@@ -237,9 +237,9 @@ export var storyboard = (
         gridColumn: '2',
         gridRow: '1',
         height: '100px',
-        left: '83px',
-        position: 'absolute',
-        top: '100px',
+        left: '',
+        position: '',
+        top: '',
         width: '100px',
       })
     })
@@ -280,9 +280,9 @@ export var storyboard = (
         gridColumn: '1',
         gridRow: '1',
         height: '100px',
-        left: '100px',
-        position: 'absolute',
-        top: '25px',
+        left: '',
+        position: '',
+        top: '',
         width: '100px',
       })
     })

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
@@ -52,6 +52,9 @@ import { newReparentSubjects } from './reparent-helpers/reparent-strategy-helper
 import { getReparentTargetUnified } from './reparent-helpers/reparent-strategy-parent-lookup'
 import { stripNulls } from '../../../../core/shared/array-utils'
 import { showGridControls } from '../../commands/show-grid-controls-command'
+import * as PP from '../../../../core/shared/property-path'
+import { propertyToDelete, updateBulkProperties } from '../../commands/set-property-command'
+import { deleteProperties } from '../../commands/delete-properties-command'
 
 export const gridDrawToInsertText: CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -218,9 +221,25 @@ const gridDrawToInsertStrategyInner =
             ? []
             : getWrappingCommands(insertedElementPath, maybeWrapperWithUid)
 
+        const isClick = interactionData.type === 'DRAG' && interactionData.drag == null
+
+        // for click-to-insert, don't use absolute positioning
+        const clickToInsertCommands = isClick
+          ? [
+              deleteProperties('always', insertedElementPath, [
+                PP.create('style', 'position'),
+                PP.create('style', 'top'),
+                PP.create('style', 'left'),
+                PP.create('style', 'bottom'),
+                PP.create('style', 'right'),
+              ]),
+            ]
+          : []
+
         return strategyApplicationResult(
           [
             insertionCommand,
+            ...clickToInsertCommands,
             ...setGridPropsCommands(insertedElementPath, gridTemplate, {
               gridRowStart: { numericalPosition: gridCellCoordinates.row },
               gridColumnStart: { numericalPosition: gridCellCoordinates.column },


### PR DESCRIPTION
**Problem:**

Click-to-insert into grids uses absolute positioning, which is not ideal.

**Fix:**

Strip positioning props when click-to-insert.

Fixes #6363 
