### PR TITLE
Hide grid resize handles on both sides when too crowded

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -405,12 +405,6 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
     })
   }, [props.fromPropsAxisValues, resizingIndex])
 
-  const scale = useEditorState(
-    Substores.canvas,
-    (store) => store.editor.canvas.scale,
-    'GridResizing scale',
-  )
-
   if (props.axisValues == null) {
     return null
   }
@@ -418,11 +412,6 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
     case 'DIMENSIONS':
       const size = GRID_RESIZE_HANDLE_CONTAINER_SIZE / canvasScale
       const dimensions = props.axisValues.dimensions
-
-      const hideControls = dimensions.some((dim) => {
-        const scaledSize = (dim.type === 'NUMBER' ? dim.value.value : 0) * scale
-        return scaledSize < GRID_RESIZE_HANDLE_SIZE
-      })
 
       return (
         <div
@@ -448,7 +437,6 @@ export const GridResizing = React.memo((props: GridResizingProps) => {
                 : undefined,
             paddingTop:
               props.axis === 'row' && props.padding != null ? `${props.padding.top}px` : undefined,
-            visibility: hideControls ? 'hidden' : 'visible',
           }}
         >
           {dimensions.flatMap((dimension, dimensionIndex) => {
@@ -594,9 +582,46 @@ export const GridRowColumnResizingControls =
       }, 0)
     }
 
+    const scale = useEditorState(
+      Substores.canvas,
+      (store) => store.editor.canvas.scale,
+      'GridRowColumnResizingControls scale',
+    )
+
+    const gridsWithVisibleResizeControls = React.useMemo(() => {
+      return grids.filter((grid) => {
+        if (
+          grid.gridTemplateColumns?.type !== 'DIMENSIONS' ||
+          grid.gridTemplateRows?.type !== 'DIMENSIONS'
+        ) {
+          return false
+        }
+
+        // returns whether the rendered dimensions are too crowded, as in there are two cols/rows that are closer than the handle sizes
+        function tooCrowded(dimensions: GridDimension[]): boolean {
+          const visualSizes = dimensions.map(
+            (dim) => (dim.type === 'NUMBER' ? dim.value.value : 0) * scale,
+          )
+          for (let i = 0; i < visualSizes.length - 1; i++) {
+            const curr = visualSizes[i]
+            const next = visualSizes[i + 1]
+            if (curr + next < GRID_RESIZE_HANDLE_SIZE * 2) {
+              return true
+            }
+          }
+          return false
+        }
+
+        return (
+          !tooCrowded(grid.gridTemplateColumns.dimensions) &&
+          !tooCrowded(grid.gridTemplateRows.dimensions)
+        )
+      })
+    }, [scale, grids])
+
     return (
       <CanvasOffsetWrapper>
-        {grids.flatMap((grid) => {
+        {gridsWithVisibleResizeControls.flatMap((grid) => {
           return (
             <GridResizing
               key={`grid-resizing-column-${EP.toString(grid.elementPath)}`}
@@ -610,7 +635,7 @@ export const GridRowColumnResizingControls =
             />
           )
         })}
-        {grids.flatMap((grid) => {
+        {gridsWithVisibleResizeControls.flatMap((grid) => {
           return (
             <GridResizing
               key={`grid-resizing-row-${EP.toString(grid.elementPath)}`}


### PR DESCRIPTION
**Problem:**

If even one side of a grid is too crowded for resize controls, hide the controls on the other side as well.

**Fix:**

1. Move the check for crowdedness to cover both axii
2. Ensure that the crowdedness check works fine with very narrow cols/rows (shorter than the resize handle) but there is still room enough to display the handles


https://github.com/user-attachments/assets/52e81327-b159-413a-b74c-34fd554a6e29



Fixes #6447 
