### PR TITLE
fix(test): dont install AtomDevtools in test envs

### DIFF
--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -10,6 +10,7 @@ import { useAtomsDevtools } from 'jotai-devtools'
 import '../utils/vite-hmr-config'
 import {
   getProjectID,
+  IS_TEST_ENVIRONMENT,
   PROBABLY_ELECTRON,
   PRODUCTION_ENV,
   requireElectron,
@@ -709,7 +710,7 @@ export class Editor {
 let canvasUpdateId: number = 0
 
 const AtomsDevtools = (props: { children: React.ReactNode }) => {
-  if (!PRODUCTION_ENV) {
+  if (!PRODUCTION_ENV && !IS_TEST_ENVIRONMENT) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useAtomsDevtools(`Utopia Jotai Atoms Debug Store`)
   }


### PR DESCRIPTION
**Problem:**
Today we get a lot of long warnings in the test logs about AtomDevtools. 

**Fix:**
Don't install AtomDevtools in test environments, since they are only relevant for browser debugging.

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Play mode
