### PR TITLE
Hide crowded grid resize controls

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -1566,7 +1566,7 @@ export const GridResizeControls = controlForStrategyMemoized<GridResizeControlPr
     const element = useEditorState(
       Substores.metadata,
       (store) => MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, target),
-      'GridCellResizeControls element',
+      'GridResizeControls element',
     )
 
     const dispatch = useDispatch()
@@ -1574,7 +1574,7 @@ export const GridResizeControls = controlForStrategyMemoized<GridResizeControlPr
     const scale = useEditorState(
       Substores.canvas,
       (store) => store.editor.canvas.scale,
-      'GridCellResizeControls scale',
+      'GridResizeControls scale',
     )
 
     const resizeControlRef = useRefEditorState((store) =>


### PR DESCRIPTION
**Problem:**

Grid resize controls should be hidden when they get too crowded, for example when zooming out.

<img width="299" alt="Screenshot 2024-09-30 at 17 32 08" src="https://github.com/user-attachments/assets/13c8354d-1080-41d0-9cf5-9cc4f915dfbb">

**Fix:**

Hide the controls for an axis if any of the control areas would become smaller than the control size.

Fixes #6429 
