### PR TITLE
Grids: presetve repeat from inspector changes

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -699,10 +699,10 @@ export function expandGridDimensions(template: GridDimension[]): ExpandedGridDim
   }, [] as ExpandedGridDimension[])
 }
 
-function alterGridDimensions(params: {
+function alterGridTemplateDimensions(params: {
   originalValues: GridDimension[]
   target: ExpandedGridDimension
-  action: AlterGridTemplateDimensionAction
+  patch: AlterGridTemplateDimensionPatch
 }): GridDimension[] {
   return mapDropNulls((dim, index) => {
     if (index !== params.target.indexes.originalIndex) {
@@ -711,42 +711,40 @@ function alterGridDimensions(params: {
       const repeatedIndex = params.target.indexes.repeatedIndex ?? 0
       const before = dim.value.slice(0, repeatedIndex)
       const after = dim.value.slice(repeatedIndex + 1)
-      switch (params.action.type) {
+      switch (params.patch.type) {
         case 'REMOVE':
           if (before.length + after.length === 0) {
             return null
           }
           return gridCSSRepeat(dim.times, [...before, ...after])
         case 'REPLACE':
-          return gridCSSRepeat(dim.times, [...before, params.action.newValue, ...after])
+          return gridCSSRepeat(dim.times, [...before, params.patch.newValue, ...after])
         default:
-          assertNever(params.action)
+          assertNever(params.patch)
       }
     } else {
-      switch (params.action.type) {
+      switch (params.patch.type) {
         case 'REPLACE':
-          return params.action.newValue
+          return params.patch.newValue
         case 'REMOVE':
           return null
         default:
-          assertNever(params.action)
+          assertNever(params.patch)
       }
     }
   }, params.originalValues)
 }
 
-export type ReplaceGridDimensionAction = {
+export type ReplaceGridDimensionPatch = {
   type: 'REPLACE'
   newValue: GridDimension
 }
 
-export type RemoveGridDimensionAction = {
+export type RemoveGridDimensionPatch = {
   type: 'REMOVE'
 }
 
-export type AlterGridTemplateDimensionAction =
-  | ReplaceGridDimensionAction
-  | RemoveGridDimensionAction
+export type AlterGridTemplateDimensionPatch = ReplaceGridDimensionPatch | RemoveGridDimensionPatch
 
 export function replaceGridTemplateDimensionAtIndex(
   template: GridDimension[],
@@ -754,10 +752,10 @@ export function replaceGridTemplateDimensionAtIndex(
   index: number,
   newValue: GridDimension,
 ): GridDimension[] {
-  return alterGridDimensions({
+  return alterGridTemplateDimensions({
     originalValues: template,
     target: expanded[index],
-    action: {
+    patch: {
       type: 'REPLACE',
       newValue: newValue,
     },
@@ -769,10 +767,10 @@ export function removeGridTemplateDimensionAtIndex(
   expanded: ExpandedGridDimension[],
   index: number,
 ): GridDimension[] {
-  return alterGridDimensions({
+  return alterGridTemplateDimensions({
     originalValues: template,
     target: expanded[index],
-    action: {
+    patch: {
       type: 'REMOVE',
     },
   })

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -89,6 +89,7 @@ import {
   getGridPlaceholderDomElementFromCoordinates,
   gridCellTargetId,
 } from '../canvas-strategies/strategies/grid-cell-bounds'
+import { getGridRelatedIndexes } from '../canvas-strategies/strategies/grid-helpers'
 
 const CELL_ANIMATION_DURATION = 0.15 // seconds
 
@@ -360,51 +361,10 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
     if (props.fromPropsAxisValues?.type !== 'DIMENSIONS' || resizingIndex == null) {
       return []
     }
-
-    // Build an array of coresizing indexes per element.
-    let coresizeIndexes: number[][][] = [] // This looks scary but it's not! It's just a list of indexes, containing a list of the indexes *per group element*.
-    // For example, 1fr repeat(3, 10px 20px) 1fr, will be represented as:
-    /**
-     * [
-     * 	[ [0] ]
-     *  [ [1, 3] [2, 4]  ]
-     *  [ [5] ]
-     * ]
-     */
-    let elementCount = 0 // basically the expanded index
-    for (const dim of props.fromPropsAxisValues.dimensions) {
-      if (dim.type === 'REPEAT') {
-        let groupIndexes: number[][] = []
-        // for each value push the coresize indexes as many times as the repeats counter
-        for (let valueIndex = 0; valueIndex < dim.value.length; valueIndex++) {
-          let repeatedValueIndexes: number[] = []
-          for (let repeatIndex = 0; repeatIndex < dim.times; repeatIndex++) {
-            repeatedValueIndexes.push(elementCount + valueIndex + repeatIndex * dim.value.length)
-          }
-          groupIndexes.push(repeatedValueIndexes)
-        }
-        coresizeIndexes.push(groupIndexes)
-        elementCount += dim.value.length * dim.times // advance the counter as many times as the repeated values *combined*
-      } else {
-        coresizeIndexes.push([[elementCount]])
-        elementCount++
-      }
-    }
-
-    // Now, expand the indexes calculated above so they "flatten out" to match the generated values
-    let expandedCoresizeIndexes: number[][] = []
-    props.fromPropsAxisValues.dimensions.forEach((dim, dimIndex) => {
-      if (dim.type === 'REPEAT') {
-        for (let repeatIndex = 0; repeatIndex < dim.times * dim.value.length; repeatIndex++) {
-          const indexes = coresizeIndexes[dimIndex][repeatIndex % dim.value.length]
-          expandedCoresizeIndexes.push(indexes)
-        }
-      } else {
-        expandedCoresizeIndexes.push(coresizeIndexes[dimIndex][0])
-      }
+    return getGridRelatedIndexes({
+      template: props.fromPropsAxisValues.dimensions,
+      index: resizingIndex,
     })
-
-    return expandedCoresizeIndexes[resizingIndex] ?? []
   }, [props.fromPropsAxisValues, resizingIndex])
 
   if (props.axisValues == null) {

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -823,14 +823,18 @@ export function printCSSNumber(
 
 export function printGridDimension(dimension: GridDimension): string {
   switch (dimension.type) {
-    case 'KEYWORD':
-      return dimension.value.value
-    case 'NUMBER':
+    case 'KEYWORD': {
+      const areaName = dimension.areaName != null ? `[${dimension.areaName}] ` : ''
+      return `${areaName}${dimension.value.value}`
+    }
+    case 'NUMBER': {
       const printed = printCSSNumber(dimension.value, null)
       const areaName = dimension.areaName != null ? `[${dimension.areaName}] ` : ''
       return `${areaName}${printed}`
-    case 'REPEAT':
+    }
+    case 'REPEAT': {
       return `repeat(${dimension.times}, ${printArrayGridDimensions(dimension.value)})`
+    }
     default:
       assertNever(dimension)
   }

--- a/editor/src/components/inspector/flex-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/flex-section.spec.browser2.tsx
@@ -60,9 +60,23 @@ describe('flex section', () => {
       )
       await selectComponentsForTest(renderResult, [EP.fromString('sb/grid')])
       const control = await screen.findByTestId('grid-dimension-column-0')
-      await typeIntoField(control, '100')
+      await typeIntoField(control, '100px')
       const grid = await renderResult.renderedDOM.findByTestId('grid')
       expect(grid.style.gridTemplateColumns).toEqual('100px auto auto')
+    })
+    it('updates a repeated value', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        gridProjectWithRepeat,
+        'await-first-dom-report',
+      )
+      await selectComponentsForTest(renderResult, [EP.fromString('sb/grid')])
+      await typeIntoField(await screen.findByTestId('grid-dimension-column-2'), '42')
+
+      const grid = await renderResult.renderedDOM.findByTestId('grid')
+      expect(grid.style.gridTemplateColumns).toEqual('[area1] 1fr repeat(2, 10px 42px) 2fr')
+
+      await typeIntoField(await screen.findByTestId('grid-dimension-column-1'), '.5fr')
+      expect(grid.style.gridTemplateColumns).toEqual('[area1] 1fr repeat(2, 0.5fr 42px) 2fr')
     })
   })
 })
@@ -145,6 +159,65 @@ export var storyboard = (
       data-testid='grid'
       style={{
         display: 'grid',
+        gridGap: 10,
+        height: 322,
+        width: 364,
+        backgroundColor: '#FFFFFF',
+        padding: 20,
+      }}
+    >
+      <div
+        data-uid='foo'
+        data-testid='foo'
+        style={{
+          backgroundColor: '#aaaaaa33',
+          gridColumn: 3,
+          gridRow: 2,
+        }}
+      />
+      <div
+        data-uid='bar'
+        data-testid='bar'
+        style={{
+          width: 41,
+          height: 23,
+          border: '1px solid #000',
+          gridColumn: 'area1',
+          gridRow: 1,
+          backgroundColor: '#09f',
+        }}
+      />
+      <div
+        data-uid='baz'
+        data-testid='baz'
+        style={{
+          height: 53,
+          width: 'max-content',
+          gridColumn: 2,
+          gridRow: 2,
+          backgroundColor: '#0f9',
+        }}
+      >
+        a test
+      </div>
+    </div>
+  </Storyboard>
+)
+`
+
+const gridProjectWithRepeat = `
+import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-uid='grid'
+      data-testid='grid'
+      style={{
+        display: 'grid',
+        gridTemplateRows: '80px 1fr 1fr',
+        gridTemplateColumns: '[area1] 1fr repeat(2, 10px 30px) 2fr',
         gridGap: 10,
         height: 322,
         width: 364,


### PR DESCRIPTION
**Problem:**

As a followup to #6380 , we should preserve `repeat` functions & co. when altering the grid template from the inspector inputs too.

**Fix:**

1. Factored out the logic to alter a table from the resize strategy to helper functions in `grid-helpers.ts`
2. Adjusted the logic to support removing elements too
3. Refactored the callbacks in the inspector section to use the new helpers

Fixes #6387 
