### PR TITLE
LocalSelectedViews 2: Electric Boogaloo

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.spec.browser2.tsx
@@ -176,6 +176,7 @@ describe('Strategy Fitness', () => {
     const canvasStrategy = findCanvasStrategy(
       RegisteredCanvasStrategies,
       pickCanvasStateFromEditorState(
+        renderResult.getEditorState().editor.selectedViews,
         renderResult.getEditorState().editor,
         renderResult.getEditorState().builtInDependencies,
       ),
@@ -226,6 +227,7 @@ describe('Strategy Fitness', () => {
     const canvasStrategy = findCanvasStrategy(
       RegisteredCanvasStrategies,
       pickCanvasStateFromEditorState(
+        renderResult.getEditorState().editor.selectedViews,
         renderResult.getEditorState().editor,
         renderResult.getEditorState().builtInDependencies,
       ),
@@ -313,6 +315,7 @@ describe('Strategy Fitness', () => {
     const canvasStrategy = findCanvasStrategy(
       RegisteredCanvasStrategies,
       pickCanvasStateFromEditorState(
+        renderResult.getEditorState().editor.selectedViews,
         renderResult.getEditorState().editor,
         renderResult.getEditorState().builtInDependencies,
       ),
@@ -363,6 +366,7 @@ describe('Strategy Fitness', () => {
     const canvasStrategy = findCanvasStrategy(
       RegisteredCanvasStrategies,
       pickCanvasStateFromEditorState(
+        renderResult.getEditorState().editor.selectedViews,
         renderResult.getEditorState().editor,
         renderResult.getEditorState().builtInDependencies,
       ),

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-duplicate-strategy.spec.tsx
@@ -74,6 +74,7 @@ function dragByPixelsIsApplicable(
   return (
     absoluteDuplicateStrategy(
       pickCanvasStateFromEditorStateWithMetadata(
+        editorState.selectedViews,
         editorState,
         createBuiltInDependenciesList(null),
         metadata,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-canvas.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy-canvas.spec.tsx
@@ -133,6 +133,7 @@ function reparentElement(
   }
 
   const canvasState = pickCanvasStateFromEditorStateWithMetadata(
+    editorState.selectedViews,
     editorState,
     createBuiltInDependenciesList(null),
     startingMetadata,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-reparent-strategy.spec.tsx
@@ -202,6 +202,7 @@ function reparentElement(
   }
 
   const canvasState = pickCanvasStateFromEditorStateWithMetadata(
+    editorState.selectedViews,
     editorState,
     createBuiltInDependenciesList(null),
     startingMetadata,

--- a/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/absolute-resize-bounding-box-strategy.spec.tsx
@@ -52,6 +52,7 @@ function multiselectResizeElements(
 
   const strategyResult = absoluteResizeBoundingBoxStrategy(
     pickCanvasStateFromEditorStateWithMetadata(
+      initialEditor.selectedViews,
       initialEditor,
       createBuiltInDependenciesList(null),
       metadata,

--- a/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/convert-to-absolute-and-move-strategy.spec.tsx
@@ -175,6 +175,7 @@ function dragByPixels(
   const strategyResultCommands =
     convertToAbsoluteAndMoveStrategy(
       pickCanvasStateFromEditorStateWithMetadata(
+        editorState.selectedViews,
         editorState,
         createBuiltInDependenciesList(null),
         metadata,

--- a/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/drag-to-insert-metastrategy.tsx
@@ -389,6 +389,7 @@ function runTargetStrategiesForFreshlyInsertedElement(
   // because that element is inserted to the storyboard before reparenting to the correct location,
   // so its index amongst its starting siblings isn't relevant.
   const canvasState = pickCanvasStateFromEditorStateWithMetadata(
+    editorState.selectedViews,
     editorState,
     builtInDependencies,
     patchedMetadata,

--- a/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/draw-to-insert-metastrategy.tsx
@@ -580,7 +580,11 @@ function runTargetStrategiesForFreshlyInsertedElementToReparent(
   strategyLifecycle: InteractionLifecycle,
   startingMetadata: ElementInstanceMetadataMap,
 ): Array<EditorStatePatch> {
-  const canvasState = pickCanvasStateFromEditorState(editorState, builtInDependencies)
+  const canvasState = pickCanvasStateFromEditorState(
+    editorState.selectedViews,
+    editorState,
+    builtInDependencies,
+  )
 
   const rootPath = getRootPath(startingMetadata)
   if (rootPath == null) {
@@ -669,6 +673,7 @@ function runTargetStrategiesForFreshlyInsertedElementToResize(
   // when actually applying the strategies. If we ever need to pick a resize strategy based on the target
   // element's index, we will need to update the elementPathTree with the new element and pass it in here.
   const canvasState = pickCanvasStateFromEditorStateWithMetadata(
+    editorState.selectedViews,
     editorState,
     builtInDependencies,
     patchedMetadata,

--- a/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/flex-reparent-to-absolute-strategy.tsx
@@ -113,6 +113,7 @@ export function baseFlexReparentToAbsoluteStrategy(
                   'always',
                   (editorState, commandLifecycle): Array<EditorStatePatch> => {
                     const updatedCanvasState = pickCanvasStateFromEditorState(
+                      editorState.selectedViews,
                       editorState,
                       canvasState.builtInDependencies,
                     )

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-interaction.test-utils.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-interaction.test-utils.tsx
@@ -80,6 +80,7 @@ export function pressKeys(
 
   const strategy = strategyFactoryFunction(
     pickCanvasStateFromEditorStateWithMetadata(
+      editorState.selectedViews,
       editorState,
       createBuiltInDependenciesList(null),
       metadata,

--- a/editor/src/components/canvas/controls/new-canvas-controls.tsx
+++ b/editor/src/components/canvas/controls/new-canvas-controls.tsx
@@ -274,9 +274,16 @@ interface NewCanvasControlsInnerProps {
 }
 
 const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
+  const {
+    localSelectedViews,
+    localHighlightedViews,
+    setLocalSelectedViews,
+    setLocalHighlightedViews,
+  } = props
+
   const dispatch = useDispatch()
   const colorTheme = useColorTheme()
-  const strategyControls = useGetApplicableStrategyControls()
+  const strategyControls = useGetApplicableStrategyControls(localSelectedViews)
   const [inspectorHoveredControls] = useAtom(InspectorHoveredCanvasControls)
   const [inspectorFocusedControls] = useAtom(InspectorFocusedCanvasControls)
 
@@ -331,12 +338,6 @@ const NewCanvasControlsInner = (props: NewCanvasControlsInnerProps) => {
     'NewCanvasControlsInner',
   )
 
-  const {
-    localSelectedViews,
-    localHighlightedViews,
-    setLocalSelectedViews,
-    setLocalHighlightedViews,
-  } = props
   const cmdKeyPressed = keysPressed['cmd'] ?? false
 
   const contextMenuEnabled = !isLiveMode(editorMode)

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -60,6 +60,7 @@ import { treatElementAsGroupLike } from '../../canvas-strategies/strategies/grou
 import { useCommentModeSelectAndHover } from '../comment-mode/comment-mode-hooks'
 import { useFollowModeSelectAndHover } from '../follow-mode/follow-mode-hooks'
 import { wait } from '../../../../core/model/performance-scripts'
+import { IS_TEST_ENVIRONMENT } from '../../../../common/env-vars'
 
 export function isDragInteractionActive(editorState: EditorState): boolean {
   return editorState.canvas.interactionSession?.interactionData.type === 'DRAG'
@@ -780,8 +781,13 @@ function useSelectOrLiveModeSelectAndHover(
             setSelectedViewsForCanvasControlsOnly(updatedSelection)
           })
 
-          await new Promise((resolve) => requestAnimationFrame(resolve))
-          await new Promise((resolve) => requestAnimationFrame(resolve))
+          if (event.detail === 1 && !IS_TEST_ENVIRONMENT) {
+            // If event.detail is 1 that means this is a first click, where it is safe to delay dispatching actions
+            // to allow the localSelectedViews to be updated.
+            // For subsequent clicks, we want to dispatch immediately to avoid the event handler clashing with the focus system and the strategy event handlers
+            await new Promise((resolve) => requestAnimationFrame(resolve))
+            await new Promise((resolve) => requestAnimationFrame(resolve))
+          }
 
           // In either case cancel insert mode.
           if (isInsertMode(editorStoreRef.current.editor.mode)) {

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import ReactDOM from 'react-dom'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { uniqBy } from '../../../../core/shared/array-utils'
 import type { ElementInstanceMetadataMap } from '../../../../core/shared/element-template'
@@ -58,6 +59,7 @@ import { getAllLockedElementPaths } from '../../../../core/shared/element-lockin
 import { treatElementAsGroupLike } from '../../canvas-strategies/strategies/group-helpers'
 import { useCommentModeSelectAndHover } from '../comment-mode/comment-mode-hooks'
 import { useFollowModeSelectAndHover } from '../follow-mode/follow-mode-hooks'
+import { wait } from '../../../../core/model/performance-scripts'
 
 export function isDragInteractionActive(editorState: EditorState): boolean {
   return editorState.canvas.interactionSession?.interactionData.type === 'DRAG'
@@ -640,7 +642,7 @@ function useSelectOrLiveModeSelectAndHover(
     [innerOnMouseMove, editorStoreRef],
   )
   const mouseHandler = React.useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
+    async (event: React.MouseEvent<HTMLDivElement>) => {
       const isLeftClick = event.button === 0
       const isRightClick = event.type === 'contextmenu' && event.detail === 0
       const isCanvasPanIntention =
@@ -774,7 +776,12 @@ function useSelectOrLiveModeSelectAndHover(
 
         if (!foundTargetIsSelected) {
           // first we only set the selected views for the canvas controls
-          setSelectedViewsForCanvasControlsOnly(updatedSelection)
+          ReactDOM.flushSync(() => {
+            setSelectedViewsForCanvasControlsOnly(updatedSelection)
+          })
+
+          await new Promise((resolve) => requestAnimationFrame(resolve))
+          await new Promise((resolve) => requestAnimationFrame(resolve))
 
           // In either case cancel insert mode.
           if (isInsertMode(editorStoreRef.current.editor.mode)) {

--- a/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
+++ b/editor/src/components/canvas/controls/select-mode/select-mode-hooks.tsx
@@ -61,6 +61,7 @@ import { useCommentModeSelectAndHover } from '../comment-mode/comment-mode-hooks
 import { useFollowModeSelectAndHover } from '../follow-mode/follow-mode-hooks'
 import { wait } from '../../../../core/model/performance-scripts'
 import { IS_TEST_ENVIRONMENT } from '../../../../common/env-vars'
+import { isFeatureEnabled } from '../../../../utils/feature-switches'
 
 export function isDragInteractionActive(editorState: EditorState): boolean {
   return editorState.canvas.interactionSession?.interactionData.type === 'DRAG'
@@ -781,7 +782,11 @@ function useSelectOrLiveModeSelectAndHover(
             setSelectedViewsForCanvasControlsOnly(updatedSelection)
           })
 
-          if (event.detail === 1 && !IS_TEST_ENVIRONMENT) {
+          if (
+            event.detail === 1 &&
+            !IS_TEST_ENVIRONMENT &&
+            isFeatureEnabled('Canvas Fast Selection Hack')
+          ) {
             // If event.detail is 1 that means this is a first click, where it is safe to delay dispatching actions
             // to allow the localSelectedViews to be updated.
             // For subsequent clicks, we want to dispatch immediately to avoid the event handler clashing with the focus system and the strategy event handlers

--- a/editor/src/components/canvas/event-helpers.test-utils.tsx
+++ b/editor/src/components/canvas/event-helpers.test-utils.tsx
@@ -56,6 +56,8 @@ export async function mouseDownAtPoint(
       }),
     )
   })
+
+  await new Promise((resolve) => requestAnimationFrame(resolve))
 }
 
 export async function mouseMoveToPoint(
@@ -428,6 +430,7 @@ export async function mouseClickAtPoint(
       }),
     )
   })
+  await new Promise((resolve) => requestAnimationFrame(resolve))
 }
 
 const isRealBrowser =
@@ -726,6 +729,8 @@ export async function mouseDoubleClickAtPoint(
       }),
     )
   })
+
+  await new Promise((resolve) => requestAnimationFrame(resolve))
 }
 
 export function keyDown(

--- a/editor/src/components/canvas/event-helpers.test-utils.tsx
+++ b/editor/src/components/canvas/event-helpers.test-utils.tsx
@@ -56,8 +56,6 @@ export async function mouseDownAtPoint(
       }),
     )
   })
-
-  await new Promise((resolve) => requestAnimationFrame(resolve))
 }
 
 export async function mouseMoveToPoint(
@@ -430,7 +428,6 @@ export async function mouseClickAtPoint(
       }),
     )
   })
-  await new Promise((resolve) => requestAnimationFrame(resolve))
 }
 
 const isRealBrowser =
@@ -729,8 +726,6 @@ export async function mouseDoubleClickAtPoint(
       }),
     )
   })
-
-  await new Promise((resolve) => requestAnimationFrame(resolve))
 }
 
 export function keyDown(

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -1445,6 +1445,9 @@ export type DispatchPriority =
   | 'topmenu'
   | 'contextmenu'
   | 'noone'
+  | 'canvas-fast-selection-hack'
+  | 'resume-canvas-fast-selection-hack'
+
 export type EditorDispatch = (
   actions: ReadonlyArray<EditorAction>,
   priority?: DispatchPriority,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -5765,7 +5765,11 @@ export const UPDATE_FNS = {
     editor: EditorModel,
     builtInDependencies: BuiltInDependencies,
   ): EditorModel => {
-    const canvasState = pickCanvasStateFromEditorState(editor, builtInDependencies)
+    const canvasState = pickCanvasStateFromEditorState(
+      editor.selectedViews,
+      editor,
+      builtInDependencies,
+    )
     if (areAllSelectedElementsNonAbsolute(action.targets, editor.jsxMetadata)) {
       const commands = getEscapeHatchCommands(
         action.targets,

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -77,6 +77,7 @@ export function interactionFinished(
       newEditorState.elementPathTree,
   )
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
+    newEditorState.selectedViews,
     newEditorState,
     result.builtInDependencies,
   )
@@ -153,6 +154,7 @@ export function interactionHardReset(
     startingMetadata: storedState.unpatchedEditor.jsxMetadata,
   }
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
+    newEditorState.selectedViews,
     newEditorState,
     result.builtInDependencies,
   )
@@ -238,6 +240,7 @@ export function interactionUpdate(
 ): HandleStrategiesResult {
   const newEditorState = result.unpatchedEditor
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
+    newEditorState.selectedViews,
     newEditorState,
     result.builtInDependencies,
   )
@@ -320,6 +323,7 @@ export function interactionStart(
       newEditorState.elementPathTree,
   )
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
+    newEditorState.selectedViews,
     newEditorState,
     result.builtInDependencies,
   )
@@ -428,6 +432,7 @@ function handleUserChangedStrategy(
   sortedApplicableStrategies: Array<ApplicableStrategy>,
 ): HandleStrategiesResult {
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
+    newEditorState.selectedViews,
     newEditorState,
     builtInDependencies,
   )
@@ -505,6 +510,7 @@ function handleAccumulatingKeypresses(
   sortedApplicableStrategies: Array<ApplicableStrategy>,
 ): HandleStrategiesResult {
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
+    newEditorState.selectedViews,
     newEditorState,
     builtInDependencies,
   )
@@ -587,6 +593,7 @@ function handleUpdate(
   sortedApplicableStrategies: Array<ApplicableStrategy>,
 ): HandleStrategiesResult {
   const canvasState: InteractionCanvasState = pickCanvasStateFromEditorState(
+    newEditorState.selectedViews,
     newEditorState,
     builtInDependencies,
   )

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -428,12 +428,24 @@ export class Editor {
     )
   }
 
+  // This is used to temporarily disable updates to the store, for example when we are in the middle of a fast selection hack
+  temporarilyDisableStoreUpdates = false
+
   boundDispatch = (
     dispatchedActions: readonly EditorAction[],
     priority?: DispatchPriority,
   ): {
     entireUpdateFinished: Promise<any>
   } => {
+    if (
+      priority === 'canvas-fast-selection-hack' &&
+      isFeatureEnabled('Canvas Fast Selection Hack')
+    ) {
+      this.temporarilyDisableStoreUpdates = true
+    } else if (priority === 'resume-canvas-fast-selection-hack') {
+      this.temporarilyDisableStoreUpdates = false
+    }
+
     resetDomSamplerExecutionCounts()
     const Measure = createPerformanceMeasure()
     Measure.logActions(dispatchedActions)
@@ -467,7 +479,8 @@ export class Editor {
 
       const shouldUpdateCanvasStore =
         !dispatchResult.nothingChanged &&
-        !anyCodeAhead(dispatchResult.unpatchedEditor.projectContents)
+        !anyCodeAhead(dispatchResult.unpatchedEditor.projectContents) &&
+        !this.temporarilyDisableStoreUpdates
 
       const updateId = canvasUpdateId++
       if (shouldUpdateCanvasStore) {
@@ -486,7 +499,9 @@ export class Editor {
         })
       }
 
-      const runDomWalker = shouldRunDOMWalker(dispatchedActions, oldEditorState, this.storedState)
+      const runDomWalker =
+        shouldRunDOMWalker(dispatchedActions, oldEditorState, this.storedState) &&
+        !this.temporarilyDisableStoreUpdates
 
       // run the dom-walker
       if (runDomWalker) {
@@ -607,7 +622,8 @@ export class Editor {
               shouldUpdateLowPriorityUI(
                 this.storedState.strategyState,
                 ElementsToRerenderGLOBAL.current,
-              )
+              ) &&
+              !this.temporarilyDisableStoreUpdates
             ) {
               Measure.taskTime(`Update Low Prio Store ${updateId}`, () => {
                 this.lowPriorityStore.setState(

--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -15,6 +15,7 @@ export type FeatureName =
   | 'Debug - Print UIDs'
   | 'Debug – Connections'
   | 'Condensed Navigator Entries'
+  | 'Canvas Fast Selection Hack'
   | 'Roll Your Own'
 
 export const AllFeatureNames: FeatureName[] = [
@@ -31,6 +32,7 @@ export const AllFeatureNames: FeatureName[] = [
   'Debug - Print UIDs',
   'Debug – Connections',
   'Condensed Navigator Entries',
+  'Canvas Fast Selection Hack',
   'Roll Your Own',
 ]
 
@@ -47,6 +49,7 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Debug - Print UIDs': false,
   'Debug – Connections': false,
   'Condensed Navigator Entries': !IS_TEST_ENVIRONMENT,
+  'Canvas Fast Selection Hack': true,
   'Roll Your Own': false,
 }
 


### PR DESCRIPTION
**Problem:**

Selection change can be upwards of 100ms, in a large enough project it may reach half a second. This is because almost all parts of the Editor UI use EditorState.selectedViews as a main part of their state, which means changing the selected elements triggers a re-render of all of the editor. For historical reasons, we also use this as an opportunity to re-render and re-measure the canvas, correcting all metadata that may be stale because of partial updates during interactions. 

**Fix:**
The idea is that instead of speeding up the actual rerender, we make the selection outline change first in a fast frame, then run the expensive editor UI update in the next frame. Turns out that _perceptually_ this is the desired behavior: the user looks at where the mouse is, they see a very responsive UI change, and after having clicked with the mouse, we have a 200-300ms deadzone of user perception before that can click or move the mouse again. We fill that space with the expensive state update, by the time the user moves their mouse or clicks again, the editor is ready again to handle events responsively. 

**Commit details**
- Adding `temporarilyDisableStoreUpdates` to `editor.tsx`
- Adding 'canvas-fast-selection-hack' and 'resume-canvas-fast-selection-hack' to the dispatch function's "priority" parameter, which toggles `temporarilyDisableStoreUpdates` to true or false.
- `mouseHandler` in `select-mode-hooks.tsx` dispatches 'canvas-fast-selection-hack' and then TWO animatonFrames later, a 'resume-canvas-fast-selection-hack'.
- Some selectors and hooks, most notably `useGetApplicableStrategyControls` get a separate selectedViews field, instead of using EditorState.selectedViews (which may be stale). This selectedViews parameter is fed from localSelectedViews which is updated sooner than the zustand editor store is. this is what enables the canvas controls to draw the changed controls immediately while the rest of the editor UI is temporarily one frame behind.

**Notes:**
- The tests DO NOT use the `temporarilyDisableStoreUpdates` system, because the test's fake mouse helper events we dispatch are all fired in a single animation frame (unlike Chrome's real mouse events). Changing all this felt like too invasive for little benefit. 
- IF we find event listeners that fire out of order or with stale state, we can create a fourth Zustand store, and delete the canvas controls localSelectedViews / localHighlightedViews. this fourth zustand store would be immediately updated, and select important parts of the UI could subscribe to it to get instant updates of the selection change.