### PR TITLE
chore(editor): remove unneeded network call

### DIFF
--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -346,7 +346,7 @@ export class Editor {
       const projectId = getProjectID()
       startPollingLoginState(this.boundDispatch, loginState)
       this.storedState.userState.loginState = loginState
-      void Promise.all([getUserConfiguration(loginState)]).then(([shortcutConfiguration]) => {
+      void getUserConfiguration(loginState).then((shortcutConfiguration) => {
         const userState = {
           ...this.storedState.userState,
           ...shortcutConfiguration,

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -34,7 +34,6 @@ import {
 import {
   getLoginState,
   getUserConfiguration,
-  getUserPermissions,
   startPollingLoginState,
 } from '../components/editor/server'
 import type { DispatchResult } from '../components/editor/store/dispatch'
@@ -347,10 +346,7 @@ export class Editor {
       const projectId = getProjectID()
       startPollingLoginState(this.boundDispatch, loginState)
       this.storedState.userState.loginState = loginState
-      void Promise.all([
-        getUserConfiguration(loginState),
-        getUserPermissions(loginState, projectId),
-      ]).then(([shortcutConfiguration, permissions]) => {
+      void Promise.all([getUserConfiguration(loginState)]).then(([shortcutConfiguration]) => {
         const userState = {
           ...this.storedState.userState,
           ...shortcutConfiguration,


### PR DESCRIPTION
**Problem:**
We have a `/permissions` network call on our loading critical path, but its result is not being used (yet?)

**Fix:**
Remove the call for now since it is sometimes blocking loading the editor (competing for network)

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Preview mode