### PR TITLE
Disable the two parsing feature flags by default for now

### DIFF
--- a/editor/src/utils/feature-switches.ts
+++ b/editor/src/utils/feature-switches.ts
@@ -62,11 +62,11 @@ let FeatureSwitches: { [feature in FeatureName]: boolean } = {
   'Canvas Strategies Debug Panel': false,
   'Project Thumbnail Generation': false,
   'Debug - Print UIDs': false,
-  'Parallel Parsing': !IS_TEST_ENVIRONMENT,
+  'Parallel Parsing': false,
   'Debug - Log Parse Timings': false,
   Tailwind: false,
   'Condensed Navigator Entries': !IS_TEST_ENVIRONMENT,
-  'Use Parsing Cache': !IS_TEST_ENVIRONMENT,
+  'Use Parsing Cache': false,
   'Canvas Fast Selection Hack': true,
   'Show Debug Features': false,
 }


### PR DESCRIPTION
**Problem:**
The two new parsing features are causing a couple of unexpected editor breaking bugs

**Fix:**
Disable the feature flags by default until we've solved the cause of the issues.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode
