### PR TITLE
fix(editor): fix warning about giving a ref to a function component

### DIFF
--- a/editor/src/uuiui/widgets/layout/flex-row.tsx
+++ b/editor/src/uuiui/widgets/layout/flex-row.tsx
@@ -13,16 +13,18 @@ import React from 'react'
 export const FlexRow = styled.div([commonSenseUtopiaLayoutShorthands, { ...flexRowStyle }])
 FlexRow.displayName = 'FlexRow'
 
-export const SimpleFlexRow = (props: JSX.IntrinsicElements['div']) => {
-  const mergedProps = React.useMemo(() => {
-    return {
-      ...props,
-      style: {
-        ...flexRowStyle,
-        ...props.style,
-      },
-    }
-  }, [props])
-  return <div {...mergedProps} />
-}
+export const SimpleFlexRow = React.forwardRef<HTMLDivElement, JSX.IntrinsicElements['div']>(
+  (props, ref) => {
+    const mergedProps = React.useMemo(() => {
+      return {
+        ...props,
+        style: {
+          ...flexRowStyle,
+          ...props.style,
+        },
+      }
+    }, [props])
+    return <div ref={ref} {...mergedProps} />
+  },
+)
 SimpleFlexRow.displayName = 'SimpleFlexRow'


### PR DESCRIPTION
**Problem:**
Today we have a constant warning about giving a ref to a function component inside `DesignPanelRoot`

<img width="988" alt="image" src="https://github.com/user-attachments/assets/0c245ef1-4de0-4f05-a4f7-4fa3baa0a9c7">


**Fix:**
Wrap the component in `forwardRef` to avoid this warning.
This will also greatly reduce our tests logs.

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Play mode
