### PR TITLE
Better grid resize element strategy

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
@@ -132,12 +132,13 @@ const gridDrawToInsertStrategyInner =
       canvasState.propertyControlsInfo,
     )?.newParent.intendedParentPath
 
-    const { metadata: parent, foundIn } = getMetadataWithGridCellBounds(
-      targetParent,
-      canvasState.startingMetadata,
-      interactionSession.latestMetadata,
-      customStrategyState,
-    )
+    const { metadata: parent, customStrategyState: updatedCustomState } =
+      getMetadataWithGridCellBounds(
+        targetParent,
+        canvasState.startingMetadata,
+        interactionSession.latestMetadata,
+        customStrategyState,
+      )
 
     if (targetParent == null || parent == null || !MetadataUtils.isGridLayoutedContainer(parent)) {
       return null
@@ -160,32 +161,17 @@ const gridDrawToInsertStrategyInner =
         const newTargetCell = getGridCellUnderMouseFromMetadata(parent, canvasPointToUse)
 
         if (strategyLifecycle === 'mid-interaction' && interactionData.type === 'HOVER') {
-          const customStatePatch =
-            foundIn === 'latestMetadata'
-              ? {
-                  ...customStrategyState,
-                  grid: {
-                    ...customStrategyState.grid,
-                    // this is added here during the hover interaction so that
-                    // `GridControls` can render the hover highlight based on the
-                    // coordinates in `targetCellData`
-                    targetCellData: newTargetCell ?? customStrategyState.grid.targetCellData,
-                    metadataCacheForGrids: {
-                      ...customStrategyState.grid.metadataCacheForGrids,
-                      [EP.toString(targetParent)]: parent,
-                    },
-                  },
-                }
-              : {
-                  ...customStrategyState,
-                  grid: {
-                    ...customStrategyState.grid,
-                    // this is added here during the hover interaction so that
-                    // `GridControls` can render the hover highlight based on the
-                    // coordinates in `targetCellData`
-                    targetCellData: newTargetCell ?? customStrategyState.grid.targetCellData,
-                  },
-                }
+          const baseCustomState = updatedCustomState ?? customStrategyState
+          const customStatePatch = {
+            ...baseCustomState,
+            grid: {
+              ...baseCustomState.grid,
+              // this is added here during the hover interaction so that
+              // `GridControls` can render the hover highlight based on the
+              // coordinates in `targetCellData`
+              targetCellData: newTargetCell ?? customStrategyState.grid.targetCellData,
+            },
+          }
           return strategyApplicationResult(
             [
               wildcardPatch('mid-interaction', {

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -770,12 +770,12 @@ export function getMetadataWithGridCellBounds(
   customStrategyState: CustomStrategyState,
 ): {
   metadata: ElementInstanceMetadata | null
-  foundIn: 'startingMetadata' | 'latestMetadata' | 'strategyState' | null
+  customStrategyState: CustomStrategyState | null
 } {
   if (path == null) {
     return {
       metadata: null,
-      foundIn: null,
+      customStrategyState: null,
     }
   }
 
@@ -784,7 +784,7 @@ export function getMetadataWithGridCellBounds(
   if (fromStartingMetadata?.specialSizeMeasurements.gridCellGlobalFrames != null) {
     return {
       metadata: fromStartingMetadata,
-      foundIn: 'startingMetadata',
+      customStrategyState: null,
     }
   }
 
@@ -792,7 +792,7 @@ export function getMetadataWithGridCellBounds(
   if (fromStrategyState != null) {
     return {
       metadata: fromStrategyState,
-      foundIn: 'strategyState',
+      customStrategyState: null,
     }
   }
 
@@ -800,12 +800,21 @@ export function getMetadataWithGridCellBounds(
   if (fromLatestMetadata?.specialSizeMeasurements.gridCellGlobalFrames != null) {
     return {
       metadata: fromLatestMetadata,
-      foundIn: 'latestMetadata',
+      customStrategyState: {
+        ...customStrategyState,
+        grid: {
+          ...customStrategyState.grid,
+          metadataCacheForGrids: {
+            ...customStrategyState.grid.metadataCacheForGrids,
+            [EP.toString(path)]: fromLatestMetadata,
+          },
+        },
+      },
     }
   }
 
   return {
     metadata: fromStartingMetadata,
-    foundIn: 'startingMetadata',
+    customStrategyState: null,
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategy.tsx
@@ -165,12 +165,13 @@ export function applyGridReparent(
           return emptyStrategyApplicationResult
         }
 
-        const { metadata: grid, foundIn } = getMetadataWithGridCellBounds(
-          newParent.intendedParentPath,
-          canvasState.startingMetadata,
-          interactionSession.latestMetadata,
-          customStrategyState,
-        )
+        const { metadata: grid, customStrategyState: updatedCustomState } =
+          getMetadataWithGridCellBounds(
+            newParent.intendedParentPath,
+            canvasState.startingMetadata,
+            interactionSession.latestMetadata,
+            customStrategyState,
+          )
 
         if (grid == null) {
           return emptyStrategyApplicationResult
@@ -241,26 +242,15 @@ export function applyGridReparent(
           ...selectedElements.map(EP.parentPath),
         ])
 
-        const customStrategyStatePatch =
-          foundIn === 'latestMetadata'
-            ? {
-                elementsToRerender: elementsToRerender,
-                grid: {
-                  ...customStrategyState.grid,
-                  targetCellData: targetCellData,
-                  metadataCacheForGrids: {
-                    ...customStrategyState.grid.metadataCacheForGrids,
-                    [EP.toString(newParent.intendedParentPath)]: grid,
-                  },
-                },
-              }
-            : {
-                elementsToRerender: elementsToRerender,
-                grid: {
-                  ...customStrategyState.grid,
-                  targetCellData: targetCellData,
-                },
-              }
+        const baseCustomState = updatedCustomState ?? customStrategyState
+        const customStrategyStatePatch = {
+          ...baseCustomState,
+          elementsToRerender: elementsToRerender,
+          grid: {
+            ...baseCustomState.grid,
+            targetCellData: targetCellData,
+          },
+        }
 
         return strategyApplicationResult(
           [

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
@@ -7,8 +7,14 @@ import type {
 } from 'utopia-shared/src/types'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
-import { getRectCenter, localRectangle } from '../../../../core/shared/math-utils'
-import { selectComponentsForTest } from '../../../../utils/utils.test-utils'
+import {
+  getRectCenter,
+  localPoint,
+  type LocalPoint,
+  localRectangle,
+  offsetPoint,
+} from '../../../../core/shared/math-utils'
+import { selectComponentsForTest, wait } from '../../../../utils/utils.test-utils'
 import { GridResizeEdgeTestId } from '../../controls/grid-controls'
 import { mouseDragFromPointToPoint } from '../../event-helpers.test-utils'
 import type { EditorRenderResult } from '../../ui-jsx.test-utils'
@@ -41,6 +47,34 @@ async function runCellResizeTest(
         height: targetGridCell.getBoundingClientRect().height,
       }),
     ),
+    {
+      moveBeforeMouseDown: true,
+    },
+  )
+}
+
+async function runCellResizeTestWithDragVector(
+  editor: EditorRenderResult,
+  edge: GridResizeEdge,
+  dragVector: LocalPoint,
+  elementPathToDrag: ElementPath = EP.fromString('sb/scene/grid/ddd'),
+) {
+  await selectComponentsForTest(editor, [elementPathToDrag])
+
+  const resizeControl = editor.renderedDOM.getByTestId(GridResizeEdgeTestId(edge))
+
+  const resizeControlCenter = getRectCenter(
+    localRectangle({
+      x: resizeControl.getBoundingClientRect().x,
+      y: resizeControl.getBoundingClientRect().y,
+      width: resizeControl.getBoundingClientRect().width,
+      height: resizeControl.getBoundingClientRect().height,
+    }),
+  )
+  await mouseDragFromPointToPoint(
+    resizeControl,
+    resizeControlCenter,
+    offsetPoint(resizeControlCenter, dragVector),
     {
       moveBeforeMouseDown: true,
     },
@@ -213,6 +247,47 @@ describe('grid resize element strategy', () => {
         })
       }
     })
+  })
+
+  it('can resize element with mouse move outside of grid cells', async () => {
+    const editor = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')
+    await runCellResizeTest(
+      editor,
+      'column-end',
+      gridCellTargetId(EP.fromString('sb/scene/grid'), 1, 8),
+    )
+
+    {
+      const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } =
+        editor.renderedDOM.getByTestId('grid-child').style
+      expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+        gridColumnEnd: '9',
+        gridColumnStart: '7',
+        gridRowEnd: 'auto',
+        gridRowStart: '2',
+      })
+    }
+
+    {
+      // moving a 2 cell wide element in the middle, over the gap between 2 cells
+      await runCellResizeTestWithDragVector(
+        editor,
+        'row-start',
+        localPoint({
+          x: 0,
+          y: -50,
+        }),
+      )
+
+      const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } =
+        editor.renderedDOM.getByTestId('grid-child').style
+      expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+        gridColumnEnd: '9',
+        gridColumnStart: '7',
+        gridRowEnd: '3',
+        gridRowStart: '1',
+      })
+    }
   })
 
   it('removes the grid-area prop on resize', async () => {

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
@@ -14,7 +14,7 @@ import {
   localRectangle,
   offsetPoint,
 } from '../../../../core/shared/math-utils'
-import { selectComponentsForTest, wait } from '../../../../utils/utils.test-utils'
+import { selectComponentsForTest } from '../../../../utils/utils.test-utils'
 import { GridResizeEdgeTestId } from '../../controls/grid-controls'
 import { mouseDragFromPointToPoint } from '../../event-helpers.test-utils'
 import type { EditorRenderResult } from '../../ui-jsx.test-utils'

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -158,12 +158,6 @@ function getNewGridPropsFromResizeBox(
   gridProps: GridElementProperties | null,
   allCellBounds: CanvasRectangle[][],
 ) {
-  const gridPositionToNumber = (
-    p: GridPosition | null | undefined,
-    defaultValue: number,
-  ): number => {
-    return p == null || isCSSKeyword(p) ? defaultValue : p.numericalPosition ?? defaultValue
-  }
   let newRowStart = Infinity
   let newRowEnd = -Infinity
   let newColumnStart = Infinity

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -114,16 +114,7 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
         null,
       )
 
-      const selectedElementGridProps = MetadataUtils.findElementByElementPath(
-        canvasState.startingMetadata,
-        selectedElement,
-      )?.specialSizeMeasurements.elementGridProperties
-
-      const gridProps = getNewGridPropsFromResizeBox(
-        resizeBoundingBox,
-        selectedElementGridProps ?? null,
-        allCellBounds,
-      )
+      const gridProps = getNewGridPropsFromResizeBox(resizeBoundingBox, allCellBounds)
 
       if (gridProps == null) {
         return emptyStrategyApplicationResult
@@ -155,7 +146,6 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
 
 function getNewGridPropsFromResizeBox(
   resizeBoundingBox: CanvasRectangle,
-  gridProps: GridElementProperties | null,
   allCellBounds: CanvasRectangle[][],
 ) {
   let newRowStart = Infinity

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -155,7 +155,7 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
 
 function getNewGridPropsFromResizeBox(
   resizeBoundingBox: CanvasRectangle,
-  selectedElementGridProps: GridElementProperties | null,
+  gridProps: GridElementProperties | null,
   allCellBounds: CanvasRectangle[][],
 ) {
   const gridPositionToNumber = (
@@ -164,10 +164,10 @@ function getNewGridPropsFromResizeBox(
   ): number => {
     return p == null || isCSSKeyword(p) ? defaultValue : p.numericalPosition ?? defaultValue
   }
-  let newRowStart = gridPositionToNumber(selectedElementGridProps?.gridRowStart, Infinity)
-  let newRowEnd = gridPositionToNumber(selectedElementGridProps?.gridRowEnd, -Infinity)
-  let newColumnStart = gridPositionToNumber(selectedElementGridProps?.gridColumnStart, Infinity)
-  let newColumnEnd = gridPositionToNumber(selectedElementGridProps?.gridColumnEnd, -Infinity)
+  let newRowStart = gridPositionToNumber(gridProps?.gridRowStart, Infinity)
+  let newRowEnd = gridPositionToNumber(gridProps?.gridRowEnd, -Infinity)
+  let newColumnStart = gridPositionToNumber(gridProps?.gridColumnStart, Infinity)
+  let newColumnEnd = gridPositionToNumber(gridProps?.gridColumnEnd, -Infinity)
 
   for (let rowIdx = 0; rowIdx < allCellBounds.length; rowIdx++) {
     for (let colIdx = 0; colIdx < allCellBounds[rowIdx].length; colIdx++) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -89,12 +89,13 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
         return emptyStrategyApplicationResult
       }
 
-      const { metadata: container, foundIn } = getMetadataWithGridCellBounds(
-        EP.parentPath(selectedElement),
-        canvasState.startingMetadata,
-        interactionSession.latestMetadata,
-        customState,
-      )
+      const { metadata: container, customStrategyState: updatedCustomState } =
+        getMetadataWithGridCellBounds(
+          EP.parentPath(selectedElement),
+          canvasState.startingMetadata,
+          interactionSession.latestMetadata,
+          customState,
+        )
 
       if (container == null) {
         return emptyStrategyApplicationResult
@@ -122,23 +123,10 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
 
       const gridTemplate = container.specialSizeMeasurements.containerGridProperties
 
-      const customStatePatch =
-        foundIn === 'latestMetadata'
-          ? {
-              ...customState,
-              grid: {
-                ...customState.grid,
-                metadataCacheForGrids: {
-                  ...customState.grid.metadataCacheForGrids,
-                  [EP.toString(container.elementPath)]: container,
-                },
-              },
-            }
-          : {}
       return strategyApplicationResult(
         setGridPropsCommands(selectedElement, gridTemplate, gridProps),
         [parentGridPath],
-        customStatePatch,
+        updatedCustomState ?? undefined,
       )
     },
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -153,6 +153,7 @@ function getNewGridPropsFromResizeBox(
   let newColumnStart = Infinity
   let newColumnEnd = -Infinity
 
+  // those cells should be occupied by the element which has an intersection with the resize box
   for (let rowIdx = 0; rowIdx < allCellBounds.length; rowIdx++) {
     for (let colIdx = 0; colIdx < allCellBounds[rowIdx].length; colIdx++) {
       if (rectangleIntersection(resizeBoundingBox, allCellBounds[rowIdx][colIdx]) != null) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -164,10 +164,10 @@ function getNewGridPropsFromResizeBox(
   ): number => {
     return p == null || isCSSKeyword(p) ? defaultValue : p.numericalPosition ?? defaultValue
   }
-  let newRowStart = gridPositionToNumber(gridProps?.gridRowStart, Infinity)
-  let newRowEnd = gridPositionToNumber(gridProps?.gridRowEnd, -Infinity)
-  let newColumnStart = gridPositionToNumber(gridProps?.gridColumnStart, Infinity)
-  let newColumnEnd = gridPositionToNumber(gridProps?.gridColumnEnd, -Infinity)
+  let newRowStart = Infinity
+  let newRowEnd = -Infinity
+  let newColumnStart = Infinity
+  let newColumnEnd = -Infinity
 
   for (let rowIdx = 0; rowIdx < allCellBounds.length; rowIdx++) {
     for (let colIdx = 0; colIdx < allCellBounds[rowIdx].length; colIdx++) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -1,12 +1,18 @@
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
 import type { GridElementProperties, GridPosition } from '../../../../core/shared/element-template'
-import { offsetPoint } from '../../../../core/shared/math-utils'
-import { assertNever } from '../../../../core/shared/utils'
+import {
+  type CanvasRectangle,
+  isInfinityRectangle,
+  rectangleIntersection,
+} from '../../../../core/shared/math-utils'
 import { isCSSKeyword } from '../../../inspector/common/css-utils'
 import { isFixedHugFillModeApplied } from '../../../inspector/inspector-common'
-import { controlsForGridPlaceholders, GridResizeControls } from '../../controls/grid-controls'
-import { canvasRectangleToWindowRectangle } from '../../dom-lookup'
+import {
+  controlsForGridPlaceholders,
+  gridEdgeToEdgePosition,
+  GridResizeControls,
+} from '../../controls/grid-controls'
 import type { CanvasStrategyFactory } from '../canvas-strategies'
 import { onlyFitWhenDraggingThisControl } from '../canvas-strategies'
 import type { InteractionCanvasState } from '../canvas-strategy-types'
@@ -16,8 +22,8 @@ import {
   strategyApplicationResult,
 } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
-import { getGridCellUnderMouseFromMetadata } from './grid-cell-bounds'
-import { setGridPropsCommands } from './grid-helpers'
+import { getMetadataWithGridCellBounds, setGridPropsCommands } from './grid-helpers'
+import { resizeBoundingBoxFromSide } from './resize-helpers'
 
 export const gridResizeElementStrategy: CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -35,6 +41,14 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
     selectedElement,
   )
   if (!isElementInsideGrid) {
+    return null
+  }
+
+  const selectedElementBounds = MetadataUtils.getFrameInCanvasCoords(
+    selectedElement,
+    canvasState.startingMetadata,
+  )
+  if (selectedElementBounds == null || isInfinityRectangle(selectedElementBounds)) {
     return null
   }
 
@@ -75,116 +89,110 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
         return emptyStrategyApplicationResult
       }
 
-      const container = MetadataUtils.findElementByElementPath(
-        canvasState.startingMetadata,
+      const { metadata: container, foundIn } = getMetadataWithGridCellBounds(
         EP.parentPath(selectedElement),
+        canvasState.startingMetadata,
+        interactionSession.latestMetadata,
+        customState,
       )
+
       if (container == null) {
         return emptyStrategyApplicationResult
       }
 
-      const mouseCanvasPoint = offsetPoint(
-        interactionSession.interactionData.dragStart,
+      const allCellBounds = container.specialSizeMeasurements.gridCellGlobalFrames
+
+      if (allCellBounds == null) {
+        return emptyStrategyApplicationResult
+      }
+
+      const resizeBoundingBox = resizeBoundingBoxFromSide(
+        selectedElementBounds,
         interactionSession.interactionData.drag,
+        gridEdgeToEdgePosition(interactionSession.activeControl.edge),
+        'non-center-based',
+        null,
       )
 
-      const cellUnderMouse = getGridCellUnderMouseFromMetadata(container, mouseCanvasPoint)
-      const targetCell = cellUnderMouse == null ? customState.grid.targetCellData : cellUnderMouse
+      const selectedElementGridProps = MetadataUtils.findElementByElementPath(
+        canvasState.startingMetadata,
+        selectedElement,
+      )?.specialSizeMeasurements.elementGridProperties
 
-      if (targetCell == null) {
+      const gridProps = getNewGridPropsFromResizeBox(
+        resizeBoundingBox,
+        selectedElementGridProps ?? null,
+        allCellBounds,
+      )
+
+      if (gridProps == null) {
         return emptyStrategyApplicationResult
       }
 
       const gridTemplate = container.specialSizeMeasurements.containerGridProperties
 
-      let gridProps: GridElementProperties = MetadataUtils.findElementByElementPath(
-        canvasState.startingMetadata,
-        selectedElement,
-      )?.specialSizeMeasurements.elementGridProperties ?? {
-        gridColumnEnd: { numericalPosition: 0 },
-        gridColumnStart: { numericalPosition: 0 },
-        gridRowEnd: { numericalPosition: 0 },
-        gridRowStart: { numericalPosition: 0 },
-      }
-
-      switch (interactionSession.activeControl.edge) {
-        case 'column-start':
-          gridProps = {
-            ...gridProps,
-            gridColumnStart: { numericalPosition: targetCell.gridCellCoordinates.column },
-          }
-          break
-        case 'column-end':
-          gridProps = {
-            ...gridProps,
-            gridColumnEnd: { numericalPosition: targetCell.gridCellCoordinates.column + 1 },
-          }
-          break
-        case 'row-end':
-          gridProps = {
-            ...gridProps,
-            gridRowEnd: { numericalPosition: targetCell.gridCellCoordinates.row + 1 },
-          }
-          break
-        case 'row-start':
-          gridProps = {
-            ...gridProps,
-            gridRowStart: { numericalPosition: targetCell.gridCellCoordinates.row },
-          }
-          break
-        default:
-          assertNever(interactionSession.activeControl.edge)
-      }
-
+      const customStatePatch =
+        foundIn === 'latestMetadata'
+          ? {
+              ...customState,
+              grid: {
+                ...customState.grid,
+                metadataCacheForGrids: {
+                  ...customState.grid.metadataCacheForGrids,
+                  [EP.toString(container.elementPath)]: container,
+                },
+              },
+            }
+          : {}
       return strategyApplicationResult(
-        setGridPropsCommands(selectedElement, gridTemplate, gridPropsWithDragOver(gridProps)),
+        setGridPropsCommands(selectedElement, gridTemplate, gridProps),
         [parentGridPath],
-        {
-          grid: { ...customState.grid, targetCellData: targetCell },
-        },
+        customStatePatch,
       )
     },
   }
 }
 
-function orderedGridPositions({
-  start,
-  end,
-}: {
-  start: GridPosition | null
-  end: GridPosition | null
-}): {
-  start: GridPosition | null
-  end: GridPosition | null
-} {
-  if (
-    start == null ||
-    isCSSKeyword(start) ||
-    start.numericalPosition == null ||
-    end == null ||
-    isCSSKeyword(end) ||
-    end.numericalPosition == null
-  ) {
-    return { start, end }
+function getNewGridPropsFromResizeBox(
+  resizeBoundingBox: CanvasRectangle,
+  selectedElementGridProps: GridElementProperties | null,
+  allCellBounds: CanvasRectangle[][],
+) {
+  const gridPositionToNumber = (
+    p: GridPosition | null | undefined,
+    defaultValue: number,
+  ): number => {
+    return p == null || isCSSKeyword(p) ? defaultValue : p.numericalPosition ?? defaultValue
+  }
+  let newRowStart = gridPositionToNumber(selectedElementGridProps?.gridRowStart, Infinity)
+  let newRowEnd = gridPositionToNumber(selectedElementGridProps?.gridRowEnd, -Infinity)
+  let newColumnStart = gridPositionToNumber(selectedElementGridProps?.gridColumnStart, Infinity)
+  let newColumnEnd = gridPositionToNumber(selectedElementGridProps?.gridColumnEnd, -Infinity)
+
+  for (let rowIdx = 0; rowIdx < allCellBounds.length; rowIdx++) {
+    for (let colIdx = 0; colIdx < allCellBounds[rowIdx].length; colIdx++) {
+      if (rectangleIntersection(resizeBoundingBox, allCellBounds[rowIdx][colIdx]) != null) {
+        newRowStart = Math.min(newRowStart, rowIdx + 1)
+        newColumnStart = Math.min(newColumnStart, colIdx + 1)
+        newRowEnd = Math.max(newRowEnd, rowIdx + 2)
+        newColumnEnd = Math.max(newColumnEnd, colIdx + 2)
+      }
+    }
   }
 
-  return start.numericalPosition < end.numericalPosition
-    ? { start, end }
-    : {
-        start: { numericalPosition: end.numericalPosition - 1 },
-        end: { numericalPosition: start.numericalPosition + 1 },
-      }
-}
+  if (
+    !isFinite(newRowStart) ||
+    !isFinite(newColumnStart) ||
+    !isFinite(newRowEnd) ||
+    !isFinite(newColumnEnd)
+  ) {
+    return null
+  }
 
-function gridPropsWithDragOver(props: GridElementProperties): GridElementProperties {
-  const { start: gridColumnStart, end: gridColumnEnd } = orderedGridPositions({
-    start: props.gridColumnStart,
-    end: props.gridColumnEnd,
-  })
-  const { start: gridRowStart, end: gridRowEnd } = orderedGridPositions({
-    start: props.gridRowStart,
-    end: props.gridRowEnd,
-  })
-
-  return { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }
+  return {
+    gridRowStart: { numericalPosition: newRowStart },
+    gridRowEnd: { numericalPosition: newRowEnd },
+    gridColumnStart: { numericalPosition: newColumnStart },
+    gridColumnEnd: { numericalPosition: newColumnEnd },
+  }
 }

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -1632,7 +1632,6 @@ export const GridResizeControls = controlForStrategyMemoized<GridResizeControlPr
       if (startingBounds == null) {
         return
       }
-
       setBounds(
         resizeBoundingBoxFromSide(
           startingBounds,
@@ -1784,7 +1783,7 @@ const GRID_RESIZE_HANDLE_SIZES = {
   short: 4,
 }
 
-function gridEdgeToEdgePosition(edge: GridResizeEdge): EdgePosition {
+export function gridEdgeToEdgePosition(edge: GridResizeEdge): EdgePosition {
   switch (edge) {
     case 'column-end':
       return EdgePositionRight


### PR DESCRIPTION
**Problem:**
The original grid-resize-element strategy was written in a way, that it resized based on the data that which cell is currently under the mouse. This made it impossible to resize with the mouse e.g. going in between cells over the gap, or outside of the grid.

**Fix:**
Let's rely on the resize bounding box coming from `resizeBoundingBoxFromSide`, and we can resize to those cells which have an intersection with the resize bounding box.

As an extra, I refactored the `getMetadataWithGridCellBounds` function, so that it returns the updated custom strategy state, and the strategies don't have to construct that (this strategy state update guarantees that if the grid cell bounds were only found in the latestmetadata, then we store them in the custom strategy state, so they are kept until the end of the interaction). For the note, some grid strategies add further changes to the strategy state, after the subsequent strategy refactors these will be removed.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

