### PR TITLE
Fix reparenting into grid

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
@@ -130,7 +130,7 @@ export const gridRearrangeMoveStrategy: CanvasStrategyFactory = (
         ),
       ]
 
-      const { commands, patch } =
+      const { commands, patch, elementsToRerender } =
         strategyToApply.type === 'GRID_REARRANGE'
           ? getCommandsAndPatchForGridRearrange(
               canvasState,
@@ -155,7 +155,7 @@ export const gridRearrangeMoveStrategy: CanvasStrategyFactory = (
 
       return strategyApplicationResult(
         [...midInteractionCommands, ...onCompleteCommands, ...commands],
-        [parentGridPath],
+        elementsToRerender,
         patch,
       )
     },
@@ -167,9 +167,13 @@ function getCommandsAndPatchForGridRearrange(
   interactionData: DragInteractionData,
   customState: CustomStrategyState,
   selectedElement: ElementPath,
-): { commands: CanvasCommand[]; patch: CustomStrategyStatePatch } {
+): {
+  commands: CanvasCommand[]
+  patch: CustomStrategyStatePatch
+  elementsToRerender: ElementPath[]
+} {
   if (interactionData.drag == null) {
-    return { commands: [], patch: {} }
+    return { commands: [], patch: {}, elementsToRerender: [] }
   }
 
   const {
@@ -197,6 +201,7 @@ function getCommandsAndPatchForGridRearrange(
         currentRootCell: targetRootCell,
       },
     },
+    elementsToRerender: [EP.parentPath(selectedElement)],
   }
 }
 
@@ -209,9 +214,13 @@ function getCommandsAndPatchForReparent(
   targetElement: ElementPath,
   strategyLifecycle: InteractionLifecycle,
   gridFrame: CanvasRectangle,
-): { commands: CanvasCommand[]; patch: CustomStrategyStatePatch } {
+): {
+  commands: CanvasCommand[]
+  patch: CustomStrategyStatePatch
+  elementsToRerender: ElementPath[]
+} {
   if (interactionData.drag == null) {
-    return { commands: [], patch: {} }
+    return { commands: [], patch: {}, elementsToRerender: [] }
   }
 
   function applyReparent() {
@@ -285,6 +294,10 @@ function getCommandsAndPatchForReparent(
   return {
     commands: commands,
     patch: result.customStatePatch,
+    elementsToRerender: [
+      EP.parentPath(targetElement),
+      strategy.target.newParent.intendedParentPath,
+    ],
   }
 }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategies.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategies.spec.browser2.tsx
@@ -577,8 +577,7 @@ describe('grid reparent strategies', () => {
         ),
       )
     })
-    // disabling flaky test
-    xit('into a grid container', async () => {
+    it('into a grid container', async () => {
       const editor = await renderTestEditorWithCode(
         makeTestProjectCode({
           insideGrid: `


### PR DESCRIPTION
**Problem:**
Reparenting into grid containers is broken.

**Fix:**
To reparent into a grid container we need grid cell measurements. The dom sampler can only measure the grid cells when the controls are displayed. The controls are displayed on hover during the interaction, so this is is possible, but recently strategies were optimized by always providing elementsToRerender values, which did not include the new parent. So the grid controls were displayed, but not measured.
In case of grid reparent we need to make sure that the dom sampler can measure the new parent, so the intendedParentPath has to be in elementsToRerender.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

