### PR TITLE
Disable alignment buttons/groups based on element

### DIFF
--- a/editor/src/components/inspector/alignment-buttons.spec.browser2.tsx
+++ b/editor/src/components/inspector/alignment-buttons.spec.browser2.tsx
@@ -8,7 +8,7 @@ describe('alignment buttons', () => {
       const renderResult = await renderTestEditorWithCode(projectCode, 'await-first-dom-report')
       const metadata = renderResult.getEditorState().editor.jsxMetadata
       expect(
-        isAlignmentGroupDisabled(metadata, EP.fromString('sb/grid/grid-child'), 'horizontal'),
+        isAlignmentGroupDisabled(metadata, EP.fromString('sb/grid/grid-child'), 'horizontal', []),
       ).toBe(false)
     })
     it('enables buttons for flex only in the opposite direction', async () => {
@@ -22,6 +22,7 @@ describe('alignment buttons', () => {
             metadata,
             EP.fromString('sb/flex-horiz/flex-horiz-child'),
             'vertical',
+            [],
           ),
         ).toBe(false)
         expect(
@@ -29,6 +30,7 @@ describe('alignment buttons', () => {
             metadata,
             EP.fromString('sb/flex-horiz/flex-horiz-child'),
             'horizontal',
+            [],
           ),
         ).toBe(true)
       }
@@ -40,6 +42,7 @@ describe('alignment buttons', () => {
             metadata,
             EP.fromString('sb/flex-vert/flex-vert-child'),
             'horizontal',
+            [],
           ),
         ).toBe(false)
         expect(
@@ -47,6 +50,7 @@ describe('alignment buttons', () => {
             metadata,
             EP.fromString('sb/flex-vert/flex-vert-child'),
             'vertical',
+            [],
           ),
         ).toBe(true)
       }
@@ -60,10 +64,20 @@ describe('alignment buttons', () => {
           metadata,
           EP.fromString('sb/flow/flow-child-absolute'),
           'horizontal',
+          [],
         ),
       ).toBe(false)
 
-      expect(isAlignmentGroupDisabled(metadata, EP.fromString('sb/flow'), 'horizontal')).toBe(true)
+      expect(isAlignmentGroupDisabled(metadata, EP.fromString('sb/flow'), 'horizontal', [])).toBe(
+        true,
+      )
+
+      expect(
+        isAlignmentGroupDisabled(metadata, EP.fromString('sb/flow'), 'horizontal', [
+          EP.fromString('sb/flow'),
+          EP.fromString('sb/grid'),
+        ]),
+      ).toBe(false)
     })
     it('disables buttons for flow', async () => {
       const renderResult = await renderTestEditorWithCode(projectCode, 'await-first-dom-report')
@@ -74,6 +88,7 @@ describe('alignment buttons', () => {
           metadata,
           EP.fromString('sb/flow/flow-child-relative'),
           'horizontal',
+          [],
         ),
       ).toBe(true)
     })

