### PR TITLE
Insert better default grids

### DIFF
--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -28,6 +28,7 @@ import {
   useEnterDrawToInsertForButton,
   useEnterDrawToInsertForConditional,
   useEnterDrawToInsertForDiv,
+  useEnterDrawToInsertForGrid,
   useEnterDrawToInsertForImage,
   useEnterTextEditMode,
 } from './insert-callbacks'
@@ -79,6 +80,7 @@ export const InsertOrEditTextButtonTestId = 'insert-or-edit-text-button'
 export const PlayModeButtonTestId = 'canvas-toolbar-play-mode'
 export const CommentModeButtonTestId = (status: string) => `canvas-toolbar-comment-mode-${status}`
 export const InsertConditionalButtonTestId = 'insert-mode-conditional'
+export const InsertGridButtonTestId = 'insert-mode-grid'
 export const CanvasToolbarId = 'canvas-toolbar'
 
 export const CanvasToolbarSearchPortalId = 'canvas-toolbar-search-portal'
@@ -220,6 +222,7 @@ export const CanvasToolbar = React.memo(() => {
   const insertTextCallback = useEnterTextEditMode()
   const insertButtonCallback = useEnterDrawToInsertForButton()
   const insertConditionalCallback = useEnterDrawToInsertForConditional()
+  const insertGridCallback = useEnterDrawToInsertForGrid()
 
   // Back to select mode, close the "floating" menu and turn off the forced insert mode.
   const dispatchSwitchToSelectModeCloseMenus = React.useCallback(() => {
@@ -546,6 +549,15 @@ export const CanvasToolbar = React.memo(() => {
                     iconType='view'
                     secondary={canvasToolbarMode.secondary.divInsertionActive}
                     onClick={insertDivCallback}
+                  />
+                </Tooltip>
+                <Tooltip title='Insert grid' placement='bottom'>
+                  <ToolbarButton
+                    testid={InsertGridButtonTestId}
+                    iconCategory='navigator-element'
+                    iconType='grid'
+                    onClick={insertGridCallback}
+                    size={12}
                   />
                 </Tooltip>
                 <Tooltip title='Insert image' placement='bottom'>

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -171,6 +171,28 @@ export function defaultButtonElement(uid: string): JSXElement {
   )
 }
 
+export function defaultGridElement(uid: string): JSXElement {
+  return jsxElement(
+    jsxElementName('div', []),
+    uid,
+    jsxAttributesFromMap({
+      'data-uid': jsExpressionValue(uid, emptyComments),
+      style: jsExpressionValue(
+        {
+          position: 'absolute',
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr 1fr',
+          gridTemplateRows: '1fr 1fr 1fr',
+          gap: 10,
+          padding: 10,
+        },
+        emptyComments,
+      ),
+    }),
+    [],
+  )
+}
+
 export function defaultFlexRowOrColStyle(): JSExpression {
   return jsExpressionValue(
     {

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -184,7 +184,6 @@ export function defaultGridElement(uid: string): JSXElement {
           gridTemplateColumns: '1fr 1fr 1fr',
           gridTemplateRows: '1fr 1fr 1fr',
           gap: 10,
-          padding: 10,
         },
         emptyComments,
       ),

--- a/editor/src/components/editor/defaults.ts
+++ b/editor/src/components/editor/defaults.ts
@@ -12,7 +12,7 @@ import {
   simpleAttribute,
 } from '../../core/shared/element-template'
 import type { NormalisedFrame } from 'utopia-api/core'
-import { defaultImageAttributes } from '../shared/project-components'
+import { defaultImageAttributes, insertableGridStyle } from '../shared/project-components'
 
 export function defaultSceneElement(
   uid: string,
@@ -177,16 +177,7 @@ export function defaultGridElement(uid: string): JSXElement {
     uid,
     jsxAttributesFromMap({
       'data-uid': jsExpressionValue(uid, emptyComments),
-      style: jsExpressionValue(
-        {
-          position: 'absolute',
-          display: 'grid',
-          gridTemplateColumns: '1fr 1fr 1fr',
-          gridTemplateRows: '1fr 1fr 1fr',
-          gap: 10,
-        },
-        emptyComments,
-      ),
+      style: jsExpressionValue(insertableGridStyle(), emptyComments),
     }),
     [],
   )

--- a/editor/src/components/editor/insert-callbacks.ts
+++ b/editor/src/components/editor/insert-callbacks.ts
@@ -23,6 +23,7 @@ import { enableInsertModeForJSXElement, showToast } from './actions/action-creat
 import {
   defaultButtonElement,
   defaultDivElement,
+  defaultGridElement,
   defaultImgElement,
   defaultSpanElement,
 } from './defaults'
@@ -104,6 +105,10 @@ export function useEnterDrawToInsertForImage(): (event: React.MouseEvent<Element
 
 export function useEnterDrawToInsertForButton(): (event: React.MouseEvent<Element>) => void {
   return useEnterDrawToInsertForElement(defaultButtonElement)
+}
+
+export function useEnterDrawToInsertForGrid(): (event: React.MouseEvent<Element>) => void {
+  return useEnterDrawToInsertForElement(defaultGridElement)
 }
 
 export function useEnterDrawToInsertForConditional(): (event: React.MouseEvent<Element>) => void {

--- a/editor/src/components/editor/insertmenu.spec.browser2.tsx
+++ b/editor/src/components/editor/insertmenu.spec.browser2.tsx
@@ -26,7 +26,7 @@ function getInsertItems() {
   return screen.queryAllByTestId(/^component-picker-item-/gi)
 }
 
-const allInsertItemsCount = 23
+const allInsertItemsCount = 24
 
 function openInsertMenu(renderResult: EditorRenderResult) {
   return renderResult.dispatch(

--- a/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
+++ b/editor/src/components/shared/__snapshots__/project-components.spec.ts.snap
@@ -337,6 +337,29 @@ Array [
     },
   },
   Object {
+    "insertableComponents": Array [
+      Object {
+        "defaultSize": Object {
+          "height": 150,
+          "width": 150,
+        },
+        "element": [Function],
+        "icon": "component",
+        "importsToAdd": Object {},
+        "insertionCeiling": Object {
+          "type": "file-root",
+        },
+        "name": "Grid",
+        "stylePropOptions": Array [
+          "do-not-add",
+        ],
+      },
+    ],
+    "source": Object {
+      "type": "HTML_GRID",
+    },
+  },
+  Object {
     "insertableComponents": Array [],
     "source": Object {
       "dependencyName": "@heroicons/react",

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -126,6 +126,14 @@ export function insertableComponentGroupDiv(): InsertableComponentGroupDiv {
   return { type: 'HTML_DIV' }
 }
 
+export interface InsertableComponentGroupGrid {
+  type: 'HTML_GRID'
+}
+
+export function insertableComponentGroupGrid(): InsertableComponentGroupGrid {
+  return { type: 'HTML_GRID' }
+}
+
 export function insertableComponentGroupHTML(): InsertableComponentGroupHTML {
   return {
     type: 'HTML_GROUP',
@@ -207,6 +215,7 @@ export type InsertableComponentGroupType =
   | InsertableComponentGroupSamples
   | InsertableComponentGroupGroups
   | InsertableComponentGroupMap
+  | InsertableComponentGroupGrid
 
 export interface InsertableComponentGroup {
   source: InsertableComponentGroupType
@@ -254,6 +263,8 @@ export function getInsertableGroupLabel(insertableType: InsertableComponentGroup
       return 'Div'
     case 'MAP_GROUP':
       return 'List'
+    case 'HTML_GRID':
+      return 'Grid'
     default:
       assertNever(insertableType)
   }
@@ -271,6 +282,7 @@ export function getInsertableGroupPackageStatus(
     case 'GROUPS_GROUP':
     case 'HTML_DIV':
     case 'MAP_GROUP':
+    case 'HTML_GRID':
       return 'loaded'
     case 'PROJECT_DEPENDENCY_GROUP':
       return insertableType.dependencyStatus
@@ -460,6 +472,41 @@ const divComponentGroup = {
       style: defaultElementStyle(),
     }),
   ),
+}
+
+const gridComponentGroup: ComponentDescriptorsForFile = {
+  grid: {
+    properties: {},
+    supportsChildren: true,
+    preferredChildComponents: [],
+    source: defaultComponentDescriptor(),
+    variants: [
+      {
+        insertMenuLabel: 'Grid',
+        elementToInsert: () =>
+          jsxElementWithoutUID(
+            'div',
+            jsxAttributesFromMap({
+              style: jsExpressionValue(
+                {
+                  display: 'grid',
+                  gridTemplateRows: '1fr 1fr 1fr',
+                  gridTemplateColumns: '1fr 1fr 1fr',
+                  gap: 10,
+                  position: 'absolute',
+                  width: 200,
+                  height: 200,
+                },
+                emptyComments,
+              ),
+            }),
+            [],
+          ),
+        importsToAdd: {},
+      },
+    ],
+    ...ComponentDescriptorDefaults,
+  },
 }
 
 const conditionalElementsDescriptors: ComponentDescriptorsForFile = {
@@ -832,6 +879,11 @@ export function getComponentGroups(
   // Add groups group.
   addDependencyDescriptor(insertableComponentGroupGroups(), groupElementsDescriptors) // TODO instead of this, use createWrapInGroupActions!
 
+  addDependencyDescriptor(insertableComponentGroupGrid(), gridComponentGroup, {
+    width: 150,
+    height: 150,
+  })
+
   // Add entries for dependencies of the project.
   for (const dependency of dependencies) {
     if (isResolvedNpmDependency(dependency)) {
@@ -909,6 +961,7 @@ export function insertMenuModesForInsertableComponentGroupType(
     case 'SAMPLES_GROUP':
     case 'HTML_DIV':
     case 'MAP_GROUP':
+    case 'HTML_GRID':
       return insertMenuModes.all
     case 'GROUPS_GROUP':
       return insertMenuModes.onlyWrap

--- a/editor/src/components/shared/project-components.ts
+++ b/editor/src/components/shared/project-components.ts
@@ -63,6 +63,7 @@ import { intrinsicHTMLElementNamesThatSupportChildren } from '../../core/shared/
 import { getTopLevelElementByExportsDetail } from '../../core/model/project-file-utils'
 import { type Icon } from 'utopia-api'
 import type { FileRootPath } from '../canvas/ui-jsx-canvas'
+import type { CSSProperties } from 'react'
 
 export type StylePropOption = 'do-not-add' | 'add-size'
 
@@ -474,6 +475,16 @@ const divComponentGroup = {
   ),
 }
 
+export function insertableGridStyle(): CSSProperties {
+  return {
+    position: 'absolute',
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr 1fr',
+    gridTemplateRows: '1fr 1fr 1fr',
+    gap: 10,
+  }
+}
+
 const gridComponentGroup: ComponentDescriptorsForFile = {
   grid: {
     properties: {},
@@ -489,13 +500,9 @@ const gridComponentGroup: ComponentDescriptorsForFile = {
             jsxAttributesFromMap({
               style: jsExpressionValue(
                 {
-                  display: 'grid',
-                  gridTemplateRows: '1fr 1fr 1fr',
-                  gridTemplateColumns: '1fr 1fr 1fr',
-                  gap: 10,
-                  position: 'absolute',
-                  width: 200,
-                  height: 200,
+                  ...insertableGridStyle(),
+                  width: 150,
+                  height: 150,
                 },
                 emptyComments,
               ),


### PR DESCRIPTION
**Problem:**

1. When creating a grid layout from the inspector the default grid should be 2x2 with a 10px gap
2. There should be an insert menu entry in the canvas toolbar for a 3x3 grid with a 10px gap
3. There should be an entry for a grid in the floating component picker too

**Fix:**

Implement all of the above:


https://github.com/user-attachments/assets/6214c47d-ae77-4735-b9ec-ab00198e4b90

Note: the icon for the grid is the one used for the navigator, there should be a dedicated one with the right size (16x16) for the canvas toolbar as well.

Fixes #6511
