### PR TITLE
Eliminate duplicate dom lookups

### DIFF
--- a/editor/src/components/canvas/dom-sampler.tsx
+++ b/editor/src/components/canvas/dom-sampler.tsx
@@ -156,7 +156,7 @@ function collectMetadataForPaths({
     )
   })
 
-  let domMetadataCollected: { [key: string]: DomElementMetadata } = {}
+  let domMetadataCollected: { [key: string]: DomElementMetadata | null } = {}
 
   if (checkExistingMetadata === 'check-existing') {
     // delete all metadata which should be collected now and those which are not in the dom anymore
@@ -176,24 +176,24 @@ function collectMetadataForPaths({
 
       if (domMetadata == null) {
         delete metadataToUpdate_MUTATE[p]
-      } else {
-        domMetadataCollected[p] = domMetadata
       }
+      domMetadataCollected[p] = domMetadata
     })
   }
 
   dynamicPathsToCollect.forEach((pathString) => {
     const path = EP.fromString(pathString)
     const domMetadata =
-      domMetadataCollected[pathString] ??
-      collectMetadataForElementPath(
-        path,
-        validPaths,
-        selectedViews,
-        scale,
-        containerRect,
-        elementCanvasRectangleCache,
-      )
+      pathString in domMetadataCollected
+        ? domMetadataCollected[pathString]
+        : collectMetadataForElementPath(
+            path,
+            validPaths,
+            selectedViews,
+            scale,
+            containerRect,
+            elementCanvasRectangleCache,
+          )
 
     const spyMetadata = spyCollector.current.spyValues.metadata[EP.toString(path)]
     if (spyMetadata == null) {

--- a/editor/src/components/canvas/dom-sampler.tsx
+++ b/editor/src/components/canvas/dom-sampler.tsx
@@ -156,6 +156,8 @@ function collectMetadataForPaths({
     )
   })
 
+  let domMetadataCollected: { [key: string]: DomElementMetadata } = {}
+
   if (checkExistingMetadata === 'check-existing') {
     // delete all metadata which should be collected now and those which are not in the dom anymore
     Object.keys(metadataToUpdate_MUTATE).forEach((p) => {
@@ -174,20 +176,24 @@ function collectMetadataForPaths({
 
       if (domMetadata == null) {
         delete metadataToUpdate_MUTATE[p]
+      } else {
+        domMetadataCollected[p] = domMetadata
       }
     })
   }
 
   dynamicPathsToCollect.forEach((pathString) => {
     const path = EP.fromString(pathString)
-    const domMetadata = collectMetadataForElementPath(
-      path,
-      validPaths,
-      selectedViews,
-      scale,
-      containerRect,
-      elementCanvasRectangleCache,
-    )
+    const domMetadata =
+      domMetadataCollected[pathString] ??
+      collectMetadataForElementPath(
+        path,
+        validPaths,
+        selectedViews,
+        scale,
+        containerRect,
+        elementCanvasRectangleCache,
+      )
 
     const spyMetadata = spyCollector.current.spyValues.metadata[EP.toString(path)]
     if (spyMetadata == null) {


### PR DESCRIPTION
**Problem:**
The DOM sampler has two phases in a function that call `collectMetadataForElementPath`, it turns out that it's often invoking the second phase with paths that were also investigated in the first phase.

**Fix:**
Collate the results of calling `collectMetadataForElementPath` and re-use them where possible.

**Results:**
In the sample project this has reduced the runtime of `runDomSampler` by around 15ms.

**Commit Details:**
- `collectMetadataForPaths` now caches the results of calls to
  `collectMetadataForElementPath` as there are two locations that
  make calls to it.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode