### PR TITLE
Clamp minimum gap for flex/grid elements

### DIFF
--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -888,6 +888,7 @@ const GapRowColumnControl = React.memo(() => {
             value={columnGap.value}
             numberType={'Length'}
             minimum={0}
+            clampOnSubmitValue={true}
             onSubmitValue={onSubmitUnifiedValue}
             onTransientSubmitValue={onSubmitUnifiedValue}
             onForcedSubmitValue={onSubmitUnifiedValue}
@@ -905,6 +906,7 @@ const GapRowColumnControl = React.memo(() => {
             value={columnGap.value}
             numberType={'Length'}
             minimum={0}
+            clampOnSubmitValue={true}
             onSubmitValue={onSubmitSplitValue('columnGap')}
             onTransientSubmitValue={onSubmitSplitValue('columnGap')}
             onForcedSubmitValue={onSubmitSplitValue('columnGap')}
@@ -919,6 +921,7 @@ const GapRowColumnControl = React.memo(() => {
             value={rowGap.value}
             numberType={'Length'}
             minimum={0}
+            clampOnSubmitValue={true}
             onSubmitValue={onSubmitSplitValue('rowGap')}
             onTransientSubmitValue={onSubmitSplitValue('rowGap')}
             onForcedSubmitValue={onSubmitSplitValue('rowGap')}

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -887,6 +887,7 @@ const GapRowColumnControl = React.memo(() => {
           <NumberInput
             value={columnGap.value}
             numberType={'Length'}
+            minimum={0}
             onSubmitValue={onSubmitUnifiedValue}
             onTransientSubmitValue={onSubmitUnifiedValue}
             onForcedSubmitValue={onSubmitUnifiedValue}
@@ -903,6 +904,7 @@ const GapRowColumnControl = React.memo(() => {
           <NumberInput
             value={columnGap.value}
             numberType={'Length'}
+            minimum={0}
             onSubmitValue={onSubmitSplitValue('columnGap')}
             onTransientSubmitValue={onSubmitSplitValue('columnGap')}
             onForcedSubmitValue={onSubmitSplitValue('columnGap')}
@@ -916,6 +918,7 @@ const GapRowColumnControl = React.memo(() => {
           <NumberInput
             value={rowGap.value}
             numberType={'Length'}
+            minimum={0}
             onSubmitValue={onSubmitSplitValue('rowGap')}
             onTransientSubmitValue={onSubmitSplitValue('rowGap')}
             onForcedSubmitValue={onSubmitSplitValue('rowGap')}

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
@@ -328,6 +328,7 @@ export const FlexGapControl = React.memo(() => {
           testId='flex.container.gap'
           key='flex.container.gap'
           value={value}
+          minimum={0}
           onSubmitValue={wrappedOnSubmitValue}
           onTransientSubmitValue={wrappedOnTransientSubmitValue}
           onForcedSubmitValue={wrappedOnSubmitValue}

--- a/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
+++ b/editor/src/components/inspector/sections/layout-section/flex-container-subsection/flex-container-controls.tsx
@@ -329,6 +329,7 @@ export const FlexGapControl = React.memo(() => {
           key='flex.container.gap'
           value={value}
           minimum={0}
+          clampOnSubmitValue={true}
           onSubmitValue={wrappedOnSubmitValue}
           onTransientSubmitValue={wrappedOnTransientSubmitValue}
           onForcedSubmitValue={wrappedOnSubmitValue}

--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -140,6 +140,7 @@ export interface NumberInputOptions {
   pasteHandler?: boolean
   descriptionLabel?: string
   disableScrubbing?: boolean
+  clampOnSubmitValue?: boolean
 }
 
 export interface AbstractNumberInputProps<T extends CSSNumber | number>
@@ -189,6 +190,7 @@ export const NumberInput = React.memo<NumberInputProps>(
     invalid,
     pasteHandler,
     disableScrubbing = false,
+    clampOnSubmitValue,
   }) => {
     const ref = React.useRef<HTMLInputElement>(null)
     const colorTheme = useColorTheme()
@@ -510,11 +512,12 @@ export const NumberInput = React.memo<NumberInputProps>(
           if (isLeft(parsed)) {
             return unknownInputValue(displayValue)
           }
-          const clamped = {
-            ...parsed.value,
-            value: clampValue(parsed.value.value, minimum, maximum),
-          }
-          return clamped
+          return clampOnSubmitValue
+            ? {
+                ...parsed.value,
+                value: clampValue(parsed.value.value, minimum, maximum),
+              }
+            : parsed.value
         }
 
         const newValue = getNewValue()
@@ -545,6 +548,7 @@ export const NumberInput = React.memo<NumberInputProps>(
         displayValue,
         minimum,
         maximum,
+        clampOnSubmitValue,
       ],
     )
 

--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -36,11 +36,10 @@ import type {
 } from '../../components/inspector/controls/control'
 import type { Either } from '../../core/shared/either'
 import { isLeft, mapEither } from '../../core/shared/either'
-import { clampValue, point } from '../../core/shared/math-utils'
+import { clampValue } from '../../core/shared/math-utils'
 import { memoize } from '../../core/shared/memoize'
 import type { ControlStyles } from '../../uuiui-deps'
 import { getControlStyles, CSSCursor } from '../../uuiui-deps'
-import type { IcnProps } from '../icn'
 import { Icn } from '../icn'
 import { useColorTheme, UtopiaTheme } from '../styles/theme'
 import { FlexRow } from '../widgets/layout/flex-row'
@@ -511,7 +510,11 @@ export const NumberInput = React.memo<NumberInputProps>(
           if (isLeft(parsed)) {
             return unknownInputValue(displayValue)
           }
-          return parsed.value
+          const clamped = {
+            ...parsed.value,
+            value: clampValue(parsed.value.value, minimum, maximum),
+          }
+          return clamped
         }
 
         const newValue = getNewValue()
@@ -540,6 +543,8 @@ export const NumberInput = React.memo<NumberInputProps>(
         updateValue,
         value,
         displayValue,
+        minimum,
+        maximum,
       ],
     )
 


### PR DESCRIPTION
**Problem:**

The grid and flex gap inspector controls can go negative, either by scrubbing as well as direct input.

**Fix:**

1. Add `minimum={0}` to those number inputs so the scrubbing cannot go lower than 0
2. Clamp the value calculated in the number input so it stays between the min/max bounds.

Fixes #6440 