### PR TITLE
Fix duplicate grid control keys

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -20,7 +20,7 @@ import {
   printGridCSSNumber,
 } from '../../../components/inspector/common/css-utils'
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import { mapDropNulls, stripNulls } from '../../../core/shared/array-utils'
+import { mapDropNulls, stripNulls, uniqBy } from '../../../core/shared/array-utils'
 import { defaultEither } from '../../../core/shared/either'
 import * as EP from '../../../core/shared/element-path'
 import type {
@@ -747,7 +747,7 @@ export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ tar
     'FlexReparentTargetIndicator lines',
   )
 
-  const grids = useGridData([...targets, ...hoveredGrids])
+  const grids = useGridData(uniqBy([...targets, ...hoveredGrids], (a, b) => EP.pathsEqual(a, b)))
 
   const cells = React.useMemo(() => {
     return grids.flatMap((grid) => {


### PR DESCRIPTION
**Problem:**

The grid controls show a bunch of duplicate keys while active.

**Fix:**

The problem is that there may be multiple instances of the same grid being rendered caused by how they are initialized, so this PS cleans that up.

Fixes #6473 
