### PR TITLE
always call exitPointerLock

### DIFF
--- a/editor/src/uuiui/inputs/number-input.tsx
+++ b/editor/src/uuiui/inputs/number-input.tsx
@@ -383,9 +383,7 @@ export const NumberInput = React.memo<NumberInputProps>(
 
     const cancelPointerLock = React.useCallback(
       (revertChanges: 'revert-nothing' | 'revert-changes') => {
-        if (document.pointerLockElement === pointerOriginRef.current) {
-          document.exitPointerLock()
-        }
+        document.exitPointerLock()
         if (
           revertChanges === 'revert-changes' &&
           onSubmitValue != null &&


### PR DESCRIPTION
**Problem:**
If a scrubbing using the new pointer lock based scrubber control was quick enough, we would often not release the pointer on mouse up – instead leaving you with a hidden cursor until you press Esc.

**Fix:**
Turns out, `document.pointerLockElement` is still null for a few moments after getting pointer lock, and our code calling `document.exitPointerLock` checks if the pointer lock element is the same as the current control's target.

By simply removing the check, we call exitPointerLock() all of the time, making it not brittle anymore.
