### PR TITLE
Scale Placeholder Borders

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -641,7 +641,11 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
   const features = useRollYourOwnFeatures()
 
   const canvasOffsetRef = useRefEditorState((store) => store.editor.canvas.roundedCanvasOffset)
-  const scaleRef = useRefEditorState((store) => store.editor.canvas.scale)
+  const scale = useEditorState(
+    Substores.canvas,
+    (store) => store.editor.canvas.scale,
+    'GridControls scale',
+  )
   const metadataRef = useRefEditorState((store) => store.editor.jsxMetadata)
 
   const activelyDraggingOrResizingCell = useEditorState(
@@ -811,7 +815,7 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
         setInitialShadowFrame(params.frame)
 
         const start = windowToCanvasCoordinates(
-          scaleRef.current,
+          scale,
           canvasOffsetRef.current,
           windowPoint({ x: event.nativeEvent.x, y: event.nativeEvent.y }),
         )
@@ -827,7 +831,7 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
           ),
         ])
       },
-    [canvasOffsetRef, dispatch, scaleRef],
+    [canvasOffsetRef, dispatch, scale],
   )
 
   // NOTE: this stuff is meant to be temporary, until we settle on the set of interaction pieces we like.
@@ -975,19 +979,19 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
                     id={id}
                     data-testid={id}
                     style={{
-                      borderTop: gridPlaceholderBorder(borderColor),
-                      borderLeft: gridPlaceholderBorder(borderColor),
+                      borderTop: gridPlaceholderBorder(borderColor, scale),
+                      borderLeft: gridPlaceholderBorder(borderColor, scale),
                       borderBottom:
                         isActiveCell ||
                         countedRow >= grid.rows ||
                         (grid.rowGap != null && grid.rowGap > 0)
-                          ? gridPlaceholderBorder(borderColor)
+                          ? gridPlaceholderBorder(borderColor, scale)
                           : undefined,
                       borderRight:
                         isActiveCell ||
                         countedColumn >= grid.columns ||
                         (grid.columnGap != null && grid.columnGap > 0)
-                          ? gridPlaceholderBorder(borderColor)
+                          ? gridPlaceholderBorder(borderColor, scale)
                           : undefined,
                       position: 'relative',
                       pointerEvents: 'initial',
@@ -1794,7 +1798,7 @@ function gridKeyFromPath(path: ElementPath): string {
   return `grid-${EP.toString(path)}`
 }
 
-const gridPlaceholderBorder = (color: string) => `2px solid ${color}`
+const gridPlaceholderBorder = (color: string, scale: number) => `${2 / scale}px solid ${color}`
 
 export function controlsForGridPlaceholders(gridPath: ElementPath): ControlWithProps<any> {
   return {


### PR DESCRIPTION
**Problem:**
The placeholder border controls around elements in a grid get scaled with the canvas and they shouldn't be.

**Fix:**
Apply our regular canvas scale value to the border width of the placeholder border controls.

**Commit Details:**
- Change `gridPlaceholderBorder` to take a value for scale.
- Change `scaleRef` to be a regular `scale` value in `GridControls` as it needs to be passed to `gridPlaceholderBorder` all the time.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode