### PR TITLE
Specify elements to rerender in keyboard & gap strategies

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-size-strategy.tsx
@@ -79,7 +79,7 @@ export function keyboardSetFontSizeStrategy(
         ),
       )
 
-      return strategyApplicationResult(commands, 'rerender-all-elements')
+      return strategyApplicationResult(commands, validTargets)
     },
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-font-weight-strategy.tsx
@@ -87,13 +87,7 @@ export function keyboardSetFontWeightStrategy(
         ),
       )
 
-      return strategyApplicationResult(
-        commands,
-        // FIXME: This was added as a default value in https://github.com/concrete-utopia/utopia/pull/6408
-        // This was to maintain the existing behaviour, but it should be replaced with a more specific value
-        // appropriate to this particular case.
-        'rerender-all-elements',
-      )
+      return strategyApplicationResult(commands, validTargets)
     },
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/keyboard-set-opacity-strategy.tsx
@@ -57,13 +57,7 @@ export function keyboardSetOpacityStrategy(
         setProperty('always', path, PP.create('style', 'opacity'), inputValue),
       )
 
-      return strategyApplicationResult(
-        commands,
-        // FIXME: This was added as a default value in https://github.com/concrete-utopia/utopia/pull/6408
-        // This was to maintain the existing behaviour, but it should be replaced with a more specific value
-        // appropriate to this particular case.
-        'rerender-all-elements',
-      )
+      return strategyApplicationResult(commands, selectedElements)
     },
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
@@ -174,10 +174,7 @@ export const setFlexGapStrategy: CanvasStrategyFactory = (
       if (shouldTearOffGap) {
         return strategyApplicationResult(
           [deleteProperties('always', selectedElement, [StyleGapProp])],
-          // FIXME: This was added as a default value in https://github.com/concrete-utopia/utopia/pull/6408
-          // This was to maintain the existing behaviour, but it should be replaced with a more specific value
-          // appropriate to this particular case.
-          'rerender-all-elements',
+          selectedElements,
         )
       }
 
@@ -200,7 +197,7 @@ export const setFlexGapStrategy: CanvasStrategyFactory = (
             },
           ]),
         ],
-        [...selectedElements, ...children.map((c) => c.elementPath)],
+        selectedElements,
       )
     },
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
@@ -196,7 +196,7 @@ export const setGridGapStrategy: CanvasStrategyFactory = (
             },
           ]),
         ],
-        [...selectedElements, ...children.map((c) => c.elementPath)],
+        selectedElements,
       )
     },
   }


### PR DESCRIPTION
## Problem
The keyboard font strategies and the gap setter strategies don't correctly declare the elements to rerender in the strategy application result

## Fix
Fill it in with the correct element path array

