### PR TITLE
Grid controls use metadata

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-cell-bounds.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-cell-bounds.ts
@@ -1,12 +1,10 @@
 import type { ElementPath } from 'utopia-shared/src/types'
 import type { ElementInstanceMetadata } from '../../../../core/shared/element-template'
-import type { WindowPoint, WindowRectangle } from '../../../../core/shared/math-utils'
 import {
   canvasPoint,
   isInfinityRectangle,
   offsetPoint,
   rectContainsPoint,
-  windowRectangle,
 } from '../../../../core/shared/math-utils'
 import * as EP from '../../../../core/shared/element-path'
 import {
@@ -101,13 +99,4 @@ export function getGridCellBoundsFromCanvas(
     width: cellWidth,
     height: cellHeight,
   }
-}
-
-export function getGridPlaceholderDomElementFromCoordinates(params: {
-  row: number
-  column: number
-}): HTMLElement | null {
-  return document.querySelector(
-    `[data-grid-row="${params.row}"]` + `[data-grid-column="${params.column}"]`,
-  )
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -426,7 +426,7 @@ function gridChildAbsoluteMoveCommands(
     return []
   }
 
-  const offsetInTarget = windowPoint({
+  const offsetInTarget = canvasPoint({
     x: dragInteractionData.originalDragStart.x - targetMetadata.globalFrame.x,
     y: dragInteractionData.originalDragStart.y - targetMetadata.globalFrame.y,
   })

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -601,7 +601,7 @@ export function getGlobalFrameOfGridCell(
     return null
   }
 
-  return gridCellGlobalFrames[coords.row - 1][coords.column - 1] ?? null
+  return gridCellGlobalFrames[coords.row - 1]?.[coords.column - 1] ?? null
 }
 
 function gridTemplateToNumbers(gridTemplate: GridTemplate | null): Array<number> | null {

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -13,7 +13,7 @@ import {
   type GridElementProperties,
   type GridPosition,
 } from '../../../../core/shared/element-template'
-import type { CanvasRectangle, CanvasVector } from '../../../../core/shared/math-utils'
+import type { CanvasRectangle } from '../../../../core/shared/math-utils'
 import {
   canvasPoint,
   canvasRectangle,

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -31,7 +31,6 @@ import {
 import type { CanvasPoint, CanvasRectangle } from '../../../core/shared/math-utils'
 import {
   canvasPoint,
-  canvasRectangle,
   isFiniteRectangle,
   isInfinityRectangle,
   nullIfInfinity,
@@ -88,10 +87,7 @@ import { CanvasOffsetWrapper } from './canvas-offset-wrapper'
 import { CanvasLabel } from './select-mode/controls-common'
 import { useMaybeHighlightElement } from './select-mode/select-mode-hooks'
 import type { GridCellCoordinates } from '../canvas-strategies/strategies/grid-cell-bounds'
-import {
-  getGridPlaceholderDomElementFromCoordinates,
-  gridCellTargetId,
-} from '../canvas-strategies/strategies/grid-cell-bounds'
+import { gridCellTargetId } from '../canvas-strategies/strategies/grid-cell-bounds'
 import {
   getGlobalFrameOfGridCell,
   getGridRelatedIndexes,
@@ -920,8 +916,6 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
                       position: 'relative',
                       pointerEvents: 'initial',
                     }}
-                    data-grid-row={countedRow}
-                    data-grid-column={countedColumn}
                   >
                     {when(
                       features.Grid.dotgrid,

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -20,7 +20,10 @@ import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { mapDropNulls, stripNulls } from '../../../core/shared/array-utils'
 import { defaultEither } from '../../../core/shared/either'
 import * as EP from '../../../core/shared/element-path'
-import type { GridAutoOrTemplateDimensions } from '../../../core/shared/element-template'
+import type {
+  ElementInstanceMetadata,
+  GridAutoOrTemplateDimensions,
+} from '../../../core/shared/element-template'
 import {
   isGridAutoOrTemplateDimensions,
   type GridAutoOrTemplateBase,
@@ -493,6 +496,7 @@ export type GridData = {
   rows: number
   columns: number
   cells: number
+  metadata: ElementInstanceMetadata
 }
 export function useGridData(elementPaths: ElementPath[]): GridData[] {
   const grids = useEditorState(
@@ -536,6 +540,7 @@ export function useGridData(elementPaths: ElementPath[]): GridData[] {
 
         return {
           elementPath: targetGridContainer.elementPath,
+          metadata: targetGridContainer,
           frame: targetGridContainer.globalFrame,
           gridTemplateColumns: gridTemplateColumns,
           gridTemplateRows: gridTemplateRows,

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -1762,10 +1762,6 @@ function gridKeyFromPath(path: ElementPath): string {
   return `grid-${EP.toString(path)}`
 }
 
-export function getGridPlaceholderDomElement(elementPath: ElementPath): HTMLElement | null {
-  return document.getElementById(gridKeyFromPath(elementPath))
-}
-
 const gridPlaceholderBorder = (color: string) => `2px solid ${color}`
 
 export function controlsForGridPlaceholders(gridPath: ElementPath): ControlWithProps<any> {

--- a/editor/src/components/canvas/controls/select-mode/grid-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/grid-gap-control.tsx
@@ -154,15 +154,10 @@ export const GridGapControl = controlForStrategyMemoized<GridGapControlProps>((p
 
   const gridRowColumnInfo = useGridData([selectedElement])
 
-  const controlBounds = gridGapControlBoundsFromMetadata(
-    selectedElement,
-    gridRowColumnInfo[0],
-    {
-      row: fallbackEmptyValue(gridGapRow),
-      column: fallbackEmptyValue(gridGapColumn),
-    },
-    scale,
-  )
+  const controlBounds = gridGapControlBoundsFromMetadata(gridRowColumnInfo[0], {
+    row: fallbackEmptyValue(gridGapRow),
+    column: fallbackEmptyValue(gridGapColumn),
+  })
 
   return (
     <CanvasOffsetWrapper>

--- a/editor/src/components/canvas/controls/select-mode/subdued-grid-gap-controls.tsx
+++ b/editor/src/components/canvas/controls/select-mode/subdued-grid-gap-controls.tsx
@@ -23,11 +23,7 @@ export const SubduedGridGapControl = React.memo<SubduedGridGapControlProps>((pro
     (store) => store.editor.selectedViews,
     'SubduedGridGapControl selectedViews',
   )
-  const scale = useEditorState(
-    Substores.canvas,
-    (store) => store.editor.canvas.scale,
-    'GridGapControl scale',
-  )
+
   const metadata = useRefEditorState((store) => store.editor.jsxMetadata)
   const selectedElement = targets.at(0)
 
@@ -46,17 +42,12 @@ export const SubduedGridGapControl = React.memo<SubduedGridGapControlProps>((pro
     const gridGapRow = gridGap.row
     const gridGapColumn = gridGap.column
 
-    const controlBounds = gridGapControlBoundsFromMetadata(
-      selectedElement,
-      selectedGrid,
-      {
-        row: fallbackEmptyValue(gridGapRow),
-        column: fallbackEmptyValue(gridGapColumn),
-      },
-      scale,
-    )
+    const controlBounds = gridGapControlBoundsFromMetadata(selectedGrid, {
+      row: fallbackEmptyValue(gridGapRow),
+      column: fallbackEmptyValue(gridGapColumn),
+    })
     return controlBounds.gaps.filter((gap) => gap.axis === axis || axis === 'both')
-  }, [axis, metadata, scale, selectedElement, selectedGrid])
+  }, [axis, metadata, selectedElement, selectedGrid])
 
   if (filteredGaps.length === 0 || selectedElement == null) {
     return null
@@ -108,15 +99,10 @@ function GridGapControl({
       return
     }
 
-    const controlBounds = gridGapControlBoundsFromMetadata(
-      selectedElement,
-      selectedGrid,
-      {
-        row: fallbackEmptyValue(gridGap.row),
-        column: fallbackEmptyValue(gridGap.column),
-      },
-      scale,
-    )
+    const controlBounds = gridGapControlBoundsFromMetadata(selectedGrid, {
+      row: fallbackEmptyValue(gridGap.row),
+      column: fallbackEmptyValue(gridGap.column),
+    })
 
     const bound = controlBounds.gaps.find((updatedGap) => updatedGap.gapId === gap.gapId)
     if (bound == null) {

--- a/editor/src/components/canvas/gap-utils.ts
+++ b/editor/src/components/canvas/gap-utils.ts
@@ -229,8 +229,7 @@ export function gridGapControlBoundsFromMetadata(
   if (gridCellBounds == null) {
     return emptyResult
   }
-
-  const cellBounds = canvasRectangle({
+  const allCellsBound = canvasRectangle({
     x: gridCellBounds[0][0].x - parentGridBounds.x,
     y: gridCellBounds[0][0].y - parentGridBounds.y,
     width:
@@ -238,8 +237,8 @@ export function gridGapControlBoundsFromMetadata(
       gridCellBounds[0][gridColumns - 1].width -
       gridCellBounds[0][0].x,
     height:
-      gridCellBounds[gridColumns - 1][0].y +
-      gridCellBounds[gridColumns - 1][0].height -
+      gridCellBounds[gridRows - 1][0].y +
+      gridCellBounds[gridRows - 1][0].height -
       gridCellBounds[0][0].y,
   })
 
@@ -251,9 +250,9 @@ export function gridGapControlBoundsFromMetadata(
     return {
       gapId: `${EP.toString(grid.elementPath)}-row-gap-${i}`,
       bounds: canvasRectangle({
-        x: cellBounds.x,
+        x: allCellsBound.x,
         y: firstChildBounds.y + firstChildBounds.height - parentGridBounds.y,
-        width: cellBounds.width,
+        width: allCellsBound.width,
         height: secondChildBounds.y - firstChildBounds.y - firstChildBounds.height,
       }),
       gap: gapValues.row,
@@ -270,9 +269,9 @@ export function gridGapControlBoundsFromMetadata(
       gapId: `${EP.toString(grid.elementPath)}-column-gap-${i}`,
       bounds: canvasRectangle({
         x: firstChildBounds.x + firstChildBounds.width - parentGridBounds.x,
-        y: cellBounds.y,
+        y: allCellsBound.y,
         width: secondChildBounds.x - firstChildBounds.x - firstChildBounds.width,
-        height: cellBounds.height,
+        height: allCellsBound.height,
       }),
       gap: gapValues.column,
       axis: 'column' as Axis,
@@ -285,7 +284,7 @@ export function gridGapControlBoundsFromMetadata(
     columns: gridColumns,
     gridTemplateRows: gridTemplateRows ?? '',
     gridTemplateColumns: gridTemplateColumns ?? '',
-    cellBounds: cellBounds,
+    cellBounds: allCellsBound,
     gapValues: gapValues,
   }
 }

--- a/editor/src/components/canvas/gap-utils.ts
+++ b/editor/src/components/canvas/gap-utils.ts
@@ -32,10 +32,7 @@ import * as EP from '../../core/shared/element-path'
 import { treatElementAsFragmentLike } from './canvas-strategies/strategies/fragment-like-helpers'
 import type { AllElementProps } from '../editor/store/editor-state'
 import type { GridData } from './controls/grid-controls'
-import {
-  getGridPlaceholderDomElement,
-  getNullableAutoOrTemplateBaseString,
-} from './controls/grid-controls'
+import { getNullableAutoOrTemplateBaseString } from './controls/grid-controls'
 import { getGlobalFramesOfGridCells } from './canvas-strategies/strategies/grid-helpers'
 
 export interface PathWithBounds {


### PR DESCRIPTION
**Problem:**
Followup to https://github.com/concrete-utopia/utopia/pull/6386
Removed dom queries from grid and grid gap controls, and converted all calculations to the canvas coordinate system.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Preview mode

