### PR TITLE
Store the Tailwind config in the editor state

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -424,6 +424,7 @@
     "source-map-loader": "0.2.3",
     "string-replace-loader": "2.2.0",
     "style-loader": "0.18.2",
+    "tailwindcss": "3.4.13",
     "tar": "6.0.5",
     "terser-webpack-plugin": "5.3.9",
     "three": "0.140.2",

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -318,6 +318,7 @@ specifiers:
   string-replace-loader: 2.2.0
   strip-ansi: 6.0.0
   style-loader: 0.18.2
+  tailwindcss: 3.4.13
   tar: 6.0.5
   terser-webpack-plugin: 5.3.9
   three: 0.140.2
@@ -643,6 +644,7 @@ devDependencies:
   source-map-loader: 0.2.3
   string-replace-loader: 2.2.0_webpack@5.88.2
   style-loader: 0.18.2
+  tailwindcss: 3.4.13
   tar: 6.0.5
   terser-webpack-plugin: 5.3.9_webpack@5.88.2
   three: 0.140.2
@@ -669,7 +671,6 @@ packages:
   /@alloc/quick-lru/5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-    dev: false
 
   /@alloc/types/1.3.0:
     resolution: {integrity: sha512-mH7LiFiq9g6rX2tvt1LtwsclfG5hnsmtIfkZiauAGrm1AwXhoRS0sF2WrN9JGN7eV5vFXqNaB0eXZ3IvMsVi9g==}
@@ -6428,7 +6429,6 @@ packages:
 
   /arg/5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
-    dev: false
 
   /argparse/1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -7459,7 +7459,6 @@ packages:
   /camelcase-css/2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
-    dev: false
 
   /camelcase/5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
@@ -8831,7 +8830,6 @@ packages:
 
   /didyoumean/1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
-    dev: false
 
   /diff-match-patch/1.0.5:
     resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
@@ -8887,7 +8885,6 @@ packages:
 
   /dlv/1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
-    dev: false
 
   /dnd-core/16.0.1:
     resolution: {integrity: sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==}
@@ -10875,7 +10872,6 @@ packages:
     engines: {node: '>=10.13.0'}
     dependencies:
       is-glob: 4.0.3
-    dev: false
 
   /glob-to-regexp/0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
@@ -10902,7 +10898,6 @@ packages:
       minipass: 7.1.2
       package-json-from-dist: 1.0.0
       path-scurry: 1.11.1
-    dev: false
 
   /glob/3.1.21:
     resolution: {integrity: sha512-ANhy2V2+tFpRajE3wN4DhkNQ08KDr0Ir1qL12/cUe5+a7STEK8jkW4onUYuY8/06qAFuT5je7mjAqzx0eKI2tQ==}
@@ -12334,7 +12329,6 @@ packages:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-    dev: false
 
   /jake/10.8.2:
     resolution: {integrity: sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==}
@@ -12972,7 +12966,6 @@ packages:
   /jiti/1.21.6:
     resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
     hasBin: true
-    dev: false
 
   /jotai-devtools/0.6.2_hgjqizhc26gc665cnflpub44vy:
     resolution: {integrity: sha512-iHKYt8V2T2Gh2DtGRpvpv2daVoFoHRJXqk5/LHnhFkJy9rMQuIGo4XgVu/v1ZMSvMzwDXdU3hDOQkfQWlDErUQ==}
@@ -13477,12 +13470,10 @@ packages:
   /lilconfig/2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
-    dev: false
 
   /lilconfig/3.1.2:
     resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
     engines: {node: '>=14'}
-    dev: false
 
   /lines-and-columns/1.1.6:
     resolution: {integrity: sha512-8ZmlJFVK9iCmtLz19HpSsR8HaAMWBT284VMNednLwlIMDP2hJDCIhUp0IZ2xUcZ+Ob6BM0VvCSJwzASDM45NLQ==}
@@ -14255,7 +14246,6 @@ packages:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
-    dev: false
 
   /nanoid/3.1.20:
     resolution: {integrity: sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==}