--- a/editor/src/components/inspector/alignment-buttons.spec.browser2.tsx
+++ b/editor/src/components/inspector/alignment-buttons.spec.browser2.tsx
@@ -1,0 +1,243 @@
+import * as EP from '../../core/shared/element-path'
+import { renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
+import { isAlignmentGroupDisabled } from './use-disable-alignment'
+
+describe('alignment buttons', () => {
+  describe('isAlignmentGroupDisabled', () => {
+    it('enables buttons for grid cells', async () => {
+      const renderResult = await renderTestEditorWithCode(projectCode, 'await-first-dom-report')
+      const metadata = renderResult.getEditorState().editor.jsxMetadata
+      expect(
+        isAlignmentGroupDisabled(metadata, EP.fromString('sb/grid/grid-child'), 'horizontal'),
+      ).toBe(false)
+    })
+    it('enables buttons for flex only in the opposite direction', async () => {
+      const renderResult = await renderTestEditorWithCode(projectCode, 'await-first-dom-report')
+      const metadata = renderResult.getEditorState().editor.jsxMetadata
+
+      // flex-direction: row
+      {
+        expect(
+          isAlignmentGroupDisabled(
+            metadata,
+            EP.fromString('sb/flex-horiz/flex-horiz-child'),
+            'vertical',
+          ),
+        ).toBe(false)
+        expect(
+          isAlignmentGroupDisabled(
+            metadata,
+            EP.fromString('sb/flex-horiz/flex-horiz-child'),
+            'horizontal',
+          ),
+        ).toBe(true)
+      }
+
+      // flex-direction: column
+      {
+        expect(
+          isAlignmentGroupDisabled(
+            metadata,
+            EP.fromString('sb/flex-vert/flex-vert-child'),
+            'horizontal',
+          ),
+        ).toBe(false)
+        expect(
+          isAlignmentGroupDisabled(
+            metadata,
+            EP.fromString('sb/flex-vert/flex-vert-child'),
+            'vertical',
+          ),
+        ).toBe(true)
+      }
+    })
+    it('enables buttons for absolute only if not storyboard children', async () => {
+      const renderResult = await renderTestEditorWithCode(projectCode, 'await-first-dom-report')
+      const metadata = renderResult.getEditorState().editor.jsxMetadata
+
+      expect(
+        isAlignmentGroupDisabled(
+          metadata,
+          EP.fromString('sb/flow/flow-child-absolute'),
+          'horizontal',
+        ),
+      ).toBe(false)
+
+      expect(isAlignmentGroupDisabled(metadata, EP.fromString('sb/flow'), 'horizontal')).toBe(true)
+    })
+    it('disables buttons for flow', async () => {
+      const renderResult = await renderTestEditorWithCode(projectCode, 'await-first-dom-report')
+      const metadata = renderResult.getEditorState().editor.jsxMetadata
+
+      expect(
+        isAlignmentGroupDisabled(
+          metadata,
+          EP.fromString('sb/flow/flow-child-relative'),
+          'horizontal',
+        ),
+      ).toBe(true)
+    })
+  })
+})
+
+const projectCode = `import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-uid='grid'
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        width: 318,
+        height: 288,
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr 1fr',
+        gridTemplateRows: '1fr 1fr 1fr',
+        padding: 20,
+        gridGap: 20,
+        justifyItems: 'flex-end',
+        alignContent: 'center',
+      }}
+    >
+      <div
+        data-uid='grid'data-uid='grid-child'
+        style={{
+          backgroundColor: '#aaaaaa33',
+          justifySelf: 'stretch',
+          gridColumn: 3,
+          gridRow: 2,
+          alignSelf: 'stretch',
+        }}
+      />
+    </div>
+    <div
+      data-uid='flow'
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: 339,
+        top: 0,
+        width: 282,
+        height: 247,
+        contain: 'layout',
+      }}
+    >
+      <div
+        data-uid='flow-child-relative'
+        style={{
+          backgroundColor: '#aaaaaa33',
+          left: 21,
+          top: 31,
+          width: 57,
+          height: 59,
+        }}
+      />
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          left: 22,
+          top: 99,
+          width: 57,
+          height: 59,
+        }}
+      />
+      <div
+        data-uid='flow-child-absolute'
+        style={{
+          backgroundColor: '#aaaaaa33',
+          position: 'absolute',
+          left: 153,
+          top: 94,
+          width: 57,
+          height: 59,
+        }}
+      />
+    </div>
+    <div
+      data-uid='flex-horiz'
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: 0,
+        top: 302,
+        width: 318,
+        height: 155,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 10,
+      }}
+    >
+      <div
+        data-uid='flex-horiz-child'
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: 57,
+          height: 37,
+          contain: 'layout',
+        }}
+      />
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: 57,
+          height: 37,
+          contain: 'layout',
+        }}
+      />
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: 57,
+          height: 37,
+          contain: 'layout',
+        }}
+      />
+    </div>
+    <div
+      data-uid='flex-vert'
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        left: 339,
+        top: 307,
+        width: 164,
+        height: 300,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexDirection: 'column',
+        gap: 10,
+      }}
+    >
+      <div
+        data-uid='flex-vert-child'
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: 54.5,
+          height: 66,
+          contain: 'layout',
+        }}
+      />
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: 54.5,
+          height: 66,
+          contain: 'layout',
+        }}
+      />
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: 54.5,
+          height: 66,
+          contain: 'layout',
+        }}
+      />
+    </div>
+  </Storyboard>
+)
+`

--- a/editor/src/components/inspector/alignment-buttons.spec.browser2.tsx
+++ b/editor/src/components/inspector/alignment-buttons.spec.browser2.tsx
@@ -1,3 +1,4 @@
+import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import * as EP from '../../core/shared/element-path'
 import { renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
 import { isAlignmentGroupDisabled } from './use-disable-alignment'
@@ -7,8 +8,14 @@ describe('alignment buttons', () => {
     it('enables buttons for grid cells', async () => {
       const renderResult = await renderTestEditorWithCode(projectCode, 'await-first-dom-report')
       const metadata = renderResult.getEditorState().editor.jsxMetadata
+
       expect(
-        isAlignmentGroupDisabled(metadata, EP.fromString('sb/grid/grid-child'), 'horizontal', []),
+        isAlignmentGroupDisabled(
+          MetadataUtils.findElementByElementPath(metadata, EP.fromString('sb/grid/grid-child')),
+          MetadataUtils.findElementByElementPath(metadata, EP.fromString('sb/grid')),
+          'horizontal',
+          [],
+        ),
       ).toBe(false)
     })
     it('enables buttons for flex only in the opposite direction', async () => {
@@ -19,16 +26,22 @@ describe('alignment buttons', () => {
       {
         expect(
           isAlignmentGroupDisabled(
-            metadata,
-            EP.fromString('sb/flex-horiz/flex-horiz-child'),
+            MetadataUtils.findElementByElementPath(
+              metadata,
+              EP.fromString('sb/flex-horiz/flex-horiz-child'),
+            ),
+            MetadataUtils.findElementByElementPath(metadata, EP.fromString('sb/flex-horiz')),
             'vertical',
             [],
           ),
         ).toBe(false)
         expect(
           isAlignmentGroupDisabled(
-            metadata,
-            EP.fromString('sb/flex-horiz/flex-horiz-child'),
+            MetadataUtils.findElementByElementPath(
+              metadata,
+              EP.fromString('sb/flex-horiz/flex-horiz-child'),
+            ),
+            MetadataUtils.findElementByElementPath(metadata, EP.fromString('sb/flex-horiz')),
             'horizontal',
             [],
           ),
@@ -39,16 +52,22 @@ describe('alignment buttons', () => {
       {
         expect(
           isAlignmentGroupDisabled(
-            metadata,
-            EP.fromString('sb/flex-vert/flex-vert-child'),
+            MetadataUtils.findElementByElementPath(
+              metadata,
+              EP.fromString('sb/flex-vert/flex-vert-child'),
+            ),
+            MetadataUtils.findElementByElementPath(metadata, EP.fromString('sb/flex-vert')),
             'horizontal',
             [],
           ),
         ).toBe(false)
         expect(
           isAlignmentGroupDisabled(
-            metadata,
-            EP.fromString('sb/flex-vert/flex-vert-child'),
+            MetadataUtils.findElementByElementPath(
+              metadata,
+              EP.fromString('sb/flex-vert/flex-vert-child'),
+            ),
+            MetadataUtils.findElementByElementPath(metadata, EP.fromString('sb/flex-vert')),
             'vertical',
             [],
           ),
@@ -61,22 +80,32 @@ describe('alignment buttons', () => {
 
       expect(
         isAlignmentGroupDisabled(
-          metadata,
-          EP.fromString('sb/flow/flow-child-absolute'),
+          MetadataUtils.findElementByElementPath(
+            metadata,
+            EP.fromString('sb/flow/flow-child-absolute'),
+          ),
+          MetadataUtils.findElementByElementPath(metadata, EP.fromString('sb/flow')),
           'horizontal',
           [],
         ),
       ).toBe(false)
 
-      expect(isAlignmentGroupDisabled(metadata, EP.fromString('sb/flow'), 'horizontal', [])).toBe(
-        true,
-      )
+      expect(
+        isAlignmentGroupDisabled(
+          MetadataUtils.findElementByElementPath(metadata, EP.fromString('sb/flow')),
+          MetadataUtils.findElementByElementPath(metadata, EP.fromString('sb')),
+          'horizontal',
+          [],
+        ),
+      ).toBe(true)
 
       expect(
-        isAlignmentGroupDisabled(metadata, EP.fromString('sb/flow'), 'horizontal', [
-          EP.fromString('sb/flow'),
-          EP.fromString('sb/grid'),
-        ]),
+        isAlignmentGroupDisabled(
+          MetadataUtils.findElementByElementPath(metadata, EP.fromString('sb/flow')),
+          MetadataUtils.findElementByElementPath(metadata, EP.fromString('sb')),
+          'horizontal',
+          [EP.fromString('sb/flow'), EP.fromString('sb/grid')],
+        ),
       ).toBe(false)
     })
     it('disables buttons for flow', async () => {
@@ -85,8 +114,11 @@ describe('alignment buttons', () => {
 
       expect(
         isAlignmentGroupDisabled(
-          metadata,
-          EP.fromString('sb/flow/flow-child-relative'),
+          MetadataUtils.findElementByElementPath(
+            metadata,
+            EP.fromString('sb/flow/flow-child-relative'),
+          ),
+          MetadataUtils.findElementByElementPath(metadata, EP.fromString('sb/flow')),
           'horizontal',
           [],
         ),

--- a/editor/src/components/inspector/controls/option-control.tsx
+++ b/editor/src/components/inspector/controls/option-control.tsx
@@ -118,7 +118,8 @@ export const OptionControl: React.FunctionComponent<
               },
             },
             '&:hover': {
-              opacity: props.controlStatus === 'disabled' ? undefined : 1,
+              opacity:
+                controlOptions.disabled || props.controlStatus === 'disabled' ? undefined : 1,
             },
             '.control-option-icon-component': {
               opacity: 0.7,

--- a/editor/src/components/inspector/use-disable-alignment.tsx
+++ b/editor/src/components/inspector/use-disable-alignment.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import type { ElementPath } from 'utopia-shared/src/types'
+import { MetadataUtils } from '../../core/model/element-metadata-utils'
+import type { ElementInstanceMetadataMap } from '../../core/shared/element-template'
+import { useEditorState, Substores } from '../editor/store/store-hook'
+import * as EP from '../../core/shared/element-path'
+
+export function useDisableAlignment(
+  selectedViews: ElementPath[],
+  orientation: 'horizontal' | 'vertical',
+) {
+  const jsxMetadata = useEditorState(
+    Substores.metadata,
+    (store) => store.editor.jsxMetadata,
+    'useDisableAlignment jsxMetadata',
+  )
+
+  return React.useMemo(() => {
+    if (selectedViews.length === 0) {
+      return true
+    }
+
+    return selectedViews.some((path) => {
+      return isAlignmentGroupDisabled(jsxMetadata, path, orientation)
+    })
+  }, [selectedViews, jsxMetadata, orientation])
+}
+
+export function isAlignmentGroupDisabled(
+  jsxMetadata: ElementInstanceMetadataMap,
+  path: ElementPath,
+  orientation: 'horizontal' | 'vertical',
+): boolean {
+  // grid cells have all alignments available
+  const isGridCell = MetadataUtils.isGridCell(jsxMetadata, path)
+  if (isGridCell) {
+    return false
+  }
+
+  // flex children have alignment enabled on the opposite orientation to their parent's flex direction
+  const isFlexChild = MetadataUtils.isFlexLayoutedContainer(
+    MetadataUtils.findElementByElementPath(jsxMetadata, EP.parentPath(path)),
+  )
+  if (isFlexChild) {
+    const flexDirection = MetadataUtils.getFlexDirection(
+      MetadataUtils.findElementByElementPath(jsxMetadata, EP.parentPath(path)),
+    )
+    return flexDirection === 'column' || flexDirection === 'column-reverse'
+      ? orientation === 'vertical'
+      : orientation === 'horizontal'
+  }
+
+  // absolute elements have all alignments available, unless they are storyboard children
+  if (
+    MetadataUtils.isPositionAbsolute(MetadataUtils.findElementByElementPath(jsxMetadata, path)) &&
+    !EP.isStoryboardChild(path)
+  ) {
+    return false
+  }
+
+  return true
+}

--- a/editor/src/components/inspector/use-disable-alignment.tsx
+++ b/editor/src/components/inspector/use-disable-alignment.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { ElementPath } from 'utopia-shared/src/types'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
-import type { ElementInstanceMetadataMap } from '../../core/shared/element-template'
+import type { ElementInstanceMetadata } from '../../core/shared/element-template'
 import { useEditorState, Substores } from '../editor/store/store-hook'
 import * as EP from '../../core/shared/element-path'
 
@@ -9,10 +9,19 @@ export function useDisableAlignment(
   selectedViews: ElementPath[],
   orientation: 'horizontal' | 'vertical',
 ) {
-  const jsxMetadata = useEditorState(
+  const selectedElements = useEditorState(
     Substores.metadata,
-    (store) => store.editor.jsxMetadata,
-    'useDisableAlignment jsxMetadata',
+    (store) =>
+      selectedViews.map((path) => {
+        return {
+          element: MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, path),
+          parent: MetadataUtils.findElementByElementPath(
+            store.editor.jsxMetadata,
+            EP.parentPath(path),
+          ),
+        }
+      }),
+    'useDisableAlignment selectedElements',
   )
 
   return React.useMemo(() => {
@@ -20,32 +29,32 @@ export function useDisableAlignment(
       return true
     }
 
-    return selectedViews.some((path, _, array) => {
-      return isAlignmentGroupDisabled(jsxMetadata, path, orientation, array)
+    return selectedElements.some(({ element, parent }) => {
+      return isAlignmentGroupDisabled(element, parent, orientation, selectedViews)
     })
-  }, [selectedViews, jsxMetadata, orientation])
+  }, [selectedViews, selectedElements, orientation])
 }
 
 export function isAlignmentGroupDisabled(
-  jsxMetadata: ElementInstanceMetadataMap,
-  path: ElementPath,
+  element: ElementInstanceMetadata | null,
+  parent: ElementInstanceMetadata | null,
   orientation: 'horizontal' | 'vertical',
   selection: ElementPath[],
 ): boolean {
+  if (element == null || parent == null) {
+    return true
+  }
+
   // grid cells have all alignments available
-  const isGridCell = MetadataUtils.isGridCell(jsxMetadata, path)
+  const isGridCell = MetadataUtils.isGridLayoutedContainer(parent)
   if (isGridCell) {
     return false
   }
 
   // flex children have alignment enabled on the opposite orientation to their parent's flex direction
-  const isFlexChild = MetadataUtils.isFlexLayoutedContainer(
-    MetadataUtils.findElementByElementPath(jsxMetadata, EP.parentPath(path)),
-  )
+  const isFlexChild = MetadataUtils.isFlexLayoutedContainer(parent)
   if (isFlexChild) {
-    const flexDirection = MetadataUtils.getFlexDirection(
-      MetadataUtils.findElementByElementPath(jsxMetadata, EP.parentPath(path)),
-    )
+    const flexDirection = MetadataUtils.getFlexDirection(parent)
     return flexDirection === 'column' || flexDirection === 'column-reverse'
       ? orientation === 'vertical'
       : orientation === 'horizontal'
@@ -54,8 +63,8 @@ export function isAlignmentGroupDisabled(
   // absolute elements have all alignments available, unless they are storyboard children or all
   // selected elements are storyboard children
   if (
-    MetadataUtils.isPositionAbsolute(MetadataUtils.findElementByElementPath(jsxMetadata, path)) &&
-    (!EP.isStoryboardChild(path) ||
+    MetadataUtils.isPositionAbsolute(element) &&
+    (!EP.isStoryboardChild(element.elementPath) ||
       (selection.length > 1 && selection.every((other) => EP.isStoryboardChild(other))))
   ) {
     return false

--- a/editor/src/components/inspector/use-disable-alignment.tsx
+++ b/editor/src/components/inspector/use-disable-alignment.tsx
@@ -20,8 +20,8 @@ export function useDisableAlignment(
       return true
     }
 
-    return selectedViews.some((path) => {
-      return isAlignmentGroupDisabled(jsxMetadata, path, orientation)
+    return selectedViews.some((path, _, array) => {
+      return isAlignmentGroupDisabled(jsxMetadata, path, orientation, array)
     })
   }, [selectedViews, jsxMetadata, orientation])
 }
@@ -30,6 +30,7 @@ export function isAlignmentGroupDisabled(
   jsxMetadata: ElementInstanceMetadataMap,
   path: ElementPath,
   orientation: 'horizontal' | 'vertical',
+  selection: ElementPath[],
 ): boolean {
   // grid cells have all alignments available
   const isGridCell = MetadataUtils.isGridCell(jsxMetadata, path)
@@ -50,10 +51,12 @@ export function isAlignmentGroupDisabled(
       : orientation === 'horizontal'
   }
 
-  // absolute elements have all alignments available, unless they are storyboard children
+  // absolute elements have all alignments available, unless they are storyboard children or all
+  // selected elements are storyboard children
   if (
     MetadataUtils.isPositionAbsolute(MetadataUtils.findElementByElementPath(jsxMetadata, path)) &&
-    !EP.isStoryboardChild(path)
+    (!EP.isStoryboardChild(path) ||
+      (selection.length > 1 && selection.every((other) => EP.isStoryboardChild(other))))
   ) {
     return false
   }


### PR DESCRIPTION
**Problem:**

Following up to https://github.com/concrete-utopia/utopia/pull/6459, the alignment buttons should be disabled following a comprehensive set of rules.

**Fix:**

This PR updates the logic to disable alignment buttons and groups following the following logic.

- Grid children all have alignment buttons enabled
- Flex children have alignment buttons enabled for the orientation opposite to their parent's flex direction
- Absolute elements have alignment buttons enabled, if they are not storyboard children
- Flow elements have all alignment buttons disabled

Fixes #6460 