### PR TITLE
Use stretch instead of fill for grid children

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/absolute-resize-control.tsx
@@ -398,6 +398,8 @@ const sizeLabel = (state: FixedHugFill['type'], actualSize: number): string => {
     case 'detected':
     case 'computed':
       return `${actualSize}`
+    case 'stretch':
+      return 'Stretch'
     default:
       assertNever(state)
   }

--- a/editor/src/components/inspector/fill-hug-fixed-control.tsx
+++ b/editor/src/components/inspector/fill-hug-fixed-control.tsx
@@ -80,6 +80,7 @@ export const CollapsedLabel = 'Collapsed' as const
 export const HugGroupContentsLabel = 'Hug' as const
 export const ComputedLabel = 'Computed' as const
 export const DetectedLabel = 'Detected' as const
+export const StretchLabel = 'Stretch' as const
 
 export function selectOptionLabel(mode: FixedHugFillMode): string {
   switch (mode) {
@@ -101,6 +102,8 @@ export function selectOptionLabel(mode: FixedHugFillMode): string {
       return ComputedLabel
     case 'detected':
       return DetectedLabel
+    case 'stretch':
+      return StretchLabel
     default:
       assertNever(mode)
   }
@@ -126,6 +129,8 @@ export function selectOptionIconType(
       return `fixed-${dimension}`
     case 'detected':
       return `fixed-${dimension}`
+    case 'stretch':
+      return `fill-${dimension}`
     default:
       assertNever(mode)
   }
@@ -396,6 +401,7 @@ function strategyForChangingFillFixedHugType(
 ): Array<InspectorStrategy> {
   switch (mode) {
     case 'fill':
+    case 'stretch':
       return setPropFillStrategies(metadata, selectedElements, axis, 'default', otherAxisSetToFill)
     case 'hug':
     case 'squeeze':
@@ -427,6 +433,7 @@ function pickFixedValue(value: FixedHugFill): CSSNumber | undefined {
     case 'fill':
     case 'hug-group':
       return value.value
+    case 'stretch':
     case 'hug':
     case 'squeeze':
     case 'collapsed':

--- a/editor/src/components/inspector/inspector-strategies/fixed-size-basic-strategy.ts
+++ b/editor/src/components/inspector/inspector-strategies/fixed-size-basic-strategy.ts
@@ -7,7 +7,11 @@ import {
 } from '../../canvas/commands/set-css-length-command'
 import type { CSSNumber } from '../common/css-utils'
 import type { Axis } from '../inspector-common'
-import { removeExtraPinsWhenSettingSize, widthHeightFromAxis } from '../inspector-common'
+import {
+  removeAlignJustifySelf,
+  removeExtraPinsWhenSettingSize,
+  widthHeightFromAxis,
+} from '../inspector-common'
 import type { InspectorStrategy } from './inspector-strategy'
 import { queueTrueUpElement } from '../../canvas/commands/queue-true-up-command'
 import {
@@ -48,6 +52,7 @@ export const fixedSizeBasicStrategy = (
 
       return [
         ...removeExtraPinsWhenSettingSize(axis, elementMetadata),
+        ...removeAlignJustifySelf(axis, elementMetadata),
         setCssLengthProperty(
           whenToRun,
           path,

--- a/editor/src/components/inspector/inspector-strategies/inspector-strategies.ts
+++ b/editor/src/components/inspector/inspector-strategies/inspector-strategies.ts
@@ -26,6 +26,7 @@ import {
 import {
   fillContainerStrategyFlexParent,
   fillContainerStrategyFlow,
+  fillContainerStrategyGridParent,
 } from './fill-container-basic-strategy'
 import { setSpacingModePacked, setSpacingModeSpaceBetween } from './spacing-mode-strategies'
 import { convertLayoutToFlexCommands } from '../../common/shared-strategies/convert-to-flex-strategy'
@@ -226,6 +227,7 @@ export const setPropFillStrategies = (
   value: 'default' | number,
   otherAxisSetToFill: boolean,
 ): Array<InspectorStrategy> => [
+  fillContainerStrategyGridParent(metadata, elementPaths, axis),
   fillContainerStrategyFlexParent(metadata, elementPaths, axis, value),
   fillContainerStrategyFlow(metadata, elementPaths, axis, value, otherAxisSetToFill),
 ]


### PR DESCRIPTION
**Problem:**

The inspector should show `Stretch` instead of `Fill` for grid children, and set `alignSelf`/`justifySelf` in those cases.

**Fix:**

1. Set `alignSelf`/`justifySelf` to `stretch` if `Stretch` is selected in the inspector dropdown for grid children
2. Show `Stretch` instead of `Fill` for label for grid children (note: I opted for just changing the label here instead of having a different strategy altogether, since in my mind it's still fulfilling the goal of "filling" the parent – but lmk if this is the wrong take)

Fixes #6423 