@@ -14537,7 +14527,6 @@ packages:
   /object-hash/3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
-    dev: false
 
   /object-inspect/1.11.0:
     resolution: {integrity: sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==}
@@ -14851,7 +14840,6 @@ packages:
 
   /package-json-from-dist/1.0.0:
     resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
-    dev: false
 
   /pako/0.2.9:
     resolution: {integrity: sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=}
@@ -15207,7 +15195,6 @@ packages:
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.2
-    dev: false
 
   /postcss-js/4.0.1_postcss@8.4.27:
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
@@ -15217,7 +15204,6 @@ packages:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.27
-    dev: false
 
   /postcss-load-config/4.0.2_postcss@8.4.27:
     resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
@@ -15234,7 +15220,6 @@ packages:
       lilconfig: 3.1.2
       postcss: 8.4.27
       yaml: 2.5.1
-    dev: false
 
   /postcss-merge-idents/2.1.7:
     resolution: {integrity: sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=}
@@ -15342,7 +15327,6 @@ packages:
     dependencies:
       postcss: 8.4.27
       postcss-selector-parser: 6.1.2
-    dev: false
 
   /postcss-normalize-charset/1.1.1:
     resolution: {integrity: sha1-757nEhLX/nWceO0WL2HtYrXLk/E=}
@@ -15401,7 +15385,6 @@ packages:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-    dev: false
 
   /postcss-svgo/2.1.6:
     resolution: {integrity: sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=}
@@ -15426,7 +15409,6 @@ packages:
 
   /postcss-value-parser/4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-    dev: false
 
   /postcss-zindex/2.2.0:
     resolution: {integrity: sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=}
@@ -16997,7 +16979,6 @@ packages:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
     dependencies:
       pify: 2.3.0
-    dev: false
 
   /read-only-stream/2.0.0:
     resolution: {integrity: sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=}
@@ -18475,7 +18456,6 @@ packages:
       mz: 2.7.0
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
-    dev: false
 
   /superstruct/0.8.4:
     resolution: {integrity: sha512-48Ors8IVWZm/tMr8r0Si6+mJiB7mkD7jqvIzktjJ4+EnP5tBp0qOpiM1J8sCUorKx+TXWrfb3i1UcjdD1YK/wA==}
@@ -18621,7 +18601,6 @@ packages:
       sucrase: 3.35.0
     transitivePeerDependencies:
       - ts-node
-    dev: false
 
   /tapable/1.1.3:
     resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
@@ -18737,13 +18716,11 @@ packages:
     engines: {node: '>=0.8'}
     dependencies:
       thenify: 3.3.1
-    dev: false
 
   /thenify/3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
     dependencies:
       any-promise: 1.3.0
-    dev: false
 
   /three/0.139.2:
     resolution: {integrity: sha512-gV7q7QY8rogu7HLFZR9cWnOQAUedUhu2WXAnpr2kdXZP9YDKsG/0ychwQvWkZN5PlNw9mv5MoCTin6zNTXoONg==}
@@ -18938,7 +18915,6 @@ packages:
 
   /ts-interface-checker/0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
-    dev: false
 
   /ts-loader/5.3.3_typescript@5.5.4:
     resolution: {integrity: sha512-KwF1SplmOJepnoZ4eRIloH/zXL195F51skt7reEsS6jvDqzgc/YSbz9b8E07GxIUwLXdcD4ssrJu6v8CwaTafA==}
@@ -20139,7 +20115,6 @@ packages:
     resolution: {integrity: sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==}
     engines: {node: '>= 14'}
     hasBin: true
-    dev: false
 
   /yargs-parser/20.2.4:
     resolution: {integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==}

--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -936,6 +936,10 @@ export interface UpdatePropertyControlsInfo {
   propertyControlsInfo: PropertyControlsInfo
 }
 
+export interface UpdateTailwindConfig {
+  action: 'UPDATE_TAILWIND_CONFIG'
+}
+
 export interface UpdateText {
   action: 'UPDATE_TEXT'
   target: ElementPath
@@ -1325,6 +1329,7 @@ export type EditorAction =
   | SetPackageStatus
   | SetShortcut
   | UpdatePropertyControlsInfo
+  | UpdateTailwindConfig
   | UpdateText
   | SetFocusedElement
   | ScrollToElement

--- a/editor/src/components/editor/actions/action-creators.ts
+++ b/editor/src/components/editor/actions/action-creators.ts
@@ -237,6 +237,7 @@ import type {
   ToggleDataCanCondense,
   UpdateMetadataInEditorState,
   SetErrorBoundaryHandling,
+  UpdateTailwindConfig,
 } from '../action-types'
 import type { InsertionSubjectWrapper, Mode } from '../editor-modes'
 import { EditorModes, insertionSubject } from '../editor-modes'
@@ -1481,6 +1482,12 @@ export function updatePropertyControlsInfo(
   return {
     action: 'UPDATE_PROPERTY_CONTROLS_INFO',
     propertyControlsInfo: propertyControlsInfo,
+  }
+}
+
+export function updateTailwindConfig(): UpdateTailwindConfig {
+  return {
+    action: 'UPDATE_TAILWIND_CONFIG',
   }
 }
 

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -137,6 +137,7 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'RESET_ONLINE_STATE':
     case 'INCREASE_ONLINE_STATE_FAILURE_COUNT':
     case 'SET_ERROR_BOUNDARY_HANDLING':
+    case 'UPDATE_TAILWIND_CONFIG':
       return true
 
     case 'TRUE_UP_ELEMENTS':

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -97,6 +97,7 @@ import {
   startPerformanceMeasure,
 } from '../../../core/performance/performance-utils'
 import { getParseCacheOptions } from '../../../core/shared/parse-cache-utils'
+import { TailwindConfigPath } from '../../../core/tailwind/tailwind-config'
 
 type DispatchResultFields = {
   nothingChanged: boolean
@@ -370,6 +371,10 @@ function maybeRequestModelUpdate(
               propertyDescriptorFilesToUpdate.map((r) => r.filename),
             ),
           )
+        }
+
+        if (parseResult.some((result) => result.filename === TailwindConfigPath)) {
+          actionsToDispatch.push(EditorActions.updateTailwindConfig())
         }
 
         dispatch([EditorActions.mergeWithPrevUndo(actionsToDispatch)])

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -188,6 +188,7 @@ import type { Collaborator } from '../../../core/shared/multiplayer'
 import type { OnlineState } from '../online-status'
 import type { NavigatorRow } from '../../navigator/navigator-row'
 import type { FancyError } from '../../../core/shared/code-exec-utils'
+import type { Config } from 'tailwindcss/types/config'
 import type { GridCellCoordinates } from '../../canvas/canvas-strategies/strategies/grid-cell-bounds'
 
 const ObjectPathImmutable: any = OPI
