### PR TITLE
Don't show grid resize handles on top of scene labels

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -498,6 +498,7 @@ export type GridData = {
   columns: number
   cells: number
   metadata: ElementInstanceMetadata
+  isScene: boolean
 }
 
 export function useGridData(elementPaths: ElementPath[]): GridData[] {
@@ -557,6 +558,9 @@ export function useGridData(elementPaths: ElementPath[]): GridData[] {
           rows: rows,
           columns: columns,
           cells: rows * columns,
+          isScene:
+            MetadataUtils.isProbablySceneFromMetadata(targetGridContainer) ||
+            MetadataUtils.isProbablyRemixSceneFromMetadata(targetGridContainer),
         }
       }, elementPaths)
     },
@@ -624,13 +628,6 @@ export const GridRowColumnResizingControls =
       })
     }, [scale, grids])
 
-    function isScene(grid: GridData) {
-      return (
-        MetadataUtils.isProbablySceneFromMetadata(grid.metadata) ||
-        MetadataUtils.isProbablyRemixSceneFromMetadata(grid.metadata)
-      )
-    }
-
     return (
       <CanvasOffsetWrapper>
         {gridsWithVisibleResizeControls.flatMap((grid) => {
@@ -644,7 +641,7 @@ export const GridRowColumnResizingControls =
               gap={grid.columnGap ?? grid.gap}
               padding={grid.padding}
               stripedAreaLength={getStripedAreaLength(grid.gridTemplateRows, grid.gap ?? 0)}
-              isScene={isScene(grid)}
+              isScene={grid.isScene}
             />
           )
         })}
@@ -659,7 +656,7 @@ export const GridRowColumnResizingControls =
               gap={grid.rowGap ?? grid.gap}
               padding={grid.padding}
               stripedAreaLength={getStripedAreaLength(grid.gridTemplateColumns, grid.gap ?? 0)}
-              isScene={isScene(grid)}
+              isScene={grid.isScene}
             />
           )
         })}

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -94,7 +94,7 @@ import {
   getGridRelatedIndexes,
 } from '../canvas-strategies/strategies/grid-helpers'
 import { canResizeGridTemplate } from '../canvas-strategies/strategies/resize-grid-strategy'
-import { SceneLabelTestID } from './select-mode/scene-label'
+import { SCENE_LABEL_HEIGHT } from './select-mode/scene-label'
 
 const CELL_ANIMATION_DURATION = 0.15 // seconds
 
@@ -1859,7 +1859,6 @@ export function controlsForGridPlaceholders(gridPath: ElementPath): ControlWithP
 }
 
 function sceneTopOffset(canvasScale: number) {
-  const labelHeight = document.getElementById(SceneLabelTestID)?.getBoundingClientRect().height ?? 0
   const borderSkew = 5
-  return (labelHeight + borderSkew) / canvasScale
+  return (SCENE_LABEL_HEIGHT + borderSkew) / canvasScale
 }

--- a/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/remix-scene-label.tsx
@@ -28,6 +28,7 @@ import { MultiplayerWrapper } from '../../../../utils/multiplayer-wrapper'
 import { getIdOfScene } from '../comment-mode/comment-mode-hooks'
 import { optionalMap } from '../../../../core/shared/optional-utils'
 import { defaultEither } from '../../../../core/shared/either'
+import { SCENE_LABEL_HEIGHT } from './scene-label'
 
 export const RemixSceneLabelPathTestId = (path: ElementPath): string =>
   `${EP.toString(path)}-remix-scene-label-path`
@@ -318,6 +319,7 @@ const RemixSceneLabel = React.memo<RemixSceneLabelProps>((props) => {
           textOverflow: 'ellipsis',
           borderRadius: borderRadius,
           justifyContent: 'space-between',
+          height: SCENE_LABEL_HEIGHT / scale,
         }}
       >
         <FlexRow style={{ gap: paddingX }}>

--- a/editor/src/components/canvas/controls/select-mode/scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/scene-label.tsx
@@ -220,6 +220,7 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
           onMouseDown={labelSelectable ? onMouseDown : NO_OP}
           onMouseMove={labelSelectable ? onMouseMove : NO_OP}
           data-testid={SceneLabelTestID}
+          id={SceneLabelTestID}
           className='roleComponentName'
           style={{
             pointerEvents: labelSelectable ? 'initial' : 'none',

--- a/editor/src/components/canvas/controls/select-mode/scene-label.tsx
+++ b/editor/src/components/canvas/controls/select-mode/scene-label.tsx
@@ -20,6 +20,8 @@ import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 import { isCommentMode, isSelectModeWithArea } from '../../../editor/editor-modes'
 import { getElementPathTreeChildren, getSubTree } from '../../../../core/shared/element-path-tree'
 
+export const SCENE_LABEL_HEIGHT = 28 //px
+
 interface SceneLabelControlProps {
   maybeHighlightOnHover: (target: ElementPath) => void
   maybeClearHighlightsOnHoverEnd: () => void
@@ -220,7 +222,6 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
           onMouseDown={labelSelectable ? onMouseDown : NO_OP}
           onMouseMove={labelSelectable ? onMouseMove : NO_OP}
           data-testid={SceneLabelTestID}
-          id={SceneLabelTestID}
           className='roleComponentName'
           style={{
             pointerEvents: labelSelectable ? 'initial' : 'none',
@@ -240,6 +241,7 @@ const SceneLabel = React.memo<SceneLabelProps>((props) => {
             borderRadius: borderRadius,
             textOverflow: 'ellipsis',
             gap: 20,
+            height: SCENE_LABEL_HEIGHT / scale,
           }}
         >
           <div


### PR DESCRIPTION
**Problem:**

The grid resize handles are shown on top of the scene label.

![image](https://github.com/user-attachments/assets/b408f8a6-56c9-49f2-8692-d819a2042008)

**Fix:**

Move the handles north of the scene label if the grid is also a scene.

<img width="850" alt="Screenshot 2024-10-07 at 14 04 32" src="https://github.com/user-attachments/assets/6f30c211-be4a-4716-a57f-154978c7428b">

Fixes #6485 