### PR TITLE
Grid move: absolute move without positioning

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -5,7 +5,6 @@ import type {
   ElementInstanceMetadataMap,
   GridPositionValue,
   GridTemplate,
-  SpecialSizeMeasurements,
 } from '../../../../core/shared/element-template'
 import {
   gridPositionValue,
@@ -21,7 +20,6 @@ import {
   canvasVector,
   isInfinityRectangle,
   offsetPoint,
-  windowPoint,
 } from '../../../../core/shared/math-utils'
 import * as PP from '../../../../core/shared/property-path'
 import { absolute } from '../../../../utils/utils'
@@ -524,18 +522,17 @@ function getGridMoveType(params: {
   possiblyReorderIndex: number
   cellsSortedByPosition: SortableGridElementProperties[]
 }): GridMoveType {
+  const specialSizeMeasurements = params.originalElementMetadata.specialSizeMeasurements
   if (MetadataUtils.isPositionAbsolute(params.originalElementMetadata)) {
-    if (hasNoGridCellPositioning(params.originalElementMetadata.specialSizeMeasurements)) {
-      return 'absolute'
-    }
-    return 'rearrange'
+    return MetadataUtils.hasNoGridCellPositioning(specialSizeMeasurements)
+      ? 'absolute'
+      : 'rearrange'
   }
   if (params.possiblyReorderIndex >= params.cellsSortedByPosition.length) {
     return 'rearrange'
   }
 
-  const elementGridProperties =
-    params.originalElementMetadata.specialSizeMeasurements.elementGridProperties
+  const elementGridProperties = specialSizeMeasurements.elementGridProperties
 
   // The first element is intrinsically in order, so try to adjust for that
   if (params.possiblyReorderIndex === 0) {
@@ -816,13 +813,4 @@ export function getGridRelatedIndexes(params: {
   })
 
   return expandedRelatedIndexes[params.index] ?? []
-}
-
-export function hasNoGridCellPositioning(specialSizeMeasurements: SpecialSizeMeasurements) {
-  return (
-    specialSizeMeasurements.elementGridPropertiesFromProps.gridColumnStart == null &&
-    specialSizeMeasurements.elementGridPropertiesFromProps.gridColumnEnd == null &&
-    specialSizeMeasurements.elementGridPropertiesFromProps.gridRowStart == null &&
-    specialSizeMeasurements.elementGridPropertiesFromProps.gridRowEnd == null
-  )
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -524,8 +524,6 @@ function getGridMoveType(params: {
   possiblyReorderIndex: number
   cellsSortedByPosition: SortableGridElementProperties[]
 }): GridMoveType {
-  // For absolute move, just use rearrange.
-  // TODO: maybe worth reconsidering in the future?
   if (MetadataUtils.isPositionAbsolute(params.originalElementMetadata)) {
     if (hasNoGridCellPositioning(params.originalElementMetadata.specialSizeMeasurements)) {
       return 'absolute'

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.spec.browser2.tsx
@@ -202,7 +202,8 @@ export var storyboard = (
   })
 
   describe('absolute move within grid', () => {
-    const ProjectCode = `import { Scene, Storyboard } from 'utopia-api'
+    describe('when the cell has positioning', () => {
+      const ProjectCode = `import { Scene, Storyboard } from 'utopia-api'
 export var storyboard = (
   <Storyboard data-uid='sb'>
     <Scene
@@ -253,131 +254,131 @@ export var storyboard = (
   </Storyboard>
 )
 `
-    it('can move absolute element inside a grid cell', async () => {
-      const editor = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')
+      it('can move absolute element inside a grid cell', async () => {
+        const editor = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')
 
-      const child = editor.renderedDOM.getByTestId('child')
+        const child = editor.renderedDOM.getByTestId('child')
 
-      {
-        const { top, left, gridColumn, gridRow } = child.style
-        expect({ top, left, gridColumn, gridRow }).toEqual({
-          gridColumn: '1',
-          gridRow: '1',
-          left: '12px',
-          top: '16px',
+        {
+          const { top, left, gridColumn, gridRow } = child.style
+          expect({ top, left, gridColumn, gridRow }).toEqual({
+            gridColumn: '1',
+            gridRow: '1',
+            left: '12px',
+            top: '16px',
+          })
+        }
+
+        await selectComponentsForTest(editor, [EP.fromString('sb/scene/grid/child')])
+
+        const childBounds = child.getBoundingClientRect()
+        const childCenter = windowPoint({
+          x: Math.floor(childBounds.left + childBounds.width / 2),
+          y: Math.floor(childBounds.top + childBounds.height / 2),
         })
-      }
 
-      await selectComponentsForTest(editor, [EP.fromString('sb/scene/grid/child')])
+        await mouseDragFromPointToPoint(
+          editor.renderedDOM.getByTestId(GridCellTestId(EP.fromString('sb/scene/grid/child'))),
+          childCenter,
+          offsetPoint(childCenter, windowPoint({ x: 20, y: 20 })),
+        )
 
-      const childBounds = child.getBoundingClientRect()
-      const childCenter = windowPoint({
-        x: Math.floor(childBounds.left + childBounds.width / 2),
-        y: Math.floor(childBounds.top + childBounds.height / 2),
+        {
+          const { top, left, gridColumn, gridRow } = child.style
+          expect({ top, left, gridColumn, gridRow }).toEqual({
+            gridColumn: '1',
+            gridRow: '1',
+            left: '37px',
+            top: '41px',
+          })
+        }
       })
 
-      await mouseDragFromPointToPoint(
-        editor.renderedDOM.getByTestId(GridCellTestId(EP.fromString('sb/scene/grid/child'))),
-        childCenter,
-        offsetPoint(childCenter, windowPoint({ x: 20, y: 20 })),
-      )
+      it('can move absolute element inside a grid cell, zoomed in', async () => {
+        const editor = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')
 
-      {
-        const { top, left, gridColumn, gridRow } = child.style
-        expect({ top, left, gridColumn, gridRow }).toEqual({
-          gridColumn: '1',
-          gridRow: '1',
-          left: '37px',
-          top: '41px',
+        await editor.dispatch([CanvasActions.zoom(2)], true)
+
+        const child = editor.renderedDOM.getByTestId('child')
+
+        {
+          const { top, left, gridColumn, gridRow } = child.style
+          expect({ top, left, gridColumn, gridRow }).toEqual({
+            gridColumn: '1',
+            gridRow: '1',
+            left: '12px',
+            top: '16px',
+          })
+        }
+
+        await selectComponentsForTest(editor, [EP.fromString('sb/scene/grid/child')])
+
+        const childBounds = child.getBoundingClientRect()
+        const childCenter = windowPoint({
+          x: Math.floor(childBounds.left + childBounds.width / 2),
+          y: Math.floor(childBounds.top + childBounds.height / 2),
         })
-      }
-    })
 
-    it('can move absolute element inside a grid cell, zoomed in', async () => {
-      const editor = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')
+        await mouseDragFromPointToPoint(
+          editor.renderedDOM.getByTestId(GridCellTestId(EP.fromString('sb/scene/grid/child'))),
+          childCenter,
+          offsetPoint(childCenter, windowPoint({ x: 240, y: 240 })),
+        )
 
-      await editor.dispatch([CanvasActions.zoom(2)], true)
-
-      const child = editor.renderedDOM.getByTestId('child')
-
-      {
-        const { top, left, gridColumn, gridRow } = child.style
-        expect({ top, left, gridColumn, gridRow }).toEqual({
-          gridColumn: '1',
-          gridRow: '1',
-          left: '12px',
-          top: '16px',
-        })
-      }
-
-      await selectComponentsForTest(editor, [EP.fromString('sb/scene/grid/child')])
-
-      const childBounds = child.getBoundingClientRect()
-      const childCenter = windowPoint({
-        x: Math.floor(childBounds.left + childBounds.width / 2),
-        y: Math.floor(childBounds.top + childBounds.height / 2),
+        {
+          const { top, left, gridColumn, gridRow } = child.style
+          expect({ top, left, gridColumn, gridRow }).toEqual({
+            gridColumn: '1',
+            gridRow: '1',
+            left: '137px',
+            top: '141px',
+          })
+        }
       })
 
-      await mouseDragFromPointToPoint(
-        editor.renderedDOM.getByTestId(GridCellTestId(EP.fromString('sb/scene/grid/child'))),
-        childCenter,
-        offsetPoint(childCenter, windowPoint({ x: 240, y: 240 })),
-      )
+      it('can move absolute element among grid cells', async () => {
+        const editor = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')
 
-      {
-        const { top, left, gridColumn, gridRow } = child.style
-        expect({ top, left, gridColumn, gridRow }).toEqual({
-          gridColumn: '1',
-          gridRow: '1',
-          left: '137px',
-          top: '141px',
+        const child = editor.renderedDOM.getByTestId('child')
+
+        {
+          const { top, left, gridColumn, gridRow } = child.style
+          expect({ top, left, gridColumn, gridRow }).toEqual({
+            gridColumn: '1',
+            gridRow: '1',
+            left: '12px',
+            top: '16px',
+          })
+        }
+
+        await selectComponentsForTest(editor, [EP.fromString('sb/scene/grid/child')])
+
+        const childBounds = child.getBoundingClientRect()
+        const childCenter = windowPoint({
+          x: Math.floor(childBounds.left + childBounds.width / 2),
+          y: Math.floor(childBounds.top + childBounds.height / 2),
         })
-      }
-    })
 
-    it('can move absolute element among grid cells', async () => {
-      const editor = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')
+        await mouseDragFromPointToPoint(
+          editor.renderedDOM.getByTestId(GridCellTestId(EP.fromString('sb/scene/grid/child'))),
+          childCenter,
+          offsetPoint(childCenter, windowPoint({ x: 240, y: 240 })),
+        )
 
-      const child = editor.renderedDOM.getByTestId('child')
-
-      {
-        const { top, left, gridColumn, gridRow } = child.style
-        expect({ top, left, gridColumn, gridRow }).toEqual({
-          gridColumn: '1',
-          gridRow: '1',
-          left: '12px',
-          top: '16px',
-        })
-      }
-
-      await selectComponentsForTest(editor, [EP.fromString('sb/scene/grid/child')])
-
-      const childBounds = child.getBoundingClientRect()
-      const childCenter = windowPoint({
-        x: Math.floor(childBounds.left + childBounds.width / 2),
-        y: Math.floor(childBounds.top + childBounds.height / 2),
+        {
+          const { top, left, gridColumn, gridRow } = child.style
+          expect({ top, left, gridColumn, gridRow }).toEqual({
+            gridColumn: '2',
+            gridRow: '2',
+            left: '26.5px',
+            top: '37px',
+          })
+        }
       })
 
-      await mouseDragFromPointToPoint(
-        editor.renderedDOM.getByTestId(GridCellTestId(EP.fromString('sb/scene/grid/child'))),
-        childCenter,
-        offsetPoint(childCenter, windowPoint({ x: 240, y: 240 })),
-      )
-
-      {
-        const { top, left, gridColumn, gridRow } = child.style
-        expect({ top, left, gridColumn, gridRow }).toEqual({
-          gridColumn: '2',
-          gridRow: '2',
-          left: '26.5px',
-          top: '37px',
-        })
-      }
-    })
-
-    it("can move element spanning multiple cell by a cell that isn't the root cell", async () => {
-      const editor = await renderTestEditorWithCode(
-        `import { Scene, Storyboard } from 'utopia-api'
+      it("can move element spanning multiple cell by a cell that isn't the root cell", async () => {
+        const editor = await renderTestEditorWithCode(
+          `import { Scene, Storyboard } from 'utopia-api'
 export var storyboard = (
   <Storyboard data-uid='sb'>
     <Scene
@@ -429,33 +430,124 @@ export var storyboard = (
   </Storyboard>
 )
 `,
-        'await-first-dom-report',
-      )
+          'await-first-dom-report',
+        )
 
-      await selectComponentsForTest(editor, [EP.fromString('sb/scene/grid/child')])
+        await selectComponentsForTest(editor, [EP.fromString('sb/scene/grid/child')])
 
-      const child = editor.renderedDOM.getByTestId('child')
-      const childBounds = child.getBoundingClientRect()
-      const startPoint = windowPoint({
-        x: Math.floor(childBounds.left + childBounds.width - 3),
-        y: Math.floor(childBounds.top + childBounds.height - 3),
-      })
-
-      await mouseDragFromPointToPoint(
-        editor.renderedDOM.getByTestId(GridCellTestId(EP.fromString('sb/scene/grid/child'))),
-        startPoint,
-        offsetPoint(startPoint, windowPoint({ x: -100, y: -100 })),
-      )
-
-      {
-        const { top, left, gridColumn, gridRow } = child.style
-        expect({ top, left, gridColumn, gridRow }).toEqual({
-          gridColumn: '1',
-          gridRow: '1',
-          left: '61.5px',
-          top: '62px',
+        const child = editor.renderedDOM.getByTestId('child')
+        const childBounds = child.getBoundingClientRect()
+        const startPoint = windowPoint({
+          x: Math.floor(childBounds.left + childBounds.width - 3),
+          y: Math.floor(childBounds.top + childBounds.height - 3),
         })
-      }
+
+        await mouseDragFromPointToPoint(
+          editor.renderedDOM.getByTestId(GridCellTestId(EP.fromString('sb/scene/grid/child'))),
+          startPoint,
+          offsetPoint(startPoint, windowPoint({ x: -100, y: -100 })),
+        )
+
+        {
+          const { top, left, gridColumn, gridRow } = child.style
+          expect({ top, left, gridColumn, gridRow }).toEqual({
+            gridColumn: '1',
+            gridRow: '1',
+            left: '61.5px',
+            top: '62px',
+          })
+        }
+      })
+    })
+    describe('when the cell has no positioning', () => {
+      const ProjectCode = `import { Scene, Storyboard } from 'utopia-api'
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <Scene
+      id='playground-scene'
+      commentId='playground-scene'
+      style={{
+        width: 700,
+        height: 759,
+        position: 'absolute',
+        left: 212,
+        top: 128,
+      }}
+      data-label='Playground'
+      data-uid='scene'
+    >
+      <div
+        data-uid='grid'
+        style={{
+          backgroundColor: '#fefefe',
+          position: 'absolute',
+          left: 123,
+          top: 133,
+          width: 461,
+          height: 448,
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gridTemplateRows: '1fr 1fr',
+          border: '5px solid #000',
+          gridGap: 10,
+        }}
+      >
+        <div
+          data-uid='child'
+          data-testid='child'
+          style={{
+            backgroundColor: '#59a6ed',
+            position: 'absolute',
+            left: 12,
+            top: 16,
+            width: 144,
+            height: 134,
+          }}
+        />
+      </div>
+    </Scene>
+  </Storyboard>
+)
+`
+      it('performs an absolute move relative to the grid', async () => {
+        const editor = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')
+
+        const child = editor.renderedDOM.getByTestId('child')
+
+        {
+          const { top, left, gridColumn, gridRow } = child.style
+          expect({ top, left, gridColumn, gridRow }).toEqual({
+            gridColumn: '',
+            gridRow: '',
+            left: '12px',
+            top: '16px',
+          })
+        }
+
+        await selectComponentsForTest(editor, [EP.fromString('sb/scene/grid/child')])
+
+        const childBounds = child.getBoundingClientRect()
+        const childCenter = windowPoint({
+          x: Math.floor(childBounds.left + childBounds.width / 2),
+          y: Math.floor(childBounds.top + childBounds.height / 2),
+        })
+
+        await mouseDragFromPointToPoint(
+          editor.renderedDOM.getByTestId(GridCellTestId(EP.fromString('sb/scene/grid/child'))),
+          childCenter,
+          offsetPoint(childCenter, windowPoint({ x: 280, y: 120 })),
+        )
+
+        {
+          const { top, left, gridColumn, gridRow } = child.style
+          expect({ top, left, gridColumn, gridRow }).toEqual({
+            gridColumn: '',
+            gridRow: '',
+            left: '297px',
+            top: '141px',
+          })
+        }
+      })
     })
   })
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
@@ -80,6 +80,8 @@ export const gridRearrangeMoveStrategy: CanvasStrategyFactory = (
     canvasState,
     interactionSession.interactionData,
     parentGridPath,
+    canvasState.startingMetadata,
+    selectedElement,
   )
   if (strategyToApply == null) {
     return null
@@ -358,6 +360,8 @@ function getStrategyToApply(
   canvasState: InteractionCanvasState,
   interactionData: DragInteractionData,
   parentGridPath: ElementPath,
+  jsxMetadata: ElementInstanceMetadataMap,
+  cell: ElementPath,
 ): StrategyToApply | null {
   if (interactionData.drag == null) {
     return null
@@ -403,9 +407,13 @@ function getStrategyToApply(
     }
   }
 
+  const name = MetadataUtils.isGridCellWithPositioning(jsxMetadata, cell)
+    ? 'Rearrange Grid (Move)'
+    : 'Grid Move (Abs)'
+
   return {
     type: 'GRID_REARRANGE',
-    name: 'Rearrange Grid (Move)',
+    name: name,
     controlsToRender: [controlsForGridPlaceholders(parentGridPath)],
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
@@ -407,9 +407,13 @@ function getStrategyToApply(
     }
   }
 
-  const name = MetadataUtils.isGridCellWithPositioning(jsxMetadata, cell)
-    ? 'Rearrange Grid (Move)'
-    : 'Grid Move (Abs)'
+  const element = MetadataUtils.findElementByElementPath(jsxMetadata, cell)
+
+  const name =
+    MetadataUtils.isPositionAbsolute(element) &&
+    !MetadataUtils.isGridCellWithPositioning(jsxMetadata, cell)
+      ? 'Grid Move (Abs)'
+      : 'Rearrange Grid (Move)'
 
   return {
     type: 'GRID_REARRANGE',

--- a/editor/src/components/canvas/canvas-strategies/strategies/rearrange-grid-swap-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/rearrange-grid-swap-strategy.spec.browser2.tsx
@@ -55,6 +55,8 @@ export var storyboard = (
         data-testid='row-1-column-2'
         style={{
           backgroundColor: 'green',
+		  gridRow: 'auto',
+		  gridColumn: 'auto',
         }}
       />
       <div

--- a/editor/src/components/canvas/canvas-strategies/strategies/rearrange-grid-swap-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/rearrange-grid-swap-strategy.ts
@@ -46,7 +46,7 @@ export const rearrangeGridSwapStrategy: CanvasStrategyFactory = (
 
   const selectedElement = selectedElements[0]
 
-  if (!MetadataUtils.isGridCell(canvasState.startingMetadata, selectedElement)) {
+  if (!MetadataUtils.isGridCellWithPositioning(canvasState.startingMetadata, selectedElement)) {
     return null
   }
 

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -706,6 +706,15 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
     'GridControls anyTargetAbsolute',
   )
 
+  const targetsAreCellsWithPositioning = useEditorState(
+    Substores.metadata,
+    (store) =>
+      store.editor.selectedViews.every((elementPath) =>
+        MetadataUtils.isGridCellWithPositioning(store.editor.jsxMetadata, elementPath),
+      ),
+    'GridControls anyTargetAbsolute',
+  )
+
   const gridPath = optionalMap(EP.parentPath, shadow?.elementPath)
 
   const gridFrame = React.useMemo(() => {
@@ -889,9 +898,10 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
                   countedColumn === currentHoveredCell?.column &&
                   countedRow === currentHoveredCell?.row
 
-                const borderColor = isActiveCell
-                  ? colorTheme.brandNeonPink.value
-                  : features.Grid.inactiveGridColor
+                const borderColor =
+                  isActiveCell && targetsAreCellsWithPositioning
+                    ? colorTheme.brandNeonPink.value
+                    : features.Grid.inactiveGridColor
 
                 return (
                   <div

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -46,6 +46,7 @@ import type {
   ConditionValue,
   JSXElementLike,
   JSPropertyAccess,
+  SpecialSizeMeasurements,
 } from '../shared/element-template'
 import {
   getJSXElementNameLastPart,
@@ -179,7 +180,6 @@ import { exists, toFirst } from '../shared/optics/optic-utilities'
 import { eitherRight, fromField, fromTypeGuard, notNull } from '../shared/optics/optic-creators'
 import { getComponentDescriptorForTarget } from '../property-controls/property-controls-utils'
 import { treatElementAsFragmentLike } from '../../components/canvas/canvas-strategies/strategies/fragment-like-helpers'
-import { hasNoGridCellPositioning } from '../../components/canvas/canvas-strategies/strategies/grid-helpers'
 
 const ObjectPathImmutable: any = OPI
 
@@ -397,7 +397,15 @@ export const MetadataUtils = {
     return (
       MetadataUtils.isGridCell(metadata, path) &&
       element != null &&
-      !hasNoGridCellPositioning(element.specialSizeMeasurements)
+      !MetadataUtils.hasNoGridCellPositioning(element.specialSizeMeasurements)
+    )
+  },
+  hasNoGridCellPositioning(specialSizeMeasurements: SpecialSizeMeasurements): boolean {
+    return (
+      specialSizeMeasurements.elementGridPropertiesFromProps.gridColumnStart == null &&
+      specialSizeMeasurements.elementGridPropertiesFromProps.gridColumnEnd == null &&
+      specialSizeMeasurements.elementGridPropertiesFromProps.gridRowStart == null &&
+      specialSizeMeasurements.elementGridPropertiesFromProps.gridRowEnd == null
     )
   },
   isComponentInstanceFromMetadata(

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -179,6 +179,7 @@ import { exists, toFirst } from '../shared/optics/optic-utilities'
 import { eitherRight, fromField, fromTypeGuard, notNull } from '../shared/optics/optic-creators'
 import { getComponentDescriptorForTarget } from '../property-controls/property-controls-utils'
 import { treatElementAsFragmentLike } from '../../components/canvas/canvas-strategies/strategies/fragment-like-helpers'
+import { hasNoGridCellPositioning } from '../../components/canvas/canvas-strategies/strategies/grid-helpers'
 
 const ObjectPathImmutable: any = OPI
 
@@ -389,6 +390,14 @@ export const MetadataUtils = {
       parent.specialSizeMeasurements.containerGridProperties.gridTemplateColumns != null &&
       parent.specialSizeMeasurements.containerGridProperties.gridTemplateRows != null &&
       MetadataUtils.isGridLayoutedContainer(parent)
+    )
+  },
+  isGridCellWithPositioning(metadata: ElementInstanceMetadataMap, path: ElementPath): boolean {
+    const element = MetadataUtils.findElementByElementPath(metadata, path)
+    return (
+      MetadataUtils.isGridCell(metadata, path) &&
+      element != null &&
+      !hasNoGridCellPositioning(element.specialSizeMeasurements)
     )
   },
   isComponentInstanceFromMetadata(


### PR DESCRIPTION
**Problem:**

Grid elements with `position: absolute` are always moved relative to the cell they appear in.

**Fix:**

For cell elements that don't have explicit grid positioning (`gridRow` / `gridColumn`), move them relative to the grid itself instead, and don't show the cell target outline during the move.

(Elements that have positioning will still be absolutely positioned relatively to their cell, and the positioning will be kept).

Fixes #6404