@@ -1398,6 +1399,7 @@ export interface EditorState {
   branchOriginContents: ProjectContentTreeRoot | null // The contents from the branch at the origin commit.
   codeResultCache: CodeResultCache
   propertyControlsInfo: PropertyControlsInfo
+  tailwindConfig: Config | null
   nodeModules: EditorStateNodeModules
   selectedViews: Array<ElementPath>
   highlightedViews: Array<ElementPath>
@@ -1481,6 +1483,7 @@ export function editorState(
   projectContents: ProjectContentTreeRoot,
   codeResultCache: CodeResultCache,
   propertyControlsInfo: PropertyControlsInfo,
+  tailwindConfig: Config | null,
   nodeModules: EditorStateNodeModules,
   selectedViews: Array<ElementPath>,
   highlightedViews: Array<ElementPath>,
@@ -1565,6 +1568,7 @@ export function editorState(
     branchOriginContents: branchOriginContents,
     codeResultCache: codeResultCache,
     propertyControlsInfo: propertyControlsInfo,
+    tailwindConfig: tailwindConfig,
     nodeModules: nodeModules,
     selectedViews: selectedViews,
     highlightedViews: highlightedViews,
@@ -2553,6 +2557,7 @@ export function createEditorState(dispatch: EditorDispatch): EditorState {
     jsxMetadata: emptyJsxMetadata,
     elementPathTree: {},
     projectContents: {},
+    tailwindConfig: null,
     codeResultCache: generateCodeResultCache({}, {}, [], {}, dispatch, {}, []),
     propertyControlsInfo: { ...DefaultThirdPartyControlDefinitions },
     nodeModules: {
@@ -2930,6 +2935,7 @@ export function editorModelFromPersistentModel(
     ),
     projectContents: persistentModel.projectContents,
     propertyControlsInfo: { ...DefaultThirdPartyControlDefinitions },
+    tailwindConfig: null,
     nodeModules: {
       skipDeepFreeze: true,
       files: {},

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -383,6 +383,8 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.SET_PACKAGE_STATUS(action, state)
     case 'UPDATE_PROPERTY_CONTROLS_INFO':
       return UPDATE_FNS.UPDATE_PROPERTY_CONTROLS_INFO(action, state)
+    case 'UPDATE_TAILWIND_CONFIG':
+      return UPDATE_FNS.UPDATE_TAILWIND_CONFIG(action, state)
     case 'SELECT_FROM_FILE_AND_POSITION':
       return UPDATE_FNS.SELECT_FROM_FILE_AND_POSITION(action, state, dispatch)
     case 'SEND_LINTER_REQUEST_MESSAGE':

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -642,6 +642,7 @@ import type {
   ComponentDescriptorPropertiesBounds,
 } from '../../../core/property-controls/component-descriptor-parser'
 import type { Axis } from '../../../components/canvas/gap-utils'
+import type { Config } from 'tailwindcss/types/config'
 import type { GridCellCoordinates } from '../../canvas/canvas-strategies/strategies/grid-cell-bounds'
 
 export function ElementPropertyPathKeepDeepEquality(): KeepDeepEqualityCall<ElementPropertyPath> {
@@ -5163,6 +5164,10 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     oldValue.propertyControlsInfo,
     newValue.propertyControlsInfo,
   )
+  const tailwindConfigResult = nullableDeepEquality(createCallWithTripleEquals<Config>())(
+    oldValue.tailwindConfig,
+    newValue.tailwindConfig,
+  )
   const nodeModulesResult = EditorStateNodeModulesKeepDeepEquality(
     oldValue.nodeModules,
     newValue.nodeModules,
@@ -5426,6 +5431,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
     projectContentsResult.areEqual &&
     codeResultCacheResult.areEqual &&
     propertyControlsInfoResult.areEqual &&
+    tailwindConfigResult.areEqual &&
     nodeModulesResult.areEqual &&
     selectedViewsResult.areEqual &&
     highlightedViewsResult.areEqual &&
@@ -5511,6 +5517,7 @@ export const EditorStateKeepDeepEquality: KeepDeepEqualityCall<EditorState> = (
       projectContentsResult.value,
       codeResultCacheResult.value,
       propertyControlsInfoResult.value,
+      tailwindConfigResult.value,
       nodeModulesResult.value,
       selectedViewsResult.value,
       highlightedViewsResult.value,

--- a/editor/src/components/editor/store/store-hook-substore-helpers.ts
+++ b/editor/src/components/editor/store/store-hook-substore-helpers.ts
@@ -16,6 +16,7 @@ export const EmptyEditorStateForKeysOnly: EditorState = {
   projectContents: {},
   codeResultCache: null as any,
   propertyControlsInfo: null as any,
+  tailwindConfig: null,
   nodeModules: {
     skipDeepFreeze: true,
     files: {},

--- a/editor/src/core/shared/github/helpers.ts
+++ b/editor/src/core/shared/github/helpers.ts
@@ -29,6 +29,7 @@ import {
   updateGithubOperations,
   updateGithubSettings,
   updateProjectContents,
+  updateTailwindConfig,
 } from '../../../components/editor/actions/action-creators'
 import type {
   EditorStorePatched,
@@ -73,6 +74,7 @@ import React from 'react'
 import { useDispatch } from '../../../components/editor/store/dispatch-context'
 import type { ExistingAsset } from '../../../components/editor/server'
 import { getBranchProjectContents } from '../../../components/editor/server'
+import { TailwindConfigPath } from '../../tailwind/tailwind-config'
 
 export function dispatchPromiseActions(
   dispatch: EditorDispatch,
@@ -515,6 +517,7 @@ export async function revertAllGithubFiles(
     const componentDescriptorFiles = getAllComponentDescriptorFilePaths(parsedBranchContents)
     actions.push(updateProjectContents(parsedBranchContents))
     actions.push(extractPropertyControlsFromDescriptorFiles(componentDescriptorFiles))
+    actions.push(updateTailwindConfig())
   }
   return actions
 }
@@ -544,6 +547,9 @@ export async function revertGithubFile(
           const componentDescriptorFiles = getAllComponentDescriptorFilePaths(newTree)
           actions.push(updateProjectContents(newTree))
           actions.push(extractPropertyControlsFromDescriptorFiles(componentDescriptorFiles))
+          if (filename === TailwindConfigPath) {
+            actions.push(updateTailwindConfig())
+          }
         }
         break
     }

--- a/editor/src/core/shared/github/operations/load-branch.ts
+++ b/editor/src/core/shared/github/operations/load-branch.ts
@@ -13,6 +13,7 @@ import {
   truncateHistory,
   updateBranchContents,
   updateProjectContents,
+  updateTailwindConfig,
 } from '../../../../components/editor/actions/action-creators'
 import type {
   GithubData,
@@ -207,6 +208,7 @@ export const updateProjectWithBranchContent =
               .finally(() => {
                 dispatch(
                   [
+                    updateTailwindConfig(),
                     extractPropertyControlsFromDescriptorFiles(componentDescriptorFiles),
                     showToast(
                       notice(

--- a/editor/src/core/tailwind/tailwind.spec.browser2.tsx
+++ b/editor/src/core/tailwind/tailwind.spec.browser2.tsx
@@ -1,7 +1,6 @@
 import { renderTestEditorWithModel } from '../../components/canvas/ui-jsx.test-utils'
 import { createModifiedProject } from '../../sample-projects/sample-project-utils.test-utils'
 import { setFeatureForBrowserTestsUseInDescribeBlockOnly } from '../../utils/utils.test-utils'
-import { wait } from '../model/performance-scripts'
 
 const Project = createModifiedProject({
   '/utopia/storyboard.js': `import { Scene, Storyboard } from 'utopia-api'
@@ -214,5 +213,14 @@ describe('rendering tailwind projects in the editor', () => {
         textShadow: 'none',
       })
     }
+  })
+})
+
+describe('tailwind config file in the editor', () => {
+  setFeatureForBrowserTestsUseInDescribeBlockOnly('Tailwind', true)
+  it('can be updated', async () => {
+    const editor = await renderTestEditorWithModel(Project, 'await-first-dom-report')
+
+    expect(editor.getEditorState().editor.tailwindConfig).toEqual({})
   })
 })

--- a/editor/src/core/tailwind/tailwind.spec.browser2.tsx
+++ b/editor/src/core/tailwind/tailwind.spec.browser2.tsx
@@ -1,87 +1,6 @@
 import { renderTestEditorWithModel } from '../../components/canvas/ui-jsx.test-utils'
-import { createModifiedProject } from '../../sample-projects/sample-project-utils.test-utils'
 import { setFeatureForBrowserTestsUseInDescribeBlockOnly } from '../../utils/utils.test-utils'
-
-const Project = createModifiedProject({
-  '/utopia/storyboard.js': `import { Scene, Storyboard } from 'utopia-api'
-
-export var storyboard = (
-  <Storyboard data-uid='sb'>
-    <Scene
-      data-uid='scene'
-      id='playground-scene'
-      commentId='playground-scene'
-      className='absolute top-[100px] left-[200px] w-[700px] h-[1050px]'
-      data-label='Playground'
-    >
-      <div data-uid='absolute' data-testid='absolute' className='absolute top-[33px] left-[40px] w-[620px] h-[177px] bg-tahiti'>
-        <div data-uid='absolute-child' data-testid='absolute-child' className='absolute top-4 left-4 w-10 h-10 bg-midnight' />
-      </div>
-      <div data-uid='flex' data-testid='flex' className='absolute bg-metal left-10 top-[250px] w-[500px] h-max flex flex-row gap-10 px-5 py-[30px] items-center justify-start'>
-        <div data-uid='flex-child-1' data-testid='flex-child-1' className='bg-silver w-32 h-32' />
-        <div data-uid='flex-child-2' data-testid='flex-child-2' className='bg-silver w-32 h-32' />
-      </div>
-      <div data-uid='grid' data-testid='grid' className='absolute left-10 top-[450px] bg-bermuda w-[600px] h-[250px] grid grid-cols-4 grid-rows-4 gap-4'>
-        <div data-uid='grid-child-1' data-testid='grid-child-1' className='bg-bubble-gum m-2' />
-        <div data-uid='grid-child-2' data-testid='grid-child-2' className='bg-bubble-gum m-2 row-start-2 col-span-3' />
-        <div data-uid='grid-child-3' data-testid='grid-child-3' className='bg-bubble-gum m-2 row-start-3 col-start-4' />
-        <div data-uid='grid-child-4' data-testid='grid-child-4' className='bg-bubble-gum m-2' />
-      </div>
-      <div data-uid='text-shadow' data-testid='text-shadow' className='absolute left-10 top-[750px] bg-bermuda w-[600px] h-[250px] flex flex-col'>
-        <span data-uid='text-shadow-1' data-testid='text-shadow-1' className='text-4xl text-shadow'>Text Shadow</span>
-        <span data-uid='text-shadow-2' data-testid='text-shadow-2' class='text-3xl text-shadow-md'>This is a medium text shadow example</span>
-        <span data-uid='text-shadow-3' data-testid='text-shadow-3' class='text-2xl text-shadow-lg'>This is a large text shadow example</span>
-        <span data-uid='text-shadow-4' data-testid='text-shadow-4' class='text-xl text-shadow-none'>This has no text shadow</span>
-      </div>
-    </Scene>
-  </Storyboard>
-)
-`,
-  '/src/app.css': `
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-`,
-  'tailwind.config.js': `
-const Tailwind = {
-  theme: {
-    colors: {
-      transparent: 'transparent',
-      current: 'currentColor',
-      white: '#ffffff',
-      purple: '#3f3cbb',
-      midnight: '#121063',
-      metal: '#565584',
-      tahiti: '#3ab7bf',
-      silver: '#ecebff',
-      'bubble-gum': '#ff77e9',
-      bermuda: '#78dcca',
-    },
-  },
-  plugins: [
-    function ({ addUtilities }) {
-      const newUtilities = {
-        '.text-shadow': {
-          textShadow: '2px 2px 4px rgba(0, 0, 0, 0.1)',
-        },
-        '.text-shadow-md': {
-          textShadow: '3px 3px 6px rgba(0, 0, 0, 0.2)',
-        },
-        '.text-shadow-lg': {
-          textShadow: '4px 4px 8px rgba(0, 0, 0, 0.3)',
-        },
-        '.text-shadow-none': {
-          textShadow: 'none',
-        },
-      }
-
-      addUtilities(newUtilities, ['responsive', 'hover'])
-    },
-  ],
-}
-export default Tailwind
-`,
-})
+import { Project } from './tailwind.test-utils'
 
 describe('rendering tailwind projects in the editor', () => {
   setFeatureForBrowserTestsUseInDescribeBlockOnly('Tailwind', true)
@@ -213,14 +132,5 @@ describe('rendering tailwind projects in the editor', () => {
         textShadow: 'none',
       })
     }
-  })
-})
-
-describe('tailwind config file in the editor', () => {
-  setFeatureForBrowserTestsUseInDescribeBlockOnly('Tailwind', true)
-  it('can be updated', async () => {
-    const editor = await renderTestEditorWithModel(Project, 'await-first-dom-report')
-
-    expect(editor.getEditorState().editor.tailwindConfig).toEqual({})
   })
 })

--- a/editor/src/core/tailwind/tailwind.spec.ts
+++ b/editor/src/core/tailwind/tailwind.spec.ts
@@ -1,0 +1,71 @@
+import { Project, TailwindConfigFileContents } from './tailwind.test-utils'
+import { renderTestEditorWithModel } from '../../components/canvas/ui-jsx.test-utils'
+import { TailwindConfigPath } from './tailwind-config'
+import { updateFromCodeEditor } from '../../components/editor/actions/actions-from-vscode'
+
+describe('tailwind config file in the editor', () => {
+  it('is set during editor load', async () => {
+    const editor = await renderTestEditorWithModel(Project, 'await-first-dom-report')
+
+    expect(editor.getEditorState().editor.tailwindConfig).toMatchInlineSnapshot(`
+      Object {
+        "plugins": Array [
+          [Function],
+        ],
+        "theme": Object {
+          "colors": Object {
+            "bermuda": "#78dcca",
+            "bubble-gum": "#ff77e9",
+            "current": "currentColor",
+            "metal": "#565584",
+            "midnight": "#121063",
+            "purple": "#3f3cbb",
+            "silver": "#ecebff",
+            "tahiti": "#3ab7bf",
+            "transparent": "transparent",
+            "white": "#ffffff",
+          },
+        },
+      }
+    `)
+  })
+  it('is updated in the editor state when the tailwind config is updated', async () => {
+    const editor = await renderTestEditorWithModel(Project, 'await-first-dom-report')
+
+    await editor.dispatch(
+      [
+        updateFromCodeEditor(
+          TailwindConfigPath,
+          TailwindConfigFileContents,
+          `
+const Tailwind = {
+    theme: {
+      colors: {
+        transparent: 'transparent',
+        current: 'currentColor',
+        white: '#ffffff',
+      },
+    },
+    plugins: [ ],
+  }
+  export default Tailwind
+`,
+        ),
+      ],
+      true,
+    )
+
+    expect(editor.getEditorState().editor.tailwindConfig).toMatchInlineSnapshot(`
+      Object {
+        "plugins": Array [],
+        "theme": Object {
+          "colors": Object {
+            "current": "currentColor",
+            "transparent": "transparent",
+            "white": "#ffffff",
+          },
+        },
+      }
+    `)
+  })
+})

--- a/editor/src/core/tailwind/tailwind.test-utils.ts
+++ b/editor/src/core/tailwind/tailwind.test-utils.ts
@@ -1,0 +1,85 @@
+import { createModifiedProject } from '../../sample-projects/sample-project-utils.test-utils'
+import { TailwindConfigPath } from './tailwind-config'
+
+export const TailwindConfigFileContents = `
+const Tailwind = {
+    theme: {
+      colors: {
+        transparent: 'transparent',
+        current: 'currentColor',
+        white: '#ffffff',
+        purple: '#3f3cbb',
+        midnight: '#121063',
+        metal: '#565584',
+        tahiti: '#3ab7bf',
+        silver: '#ecebff',
+        'bubble-gum': '#ff77e9',
+        bermuda: '#78dcca',
+      },
+    },
+    plugins: [
+      function ({ addUtilities }) {
+        const newUtilities = {
+          '.text-shadow': {
+            textShadow: '2px 2px 4px rgba(0, 0, 0, 0.1)',
+          },
+          '.text-shadow-md': {
+            textShadow: '3px 3px 6px rgba(0, 0, 0, 0.2)',
+          },
+          '.text-shadow-lg': {
+            textShadow: '4px 4px 8px rgba(0, 0, 0, 0.3)',
+          },
+          '.text-shadow-none': {
+            textShadow: 'none',
+          },
+        }
+  
+        addUtilities(newUtilities, ['responsive', 'hover'])
+      },
+    ],
+  }
+  export default Tailwind
+`
+
+export const Project = createModifiedProject({
+  '/utopia/storyboard.js': `import { Scene, Storyboard } from 'utopia-api'
+  
+  export var storyboard = (
+    <Storyboard data-uid='sb'>
+      <Scene
+        data-uid='scene'
+        id='playground-scene'
+        commentId='playground-scene'
+        className='absolute top-[100px] left-[200px] w-[700px] h-[1050px]'
+        data-label='Playground'
+      >
+        <div data-uid='absolute' data-testid='absolute' className='absolute top-[33px] left-[40px] w-[620px] h-[177px] bg-tahiti'>
+          <div data-uid='absolute-child' data-testid='absolute-child' className='absolute top-4 left-4 w-10 h-10 bg-midnight' />
+        </div>
+        <div data-uid='flex' data-testid='flex' className='absolute bg-metal left-10 top-[250px] w-[500px] h-max flex flex-row gap-10 px-5 py-[30px] items-center justify-start'>
+          <div data-uid='flex-child-1' data-testid='flex-child-1' className='bg-silver w-32 h-32' />
+          <div data-uid='flex-child-2' data-testid='flex-child-2' className='bg-silver w-32 h-32' />
+        </div>
+        <div data-uid='grid' data-testid='grid' className='absolute left-10 top-[450px] bg-bermuda w-[600px] h-[250px] grid grid-cols-4 grid-rows-4 gap-4'>
+          <div data-uid='grid-child-1' data-testid='grid-child-1' className='bg-bubble-gum m-2' />
+          <div data-uid='grid-child-2' data-testid='grid-child-2' className='bg-bubble-gum m-2 row-start-2 col-span-3' />
+          <div data-uid='grid-child-3' data-testid='grid-child-3' className='bg-bubble-gum m-2 row-start-3 col-start-4' />
+          <div data-uid='grid-child-4' data-testid='grid-child-4' className='bg-bubble-gum m-2' />
+        </div>
+        <div data-uid='text-shadow' data-testid='text-shadow' className='absolute left-10 top-[750px] bg-bermuda w-[600px] h-[250px] flex flex-col'>
+          <span data-uid='text-shadow-1' data-testid='text-shadow-1' className='text-4xl text-shadow'>Text Shadow</span>
+          <span data-uid='text-shadow-2' data-testid='text-shadow-2' class='text-3xl text-shadow-md'>This is a medium text shadow example</span>
+          <span data-uid='text-shadow-3' data-testid='text-shadow-3' class='text-2xl text-shadow-lg'>This is a large text shadow example</span>
+          <span data-uid='text-shadow-4' data-testid='text-shadow-4' class='text-xl text-shadow-none'>This has no text shadow</span>
+        </div>
+      </Scene>
+    </Storyboard>
+  )
+  `,
+  '/src/app.css': `
+  @tailwind base;
+  @tailwind components;
+  @tailwind utilities;
+  `,
+  [TailwindConfigPath]: TailwindConfigFileContents,
+})


### PR DESCRIPTION
split out from https://github.com/concrete-utopia/utopia/pull/6492

## Problem
The Tailwind config is only accessible inside `useTailwindCompilation`, which means that the upcoming element style plugins won't be able to access it

## Fix
Store the Tailwind config in the editor state, the same way that we store the property control descriptors. This way, the tailwind config will be accessible from hooks, actions, the strategy dispatch etc.