### PR TITLE
Grid Template Field Dropdowns

### DIFF
--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -30,6 +30,7 @@ import {
   SquareButton,
   Subdued,
   Tooltip,
+  UtopiaTheme,
 } from '../../uuiui'
 import type {
   CSSKeyword,
@@ -580,10 +581,21 @@ function AxisDimensionControl({
         },
       }}
     >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 6, flex: 1 }}>
+      <div
+        style={{
+          display: 'grid',
+          gridAutoFlow: 'column',
+          alignItems: 'center',
+          gap: 6,
+          gridTemplateColumns: gridExpressionInputFocused.focused
+            ? `40px auto`
+            : `40px auto ${UtopiaTheme.layout.inputHeight.default}px`,
+          gridTemplateRows: '1fr',
+          width: `100%`,
+        }}
+      >
         <Subdued
           style={{
-            width: 40,
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
@@ -601,13 +613,13 @@ function AxisDimensionControl({
           onBlur={gridExpressionInputFocused.onBlur}
           keywords={gridDimensionDropdownKeywords}
         />
+        {unless(
+          gridExpressionInputFocused.focused,
+          <SquareButton className={axisDropdownMenuButton}>
+            <DropdownMenu align='end' items={items} opener={opener} onOpenChange={onOpenChange} />
+          </SquareButton>,
+        )}
       </div>
-      {unless(
-        gridExpressionInputFocused.focused,
-        <SquareButton className={axisDropdownMenuButton}>
-          <DropdownMenu align='end' items={items} opener={opener} onOpenChange={onOpenChange} />
-        </SquareButton>,
-      )}
     </div>
   )
 }

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -513,6 +513,12 @@ const TemplateDimensionControl = React.memo(
 )
 TemplateDimensionControl.displayName = 'TemplateDimensionControl'
 
+const gridDimensionDropdownKeywords = [
+  { label: 'Auto', value: cssKeyword('auto') },
+  { label: 'Min-Content', value: cssKeyword('min-content') },
+  { label: 'Max-Content', value: cssKeyword('max-content') },
+]
+
 function AxisDimensionControl({
   value,
   index,
@@ -593,6 +599,7 @@ function AxisDimensionControl({
           onUpdateDimension={onUpdateDimension(index)}
           onFocus={gridExpressionInputFocused.onFocus}
           onBlur={gridExpressionInputFocused.onBlur}
+          keywords={gridDimensionDropdownKeywords}
         />
       </div>
       {unless(

--- a/editor/src/uuiui/inputs/grid-expression-input.tsx
+++ b/editor/src/uuiui/inputs/grid-expression-input.tsx
@@ -1,3 +1,7 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { jsx } from '@emotion/react'
+import type { CSSProperties } from 'react'
 import React from 'react'
 import {
   cssKeyword,
@@ -22,6 +26,7 @@ import {
 import { Icons, SmallerIcons } from '../icons'
 import { NO_OP } from '../../core/shared/utils'
 import { unless } from '../../utils/react-conditionals'
+import { useColorTheme } from '../styles/theme'
 
 interface GridExpressionInputProps {
   testId: string
@@ -31,7 +36,10 @@ interface GridExpressionInputProps {
   onFocus: () => void
   onBlur: () => void
   keywords: Array<{ label: string; value: CSSKeyword<any> }>
+  style?: CSSProperties
 }
+
+const DropdownWidth = 25
 
 export const GridExpressionInput = React.memo(
   ({
@@ -42,7 +50,10 @@ export const GridExpressionInput = React.memo(
     onFocus,
     onBlur,
     keywords,
+    style = {},
   }: GridExpressionInputProps) => {
+    const colorTheme = useColorTheme()
+
     const [printValue, setPrintValue] = React.useState<string>(stringifyGridDimension(value))
     React.useEffect(() => setPrintValue(stringifyGridDimension(value)), [value])
 
@@ -148,25 +159,37 @@ export const GridExpressionInput = React.memo(
 
     return (
       <div
-        style={{
-          position: 'relative',
+        style={style}
+        css={{
           borderRadius: 2,
           display: 'flex',
           alignItems: 'center',
           flexGrow: 1,
+          flexDirection: 'row',
+          '&:hover': {
+            boxShadow: `inset 0px 0px 0px 1px ${
+              dropdownOpen ? colorTheme.dynamicBlue.value : colorTheme.fg7.value
+            }`,
+          },
+          '&:focus-within': {
+            boxShadow: `inset 0px 0px 0px 1px ${colorTheme.dynamicBlue.value}`,
+          },
         }}
         onMouseOver={onMouseOver}
         onMouseOut={onMouseOut}
       >
         <StringInput
-          style={{ width: '100%' }}
           testId={testId}
           value={printValue}
           onChange={onChange}
           onKeyDown={onKeyDown}
           onFocus={inputOnFocus}
           onBlur={inputOnBlur}
-          showBorder={dropdownOpen ? true : undefined}
+          showBorder={false}
+          includeBoxShadow={false}
+          style={{
+            width: inputFocused ? '100%' : `calc(100% - ${DropdownWidth}px)`,
+          }}
         />
         {unless(
           inputFocused,
@@ -175,10 +198,7 @@ export const GridExpressionInput = React.memo(
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              position: 'absolute',
-              top: 0,
-              bottom: 0,
-              right: 0,
+              width: `${DropdownWidth}px`,
             }}
           >
             <DropdownMenu
@@ -186,9 +206,6 @@ export const GridExpressionInput = React.memo(
               items={dropdownItems}
               opener={dropdownButton}
               onOpenChange={setDropdownOpen}
-              style={{
-                marginTop: 8,
-              }}
             />
           </div>,
         )}

--- a/editor/src/uuiui/inputs/grid-expression-input.tsx
+++ b/editor/src/uuiui/inputs/grid-expression-input.tsx
@@ -21,7 +21,7 @@ import {
 } from '../radix-components'
 import { Icons, SmallerIcons } from '../icons'
 import { NO_OP } from '../../core/shared/utils'
-import type { ControlStatus } from '../../uuiui-deps'
+import { unless } from '../../utils/react-conditionals'
 
 interface GridExpressionInputProps {
   testId: string
@@ -134,6 +134,18 @@ export const GridExpressionInput = React.memo(
       return items
     }, [keywords, printValue, onUpdateNumberOrKeyword])
 
+    const [inputFocused, setInputFocused] = React.useState(false)
+
+    const inputOnFocus = React.useCallback(() => {
+      setInputFocused(true)
+      onFocus()
+    }, [onFocus])
+
+    const inputOnBlur = React.useCallback(() => {
+      setInputFocused(false)
+      onBlur()
+    }, [onBlur])
+
     return (
       <div
         style={{
@@ -141,6 +153,7 @@ export const GridExpressionInput = React.memo(
           borderRadius: 2,
           display: 'flex',
           alignItems: 'center',
+          flexGrow: 1,
         }}
         onMouseOver={onMouseOver}
         onMouseOut={onMouseOut}
@@ -151,30 +164,34 @@ export const GridExpressionInput = React.memo(
           value={printValue}
           onChange={onChange}
           onKeyDown={onKeyDown}
-          onFocus={onFocus}
-          onBlur={onBlur}
+          onFocus={inputOnFocus}
+          onBlur={inputOnBlur}
+          showBorder={dropdownOpen ? true : undefined}
         />
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            position: 'absolute',
-            top: 0,
-            bottom: 0,
-            right: 0,
-          }}
-        >
-          <DropdownMenu
-            align='end'
-            items={dropdownItems}
-            opener={dropdownButton}
-            onOpenChange={setDropdownOpen}
+        {unless(
+          inputFocused,
+          <div
             style={{
-              marginTop: 8,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              position: 'absolute',
+              top: 0,
+              bottom: 0,
+              right: 0,
             }}
-          />
-        </div>
+          >
+            <DropdownMenu
+              align='end'
+              items={dropdownItems}
+              opener={dropdownButton}
+              onOpenChange={setDropdownOpen}
+              style={{
+                marginTop: 8,
+              }}
+            />
+          </div>,
+        )}
       </div>
     )
   },


### PR DESCRIPTION
**Problem:**
Previously the grid template column fields in the inspector supported a dropdown with some stock keywords in it. It would be nice if those returned.

**Fix:**
Some logic akin to that present in `NumberOrKeywordControl` has been implemented into `GridExpressionInput`.
![image](https://github.com/user-attachments/assets/eff55039-25dc-43f7-b7b1-113b2045989f)


**Commit Details:**
- Integrated some similar logic into `GridExpressionInput` that is in `NumberOrKeywordControl`.
- Resurrected `gridDimensionDropdownKeywords` from the previous code so that it can be passed to `GridExpressionInput`.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode