### PR TITLE
Remove dom queries from grid rearrange move strategies

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-cell-bounds.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-cell-bounds.ts
@@ -111,14 +111,3 @@ export function getGridPlaceholderDomElementFromCoordinates(params: {
     `[data-grid-row="${params.row}"]` + `[data-grid-column="${params.column}"]`,
   )
 }
-
-export function getCellWindowRect(coords: GridCellCoordinates): WindowRectangle | null {
-  const element = getGridPlaceholderDomElementFromCoordinates(coords)
-  if (element == null) {
-    return null
-  }
-
-  const domRect = element!.getBoundingClientRect()
-  const windowRect = windowRectangle(domRect)
-  return windowRect
-}

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-duplicate-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-duplicate-strategy.ts
@@ -83,8 +83,6 @@ export const gridRearrangeMoveDuplicateStrategy: CanvasStrategyFactory = (
         selectedElement,
         canvasState.startingMetadata,
         interactionSession.interactionData,
-        canvasState.scale,
-        canvasState.canvasOffset,
         customState.grid,
       )
       if (moveCommands.length === 0) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.spec.browser2.tsx
@@ -287,8 +287,8 @@ export var storyboard = (
         expect({ top, left, gridColumn, gridRow }).toEqual({
           gridColumn: '1',
           gridRow: '1',
-          left: '36px',
-          top: '40px',
+          left: '37px',
+          top: '41px',
         })
       }
     })
@@ -329,8 +329,8 @@ export var storyboard = (
         expect({ top, left, gridColumn, gridRow }).toEqual({
           gridColumn: '1',
           gridRow: '1',
-          left: '136.5px',
-          top: '140.5px',
+          left: '137px',
+          top: '141px',
         })
       }
     })
@@ -369,8 +369,8 @@ export var storyboard = (
         expect({ top, left, gridColumn, gridRow }).toEqual({
           gridColumn: '2',
           gridRow: '2',
-          left: '25.5px',
-          top: '36px',
+          left: '26.5px',
+          top: '37px',
         })
       }
     })
@@ -452,8 +452,8 @@ export var storyboard = (
         expect({ top, left, gridColumn, gridRow }).toEqual({
           gridColumn: '1',
           gridRow: '1',
-          left: '60.5px',
-          top: '61px',
+          left: '61.5px',
+          top: '62px',
         })
       }
     })

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
@@ -180,8 +180,6 @@ function getCommandsAndPatchForGridRearrange(
     selectedElement,
     canvasState.startingMetadata,
     interactionData,
-    canvasState.scale,
-    canvasState.canvasOffset,
     customState.grid,
   )
 


### PR DESCRIPTION
**Problem:**
Followup to https://github.com/concrete-utopia/utopia/pull/6384
Rewrite `runGridRearrangeMove` and remove dom queries and calculation in window rectangles.

**Commit Details:**
- `runGridRearrangeRemove` called `getCellWindowRect`, remove that function and replace it with a new one working from the result of `getGlobalFramesOfGridCells`.
- I removed plenty of canvas<->window conversions and could remove canvasScale and canvasOffset parameters too.
- Some test results were changed by ~1 pixel, I believe this is a result of the removed back and forth conversions between canvas and window.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

