### PR TITLE
unify elements to rerender calculation between the real and fake dispatch

### DIFF
--- a/editor/src/components/canvas/ui-jsx.test-utils.tsx
+++ b/editor/src/components/canvas/ui-jsx.test-utils.tsx
@@ -59,7 +59,7 @@ import {
   FakeWatchdogWorker,
 } from '../../core/workers/test-workers'
 import { UtopiaTsWorkersImplementation } from '../../core/workers/workers'
-import { EditorRoot } from '../../templates/editor'
+import { collectElementsToRerender, EditorRoot } from '../../templates/editor'
 import Utils from '../../utils/utils'
 import { getNamedPath } from '../../utils/react-helpers'
 import type {
@@ -435,8 +435,9 @@ export async function renderTestEditorWithModel(
     {
       resubscribeObservers(domWalkerMutableState)
 
+      const elementsToFocusOn = collectElementsToRerender(workingEditorState, actions)
       const metadataResult = runDomSamplerRegular({
-        elementsToFocusOn: workingEditorState.patchedEditor.canvas.elementsToRerender,
+        elementsToFocusOn: elementsToFocusOn,
         domWalkerAdditionalElementsToFocusOn:
           workingEditorState.patchedEditor.canvas.domWalkerAdditionalElementsToUpdate,
         scale: workingEditorState.patchedEditor.canvas.scale,
@@ -507,8 +508,9 @@ export async function renderTestEditorWithModel(
         {
           resubscribeObservers(domWalkerMutableState)
 
+          const elementsToFocusOn = collectElementsToRerender(workingEditorState, actions)
           const metadataResult = runDomSamplerGroups({
-            elementsToFocusOn: workingEditorState.patchedEditor.canvas.elementsToRerender,
+            elementsToFocusOn: elementsToFocusOn,
             domWalkerAdditionalElementsToFocusOn:
               workingEditorState.patchedEditor.canvas.domWalkerAdditionalElementsToUpdate,
             scale: workingEditorState.patchedEditor.canvas.scale,

--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -165,11 +165,27 @@ function collectElementsToRerenderForTransientActions(
 // for this pass use a union of the two arrays, to make sure we clear a previously focused element from the metadata
 // and let the canvas re-render components that may have a missing child now.
 let lastElementsToRerender: ElementsToRerender = 'rerender-all-elements'
-function fixElementsToRerender(
-  currentElementsToRerender: ElementsToRerender,
+function fixElementsToRerender(elementsToRerender: ElementsToRerender): ElementsToRerender {
+  let fixedElementsToRerender: ElementsToRerender = elementsToRerender
+  if (
+    elementsToRerender !== 'rerender-all-elements' &&
+    lastElementsToRerender !== 'rerender-all-elements'
+  ) {
+    // if the current elements to rerender array doesn't match the previous elements to rerender array, for a single frame let's use the union of the two arrays
+    fixedElementsToRerender = EP.uniqueElementPaths([
+      ...lastElementsToRerender,
+      ...elementsToRerender,
+    ])
+  }
+
+  lastElementsToRerender = fixedElementsToRerender
+  return fixedElementsToRerender
+}
+
+export function collectElementsToRerender(
+  editorStore: EditorStoreFull,
   dispatchedActions: readonly EditorAction[],
 ): ElementsToRerender {
-  // while running transient actions there is an optional elementsToRerender
   const elementsToRerenderTransient = uniqBy<ElementPath>(
     dispatchedActions.reduce(
       collectElementsToRerenderForTransientActions,
@@ -178,22 +194,12 @@ function fixElementsToRerender(
     EP.pathsEqual,
   )
 
-  const currentOrTransientElementsToRerender =
-    elementsToRerenderTransient.length > 0 ? elementsToRerenderTransient : currentElementsToRerender
+  const elementsToRerender =
+    elementsToRerenderTransient.length > 0
+      ? elementsToRerenderTransient
+      : editorStore.patchedEditor.canvas.elementsToRerender
 
-  let fixedElementsToRerender: ElementsToRerender = currentOrTransientElementsToRerender
-  if (
-    currentOrTransientElementsToRerender !== 'rerender-all-elements' &&
-    lastElementsToRerender !== 'rerender-all-elements'
-  ) {
-    // if the current elements to rerender array doesn't match the previous elements to rerender array, for a single frame let's use the union of the two arrays
-    fixedElementsToRerender = EP.uniqueElementPaths([
-      ...lastElementsToRerender,
-      ...currentOrTransientElementsToRerender,
-    ])
-  }
-
-  lastElementsToRerender = currentOrTransientElementsToRerender
+  const fixedElementsToRerender = fixElementsToRerender(elementsToRerender)
   return fixedElementsToRerender
 }
 
@@ -460,8 +466,8 @@ export class Editor {
       if (shouldUpdateCanvasStore) {
         // this will re-render the canvas root and potentially the canvas contents itself
         Measure.taskTime(`update canvas ${updateId}`, () => {
-          const currentElementsToRender = fixElementsToRerender(
-            this.storedState.patchedEditor.canvas.elementsToRerender,
+          const currentElementsToRender = collectElementsToRerender(
+            this.storedState,
             dispatchedActions,
           )
           ElementsToRerenderGLOBAL.current = currentElementsToRender // Mutation!
@@ -521,10 +527,11 @@ export class Editor {
 
           // re-render the canvas
           Measure.taskTime(`Canvas re-render because of groups ${updateId}`, () => {
-            ElementsToRerenderGLOBAL.current = fixElementsToRerender(
-              this.storedState.patchedEditor.canvas.elementsToRerender,
+            const currentElementsToRender = collectElementsToRerender(
+              this.storedState,
               dispatchedActions,
-            ) // Mutation!
+            )
+            ElementsToRerenderGLOBAL.current = currentElementsToRender // Mutation!
 
             ReactDOM.flushSync(() => {
               ReactDOM.unstable_batchedUpdates(() => {


### PR DESCRIPTION
## Problem
The real dispatch in editor.tsx and the fake dispatch have a different way to calculate which elements to sample with the DOM sampler. This has been OK up until now, since often all elements we re-rendered/re-sampled, but now that we started to get more selective with what to re-render/re-sample, this discrepancy caused some test failures in an [upcoming PR](https://github.com/concrete-utopia/utopia/pull/6450).

## Fix
Extract out the logic to determine which elements to re-render/re-sample into a function that's used by both the real and fake dispatch

### Note on `ElementsToRerenderGLOBAL.current`
The real dispatch updates `ElementsToRerenderGLOBAL.current`, while the fake one doesn't. Ideally this behaviour would be the same too, but updating `ElementsToRerenderGLOBAL.current` inside `collectElementsToRerender` led to test failures that didn't happen on the PR where this problem was discovered, so this is out of scope for this PR