### PR TITLE
DomWalkerObservers know about ElementsToRerenderGLOBAL

### DIFF
--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -307,7 +307,7 @@ export function resubscribeObservers(domWalkerMutableState: {
   }
 }
 
-function selectCanvasInteractionHappening(store: EditorStorePatched): boolean {
+function isCanvasInteractionHappening(store: EditorStorePatched): boolean {
   const interactionSessionActive = store.editor.canvas.interactionSession != null
   return interactionSessionActive || ElementsToRerenderGLOBAL.current !== 'rerender-all-elements'
 }
@@ -330,7 +330,7 @@ export function initDomWalkerObservers(
   // adequately assess the performance impact of doing so, and ideally find a way to only do so when the observed
   // change was not triggered by a user interaction
   const resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => {
-    const canvasInteractionHappening = selectCanvasInteractionHappening(editorStore.getState())
+    const canvasInteractionHappening = isCanvasInteractionHappening(editorStore.getState())
     const selectedViews = editorStore.getState().editor.selectedViews
     if (canvasInteractionHappening) {
       // Warning this only adds the selected views instead of the observed element
@@ -353,7 +353,7 @@ export function initDomWalkerObservers(
   })
 
   const mutationObserver = new window.MutationObserver((mutations: MutationRecord[]) => {
-    const canvasInteractionHappening = selectCanvasInteractionHappening(editorStore.getState())
+    const canvasInteractionHappening = isCanvasInteractionHappening(editorStore.getState())
     const selectedViews = editorStore.getState().editor.selectedViews
 
     if (canvasInteractionHappening) {

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -72,6 +72,7 @@ import { getFlexAlignment, getFlexJustifyContent, MaxContent } from '../inspecto
 import type { EditorDispatch } from '../editor/action-types'
 import { runDOMWalker } from '../editor/actions/action-creators'
 import { CanvasContainerOuterId } from './canvas-component-entry'
+import { ElementsToRerenderGLOBAL } from './ui-jsx-canvas'
 
 export const ResizeObserver =
   window.ResizeObserver ?? ResizeObserverSyntheticDefault.default ?? ResizeObserverSyntheticDefault
@@ -308,7 +309,7 @@ export function resubscribeObservers(domWalkerMutableState: {
 
 function selectCanvasInteractionHappening(store: EditorStorePatched): boolean {
   const interactionSessionActive = store.editor.canvas.interactionSession != null
-  return interactionSessionActive
+  return interactionSessionActive || ElementsToRerenderGLOBAL.current !== 'rerender-all-elements'
 }
 
 export function initDomWalkerObservers(


### PR DESCRIPTION
**Problem:**
The dom-walker observers (now used for triggering the dom-sampler) fire for continuous interactions that don't have `editor.canvas.interactionSession`, such as scrubbing in the inspector.

**Fix:**
The mutation callback now checks if `ElementsToRerenderGLOBAL.current` is in selective mode, and then it will behave similarly to when there is an active interactionSession.

**Commit Details:**

- Renamed `selectCanvasInteractionHappening ` to `isCanvasInteractionHappening`
- `isCanvasInteractionHappening` is aware of ElementsToRerenderGLOBAL.current
