### PR TITLE
Fix width of toolbar url input

### DIFF
--- a/editor/src/components/editor/remix-navigation-bar.tsx
+++ b/editor/src/components/editor/remix-navigation-bar.tsx
@@ -137,13 +137,11 @@ export const RemixNavigationBar = React.memo(() => {
     <FlexRow
       style={{
         gap: 10,
-        alignSelf: 'stretch',
-        alignItems: 'center',
-        justifyContent: 'center',
         pointerEvents: 'initial',
         userSelect: 'none',
         padding: '0 8px',
         height: 32,
+        width: '100%',
       }}
       onMouseDown={stopPropagation}
       onClick={stopPropagation}
@@ -201,8 +199,10 @@ export const RemixNavigationBar = React.memo(() => {
           padding: '2px 2px 2px 6px',
           fontSize: 11,
           minWidth: 150,
+          flexGrow: 1,
           height: 20,
           alignItems: 'center',
+          justifyContent: 'space-between',
         }}
       >
         <StringInput


### PR DESCRIPTION
Before:
<img width="352" alt="Screenshot 2024-10-03 at 2 11 38 PM" src="https://github.com/user-attachments/assets/a767f00c-8546-48a8-91e7-e3e8833aa922">

After:
<img width="345" alt="Screenshot 2024-10-03 at 2 11 18 PM" src="https://github.com/user-attachments/assets/be6400c6-f3a3-496e-b0c3-c3b0488a3505">
