### PR TITLE
chore(types): remove duplicate type definitions

### DIFF
--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -44,6 +44,18 @@ import type {
   NodeModules,
   ProjectContents,
   NodeModuleFile,
+  PackageType,
+  BaseTemplateName,
+  SvgTemplateName,
+  Dependencies,
+  id,
+  StaticElementPathPart,
+  ElementPathPart,
+  StaticElementPath,
+  ElementPath,
+  PropertyPathPart,
+  PropertyPath,
+  ElementPropertyPath,
 } from 'utopia-shared/src/types'
 import {
   imageFile,
@@ -51,6 +63,7 @@ import {
   RevisionsState,
   unparsed,
   EmptyExportsDetail,
+  PinType,
 } from 'utopia-shared/src/types'
 
 export type {
@@ -90,56 +103,20 @@ export type {
   NodeModules,
   ProjectContents,
   NodeModuleFile,
+  PackageType,
+  BaseTemplateName,
+  SvgTemplateName,
+  Dependencies,
+  id,
+  StaticElementPathPart,
+  ElementPathPart,
+  StaticElementPath,
+  ElementPath,
+  PropertyPathPart,
+  PropertyPath,
+  ElementPropertyPath,
 }
-export { imageFile, assetFile, RevisionsState, unparsed, EmptyExportsDetail }
-
-export type id = string
-enum StaticModifier {}
-
-export type StaticElementPathPart = StaticModifier & Array<id>
-export type ElementPathPart = Array<id> | StaticElementPathPart
-
-export interface StaticElementPath {
-  type: 'elementpath'
-  parts: Array<StaticElementPathPart>
-}
-
-export interface ElementPath {
-  type: 'elementpath'
-  parts: Array<ElementPathPart>
-}
-
-export type PropertyPathPart = string | number
-
-export type PropertyPath<T extends Array<PropertyPathPart> = Array<PropertyPathPart>> = {
-  propertyElements: T
-}
-
-export type PackageType = 'base' | 'svg' | 'app'
-export type BaseTemplateName =
-  | 'output'
-  | 'view'
-  | 'multi-generator'
-  | 'placeholder'
-  | 'image'
-  | 'text'
-  | 'rectangle'
-  | 'ellipse'
-  | 'custom-code'
-  | 'code-component'
-export type SvgTemplateName = 'arc' | 'circle' | 'ellipse' | 'path' | 'polygon' | 'rect'
-
-export type ElementPropertyPath = {
-  elementPath: ElementPath
-  propertyPath: PropertyPath
-}
-
-export type Dependencies = { [key: string]: ElementPropertyPath }
-
-export enum PinType {
-  Absolute = 'absolute',
-  Relative = 'relative',
-}
+export { imageFile, assetFile, RevisionsState, unparsed, EmptyExportsDetail, PinType }
 
 export interface SceneMetadata {
   uid: string

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -7,11 +7,77 @@ import type {
 } from './element-template'
 import type { ErrorMessage } from './error-messages'
 import { arrayEqualsByValue, objectEquals } from './utils'
-import type { ImageFile, AssetFile, RevisionsStateType } from 'utopia-shared/src/types'
-import { imageFile, assetFile, RevisionsState } from 'utopia-shared/src/types'
+import type {
+  ImageFile,
+  AssetFile,
+  RevisionsStateType,
+  ParsedJSONResult,
+  TextFileContents,
+  ParseSuccess,
+  ParseFailure,
+  Unparsed,
+  ParsedTextFile,
+  ImportAlias,
+  ImportDetails,
+  Imports,
+  ExportFunction,
+  ExportClass,
+  ExportVariable,
+  ExportVariables,
+  ExportDestructuredAssignment,
+  ExportDefaultFunctionOrClass,
+  ExportDefaultIdentifier,
+  ReexportWildcard,
+  ReexportVariables,
+  ExportDetail,
+  ExportsDetail,
+  ExportVariablesWithModifier,
+  HighlightBounds,
+  HighlightBoundsForUids,
+  TextFile,
+  ParsedJSONSuccess,
+  ParsedJSONFailure,
+} from 'utopia-shared/src/types'
+import {
+  imageFile,
+  assetFile,
+  RevisionsState,
+  unparsed,
+  EmptyExportsDetail,
+} from 'utopia-shared/src/types'
 
-export type { ImageFile, AssetFile, RevisionsStateType }
-export { imageFile, assetFile, RevisionsState }
+export type {
+  ImageFile,
+  AssetFile,
+  RevisionsStateType,
+  ParsedJSONResult,
+  TextFileContents,
+  ParseSuccess,
+  ParseFailure,
+  Unparsed,
+  ParsedTextFile,
+  ImportAlias,
+  ImportDetails,
+  Imports,
+  ExportFunction,
+  ExportClass,
+  ExportVariable,
+  ExportVariables,
+  ExportDestructuredAssignment,
+  ExportDefaultFunctionOrClass,
+  ExportDefaultIdentifier,
+  ReexportWildcard,
+  ReexportVariables,
+  ExportDetail,
+  ExportsDetail,
+  ExportVariablesWithModifier,
+  HighlightBounds,
+  HighlightBoundsForUids,
+  TextFile,
+  ParsedJSONSuccess,
+  ParsedJSONFailure,
+}
+export { imageFile, assetFile, RevisionsState, unparsed, EmptyExportsDetail }
 
 export type id = string
 enum StaticModifier {}
@@ -69,11 +135,6 @@ export interface SceneMetadata {
   label?: string
 }
 
-export interface ImportAlias {
-  name: string
-  alias: string
-}
-
 export function importAlias(name: string, alias?: string): ImportAlias {
   return {
     name: name,
@@ -83,12 +144,6 @@ export function importAlias(name: string, alias?: string): ImportAlias {
 
 export function importAliasEquals(first: ImportAlias, second: ImportAlias): boolean {
   return first.name === second.name && first.alias === second.alias
-}
-
-export interface ImportDetails {
-  importedWithName: string | null // import name from './place'
-  importedFromWithin: Array<ImportAlias> // import { name as alias } from './place'
-  importedAs: string | null // import * as name from './place'
 }
 
 export function importDetails(
@@ -153,8 +208,6 @@ export function importDetailsEquals(first: ImportDetails, second: ImportDetails)
   )
 }
 
-export type Imports = { [importSource: string]: ImportDetails }
-
 export type ImportsMergeResolution = {
   imports: Imports
   duplicateNameMapping: Map<string, string>
@@ -190,24 +243,11 @@ export function importDetailsFromImportOption(importOption: ImportType): ImportD
   return importDetails(importedWithName, importedFromWithin, importedAs)
 }
 
-// export let name1, name2, …, nameN; // also var, const
-// export let name1 = …, name2 = …, …, nameN; // also var, const
-export interface ExportVariablesWithModifier {
-  type: 'EXPORT_VARIABLES_WITH_MODIFIER'
-  variables: Array<string>
-}
-
 export function exportVariablesWithModifier(variables: Array<string>): ExportVariablesWithModifier {
   return {
     type: 'EXPORT_VARIABLES_WITH_MODIFIER',
     variables: variables,
   }
-}
-
-// export function functionName(){...}
-export interface ExportFunction {
-  type: 'EXPORT_FUNCTION'
-  functionName: string
 }
 
 export function exportFunction(functionName: string): ExportFunction {
@@ -221,25 +261,11 @@ export function isExportFunction(e: ExportDetail): e is ExportFunction {
   return e.type === 'EXPORT_FUNCTION'
 }
 
-// export class ClassName {...}
-export interface ExportClass {
-  type: 'EXPORT_CLASS'
-  className: string
-}
-
 export function exportClass(className: string): ExportClass {
   return {
     type: 'EXPORT_CLASS',
     className: className,
   }
-}
-
-// export { name1, name2, …, nameN };
-// export { variable1 as name1, variable2 as name2, …, nameN };
-// export { name1 as default, … };
-export interface ExportVariable {
-  variableName: string
-  variableAlias: string | null
 }
 
 export function exportVariable(variableName: string, variableAlias: string | null): ExportVariable {
@@ -249,22 +275,11 @@ export function exportVariable(variableName: string, variableAlias: string | nul
   }
 }
 
-export interface ExportVariables {
-  type: 'EXPORT_VARIABLES'
-  variables: Array<ExportVariable>
-}
-
 export function exportVariables(variables: Array<ExportVariable>): ExportVariables {
   return {
     type: 'EXPORT_VARIABLES',
     variables: variables,
   }
-}
-
-// export const { name1, name2: bar } = o;
-export interface ExportDestructuredAssignment {
-  type: 'EXPORT_DESTRUCTURED_ASSIGNMENT'
-  variables: Array<ExportVariable>
 }
 
 export function exportDestructuredAssignment(
@@ -276,13 +291,6 @@ export function exportDestructuredAssignment(
   }
 }
 
-// export default function (…) { … } // also class, function*
-// export default function name1(…) { … } // also class, function*
-export interface ExportDefaultFunctionOrClass {
-  type: 'EXPORT_DEFAULT_FUNCTION_OR_CLASS'
-  name: string | null
-}
-
 export function exportDefaultFunctionOrClass(name: string | null): ExportDefaultFunctionOrClass {
   return {
     type: 'EXPORT_DEFAULT_FUNCTION_OR_CLASS',
@@ -292,13 +300,6 @@ export function exportDefaultFunctionOrClass(name: string | null): ExportDefault
 
 export function isExportDefaultFunctionOrClass(e: ExportDetail): e is ExportDefaultFunctionOrClass {
   return e.type === 'EXPORT_DEFAULT_FUNCTION_OR_CLASS'
-}
-
-// const App = (…) { … }
-// export default App;
-export interface ExportDefaultIdentifier {
-  type: 'EXPORT_DEFAULT_IDENTIFIER'
-  name: string
 }
 
 export function exportDefaultIdentifier(name: string): ExportDefaultIdentifier {
@@ -318,14 +319,6 @@ export function isExportDefault(
   return isExportDefaultFunctionOrClass(e) || isExportDefaultIdentifier(e)
 }
 
-// export * from …; // does not set the default export
-// export * as name1 from …; // Draft ECMAScript® 2O21
-export interface ReexportWildcard {
-  type: 'REEXPORT_WILDCARD'
-  reexportedModule: string
-  namespacedVariable: string | null
-}
-
 export function reexportWildcard(
   reexportedModule: string,
   namespacedVariable: string | null,
@@ -335,15 +328,6 @@ export function reexportWildcard(
     reexportedModule: reexportedModule,
     namespacedVariable: namespacedVariable,
   }
-}
-
-//export { name1, name2, …, nameN } from …;
-//export { import1 as name1, import2 as name2, …, nameN } from …;
-//export { default, … } from …;
-export interface ReexportVariables {
-  type: 'REEXPORT_VARIABLES'
-  reexportedModule: string
-  variables: Array<ExportVariable>
 }
 
 export function reexportVariables(
@@ -356,21 +340,6 @@ export function reexportVariables(
     variables: variables,
   }
 }
-
-export type ExportDetail =
-  | ExportVariablesWithModifier
-  | ExportFunction
-  | ExportClass
-  | ExportVariables
-  | ExportDestructuredAssignment
-  | ExportDefaultFunctionOrClass
-  | ExportDefaultIdentifier
-  | ReexportWildcard
-  | ReexportVariables
-
-export type ExportsDetail = Array<ExportDetail>
-
-export const EmptyExportsDetail: ExportsDetail = []
 
 export function mergeExportsDetail(first: ExportsDetail, second: ExportsDetail): ExportsDetail {
   return [...first, ...second]
@@ -388,14 +357,6 @@ export function isReexportExportDetail(
   return exportDetail.type === 'REEXPORT_WILDCARD' || exportDetail.type === 'REEXPORT_VARIABLES'
 }
 
-export interface HighlightBounds {
-  startLine: number
-  startCol: number
-  endLine: number
-  endCol: number
-  uid: string
-}
-
 export function highlightBounds(
   startLine: number,
   startCol: number,
@@ -411,27 +372,12 @@ export function highlightBounds(
     uid: uid,
   }
 }
-
-export type HighlightBoundsForUids = { [uid: string]: HighlightBounds }
-
 export interface HighlightBoundsWithFile {
   bounds: HighlightBounds
   filePath: string
 }
 
 export type HighlightBoundsWithFileForUids = { [uid: string]: HighlightBoundsWithFile }
-
-// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
-export interface ParseSuccess {
-  type: 'PARSE_SUCCESS'
-  imports: Imports
-  topLevelElements: Array<TopLevelElement>
-  highlightBounds: HighlightBoundsForUids
-  fullHighlightBounds: HighlightBoundsForUids
-  jsxFactoryFunction: string | null
-  combinedTopLevelArbitraryBlock: ArbitraryJSBlock | null
-  exportsDetail: ExportsDetail
-}
 
 export function parseSuccess(
   imports: Imports,
@@ -458,15 +404,6 @@ export function isParseSuccess(parsed: ParsedTextFile): parsed is ParseSuccess {
   return parsed.type === 'PARSE_SUCCESS'
 }
 
-// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
-export interface ParseFailure {
-  type: 'PARSE_FAILURE'
-  diagnostics: Array<ErrorMessage> | null
-  parsedJSONFailure: ParsedJSONFailure | null
-  errorMessage: string | null
-  errorMessages: Array<ErrorMessage>
-}
-
 export function parseFailure(
   diagnostics: Array<ErrorMessage> | null,
   parsedJSON: ParsedJSONFailure | null,
@@ -486,21 +423,9 @@ export function isParseFailure(parsed: ParsedTextFile): parsed is ParseFailure {
   return parsed.type === 'PARSE_FAILURE'
 }
 
-// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
-export interface Unparsed {
-  type: 'UNPARSED'
-}
-
-export const unparsed: Unparsed = {
-  type: 'UNPARSED',
-}
-
 export function isUnparsed(parsed: ParsedTextFile): parsed is Unparsed {
   return parsed.type === 'UNPARSED'
 }
-
-// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
-export type ParsedTextFile = ParseFailure | ParseSuccess | Unparsed
 
 export function foldParsedTextFile<X>(
   foldFailure: (failure: ParseFailure) => X,
@@ -541,39 +466,12 @@ export function forEachParseSuccess(
   }
 }
 
-// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
-export interface ParsedJSONSuccess {
-  type: 'SUCCESS'
-  value: any
-}
-
 export function isParsedJSONSuccess(result: ParsedJSONResult): result is ParsedJSONSuccess {
   return result.type === 'SUCCESS'
 }
 
-// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
-export interface ParsedJSONFailure {
-  type: 'FAILURE'
-  codeSnippet: string
-  reason: string
-  startLine: number
-  startCol: number
-  endLine: number
-  endCol: number
-}
-
 export function isParsedJSONFailure(result: ParsedJSONResult): result is ParsedJSONFailure {
   return result.type === 'FAILURE'
-}
-
-// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
-export type ParsedJSONResult = ParsedJSONSuccess | ParsedJSONFailure
-
-// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
-export interface TextFileContents {
-  code: string
-  parsed: ParsedTextFile
-  revisionsState: RevisionsStateType
 }
 
 export function textFileContents(
@@ -586,15 +484,6 @@ export function textFileContents(
     parsed: parsed,
     revisionsState: revisionsState,
   }
-}
-
-// Ensure this is kept up to date with clientmodel/lib/src/Utopia/ClientModel.hs.
-export interface TextFile {
-  type: 'TEXT_FILE'
-  fileContents: TextFileContents
-  lastSavedContents: TextFileContents | null // it is null when the file is saved
-  lastParseSuccess: ParseSuccess | null
-  versionNumber: number
 }
 
 export function textFile(

--- a/editor/src/core/shared/project-file-types.ts
+++ b/editor/src/core/shared/project-file-types.ts
@@ -37,6 +37,13 @@ import type {
   TextFile,
   ParsedJSONSuccess,
   ParsedJSONFailure,
+  ESCodeFile,
+  ESCodeFileOrigin,
+  ProjectFile,
+  ProjectFileType,
+  NodeModules,
+  ProjectContents,
+  NodeModuleFile,
 } from 'utopia-shared/src/types'
 import {
   imageFile,
@@ -76,6 +83,13 @@ export type {
   TextFile,
   ParsedJSONSuccess,
   ParsedJSONFailure,
+  ESCodeFile,
+  ESCodeFileOrigin,
+  ProjectFile,
+  ProjectFileType,
+  NodeModules,
+  ProjectContents,
+  NodeModuleFile,
 }
 export { imageFile, assetFile, RevisionsState, unparsed, EmptyExportsDetail }
 
@@ -545,15 +559,6 @@ interface EvalResult {
   }
 }
 
-export type ESCodeFileOrigin = 'PROJECT_CONTENTS' | 'NODE_MODULES'
-
-export interface ESCodeFile {
-  type: 'ES_CODE_FILE'
-  fileContents: string
-  origin: ESCodeFileOrigin
-  fullPath: string
-}
-
 export function esCodeFile(
   fileContents: string,
   origin: ESCodeFileOrigin,
@@ -615,16 +620,3 @@ export function directory(): Directory {
 export function isDirectory(projectFile: ProjectFile): projectFile is Directory {
   return projectFile.type === 'DIRECTORY'
 }
-
-export type ProjectFile = TextFile | ImageFile | Directory | AssetFile
-
-export type ProjectFileType = ProjectFile['type']
-
-export type NodeModuleFile = ESCodeFile | ESRemoteDependencyPlaceholder // TODO maybe ESCodeFile is too strict, eventually we want to have ProjectFile here
-
-export type NodeModules = {
-  [filepath: string]: NodeModuleFile
-}
-
-// Key here is the full filename.
-export type ProjectContents = { [filepath: string]: ProjectFile }

--- a/utopia-shared/src/types/project-file-types.ts
+++ b/utopia-shared/src/types/project-file-types.ts
@@ -74,6 +74,7 @@ export interface ExportVariablesWithModifier {
   variables: Array<string>
 }
 
+// export function functionName(){...}
 export interface ExportFunction {
   type: 'EXPORT_FUNCTION'
   functionName: string


### PR DESCRIPTION
**Problem:**
Today we have shared types between the editor and our Remix code (`utopia-shared`), however some of these definitions are still duplicated in the editor code (even if identical), which can lead to divergence over time.

**Fix:**
Make sure the duplicated types are identical and remove them, reference `utopia-shared` as the source of truth.
Actual code (functions) was not moved, only types, since `utopia-shared` should be kept separated from editor code and imports.

**Note:**
In the future this can allow us to have `utopia-shared` code hash (or package version) as the cache version for `ParseSuccess` objects.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode
