### PR TITLE
Dedupe `validPaths`.

### DIFF
--- a/editor/src/components/canvas/dom-sampler.tsx
+++ b/editor/src/components/canvas/dom-sampler.tsx
@@ -42,6 +42,7 @@ import {
   getAttributesComingFromStyleSheets,
 } from './dom-walker'
 import type { UiJsxCanvasContextData } from './ui-jsx-canvas'
+import { IS_TEST_ENVIRONMENT } from '../../common/env-vars'
 
 export function runDomSampler(options: {
   elementsToFocusOn: ElementsToRerender
@@ -67,6 +68,15 @@ export function runDomSampler(options: {
   }
 
   const validPaths = getValidPathsFromCanvasContainer(canvasRootContainer)
+  // Only perform this validation while in a test environment.
+  if (IS_TEST_ENVIRONMENT) {
+    const uniqueValidPaths = new Set(validPaths.map(EP.toString))
+    if (uniqueValidPaths.size !== validPaths.length) {
+      throw new Error(
+        `Duplicate paths in validPaths: ${JSON.stringify(validPaths.map(EP.toString), null, 2)}`,
+      )
+    }
+  }
 
   const spyPaths = Object.keys(options.spyCollector.current.spyValues.metadata)
   if (spyPaths.length === 0 && validPaths.length > 0) {

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -833,7 +833,7 @@ function useGetStoryboardRoot(
           getRemixValidPathsGenerationContext,
         )
   const storyboardRootElementPath = useKeepReferenceEqualityIfPossible(
-    validPaths[0] ?? EP.emptyElementPath,
+    validPaths.at(0) ?? EP.emptyElementPath,
   )
 
   const rootValidPathsArray = validPaths.map(EP.makeLastPartOfPathStatic)

--- a/editor/src/core/shared/set-utils.ts
+++ b/editor/src/core/shared/set-utils.ts
@@ -45,3 +45,9 @@ export function getSingleValueOnly<T>(set: Set<T>): T {
   }
   throw new Error(`Set had ${set.size} when it was expected to have just 1.`)
 }
+
+export function addAll<T>(set: Set<T>, values: Array<T>): void {
+  for (const value of values) {
+    set.add(value)
+  }
+}


### PR DESCRIPTION
**Problem:**
Duplicate entries have been making their way into the result of `getValidElementPathsFromElements`.

**Fix:**
Rather than accumulating the paths in an array, now they are being accumulated in a `Set`.

Along with this a check has been added to ensure there are no duplicates, but which only runs in test environments.

**Commit Details:**
- Added `addAll` utility function for sets.
- `runDomSampler` now includes a test environment only check that there are no duplicate entries in `validPaths`.
- `getValidElementPathsFromElement` now uses a `Set` instead of any array for storing the paths as it builds up the result.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode