### PR TITLE
No more stateful grid strategies

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -14,8 +14,6 @@ import type { AllElementProps } from '../../editor/store/editor-state'
 import type { CanvasCommand } from '../commands/commands'
 import type { ActiveFrameAction } from '../commands/set-active-frames-command'
 import type { StrategyApplicationStatus } from './interaction-state'
-import type { TargetGridCellData } from './strategies/grid-helpers'
-import type { GridCellCoordinates } from './strategies/grid-cell-bounds'
 
 // TODO: fill this in, maybe make it an ADT for different strategies
 export interface CustomStrategyState {
@@ -29,8 +27,6 @@ export interface CustomStrategyState {
 }
 
 export type GridCustomStrategyState = {
-  targetCellData: TargetGridCellData | null
-  currentRootCell: GridCellCoordinates | null
   metadataCacheForGrids: { [gridPath: string]: ElementInstanceMetadata }
 }
 
@@ -45,8 +41,6 @@ export function defaultCustomStrategyState(): CustomStrategyState {
     elementsToRerender: [],
     action: null,
     grid: {
-      targetCellData: null,
-      currentRootCell: null,
       metadataCacheForGrids: {},
     },
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
@@ -161,27 +161,21 @@ const gridDrawToInsertStrategyInner =
         const newTargetCell = getGridCellUnderMouseFromMetadata(parent, canvasPointToUse)
 
         if (strategyLifecycle === 'mid-interaction' && interactionData.type === 'HOVER') {
-          const baseCustomState = updatedCustomState ?? customStrategyState
-          const customStatePatch = {
-            ...baseCustomState,
-            grid: {
-              ...baseCustomState.grid,
-              // this is added here during the hover interaction so that
-              // `GridControls` can render the hover highlight based on the
-              // coordinates in `targetCellData`
-              targetCellData: newTargetCell ?? customStrategyState.grid.targetCellData,
-            },
-          }
           return strategyApplicationResult(
             [
               wildcardPatch('mid-interaction', {
                 selectedViews: { $set: [] },
               }),
-              showGridControls('mid-interaction', targetParent),
+              showGridControls(
+                'mid-interaction',
+                targetParent,
+                newTargetCell?.gridCellCoordinates ?? null,
+                null,
+              ),
               updateHighlightedViews('mid-interaction', [targetParent]),
             ],
             [targetParent],
-            customStatePatch,
+            updatedCustomState ?? undefined,
           )
         }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-duplicate-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-duplicate-strategy.ts
@@ -72,11 +72,7 @@ export const gridRearrangeMoveDuplicateStrategy: CanvasStrategyFactory = (
 
       const targetElement = EP.appendToPath(EP.parentPath(selectedElement), newUid)
 
-      const {
-        commands: moveCommands,
-        targetCell,
-        targetRootCell,
-      } = runGridRearrangeMove(
+      const moveCommands = runGridRearrangeMove(
         targetElement,
         selectedElement,
         canvasState.startingMetadata,
@@ -96,11 +92,6 @@ export const gridRearrangeMoveDuplicateStrategy: CanvasStrategyFactory = (
         ],
         [...selectedElements, targetElement],
         {
-          grid: {
-            ...customState.grid,
-            targetCellData: targetCell,
-            currentRootCell: targetRootCell,
-          },
           duplicatedElementNewUids: duplicatedElementNewUids,
         },
       )

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
@@ -135,7 +135,6 @@ export const gridRearrangeMoveStrategy: CanvasStrategyFactory = (
           ? getCommandsAndPatchForGridRearrange(
               canvasState,
               interactionSession.interactionData,
-              customState,
               selectedElement,
             )
           : getCommandsAndPatchForReparent(
@@ -165,7 +164,6 @@ export const gridRearrangeMoveStrategy: CanvasStrategyFactory = (
 function getCommandsAndPatchForGridRearrange(
   canvasState: InteractionCanvasState,
   interactionData: DragInteractionData,
-  customState: CustomStrategyState,
   selectedElement: ElementPath,
 ): {
   commands: CanvasCommand[]
@@ -176,7 +174,7 @@ function getCommandsAndPatchForGridRearrange(
     return { commands: [], patch: {}, elementsToRerender: [] }
   }
 
-  const { commands, targetCell, targetRootCell } = runGridRearrangeMove(
+  const commands = runGridRearrangeMove(
     selectedElement,
     selectedElement,
     canvasState.startingMetadata,
@@ -185,13 +183,7 @@ function getCommandsAndPatchForGridRearrange(
 
   return {
     commands: commands,
-    patch: {
-      grid: {
-        ...customState.grid,
-        targetCellData: targetCell,
-        currentRootCell: targetRootCell,
-      },
-    },
+    patch: {},
     elementsToRerender: [EP.parentPath(selectedElement)],
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategy.tsx
@@ -45,7 +45,11 @@ import { removeAbsolutePositioningProps } from './reparent-helpers/reparent-prop
 import type { ReparentTarget } from './reparent-helpers/reparent-strategy-helpers'
 import { getReparentOutcome, pathToReparent } from './reparent-utils'
 import { flattenSelection } from './shared-move-strategies-helpers'
-import { getGridCellUnderMouseFromMetadata, type GridCellCoordinates } from './grid-cell-bounds'
+import {
+  getClosestGridCellToPointFromMetadata,
+  getGridCellUnderMouseFromMetadata,
+  type GridCellCoordinates,
+} from './grid-cell-bounds'
 
 export function gridReparentStrategy(
   reparentTarget: ReparentTarget,
@@ -195,9 +199,7 @@ export function applyGridReparent(
           interactionData.drag ?? canvasVector({ x: 0, y: 0 }),
         )
 
-        const targetCellData =
-          getGridCellUnderMouseFromMetadata(grid, mousePos) ??
-          customStrategyState.grid.targetCellData
+        const targetCellData = getClosestGridCellToPointFromMetadata(grid, mousePos)
 
         if (targetCellData == null) {
           return strategyApplicationResult([], [newParent.intendedParentPath])
@@ -247,10 +249,6 @@ export function applyGridReparent(
         const customStrategyStatePatch = {
           ...baseCustomState,
           elementsToRerender: elementsToRerender,
-          grid: {
-            ...baseCustomState.grid,
-            targetCellData: targetCellData,
-          },
         }
 
         return strategyApplicationResult(
@@ -259,7 +257,12 @@ export function applyGridReparent(
             gridContainerCommands,
             updateSelectedViews('always', newPaths),
             setCursorCommand(CSSCursor.Reparent),
-            showGridControls('mid-interaction', reparentTarget.newParent.intendedParentPath),
+            showGridControls(
+              'mid-interaction',
+              reparentTarget.newParent.intendedParentPath,
+              targetCellData.gridCellCoordinates,
+              null,
+            ),
           ],
           elementsToRerender,
           customStrategyStatePatch,

--- a/editor/src/components/canvas/commands/show-grid-controls-command.ts
+++ b/editor/src/components/canvas/commands/show-grid-controls-command.ts
@@ -1,20 +1,27 @@
 import type { ElementPath } from 'utopia-shared/src/types'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
 import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { GridCellCoordinates } from '../canvas-strategies/strategies/grid-cell-bounds'
 
 export interface ShowGridControlsCommand extends BaseCommand {
   type: 'SHOW_GRID_CONTROLS'
   target: ElementPath
+  targetCell: GridCellCoordinates | null
+  rootCell: GridCellCoordinates | null
 }
 
 export function showGridControls(
   whenToRun: WhenToRun,
   target: ElementPath,
+  targetCell: GridCellCoordinates | null,
+  rootCell: GridCellCoordinates | null,
 ): ShowGridControlsCommand {
   return {
     type: 'SHOW_GRID_CONTROLS',
     whenToRun: whenToRun,
     target: target,
+    targetCell: targetCell,
+    rootCell: rootCell,
   }
 }
 
@@ -25,7 +32,13 @@ export const runShowGridControlsCommand: CommandFunction<ShowGridControlsCommand
   const editorStatePatch: EditorStatePatch = {
     canvas: {
       controls: {
-        gridControls: { $set: command.target },
+        gridControlData: {
+          $set: {
+            grid: command.target,
+            targetCell: command.targetCell,
+            rootCell: command.rootCell,
+          },
+        },
       },
     },
   }

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -699,9 +699,8 @@ export const GridControl = React.memo<GridControlProps>(({ grid }) => {
   )
 
   const currentHoveredCell = useEditorState(
-    Substores.restOfStore,
-    (store) =>
-      store.strategyState.customStrategyState.grid.targetCellData?.gridCellCoordinates ?? null,
+    Substores.canvas,
+    (store) => store.editor.canvas.controls.gridControlData?.targetCell ?? null,
     'GridControl currentHoveredCell',
   )
 
@@ -878,8 +877,8 @@ export const GridControl = React.memo<GridControlProps>(({ grid }) => {
   const gridPath = optionalMap(EP.parentPath, shadow?.elementPath)
 
   const targetRootCell = useEditorState(
-    Substores.restOfStore,
-    (store) => store.strategyState.customStrategyState.grid.currentRootCell,
+    Substores.canvas,
+    (store) => store.editor.canvas.controls.gridControlData?.rootCell ?? null,
     'GridControl targetRootCell',
   )
 
@@ -1126,14 +1125,14 @@ export interface GridControlsProps {
 
 export const GridControls = controlForStrategyMemoized<GridControlsProps>(({ targets }) => {
   const targetRootCell = useEditorState(
-    Substores.restOfStore,
-    (store) => store.strategyState.customStrategyState.grid.currentRootCell,
+    Substores.canvas,
+    (store) => store.editor.canvas.controls.gridControlData?.rootCell ?? null,
     'GridControls targetRootCell',
   )
 
   const hoveredGrids = useEditorState(
     Substores.canvas,
-    (store) => stripNulls([store.editor.canvas.controls.gridControls]),
+    (store) => stripNulls([store.editor.canvas.controls.gridControlData?.grid]),
     'GridControls hoveredGrids',
   )
 

--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -199,9 +199,7 @@ describe('interactionStart', () => {
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "grid": Object {
-            "currentRootCell": null,
             "metadataCacheForGrids": Object {},
-            "targetCellData": null,
           },
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
@@ -266,9 +264,7 @@ describe('interactionStart', () => {
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "grid": Object {
-            "currentRootCell": null,
             "metadataCacheForGrids": Object {},
-            "targetCellData": null,
           },
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
@@ -353,9 +349,7 @@ describe('interactionUpdate', () => {
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "grid": Object {
-            "currentRootCell": null,
             "metadataCacheForGrids": Object {},
-            "targetCellData": null,
           },
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
@@ -440,9 +434,7 @@ describe('interactionUpdate', () => {
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "grid": Object {
-            "currentRootCell": null,
             "metadataCacheForGrids": Object {},
-            "targetCellData": null,
           },
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
@@ -521,9 +513,7 @@ describe('interactionHardReset', () => {
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "grid": Object {
-            "currentRootCell": null,
             "metadataCacheForGrids": Object {},
-            "targetCellData": null,
           },
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
@@ -610,9 +600,7 @@ describe('interactionHardReset', () => {
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "grid": Object {
-            "currentRootCell": null,
             "metadataCacheForGrids": Object {},
-            "targetCellData": null,
           },
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
@@ -705,9 +693,7 @@ describe('interactionUpdate with user changed strategy', () => {
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "grid": Object {
-            "currentRootCell": null,
             "metadataCacheForGrids": Object {},
-            "targetCellData": null,
           },
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},
@@ -795,9 +781,7 @@ describe('interactionUpdate with user changed strategy', () => {
           "elementsToRerender": Array [],
           "escapeHatchActivated": false,
           "grid": Object {
-            "currentRootCell": null,
             "metadataCacheForGrids": Object {},
-            "targetCellData": null,
           },
           "lastReorderIdx": null,
           "strategyGeneratedUidsCache": Object {},

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -31,7 +31,6 @@ import type {
 } from '../../../core/shared/element-template'
 import {
   emptyJsxMetadata,
-  getElementsByUIDFromTopLevelElements,
   isJSExpression,
   isJSXConditionalExpression,
   isJSXElement,
@@ -61,14 +60,12 @@ import type {
   NodeModules,
   ParseSuccess,
   ProjectFile,
-  PropertyPath,
   StaticElementPath,
   TextFile,
 } from '../../../core/shared/project-file-types'
 import {
   RevisionsState,
   codeFile,
-  foldParsedTextFile,
   isParseFailure,
   isParseSuccess,
   isParsedTextFile,
@@ -125,7 +122,6 @@ import type { Notice } from '../../common/notice'
 import type { ShortcutConfiguration } from '../shortcut-definitions'
 import {
   DerivedStateKeepDeepEquality,
-  ElementInstanceMetadataMapKeepDeepEquality,
   InvalidOverrideNavigatorEntryKeepDeepEquality,
   RenderPropNavigatorEntryKeepDeepEquality,
   RenderPropValueNavigatorEntryKeepDeepEquality,
@@ -192,6 +188,7 @@ import type { Collaborator } from '../../../core/shared/multiplayer'
 import type { OnlineState } from '../online-status'
 import type { NavigatorRow } from '../../navigator/navigator-row'
 import type { FancyError } from '../../../core/shared/code-exec-utils'
+import type { GridCellCoordinates } from '../../canvas/canvas-strategies/strategies/grid-cell-bounds'
 
 const ObjectPathImmutable: any = OPI
 
@@ -812,6 +809,12 @@ export interface DragToMoveIndicatorFlags {
   ancestor: boolean
 }
 
+export interface GridControlData {
+  grid: ElementPath
+  targetCell: GridCellCoordinates | null // the cell under the mouse
+  rootCell: GridCellCoordinates | null // the top-left cell of the target child
+}
+
 export interface EditorStateCanvasControls {
   // this is where we can put props for the strategy controls
   snappingGuidelines: Array<GuidelineWithSnappingVectorAndPointsOfRelevance>
@@ -822,7 +825,7 @@ export interface EditorStateCanvasControls {
   reparentedToPaths: Array<ElementPath>
   dragToMoveIndicatorFlags: DragToMoveIndicatorFlags
   parentOutlineHighlight: ElementPath | null
-  gridControls: ElementPath | null
+  gridControlData: GridControlData | null
 }
 
 export function editorStateCanvasControls(
@@ -834,7 +837,7 @@ export function editorStateCanvasControls(
   reparentedToPaths: Array<ElementPath>,
   dragToMoveIndicatorFlagsValue: DragToMoveIndicatorFlags,
   parentOutlineHighlight: ElementPath | null,
-  gridControls: ElementPath | null,
+  gridControlData: GridControlData | null,
 ): EditorStateCanvasControls {
   return {
     snappingGuidelines: snappingGuidelines,
@@ -845,7 +848,7 @@ export function editorStateCanvasControls(
     reparentedToPaths: reparentedToPaths,
     dragToMoveIndicatorFlags: dragToMoveIndicatorFlagsValue,
     parentOutlineHighlight: parentOutlineHighlight,
-    gridControls: gridControls,
+    gridControlData: gridControlData,
   }
 }
 
@@ -2624,7 +2627,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
         reparentedToPaths: [],
         dragToMoveIndicatorFlags: emptyDragToMoveIndicatorFlags,
         parentOutlineHighlight: null,
-        gridControls: null,
+        gridControlData: null,
       },
     },
     inspector: {
@@ -2999,7 +3002,7 @@ export function editorModelFromPersistentModel(
         reparentedToPaths: [],
         dragToMoveIndicatorFlags: emptyDragToMoveIndicatorFlags,
         parentOutlineHighlight: null,
-        gridControls: null,
+        gridControlData: null,
       },
     },
     inspector: {

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -361,6 +361,7 @@ import type {
   RenderedAt,
   EditorRemixConfig,
   ErrorBoundaryHandling,
+  GridControlData,
 } from './editor-state'
 import {
   trueUpGroupElementChanged,
@@ -641,6 +642,7 @@ import type {
   ComponentDescriptorPropertiesBounds,
 } from '../../../core/property-controls/component-descriptor-parser'
 import type { Axis } from '../../../components/canvas/gap-utils'
+import type { GridCellCoordinates } from '../../canvas/canvas-strategies/strategies/grid-cell-bounds'
 
 export function ElementPropertyPathKeepDeepEquality(): KeepDeepEqualityCall<ElementPropertyPath> {
   return combine2EqualityCalls(
@@ -2718,6 +2720,30 @@ export const DragToMoveIndicatorFlagsKeepDeepEquality: KeepDeepEqualityCall<Drag
     dragToMoveIndicatorFlags,
   )
 
+export const GridCellCoordinatesKeepDeepEquality: KeepDeepEqualityCall<GridCellCoordinates> =
+  combine2EqualityCalls(
+    (data) => data.row,
+    createCallWithTripleEquals(),
+    (data) => data.column,
+    createCallWithTripleEquals(),
+    (row, column) => ({ row, column }),
+  )
+
+export const GridControlDataKeepDeepEquality: KeepDeepEqualityCall<GridControlData> =
+  combine3EqualityCalls(
+    (data) => data.grid,
+    ElementPathKeepDeepEquality,
+    (data) => data.targetCell,
+    nullableDeepEquality(GridCellCoordinatesKeepDeepEquality),
+    (data) => data.rootCell,
+    nullableDeepEquality(GridCellCoordinatesKeepDeepEquality),
+    (grid, targetCell, rootCell) => ({
+      grid,
+      targetCell,
+      rootCell,
+    }),
+  )
+
 export const EditorStateCanvasControlsKeepDeepEquality: KeepDeepEqualityCall<EditorStateCanvasControls> =
   combine9EqualityCalls(
     (controls) => controls.snappingGuidelines,
@@ -2736,8 +2762,8 @@ export const EditorStateCanvasControlsKeepDeepEquality: KeepDeepEqualityCall<Edi
     DragToMoveIndicatorFlagsKeepDeepEquality,
     (controls) => controls.parentOutlineHighlight,
     nullableDeepEquality(ElementPathKeepDeepEquality),
-    (controls) => controls.gridControls,
-    nullableDeepEquality(ElementPathKeepDeepEquality),
+    (controls) => controls.gridControlData,
+    nullableDeepEquality(GridControlDataKeepDeepEquality),
     editorStateCanvasControls,
   )
 

--- a/editor/src/components/editor/store/store-hook-substore-helpers.ts
+++ b/editor/src/components/editor/store/store-hook-substore-helpers.ts
@@ -88,7 +88,7 @@ export const EmptyEditorStateForKeysOnly: EditorState = {
       reparentedToPaths: [],
       dragToMoveIndicatorFlags: null as any,
       parentOutlineHighlight: null,
-      gridControls: null,
+      gridControlData: null,
     },
   },
   inspector: {


### PR DESCRIPTION
**Description:**
I removed custom state strategy usage from grid reparent strategy:
- the target cell was cached in custom strategy state to make sure we can reparent over gaps between cells. I removed this and just reparent into the closest cell.

Removed custom strategy state usage from grid controls, and moved the necessary information to `EditorStateCanvasControls`. Instead of custom strategy state patches i needed to return showGridControls commands.

Removed all fields from `GridCustomStrategyState` except `metadataCacheForGrids`, which is still necessary

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

