### PR TITLE
Check null when syncing flags

### DIFF
--- a/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
+++ b/editor/src/components/navigator/left-pane/roll-your-own-pane.tsx
@@ -302,7 +302,10 @@ function syncFeatureFlagIfExists(
   setFeatureEnabled(featureFlag, value)
 }
 
-function syncWithFeatureFlags(features: Record<string, any>) {
+function syncWithFeatureFlags(features: Record<string, any> | undefined) {
+  if (features == null) {
+    return {}
+  }
   return Object.fromEntries(
     Object.entries(features).map(([key, value]) => {
       if (typeof value === 'boolean' && key in featureToFeatureFlagMap) {


### PR DESCRIPTION
**Problem:**

The object passed to `syncWithFeatureFlags` might be undefined, and if it is the editor crashes.

**Fix:**

Handle with an early exit the case for which the features passed/loaded from the atom are undefined.
