### PR TITLE
Specify elements to rerender in grid strategies

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
@@ -259,10 +259,7 @@ const gridDrawToInsertStrategyInner =
                 : null,
             ]),
           ],
-          // FIXME: This was added as a default value in https://github.com/concrete-utopia/utopia/pull/6408
-          // This was to maintain the existing behaviour, but it should be replaced with a more specific value
-          // appropriate to this particular case.
-          'rerender-all-elements',
+          [targetParent],
           {
             strategyGeneratedUidsCache: {
               [insertionSubject.uid]: maybeWrapperWithUid?.uid,

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-keyboard-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-keyboard-strategy.ts
@@ -133,10 +133,7 @@ export function gridRearrangeResizeKeyboardStrategy(
           gridRowStart,
           gridRowEnd,
         }),
-        // FIXME: This was added as a default value in https://github.com/concrete-utopia/utopia/pull/6408
-        // This was to maintain the existing behaviour, but it should be replaced with a more specific value
-        // appropriate to this particular case.
-        'rerender-all-elements',
+        [parentGridPath],
       )
     },
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
@@ -155,10 +155,7 @@ export const gridRearrangeMoveStrategy: CanvasStrategyFactory = (
 
       return strategyApplicationResult(
         [...midInteractionCommands, ...onCompleteCommands, ...commands],
-        // FIXME: This was added as a default value in https://github.com/concrete-utopia/utopia/pull/6408
-        // This was to maintain the existing behaviour, but it should be replaced with a more specific value
-        // appropriate to this particular case.
-        'rerender-all-elements',
+        [parentGridPath],
         patch,
       )
     },

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -138,10 +138,7 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
 
       return strategyApplicationResult(
         setGridPropsCommands(selectedElement, gridTemplate, gridPropsWithDragOver(gridProps)),
-        // FIXME: This was added as a default value in https://github.com/concrete-utopia/utopia/pull/6408
-        // This was to maintain the existing behaviour, but it should be replaced with a more specific value
-        // appropriate to this particular case.
-        'rerender-all-elements',
+        [parentGridPath],
         {
           grid: { ...customState.grid, targetCellData: targetCell },
         },

--- a/editor/src/components/canvas/canvas-strategies/strategies/rearrange-grid-swap-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/rearrange-grid-swap-strategy.ts
@@ -121,13 +121,7 @@ export const rearrangeGridSwapStrategy: CanvasStrategyFactory = (
         return emptyStrategyApplicationResult
       }
 
-      return strategyApplicationResult(
-        commands,
-        // FIXME: This was added as a default value in https://github.com/concrete-utopia/utopia/pull/6408
-        // This was to maintain the existing behaviour, but it should be replaced with a more specific value
-        // appropriate to this particular case.
-        'rerender-all-elements',
-      )
+      return strategyApplicationResult(commands, [EP.parentPath(selectedElement)])
     },
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.ts
@@ -118,10 +118,7 @@ export const resizeGridStrategy: CanvasStrategyFactory = (
       }
 
       if (!canResizeGridTemplate(originalValues)) {
-        return strategyApplicationResult(
-          [setCursorCommand(CSSCursor.NotPermitted)],
-          'rerender-all-elements',
-        )
+        return strategyApplicationResult([setCursorCommand(CSSCursor.NotPermitted)], [])
       }
 
       const expandedOriginalValues = expandGridDimensions(originalValues.dimensions)

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
@@ -173,10 +173,7 @@ export const setGridGapStrategy: CanvasStrategyFactory = (
       if (shouldTearOffGapByAxis) {
         return strategyApplicationResult(
           [deleteProperties('always', selectedElement, [axisStyleProp])],
-          // FIXME: This was added as a default value in https://github.com/concrete-utopia/utopia/pull/6408
-          // This was to maintain the existing behaviour, but it should be replaced with a more specific value
-          // appropriate to this particular case.
-          'rerender-all-elements',
+          selectedElements,
         )
       }
 


### PR DESCRIPTION
## Problem
The grid strategies opt to rerender all elements in their strategy result, which is adds a performance penalty.

## Fix
Only re-render the elements affected by a given strategy