### PR TITLE
fix(cache): dont include file version in cache

### DIFF
--- a/editor/src/core/workers/parser-printer/parse-cache-utils.worker.ts
+++ b/editor/src/core/workers/parser-printer/parse-cache-utils.worker.ts
@@ -76,7 +76,7 @@ export async function getParseResultFromCache(
   //check localforage for cache
   const cachedResult = await getParseCacheStore().getItem<CachedParseResult>(cacheKey)
   const cachedResultForContent = cachedResult?.[getCacheIndexKeyWithVersion(content)]
-  if (cachedResultForContent != null) {
+  if (cachedResultForContent?.type === 'PARSE_SUCCESS') {
     logCacheMessage(parsingCacheOptions, 'Cache hit for', ...stringIdentifiers(filename, content))
     return createParseFileResult(filename, cachedResultForContent, versionNumber)
   }

--- a/editor/src/core/workers/parser-printer/parse-cache-utils.worker.ts
+++ b/editor/src/core/workers/parser-printer/parse-cache-utils.worker.ts
@@ -3,10 +3,12 @@ import { URL_HASH } from '../../../common/env-vars'
 import { type ParseCacheOptions } from '../../../core/shared/parse-cache-utils'
 import {
   ARBITRARY_CODE_FILE_NAME,
+  createParseFileResult,
   type ParseFile,
   type ParseFileResult,
 } from '../common/worker-types'
 import localforage from 'localforage'
+import type { ParsedTextFile } from 'utopia-shared/src/types'
 
 export const CACHE_DB_NAME = 'editor-cache'
 export const PARSE_CACHE_STORE_NAME = 'file-parse-cache'
@@ -66,7 +68,7 @@ export async function getParseResultFromCache(
   file: ParseFile,
   parsingCacheOptions: ParseCacheOptions,
 ): Promise<ParseFileResult | null> {
-  const { filename, content } = file
+  const { filename, content, versionNumber } = file
   if (!shouldUseCacheForFile(filename, parsingCacheOptions)) {
     return null
   }
@@ -74,9 +76,9 @@ export async function getParseResultFromCache(
   //check localforage for cache
   const cachedResult = await getParseCacheStore().getItem<CachedParseResult>(cacheKey)
   const cachedResultForContent = cachedResult?.[getCacheIndexKeyWithVersion(content)]
-  if (cachedResultForContent?.parseResult?.type === 'PARSE_SUCCESS') {
+  if (cachedResultForContent != null) {
     logCacheMessage(parsingCacheOptions, 'Cache hit for', ...stringIdentifiers(filename, content))
-    return cachedResultForContent
+    return createParseFileResult(filename, cachedResultForContent, versionNumber)
   }
   logCacheMessage(parsingCacheOptions, 'Cache miss for', ...stringIdentifiers(filename, content))
   return null
@@ -84,7 +86,7 @@ export async function getParseResultFromCache(
 
 export async function storeParseResultInCache(
   file: ParseFile,
-  result: ParseFileResult,
+  result: ParsedTextFile,
   parsingCacheOptions: ParseCacheOptions,
 ): Promise<void> {
   const { filename, content } = file
@@ -121,4 +123,4 @@ export async function clearParseCache(parsingCacheOptions: ParseCacheOptions) {
   })
 }
 
-type CachedParseResult = { [fileContent: string]: ParseFileResult }
+type CachedParseResult = { [fileContent: string]: ParsedTextFile }

--- a/editor/src/core/workers/parser-printer/parser-printer-worker.ts
+++ b/editor/src/core/workers/parser-printer/parser-printer-worker.ts
@@ -104,7 +104,7 @@ export function getParseFileResult(
     parseOptions.parsingCacheOptions.useParsingCache
   ) {
     // non blocking cache write
-    void storeParseResultInCache(file, result, parseOptions.parsingCacheOptions)
+    void storeParseResultInCache(file, result.parseResult, parseOptions.parsingCacheOptions)
   }
 
   return result


### PR DESCRIPTION
**Problem:**
The current cache cached `ParseFileResult`, which contained the file version, which was incorrect when saving files from the vs code.

**Fix:**
Cache `ParsedTextFile` (which is only the parse result itself), which doesn't rely on the file version.

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Play mode
