### PR TITLE
call `fixElementsToRerender` last in `collectElementsToRerender`

### DIFF
--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -200,18 +200,18 @@ export function collectElementsToRerender(
       ? elementsToRerenderTransient
       : editorStore.patchedEditor.canvas.elementsToRerender
 
-  const fixedElementsToRerender = fixElementsToRerender(elementsToRerender)
   const fixedElementsWithChildGroups =
-    fixedElementsToRerender === 'rerender-all-elements'
-      ? fixedElementsToRerender
+    elementsToRerender === 'rerender-all-elements'
+      ? elementsToRerender
       : [
-          ...fixedElementsToRerender,
+          ...elementsToRerender,
           ...getChildGroupsForNonGroupParents(
             editorStore.patchedEditor.jsxMetadata,
-            fixedElementsToRerender,
+            elementsToRerender,
           ),
         ]
-  return fixedElementsWithChildGroups
+  const fixedElementsToRerender = fixElementsToRerender(fixedElementsWithChildGroups)
+  return fixedElementsToRerender
 }
 
 export class Editor {


### PR DESCRIPTION
## Problem
`fixElementsToRerender` needs to be called last in `collectElementsToRerender`, since it needs to store all elements paths passed to it in `lastElementsToRerender`. Otherwise, any subsequent elements paths that are calculated based on the return value won't be cleared from the metadata 

## Fix
Re-order the contents of `collectElementsToRerender` so that `fixElementsToRerender` can store all element paths that `collectElementsToRerender` collected