### PR TITLE
Grid reparent uses rearrange helper

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -57,7 +57,7 @@ export function runGridRearrangeMove(
     return []
   }
 
-  const isReparent = !EP.pathsEqual(EP.parentPath(selectedElement), grid.elementPath)
+  const isReparent = !EP.isParentOf(grid.elementPath, selectedElement)
 
   const { gridCellGlobalFrames, containerGridProperties: gridTemplate } =
     grid.specialSizeMeasurements

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-duplicate-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-duplicate-strategy.ts
@@ -72,11 +72,20 @@ export const gridRearrangeMoveDuplicateStrategy: CanvasStrategyFactory = (
 
       const targetElement = EP.appendToPath(EP.parentPath(selectedElement), newUid)
 
+      const grid = MetadataUtils.findElementByElementPath(
+        canvasState.startingMetadata,
+        EP.parentPath(selectedElement),
+      )
+      if (grid == null) {
+        return emptyStrategyApplicationResult
+      }
+
       const moveCommands = runGridRearrangeMove(
         targetElement,
         selectedElement,
         canvasState.startingMetadata,
         interactionSession.interactionData,
+        grid,
       )
       if (moveCommands.length === 0) {
         return emptyStrategyApplicationResult

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategy.tsx
@@ -5,11 +5,11 @@ import { mapDropNulls } from '../../../../core/shared/array-utils'
 import * as EP from '../../../../core/shared/element-path'
 import type { ElementPathTrees } from '../../../../core/shared/element-path-tree'
 import {
-  gridPositionValue,
+  type ElementInstanceMetadata,
   type ElementInstanceMetadataMap,
 } from '../../../../core/shared/element-template'
 import type { CanvasRectangle } from '../../../../core/shared/math-utils'
-import { canvasVector, isInfinityRectangle, offsetPoint } from '../../../../core/shared/math-utils'
+import { isInfinityRectangle } from '../../../../core/shared/math-utils'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import * as PP from '../../../../core/shared/property-path'
 import type { AllElementProps } from '../../../editor/store/editor-state'
@@ -39,13 +39,12 @@ import {
 import type { DragInteractionData, InteractionSession, UpdatedPathMap } from '../interaction-state'
 import { honoursPropsPosition, shouldKeepMovingDraggedGroupChildren } from './absolute-utils'
 import { replaceFragmentLikePathsWithTheirChildrenRecursive } from './fragment-like-helpers'
-import { getMetadataWithGridCellBounds, setGridPropsCommands } from './grid-helpers'
+import { getMetadataWithGridCellBounds, runGridRearrangeMove } from './grid-helpers'
 import { ifAllowedToReparent, isAllowedToReparent } from './reparent-helpers/reparent-helpers'
 import { removeAbsolutePositioningProps } from './reparent-helpers/reparent-property-changes'
 import type { ReparentTarget } from './reparent-helpers/reparent-strategy-helpers'
 import { getReparentOutcome, pathToReparent } from './reparent-utils'
 import { flattenSelection } from './shared-move-strategies-helpers'
-import { getClosestGridCellToPointFromMetadata, type GridCellCoordinates } from './grid-cell-bounds'
 
 export function gridReparentStrategy(
   reparentTarget: ReparentTarget,
@@ -190,16 +189,6 @@ export function applyGridReparent(
           return emptyStrategyApplicationResult
         }
 
-        const mousePos = offsetPoint(
-          interactionData.dragStart,
-          interactionData.drag ?? canvasVector({ x: 0, y: 0 }),
-        )
-
-        const targetCellData = getClosestGridCellToPointFromMetadata(grid, mousePos)
-
-        if (targetCellData == null) {
-          return strategyApplicationResult([], [newParent.intendedParentPath])
-        }
         const outcomes = mapDropNulls(
           (selectedElement) =>
             gridReparentCommands(
@@ -211,7 +200,8 @@ export function applyGridReparent(
               nodeModules,
               selectedElement,
               newParent,
-              targetCellData.gridCellCoordinates,
+              interactionData,
+              grid,
             ),
           selectedElements,
         )
@@ -253,12 +243,6 @@ export function applyGridReparent(
             gridContainerCommands,
             updateSelectedViews('always', newPaths),
             setCursorCommand(CSSCursor.Reparent),
-            showGridControls(
-              'mid-interaction',
-              reparentTarget.newParent.intendedParentPath,
-              targetCellData.gridCellCoordinates,
-              null,
-            ),
           ],
           elementsToRerender,
           customStrategyStatePatch,
@@ -266,35 +250,6 @@ export function applyGridReparent(
       },
     )
   }
-}
-
-function getGridPositioningCommands(
-  jsxMetadata: ElementInstanceMetadataMap,
-  hoveredCoordinates: GridCellCoordinates,
-  {
-    parentPath,
-    target,
-  }: {
-    parentPath: ElementPath
-    target: ElementPath
-  },
-) {
-  const containerMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, parentPath)
-  if (containerMetadata == null) {
-    return null
-  }
-  const { column, row } = hoveredCoordinates
-
-  const gridTemplate = containerMetadata.specialSizeMeasurements.containerGridProperties
-
-  const gridPropsCommands = setGridPropsCommands(target, gridTemplate, {
-    gridColumnStart: gridPositionValue(column),
-    gridColumnEnd: gridPositionValue(column),
-    gridRowEnd: gridPositionValue(row),
-    gridRowStart: gridPositionValue(row),
-  })
-
-  return gridPropsCommands
 }
 
 function gridReparentCommands(
@@ -306,7 +261,8 @@ function gridReparentCommands(
   nodeModules: NodeModules,
   target: ElementPath,
   newParent: InsertionPath,
-  hoveredCoordinates: GridCellCoordinates,
+  interactionData: DragInteractionData,
+  grid: ElementInstanceMetadata,
 ) {
   const reparentResult = getReparentOutcome(
     jsxMetadata,
@@ -324,11 +280,7 @@ function gridReparentCommands(
   if (reparentResult == null) {
     return null
   }
-
-  const gridPropsCommands = getGridPositioningCommands(jsxMetadata, hoveredCoordinates, {
-    parentPath: newParent.intendedParentPath,
-    target: target,
-  })
+  const gridPropsCommands = runGridRearrangeMove(target, target, jsxMetadata, interactionData, grid)
 
   if (gridPropsCommands == null) {
     return null


### PR DESCRIPTION
**Description:**
Grid reparent uses the grid rearrange helper to set the grid specific properties.

When you reparent into a grid container, moving the element to the target cell, setting the grid control properties to support animation, etc. is really similar to grid rearrange. Despite that, the two strategies did not share code.

I modified the grid reparent strategy to call runGridRearrangeMove. This automatically added animation to grid reparent, and fixed some jumping around.

**Commit Details:** (< vv pls delete this section if's not relevant)
- `runGridRearrangeMove` has a new parameter for the grid metadata (before that it could assume that the grid is parent of the selected element, but during reparent this is not true)
- some of the `runGridRearrangeMove` which handles multicell elements is not needed for grid reparent, I needed to handle that (e.g. during grid reparent we always put the element into a single target cell, so no need to handle the original size in cells, the offset between the dragged cell and root cell, etc)
- Removed `getGridPositioningCommands` which is replaced by `runGridRearrangeMove`

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

