### PR TITLE
Grids: basic `minmax` support

### DIFF
--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -567,11 +567,13 @@ import type {
   GridDimension,
   GridAutoFlow,
   GridCSSRepeat,
+  GridCSSMinmax,
 } from '../../inspector/common/css-utils'
 import {
   cssNumber,
   fontSettings,
   gridCSSKeyword,
+  gridCSSMinmax,
   gridCSSNumber,
   gridCSSRepeat,
   isCSSKeyword,
@@ -2009,6 +2011,11 @@ export const GridDimensionKeepDeepEquality: KeepDeepEqualityCall<GridDimension> 
             return GridCSSRepeatKeepDeepEquality(oldValue, newValue)
           }
           break
+        case 'MINMAX':
+          if (newValue.type === oldValue.type) {
+            return GridCSSMinmaxKeepDeepEquality(oldValue, newValue)
+          }
+          break
         default:
           assertNever(oldValue)
       }
@@ -2024,6 +2031,40 @@ export const GridCSSRepeatKeepDeepEquality: KeepDeepEqualityCall<GridCSSRepeat> 
     (p) => p.value,
     arrayDeepEquality(GridDimensionKeepDeepEquality),
     gridCSSRepeat,
+  )
+
+const GridCSSNumberOrKeywordKeepDeepEquality: KeepDeepEqualityCall<GridCSSNumber | GridCSSKeyword> =
+  combine1EqualityCall(
+    (dim) => dim,
+    (oldValue, newValue) => {
+      switch (oldValue.type) {
+        case 'KEYWORD':
+          if (newValue.type === oldValue.type) {
+            return GridCSSKeywordKeepDeepEquality(oldValue, newValue)
+          }
+          break
+        case 'NUMBER':
+          if (newValue.type === oldValue.type) {
+            return GridCSSNumberKeepDeepEquality(oldValue, newValue)
+          }
+          break
+        default:
+          assertNever(oldValue)
+      }
+      return keepDeepEqualityResult(newValue, false)
+    },
+    (dim) => dim,
+  )
+
+export const GridCSSMinmaxKeepDeepEquality: KeepDeepEqualityCall<GridCSSMinmax> =
+  combine3EqualityCalls(
+    (p) => p.min,
+    GridCSSNumberOrKeywordKeepDeepEquality,
+    (p) => p.max,
+    GridCSSNumberOrKeywordKeepDeepEquality,
+    (p) => p.areaName,
+    NullableStringKeepDeepEquality,
+    gridCSSMinmax,
   )
 
 export const GridAutoOrTemplateDimensionsKeepDeepEquality: KeepDeepEqualityCall<GridAutoOrTemplateDimensions> =

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -608,21 +608,6 @@ export type GridCSSMinmax = BaseGridDimension & {
   max: GridCSSNumber | GridCSSKeyword
 }
 
-export function parseGridCSSMinmax(input: string): GridCSSMinmax | null {
-  const parsed = csstree.parse(input, { context: 'value' })
-  if (parsed.type === 'Value') {
-    const parsedDimensions = parseGridChildren(parsed.children)
-    if (
-      isRight(parsedDimensions) &&
-      parsedDimensions.value.length === 1 &&
-      parsedDimensions.value[0].type === 'MINMAX'
-    ) {
-      return parsedDimensions.value[0]
-    }
-  }
-  return null
-}
-
 export function isGridCSSKeyword(dim: GridDimension): dim is GridCSSKeyword {
   return dim.type === 'KEYWORD'
 }
@@ -977,7 +962,7 @@ const validGridDimensionKeywords = [
   'subgrid',
   'auto-fit',
   'auto-fill',
-  'minmax',
+  'minmax', // TODO this should be removed once we have proper editing of grid template expressions!
 ] as const
 
 export type ValidGridDimensionKeyword = (typeof validGridDimensionKeywords)[number]

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -28,6 +28,7 @@ import {
   InspectorSectionIcons,
   NumberInput,
   SquareButton,
+  StringInput,
   Subdued,
   Tooltip,
 } from '../../uuiui'
@@ -36,6 +37,7 @@ import type {
   CSSNumber,
   GridAutoFlow,
   GridCSSKeyword,
+  GridCSSMinmax,
   GridDiscreteDimension,
   UnknownOrEmptyInput,
   ValidGridDimensionKeyword,
@@ -54,7 +56,10 @@ import {
   isGridCSSNumber,
   isGridCSSRepeat,
   isValidGridDimensionKeyword,
+  parseCSSNumber,
+  parseGridCSSMinmax,
   printArrayGridDimensions,
+  printGridDimension,
   type GridDimension,
 } from './common/css-utils'
 import { applyCommandsAction, transientActions } from '../editor/actions/action-creators'
@@ -104,6 +109,7 @@ import {
   useSetHoveredControlsHandlers,
 } from '../canvas/controls/select-mode/select-mode-hooks'
 import type { Axis } from '../canvas/gap-utils'
+import { isRight } from '../../core/shared/either'
 
 const axisDropdownMenuButton = 'axisDropdownMenuButton'
 
@@ -287,13 +293,35 @@ const TemplateDimensionControl = React.memo(
       return expandGridDimensions(template.dimensions)
     }, [template])
 
-    const onUpdate = React.useCallback(
+    const onUpdateDimension = React.useCallback(
+      (index: number) => (newValue: GridDimension) => {
+        if (template?.type !== 'DIMENSIONS') {
+          return
+        }
+        const newDimensions = replaceGridTemplateDimensionAtIndex(
+          template.dimensions,
+          expandedTemplate,
+          index,
+          newValue,
+        )
+
+        dispatch([
+          applyCommandsAction([
+            setProperty(
+              'always',
+              grid.elementPath,
+              PP.create('style', axis === 'column' ? 'gridTemplateColumns' : 'gridTemplateRows'),
+              printArrayGridDimensions(newDimensions),
+            ),
+          ]),
+        ])
+      },
+      [template, expandedTemplate, dispatch, axis, grid],
+    )
+
+    const onUpdateNumberOrKeyword = React.useCallback(
       (index: number) =>
         (value: UnknownOrEmptyInput<CSSNumber | CSSKeyword<ValidGridDimensionKeyword>>) => {
-          if (template?.type !== 'DIMENSIONS') {
-            return
-          }
-
           function getNewValue() {
             const gridValueAtIndex = values[index]
             if (isCSSNumber(value)) {
@@ -317,25 +345,9 @@ const TemplateDimensionControl = React.memo(
             return
           }
 
-          const newDimensions = replaceGridTemplateDimensionAtIndex(
-            template.dimensions,
-            expandedTemplate,
-            index,
-            newValue,
-          )
-
-          dispatch([
-            applyCommandsAction([
-              setProperty(
-                'always',
-                grid.elementPath,
-                PP.create('style', axis === 'column' ? 'gridTemplateColumns' : 'gridTemplateRows'),
-                printArrayGridDimensions(newDimensions),
-              ),
-            ]),
-          ])
+          onUpdateDimension(index)(newValue)
         },
-      [grid, values, dispatch, axis, template, expandedTemplate],
+      [values, onUpdateDimension],
     )
 
     const onRemove = React.useCallback(
@@ -545,7 +557,8 @@ const TemplateDimensionControl = React.memo(
             value={value}
             index={index}
             axis={axis}
-            onUpdate={onUpdate}
+            onUpdateNumberOrKeyword={onUpdateNumberOrKeyword}
+            onUpdateDimension={onUpdateDimension}
             items={dropdownMenuItems(index)}
             opener={openDropdown}
           />
@@ -561,16 +574,18 @@ function AxisDimensionControl({
   index,
   items,
   axis,
-  onUpdate,
+  onUpdateNumberOrKeyword,
+  onUpdateDimension,
   opener,
 }: {
   value: GridDiscreteDimension
   index: number
   items: DropdownMenuItem[]
   axis: 'column' | 'row'
-  onUpdate: (
+  onUpdateNumberOrKeyword: (
     index: number,
   ) => (value: UnknownOrEmptyInput<CSSNumber | CSSKeyword<ValidGridDimensionKeyword>>) => void
+  onUpdateDimension: (index: number) => (value: GridDimension) => void
   opener: (isOpen: boolean) => React.ReactElement
 }) {
   const testId = `grid-dimension-${axis}-${index}`
@@ -605,16 +620,25 @@ function AxisDimensionControl({
         >
           {value.areaName ?? index + 1}
         </Subdued>
-        <NumberOrKeywordControl
-          testId={testId}
-          value={value.type === 'MINMAX' ? cssKeyword('minmax') : value.value}
-          keywords={gridDimensionDropdownKeywords}
-          keywordTypeCheck={isValidGridDimensionKeyword}
-          onSubmitValue={onUpdate(index)}
-          controlStatus={
-            isGridCSSKeyword(value) && value.value.value === 'auto' ? 'off' : undefined
-          }
-        />
+        {value.type === 'MINMAX' ? (
+          <GridFunctionInput
+            testId={testId}
+            value={value}
+            onUpdateNumberOrKeyword={onUpdateNumberOrKeyword(index)}
+            onUpdateDimension={onUpdateDimension(index)}
+          />
+        ) : (
+          <NumberOrKeywordControl
+            testId={testId}
+            value={value.value}
+            keywords={gridDimensionDropdownKeywords}
+            keywordTypeCheck={isValidGridDimensionKeyword}
+            onSubmitValue={onUpdateNumberOrKeyword(index)}
+            controlStatus={
+              isGridCSSKeyword(value) && value.value.value === 'auto' ? 'off' : undefined
+            }
+          />
+        )}
       </div>
       <SquareButton className={axisDropdownMenuButton}>
         <DropdownMenu align='end' items={items} opener={opener} onOpenChange={onOpenChange} />
@@ -622,6 +646,53 @@ function AxisDimensionControl({
     </div>
   )
 }
+
+const GridFunctionInput = React.memo(
+  ({
+    testId,
+    value,
+    onUpdateNumberOrKeyword,
+    onUpdateDimension,
+  }: {
+    testId: string
+    value: GridCSSMinmax // This can be extended to support more function types
+    onUpdateNumberOrKeyword: (v: CSSNumber | CSSKeyword<ValidGridDimensionKeyword>) => void
+    onUpdateDimension: (v: GridDimension) => void
+  }) => {
+    const [printValue, setPrintValue] = React.useState<string>(printGridDimension(value))
+    const onChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+      setPrintValue(e.target.value)
+    }, [])
+
+    const onKeyDown = React.useCallback(
+      (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') {
+          if (isValidGridDimensionKeyword(printValue)) {
+            return onUpdateNumberOrKeyword(cssKeyword(printValue))
+          }
+
+          const maybeNumber = parseCSSNumber(printValue, 'AnyValid', 'px')
+          if (isRight(maybeNumber)) {
+            return onUpdateNumberOrKeyword(maybeNumber.value)
+          }
+
+          const maybeMinmax = parseGridCSSMinmax(printValue)
+          if (maybeMinmax != null) {
+            return onUpdateDimension({ ...maybeMinmax, areaName: value.areaName })
+          }
+
+          setPrintValue(printGridDimension(value))
+        }
+      },
+      [printValue, onUpdateNumberOrKeyword, onUpdateDimension, value],
+    )
+
+    return (
+      <StringInput testId={testId} value={printValue} onChange={onChange} onKeyDown={onKeyDown} />
+    )
+  },
+)
+GridFunctionInput.displayName = 'GridFunctionInput'
 
 function removeTemplateValueAtIndex(
   original: GridContainerProperties,

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -660,6 +660,8 @@ const GridFunctionInput = React.memo(
     onUpdateDimension: (v: GridDimension) => void
   }) => {
     const [printValue, setPrintValue] = React.useState<string>(printGridDimension(value))
+    React.useEffect(() => setPrintValue(printGridDimension(value)), [value])
+
     const onChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
       setPrintValue(e.target.value)
     }, [])

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -607,7 +607,7 @@ function AxisDimensionControl({
         </Subdued>
         <NumberOrKeywordControl
           testId={testId}
-          value={value.value}
+          value={value.type === 'MINMAX' ? cssKeyword('minmax') : value.value}
           keywords={gridDimensionDropdownKeywords}
           keywordTypeCheck={isValidGridDimensionKeyword}
           onSubmitValue={onUpdate(index)}

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -28,7 +28,6 @@ import {
   InspectorSectionIcons,
   NumberInput,
   SquareButton,
-  StringInput,
   Subdued,
   Tooltip,
 } from '../../uuiui'
@@ -37,7 +36,6 @@ import type {
   CSSNumber,
   GridAutoFlow,
   GridCSSKeyword,
-  GridCSSMinmax,
   GridDiscreteDimension,
   UnknownOrEmptyInput,
   ValidGridDimensionKeyword,
@@ -56,10 +54,7 @@ import {
   isGridCSSNumber,
   isGridCSSRepeat,
   isValidGridDimensionKeyword,
-  parseCSSNumber,
-  parseGridCSSMinmax,
   printArrayGridDimensions,
-  printGridDimension,
   type GridDimension,
 } from './common/css-utils'
 import { applyCommandsAction, transientActions } from '../editor/actions/action-creators'
@@ -109,7 +104,6 @@ import {
   useSetHoveredControlsHandlers,
 } from '../canvas/controls/select-mode/select-mode-hooks'
 import type { Axis } from '../canvas/gap-utils'
-import { isRight } from '../../core/shared/either'
 
 const axisDropdownMenuButton = 'axisDropdownMenuButton'
 
@@ -620,25 +614,16 @@ function AxisDimensionControl({
         >
           {value.areaName ?? index + 1}
         </Subdued>
-        {value.type === 'MINMAX' ? (
-          <GridFunctionInput
-            testId={testId}
-            value={value}
-            onUpdateNumberOrKeyword={onUpdateNumberOrKeyword(index)}
-            onUpdateDimension={onUpdateDimension(index)}
-          />
-        ) : (
-          <NumberOrKeywordControl
-            testId={testId}
-            value={value.value}
-            keywords={gridDimensionDropdownKeywords}
-            keywordTypeCheck={isValidGridDimensionKeyword}
-            onSubmitValue={onUpdateNumberOrKeyword(index)}
-            controlStatus={
-              isGridCSSKeyword(value) && value.value.value === 'auto' ? 'off' : undefined
-            }
-          />
-        )}
+        <NumberOrKeywordControl
+          testId={testId}
+          value={value.type === 'MINMAX' ? cssKeyword('minmax') : value.value} // TODO: this is just a placeholder for real editing of expressions
+          keywords={gridDimensionDropdownKeywords}
+          keywordTypeCheck={isValidGridDimensionKeyword}
+          onSubmitValue={onUpdateNumberOrKeyword(index)}
+          controlStatus={
+            isGridCSSKeyword(value) && value.value.value === 'auto' ? 'off' : undefined
+          }
+        />
       </div>
       <SquareButton className={axisDropdownMenuButton}>
         <DropdownMenu align='end' items={items} opener={opener} onOpenChange={onOpenChange} />
@@ -646,55 +631,6 @@ function AxisDimensionControl({
     </div>
   )
 }
-
-const GridFunctionInput = React.memo(
-  ({
-    testId,
-    value,
-    onUpdateNumberOrKeyword,
-    onUpdateDimension,
-  }: {
-    testId: string
-    value: GridCSSMinmax // This can be extended to support more function types
-    onUpdateNumberOrKeyword: (v: CSSNumber | CSSKeyword<ValidGridDimensionKeyword>) => void
-    onUpdateDimension: (v: GridDimension) => void
-  }) => {
-    const [printValue, setPrintValue] = React.useState<string>(printGridDimension(value))
-    React.useEffect(() => setPrintValue(printGridDimension(value)), [value])
-
-    const onChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-      setPrintValue(e.target.value)
-    }, [])
-
-    const onKeyDown = React.useCallback(
-      (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter') {
-          if (isValidGridDimensionKeyword(printValue)) {
-            return onUpdateNumberOrKeyword(cssKeyword(printValue))
-          }
-
-          const maybeNumber = parseCSSNumber(printValue, 'AnyValid', 'px')
-          if (isRight(maybeNumber)) {
-            return onUpdateNumberOrKeyword(maybeNumber.value)
-          }
-
-          const maybeMinmax = parseGridCSSMinmax(printValue)
-          if (maybeMinmax != null) {
-            return onUpdateDimension({ ...maybeMinmax, areaName: value.areaName })
-          }
-
-          setPrintValue(printGridDimension(value))
-        }
-      },
-      [printValue, onUpdateNumberOrKeyword, onUpdateDimension, value],
-    )
-
-    return (
-      <StringInput testId={testId} value={printValue} onChange={onChange} onKeyDown={onKeyDown} />
-    )
-  },
-)
-GridFunctionInput.displayName = 'GridFunctionInput'
 
 function removeTemplateValueAtIndex(
   original: GridContainerProperties,


### PR DESCRIPTION
**Problem:**

We currently don't support `minmax` in grid templates.

**Fix:**

This PR adds initial support for `minmax` throughout the grid flows.

**Commit Details:**

Parse `minmax` functions and keep them in the grid template data, so they correctly are kept while operating on the grid template itself.

**⚠️ Note:** there's ongoing work to support editing grid template expressions as strings, so I did not include proper editing in this one (there was a simple version [`3919cf7` (#6393)](https://github.com/concrete-utopia/utopia/pull/6393/commits/3919cf7bc7d14ecad2b3e0195e24496fca0be188) but I decided to remove it to not create stuttering code), see the two important `TODO` comments left in the code.

Fixes #6392 
