### PR TITLE
NumberInput: holding arrow up-down makes the updates transient

### DIFF
--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -467,10 +467,10 @@ export const NumberInput = React.memo<NumberInputProps>(
     const onKeyDown = React.useCallback(
       (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'ArrowUp') {
-          updateValue(incrementBy(stepSize, e.shiftKey, false))
+          updateValue(incrementBy(stepSize, e.shiftKey, true))
         } else if (e.key === 'ArrowDown') {
           e.preventDefault()
-          updateValue(incrementBy(-stepSize, e.shiftKey, false))
+          updateValue(incrementBy(-stepSize, e.shiftKey, true))
         } else if (e.key === 'Enter' || e.key === 'Escape') {
           e.nativeEvent.stopImmediatePropagation()
           e.preventDefault()


### PR DESCRIPTION
**Problem:**
The `NumberInput` component which is used all over the inspector did not properly handle when the arrow up/down keys were pressed and held.

**Fix:**
It _looks like_ this did not work in the last 4 years! Amazingly, all of the proper handling _was_ wired in, but then instead of passing in a true flag, the code passed in a false flag, which made every event non-transient. Weird!

**Commit Details:**
- Just passing in `true` as `incrementBy`'s transient parameter
