### PR TITLE
Style plugins

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -82,6 +82,7 @@ import { reparentSubjectsForInteractionTarget } from './strategies/reparent-help
 import { getReparentTargetUnified } from './strategies/reparent-helpers/reparent-strategy-parent-lookup'
 import { gridRearrangeResizeKeyboardStrategy } from './strategies/grid-rearrange-keyboard-strategy'
 import createCachedSelector from 're-reselect'
+import { getActivePlugin } from '../plugins/style-plugins'
 
 export type CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -202,6 +203,7 @@ export function pickCanvasStateFromEditorState(
   editorState: EditorState,
   builtInDependencies: BuiltInDependencies,
 ): InteractionCanvasState {
+  const activePlugin = getActivePlugin(editorState)
   return {
     builtInDependencies: builtInDependencies,
     interactionTarget: getInteractionTargetFromEditorState(editorState, localSelectedViews),
@@ -214,6 +216,11 @@ export function pickCanvasStateFromEditorState(
     startingElementPathTree: editorState.elementPathTree,
     startingAllElementProps: editorState.allElementProps,
     propertyControlsInfo: editorState.propertyControlsInfo,
+    styleInfoReader: activePlugin.styleInfoFactory({
+      projectContents: editorState.projectContents,
+      metadata: editorState.jsxMetadata,
+      elementPathTree: editorState.elementPathTree,
+    }),
   }
 }
 
@@ -224,6 +231,8 @@ export function pickCanvasStateFromEditorStateWithMetadata(
   metadata: ElementInstanceMetadataMap,
   allElementProps?: AllElementProps,
 ): InteractionCanvasState {
+  const activePlugin = getActivePlugin(editorState)
+
   return {
     builtInDependencies: builtInDependencies,
     interactionTarget: getInteractionTargetFromEditorState(editorState, localSelectedViews),
@@ -236,6 +245,11 @@ export function pickCanvasStateFromEditorStateWithMetadata(
     startingElementPathTree: editorState.elementPathTree, // IMPORTANT! This isn't based on the passed in metadata
     startingAllElementProps: allElementProps ?? editorState.allElementProps,
     propertyControlsInfo: editorState.propertyControlsInfo,
+    styleInfoReader: activePlugin.styleInfoFactory({
+      projectContents: editorState.projectContents,
+      metadata: metadata,
+      elementPathTree: editorState.elementPathTree,
+    }),
   }
 }
 

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -14,6 +14,7 @@ import type { AllElementProps } from '../../editor/store/editor-state'
 import type { CanvasCommand } from '../commands/commands'
 import type { ActiveFrameAction } from '../commands/set-active-frames-command'
 import type { StrategyApplicationStatus } from './interaction-state'
+import type { StyleInfo } from '../canvas-types'
 
 // TODO: fill this in, maybe make it an ADT for different strategies
 export interface CustomStrategyState {
@@ -105,6 +106,14 @@ export function controlWithProps<P>(value: ControlWithProps<P>): ControlWithProp
   return value
 }
 
+export type StyleInfoReader = (elementPath: ElementPath) => StyleInfo | null
+
+export type StyleInfoFactory = (context: {
+  projectContents: ProjectContentTreeRoot
+  metadata: ElementInstanceMetadataMap
+  elementPathTree: ElementPathTrees
+}) => StyleInfoReader
+
 export interface InteractionCanvasState {
   interactionTarget: InteractionTarget
   projectContents: ProjectContentTreeRoot
@@ -117,6 +126,7 @@ export interface InteractionCanvasState {
   startingElementPathTree: ElementPathTrees
   startingAllElementProps: AllElementProps
   propertyControlsInfo: PropertyControlsInfo
+  styleInfoReader: StyleInfoReader
 }
 
 export type InteractionTarget = TargetPaths | InsertionSubjects

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.spec.browser2.tsx
@@ -13,6 +13,7 @@ import {
   getPrintedUiJsCode,
   makeTestProjectCodeWithSnippet,
   renderTestEditorWithCode,
+  renderTestEditorWithModel,
 } from '../../ui-jsx.test-utils'
 import { shiftModifier } from '../../../../utils/modifiers'
 import { FlexGapTearThreshold } from './set-flex-gap-strategy'
@@ -20,8 +21,14 @@ import type { CanvasPoint } from '../../../../core/shared/math-utils'
 import { canvasPoint } from '../../../../core/shared/math-utils'
 import { checkFlexGapHandlesPositionedCorrectly } from '../../controls/select-mode/flex-gap-control.test-utils'
 import { BakedInStoryboardUID } from '../../../../core/model/scene-utils'
-import { selectComponentsForTest, wait } from '../../../../utils/utils.test-utils'
+import {
+  selectComponentsForTest,
+  setFeatureForBrowserTestsUseInDescribeBlockOnly,
+} from '../../../../utils/utils.test-utils'
 import * as EP from '../../../../core/shared/element-path'
+import { createModifiedProject } from '../../../../sample-projects/sample-project-utils.test-utils'
+import { StoryboardFilePath } from '../../../editor/store/editor-state'
+import { TailwindConfigPath } from '../../../../core/tailwind/tailwind-config'
 
 const DivTestId = 'mydiv'
 
@@ -712,6 +719,58 @@ export var storyboard = (
       await dragGapHandle(editor, canvasPoint({ x: 10, y: 0 }))
 
       expect(getPrintedUiJsCode(editor.getEditorState())).toEqual(code(20))
+    })
+  })
+
+  describe('tailwind', () => {
+    setFeatureForBrowserTestsUseInDescribeBlockOnly('Tailwind', true)
+    const Project = createModifiedProject({
+      [StoryboardFilePath]: `
+  import React from 'react'
+  import { Scene, Storyboard } from 'utopia-api'
+  export var storyboard = (
+    <Storyboard data-uid='sb'>
+      <Scene
+        id='scene'
+        commentId='scene'
+        data-uid='scene'
+        style={{
+          width: 700,
+          height: 759,
+          position: 'absolute',
+          left: 212,
+          top: 128,
+        }}
+      >
+        <div
+          data-uid='div'
+          data-testid='${DivTestId}'
+          className='top-10 left-10 absolute flex flex-row gap-12'
+        >
+          <div className='bg-red-500 w-10 h-10' data-uid='child-1' />
+          <div className='bg-red-500 w-10 h-10' data-uid='child-2' />
+        </div>  
+      </Scene>
+    </Storyboard>
+  )
+  
+  `,
+      [TailwindConfigPath]: `
+      const TailwindConfig = { }
+      export default TailwindConfig
+  `,
+      'app.css': `
+      @tailwind base;
+      @tailwind components;
+      @tailwind utilities;`,
+    })
+
+    it('can set tailwind gap', async () => {
+      const editor = await renderTestEditorWithModel(Project, 'await-first-dom-report')
+      await selectComponentsForTest(editor, [EP.fromString('sb/scene/div')])
+      await doGapResize(editor, canvasPoint({ x: 10, y: 0 }))
+      const div = editor.renderedDOM.getByTestId(DivTestId)
+      expect(div.className).toEqual('top-10 left-10 absolute flex flex-row gap-16')
     })
   })
 })

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
@@ -29,7 +29,7 @@ import type { FlexGapData } from '../../gap-utils'
 import {
   cursorFromFlexDirection,
   dragDeltaForOrientation,
-  getFlexGapData,
+  maybeFlexGapData,
   recurseIntoChildrenOfMapOrFragment,
 } from '../../gap-utils'
 import type { CanvasStrategyFactory } from '../canvas-strategies'
@@ -95,7 +95,7 @@ export const setFlexGapStrategy: CanvasStrategyFactory = (
     return null
   }
 
-  const flexGap = getFlexGapData(
+  const flexGap = maybeFlexGapData(
     canvasState.styleInfoReader(selectedElement),
     MetadataUtils.findElementByElementPath(canvasState.startingMetadata, selectedElement),
   )

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.tsx
@@ -29,7 +29,7 @@ import type { FlexGapData } from '../../gap-utils'
 import {
   cursorFromFlexDirection,
   dragDeltaForOrientation,
-  maybeFlexGapData,
+  getFlexGapData,
   recurseIntoChildrenOfMapOrFragment,
 } from '../../gap-utils'
 import type { CanvasStrategyFactory } from '../canvas-strategies'
@@ -95,7 +95,11 @@ export const setFlexGapStrategy: CanvasStrategyFactory = (
     return null
   }
 
-  const flexGap = maybeFlexGapData(canvasState.startingMetadata, selectedElement)
+  const flexGap = getFlexGapData(
+    canvasState.styleInfoReader(selectedElement),
+    MetadataUtils.findElementByElementPath(canvasState.startingMetadata, selectedElement),
+  )
+
   if (flexGap == null) {
     return null
   }

--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -26,6 +26,8 @@ import type {
 import { InteractionSession } from './canvas-strategies/interaction-state'
 import type { CanvasStrategyId } from './canvas-strategies/canvas-strategy-types'
 import type { MouseButtonsPressed } from '../../utils/mouse'
+import type { FlexDirection } from '../inspector/common/css-utils'
+import type { CSSNumberWithRenderedValue } from './controls/select-mode/controls-common'
 
 export const CanvasContainerID = 'canvas-container'
 
@@ -533,3 +535,47 @@ export const EdgePositionBottomRight: EdgePosition = { x: 1, y: 1 }
 export const EdgePositionTopRight: EdgePosition = { x: 1, y: 0 }
 
 export type SelectionLocked = 'locked' | 'locked-hierarchy' | 'selectable'
+
+export type PropertyTag = { type: 'hover' } | { type: 'breakpoint'; name: string }
+
+export interface FlexGapInfo {
+  name: 'gap'
+  gap: CSSNumberWithRenderedValue
+}
+
+export const flexGapInfo = (gap: CSSNumberWithRenderedValue): FlexGapInfo => ({
+  name: 'gap',
+  gap: gap,
+})
+
+export interface FlexDirectionInfo {
+  name: 'flexDirection'
+  flexDirection: FlexDirection
+}
+
+export const flexDirectionInfo = (flexDirection: FlexDirection): FlexDirectionInfo => ({
+  name: 'flexDirection',
+  flexDirection: flexDirection,
+})
+
+export type StylePropInfo = FlexGapInfo | FlexDirectionInfo
+
+export interface StyleProperty<T extends StylePropInfo> {
+  tags: PropertyTag[]
+  value: T
+}
+
+export const stylePropertyWithTags = <T extends StylePropInfo>(
+  tags: PropertyTag[],
+  value: T,
+): StyleProperty<T> => ({
+  tags: tags,
+  value: value,
+})
+
+export const styleProperty = <T extends StylePropInfo>(value: T): StyleProperty<T> => ({
+  tags: [],
+  value: value,
+})
+
+export type StyleInfo = Array<StyleProperty<StylePropInfo>>

--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -26,8 +26,7 @@ import type {
 import { InteractionSession } from './canvas-strategies/interaction-state'
 import type { CanvasStrategyId } from './canvas-strategies/canvas-strategy-types'
 import type { MouseButtonsPressed } from '../../utils/mouse'
-import type { FlexDirection } from '../inspector/common/css-utils'
-import type { CSSNumberWithRenderedValue } from './controls/select-mode/controls-common'
+import type { CSSNumber, FlexDirection } from '../inspector/common/css-utils'
 
 export const CanvasContainerID = 'canvas-container'
 
@@ -538,44 +537,21 @@ export type SelectionLocked = 'locked' | 'locked-hierarchy' | 'selectable'
 
 export type PropertyTag = { type: 'hover' } | { type: 'breakpoint'; name: string }
 
-export interface FlexGapInfo {
-  name: 'gap'
-  gap: CSSNumberWithRenderedValue
-}
-
-export const flexGapInfo = (gap: CSSNumberWithRenderedValue): FlexGapInfo => ({
-  name: 'gap',
-  gap: gap,
-})
-
-export interface FlexDirectionInfo {
-  name: 'flexDirection'
-  flexDirection: FlexDirection
-}
-
-export const flexDirectionInfo = (flexDirection: FlexDirection): FlexDirectionInfo => ({
-  name: 'flexDirection',
-  flexDirection: flexDirection,
-})
-
-export type StylePropInfo = FlexGapInfo | FlexDirectionInfo
-
-export interface StyleProperty<T extends StylePropInfo> {
-  tags: PropertyTag[]
+export interface WithPropertyTag<T> {
+  tag: PropertyTag | null
   value: T
 }
 
-export const stylePropertyWithTags = <T extends StylePropInfo>(
-  tags: PropertyTag[],
-  value: T,
-): StyleProperty<T> => ({
-  tags: tags,
+export const withPropertyTag = <T>(value: T): WithPropertyTag<T> => ({
+  tag: null,
   value: value,
 })
 
-export const styleProperty = <T extends StylePropInfo>(value: T): StyleProperty<T> => ({
-  tags: [],
-  value: value,
-})
+export type FlexGapInfo = WithPropertyTag<CSSNumber>
 
-export type StyleInfo = Array<StyleProperty<StylePropInfo>>
+export type FlexDirectionInfo = WithPropertyTag<FlexDirection>
+
+export interface StyleInfo {
+  gap: FlexGapInfo | null
+  flexDirection: FlexDirectionInfo | null
+}

--- a/editor/src/components/canvas/commands/update-class-list-command.ts
+++ b/editor/src/components/canvas/commands/update-class-list-command.ts
@@ -56,16 +56,9 @@ export const runUpdateClassList: CommandFunction<UpdateClassList> = (
 ) => {
   const { element, classNameUpdates } = command
 
-  const currentClassNameAttribute = getClassNameAttribute(
-    getElementFromProjectContents(element, editorState.projectContents),
-  )?.value
-
-  if (currentClassNameAttribute == null) {
-    return {
-      editorStatePatches: [],
-      commandDescription: `Update class list for ${EP.toUid(element)} with ${classNameUpdates}`,
-    }
-  }
+  const currentClassNameAttribute =
+    getClassNameAttribute(getElementFromProjectContents(element, editorState.projectContents))
+      ?.value ?? ''
 
   const parsedClassList = getParsedClassList(
     currentClassNameAttribute,

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
@@ -24,8 +24,8 @@ import { createInteractionViaMouse, flexGapHandle } from '../../canvas-strategie
 import { windowToCanvasCoordinates } from '../../dom-lookup'
 import {
   cursorFromFlexDirection,
-  maybeFlexGapData,
   gapControlBoundsFromMetadata,
+  getFlexGapData,
   recurseIntoChildrenOfMapOrFragment,
 } from '../../gap-utils'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
@@ -46,6 +46,7 @@ import {
   reverseJustifyContent,
 } from '../../../../core/model/flex-utils'
 import { optionalMap } from '../../../../core/shared/optional-utils'
+import { getActivePlugin } from '../../plugins/style-plugins'
 
 interface FlexGapControlProps {
   selectedElement: ElementPath
@@ -130,7 +131,21 @@ export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((p
     elementPathTrees,
     selectedElement,
   )
-  const flexGap = maybeFlexGapData(metadata, selectedElement)
+
+  const flexGap = useEditorState(
+    Substores.fullStore,
+    (store) =>
+      getFlexGapData(
+        getActivePlugin(store.editor).styleInfoFactory({
+          projectContents: store.editor.projectContents,
+          metadata: metadata,
+          elementPathTree: store.editor.elementPathTree,
+        })(selectedElement),
+        MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, selectedElement),
+      ),
+    'FlexGapControl flexGap',
+  )
+
   if (flexGap == null) {
     return null
   }

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
@@ -144,7 +144,7 @@ export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((p
         })(selectedElement),
         MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, selectedElement),
       ),
-    'FlexGapControl flexGap',
+    'FlexGapControl flexGapFromEditor',
   )
 
   const flexGap: FlexGapData | null = optionalMap(

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
@@ -26,7 +26,7 @@ import type { FlexGapData } from '../../gap-utils'
 import {
   cursorFromFlexDirection,
   gapControlBoundsFromMetadata,
-  getFlexGapData,
+  maybeFlexGapData,
   recurseIntoChildrenOfMapOrFragment,
 } from '../../gap-utils'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
@@ -136,7 +136,7 @@ export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((p
   const flexGapFromEditor = useEditorState(
     Substores.fullStore,
     (store) =>
-      getFlexGapData(
+      maybeFlexGapData(
         getActivePlugin(store.editor).styleInfoFactory({
           projectContents: store.editor.projectContents,
           metadata: metadata,

--- a/editor/src/components/canvas/controls/select-mode/subdued-flex-gap-controls.tsx
+++ b/editor/src/components/canvas/controls/select-mode/subdued-flex-gap-controls.tsx
@@ -6,7 +6,7 @@ import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
 import type { FlexGapData, PathWithBounds } from '../../gap-utils'
 import {
   gapControlBoundsFromMetadata,
-  getFlexGapData,
+  maybeFlexGapData,
   recurseIntoChildrenOfMapOrFragment,
 } from '../../gap-utils'
 import type { ElementPath } from 'utopia-shared/src/types'
@@ -40,7 +40,7 @@ export const SubduedFlexGapControl = React.memo<SubduedFlexGapControlProps>((pro
   const flexGap = useEditorState(
     Substores.fullStore,
     (store) =>
-      getFlexGapData(
+      maybeFlexGapData(
         getActivePlugin(store.editor).styleInfoFactory({
           projectContents: store.editor.projectContents,
           metadata: store.editor.jsxMetadata,

--- a/editor/src/components/canvas/gap-utils.ts
+++ b/editor/src/components/canvas/gap-utils.ts
@@ -332,23 +332,35 @@ export interface FlexGapData {
   direction: FlexDirection
 }
 
-export function getFlexGapData(
+export function maybeFlexGapData(
   info: StyleInfo | null,
-  instance: ElementInstanceMetadata | null,
+  element: ElementInstanceMetadata | null,
 ): FlexGapData | null {
-  if (instance == null || info == null) {
+  if (
+    element == null ||
+    element.specialSizeMeasurements.display !== 'flex' ||
+    isLeft(element.element) ||
+    !isJSXElement(element.element.value) ||
+    info == null
+  ) {
     return null
   }
 
-  const gap = info.gap?.value
-  const renderedValuePx = instance.specialSizeMeasurements.gap
-  if (gap == null || renderedValuePx == null) {
+  if (element.specialSizeMeasurements.justifyContent?.startsWith('space')) {
     return null
   }
+
+  const gap = element.specialSizeMeasurements.gap ?? 0
+  const gapFromReader = info.gap?.value
+
+  const flexDirection = element.specialSizeMeasurements.flexDirection ?? 'row'
 
   return {
-    value: cssNumberWithRenderedValue(gap, renderedValuePx),
-    direction: info.flexDirection?.value ?? 'row',
+    value: {
+      renderedValuePx: gap,
+      value: gapFromReader ?? null,
+    },
+    direction: flexDirection,
   }
 }
 

--- a/editor/src/components/canvas/gap-utils.ts
+++ b/editor/src/components/canvas/gap-utils.ts
@@ -18,10 +18,7 @@ import type { ElementPath } from '../../core/shared/project-file-types'
 import { assertNever } from '../../core/shared/utils'
 import type { StyleInfo } from './canvas-types'
 import { CSSCursor } from './canvas-types'
-import {
-  cssNumberWithRenderedValue,
-  type CSSNumberWithRenderedValue,
-} from './controls/select-mode/controls-common'
+import type { CSSNumberWithRenderedValue } from './controls/select-mode/controls-common'
 import type { CSSNumber, FlexDirection } from '../inspector/common/css-utils'
 import type { Sides } from 'utopia-api/core'
 import { sides } from 'utopia-api/core'

--- a/editor/src/components/canvas/gap-utils.ts
+++ b/editor/src/components/canvas/gap-utils.ts
@@ -16,8 +16,12 @@ import type { CanvasRectangle, CanvasVector, Size } from '../../core/shared/math
 import { canvasRectangle, isInfinityRectangle } from '../../core/shared/math-utils'
 import type { ElementPath } from '../../core/shared/project-file-types'
 import { assertNever } from '../../core/shared/utils'
+import type { StyleInfo } from './canvas-types'
 import { CSSCursor } from './canvas-types'
-import type { CSSNumberWithRenderedValue } from './controls/select-mode/controls-common'
+import {
+  cssNumberWithRenderedValue,
+  type CSSNumberWithRenderedValue,
+} from './controls/select-mode/controls-common'
 import type { CSSNumber, FlexDirection } from '../inspector/common/css-utils'
 import type { Sides } from 'utopia-api/core'
 import { sides } from 'utopia-api/core'
@@ -328,39 +332,23 @@ export interface FlexGapData {
   direction: FlexDirection
 }
 
-export function maybeFlexGapData(
-  metadata: ElementInstanceMetadataMap,
-  elementPath: ElementPath,
+export function getFlexGapData(
+  info: StyleInfo | null,
+  instance: ElementInstanceMetadata | null,
 ): FlexGapData | null {
-  const element = MetadataUtils.findElementByElementPath(metadata, elementPath)
-  if (
-    element == null ||
-    element.specialSizeMeasurements.display !== 'flex' ||
-    isLeft(element.element) ||
-    !isJSXElement(element.element.value)
-  ) {
+  if (instance == null || info == null) {
     return null
   }
 
-  if (element.specialSizeMeasurements.justifyContent?.startsWith('space')) {
+  const gap = info.gap?.value
+  const renderedValuePx = instance.specialSizeMeasurements.gap
+  if (gap == null || renderedValuePx == null) {
     return null
   }
-
-  const gap = element.specialSizeMeasurements.gap ?? 0
-
-  const gapFromProps: CSSNumber | undefined = defaultEither(
-    undefined,
-    getLayoutProperty('gap', right(element.element.value.props), styleStringInArray),
-  )
-
-  const flexDirection = element.specialSizeMeasurements.flexDirection ?? 'row'
 
   return {
-    value: {
-      renderedValuePx: gap,
-      value: gapFromProps ?? null,
-    },
-    direction: flexDirection,
+    value: cssNumberWithRenderedValue(gap, renderedValuePx),
+    direction: info.flexDirection?.value ?? 'row',
   }
 }
 

--- a/editor/src/components/canvas/plugins/inline-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/inline-style-plugin.ts
@@ -1,0 +1,66 @@
+import type { ElementPath } from 'utopia-shared/src/types'
+import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { defaultEither, isLeft, right } from '../../../core/shared/either'
+import type { ElementInstanceMetadataMap } from '../../../core/shared/element-template'
+import { isJSXElement } from '../../../core/shared/element-template'
+import { styleStringInArray } from '../../../utils/common-constants'
+import type { CSSNumber } from '../../inspector/common/css-utils'
+import type { FlexGapData } from '../gap-utils'
+import type { StylePlugin } from './style-plugins'
+import { stripNulls } from '../../../core/shared/array-utils'
+import { optionalMap } from '../../../core/shared/optional-utils'
+import { flexDirectionInfo, flexGapInfo, styleProperty } from '../canvas-types'
+
+function maybeFlexGapData(
+  metadata: ElementInstanceMetadataMap,
+  elementPath: ElementPath,
+): FlexGapData | null {
+  const element = MetadataUtils.findElementByElementPath(metadata, elementPath)
+  if (
+    element == null ||
+    element.specialSizeMeasurements.display !== 'flex' ||
+    isLeft(element.element) ||
+    !isJSXElement(element.element.value)
+  ) {
+    return null
+  }
+
+  if (element.specialSizeMeasurements.justifyContent?.startsWith('space')) {
+    return null
+  }
+
+  const gap = element.specialSizeMeasurements.gap ?? 0
+
+  const gapFromProps: CSSNumber | undefined = defaultEither(
+    undefined,
+    getLayoutProperty('gap', right(element.element.value.props), styleStringInArray),
+  )
+
+  const flexDirection = element.specialSizeMeasurements.flexDirection ?? 'row'
+
+  return {
+    value: {
+      renderedValuePx: gap,
+      value: gapFromProps ?? null,
+    },
+    direction: flexDirection,
+  }
+}
+
+export const InlineStylePlugin: StylePlugin = {
+  name: 'Inline Style',
+  styleInfoFactory:
+    ({ metadata }) =>
+    (elementPath) => {
+      const flexGapData = maybeFlexGapData(metadata, elementPath)
+      return stripNulls([
+        optionalMap((gap) => styleProperty(flexGapInfo(gap)), flexGapData?.value),
+        optionalMap(
+          (direction) => styleProperty(flexDirectionInfo(direction)),
+          flexGapData?.direction,
+        ),
+      ])
+    },
+  normalizeFromInlineStyle: (editor) => editor,
+}

--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -3,7 +3,10 @@ import type { EditorState } from '../../editor/store/editor-state'
 import type { StyleInfoFactory } from '../canvas-strategies/canvas-strategy-types'
 import { InlineStylePlugin } from './inline-style-plugin'
 import { TailwindPlugin } from './tailwind-style-plugin'
-import { isTailwindEnabled } from '../../../core/tailwind/tailwind-compilation'
+import {
+  getTailwindConfigCached,
+  isTailwindEnabled,
+} from '../../../core/tailwind/tailwind-compilation'
 
 export interface StylePlugin {
   name: string
@@ -19,14 +22,9 @@ export const Plugins = {
   Tailwind: TailwindPlugin,
 } as const
 
-export function getActivePlugin(
-  // The `_editorState` is not used now because `isTailwindEnabled` reads a
-  // global behind the scenes, it's still passed to make it easy to add new
-  // cases here without a big refactor
-  _editorState: EditorState,
-): StylePlugin {
+export function getActivePlugin(editorState: EditorState): StylePlugin {
   if (isTailwindEnabled()) {
-    return TailwindPlugin
+    return TailwindPlugin(getTailwindConfigCached(editorState))
   }
   return InlineStylePlugin
 }

--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -1,0 +1,32 @@
+import type { ElementPath } from 'utopia-shared/src/types'
+import type { EditorState } from '../../editor/store/editor-state'
+import type { StyleInfoFactory } from '../canvas-strategies/canvas-strategy-types'
+import { InlineStylePlugin } from './inline-style-plugin'
+import { TailwindPlugin } from './tailwind-style-plugin'
+import { isTailwindEnabled } from '../../../core/tailwind/tailwind-compilation'
+
+export interface StylePlugin {
+  name: string
+  styleInfoFactory: StyleInfoFactory
+  normalizeFromInlineStyle: (
+    editorState: EditorState,
+    elementsToNormalize: ElementPath[],
+  ) => EditorState
+}
+
+export const Plugins = {
+  InlineStyle: InlineStylePlugin,
+  Tailwind: TailwindPlugin,
+} as const
+
+export function getActivePlugin(
+  // The `_editorState` is not used now because `isTailwindEnabled` reads a
+  // global behind the scenes, it's still passed to make it easy to add new
+  // cases here without a big refactor
+  _editorState: EditorState,
+): StylePlugin {
+  if (isTailwindEnabled()) {
+    return TailwindPlugin
+  }
+  return InlineStylePlugin
+}

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.spec.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.spec.ts
@@ -4,7 +4,7 @@ import {
   getJSXElementFromProjectContents,
   StoryboardFilePath,
 } from '../../editor/store/editor-state'
-import { renderTestEditorWithCode, renderTestEditorWithModel } from '../ui-jsx.test-utils'
+import { renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import { TailwindPlugin } from './tailwind-style-plugin'
 import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
 import { TailwindConfigPath } from '../../../core/tailwind/tailwind-config'

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.spec.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.spec.ts
@@ -1,10 +1,18 @@
 import type { JSXAttributes } from 'utopia-shared/src/types'
 import * as EP from '../../../core/shared/element-path'
-import { getJSXElementFromProjectContents } from '../../editor/store/editor-state'
-import { renderTestEditorWithCode } from '../ui-jsx.test-utils'
+import {
+  getJSXElementFromProjectContents,
+  StoryboardFilePath,
+} from '../../editor/store/editor-state'
+import { renderTestEditorWithCode, renderTestEditorWithModel } from '../ui-jsx.test-utils'
 import { TailwindPlugin } from './tailwind-style-plugin'
+import { createModifiedProject } from '../../../sample-projects/sample-project-utils.test-utils'
+import { TailwindConfigPath } from '../../../core/tailwind/tailwind-config'
+import { getTailwindConfigCached } from '../../../core/tailwind/tailwind-compilation'
 
-const Project = `
+const Project = (style: Record<string, unknown>) =>
+  createModifiedProject({
+    [StoryboardFilePath]: `
 import React from 'react'
 import { Scene, Storyboard } from 'utopia-api'
 export var storyboard = (
@@ -23,27 +31,37 @@ export var storyboard = (
     >
       <div
         data-uid='div'
-        className=''
-        style={{
-          top: 2,
-          left: 2,
-          width: 100,
-          height: 100,
-          backgroundColor: 'blue',
-          display: 'flex',
-          flexDirection: 'row',
-          gap: '12px',
-        }}
+        style={${JSON.stringify(style)}}
       />
     </Scene>
   </Storyboard>
 )
 
-`
+`,
+    [TailwindConfigPath]: `
+    const TailwindConfig = {
+        content: [],
+        theme: { extend: { gap: { enormous: '222px' } } }
+    }
+    export default TailwindConfig
+`,
+  })
 
 describe('tailwind style plugin', () => {
   it('can normalize inline style', async () => {
-    const editor = await renderTestEditorWithCode(Project, 'await-first-dom-report')
+    const editor = await renderTestEditorWithModel(
+      Project({
+        top: 2,
+        left: 2,
+        width: 100,
+        height: 100,
+        backgroundColor: 'blue',
+        display: 'flex',
+        flexDirection: 'row',
+        gap: '12px',
+      }),
+      'await-first-dom-report',
+    )
     const target = EP.fromString('sb/scene/div')
     const normalizedEditor = TailwindPlugin(null).normalizeFromInlineStyle(
       editor.getEditorState().editor,
@@ -55,15 +73,45 @@ describe('tailwind style plugin', () => {
       normalizedEditor.projectContents,
     )!
 
-    expect(jsxAttributesSlice(normalizedElement.props)).toEqual({
+    expect(formatJSXAttributes(normalizedElement.props)).toEqual({
       className: 'flex-row gap-[12px]',
+      'data-uid': 'div',
+      style: { backgroundColor: 'blue', display: 'flex', height: 100, left: 2, top: 2, width: 100 },
+    })
+  })
+  it('can normalize inline style with custom Tailwind config', async () => {
+    const editor = await renderTestEditorWithModel(
+      Project({
+        top: 2,
+        left: 2,
+        width: 100,
+        height: 100,
+        backgroundColor: 'blue',
+        display: 'flex',
+        flexDirection: 'row',
+        gap: '222px',
+      }),
+      'await-first-dom-report',
+    )
+    const target = EP.fromString('sb/scene/div')
+    const normalizedEditor = TailwindPlugin(
+      getTailwindConfigCached(editor.getEditorState().editor),
+    ).normalizeFromInlineStyle(editor.getEditorState().editor, [target])
+
+    const normalizedElement = getJSXElementFromProjectContents(
+      target,
+      normalizedEditor.projectContents,
+    )!
+
+    expect(formatJSXAttributes(normalizedElement.props)).toEqual({
+      className: 'flex-row gap-enormous',
       'data-uid': 'div',
       style: { backgroundColor: 'blue', display: 'flex', height: 100, left: 2, top: 2, width: 100 },
     })
   })
 })
 
-function jsxAttributesSlice(attributes: JSXAttributes) {
+function formatJSXAttributes(attributes: JSXAttributes) {
   return attributes.reduce((acc: Record<string, unknown>, attribute) => {
     if (attribute.type === 'JSX_ATTRIBUTES_SPREAD' || attribute.value.type !== 'ATTRIBUTE_VALUE') {
       return acc

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.spec.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.spec.ts
@@ -1,0 +1,73 @@
+import type { JSXAttributes } from 'utopia-shared/src/types'
+import * as EP from '../../../core/shared/element-path'
+import { getJSXElementFromProjectContents } from '../../editor/store/editor-state'
+import { renderTestEditorWithCode } from '../ui-jsx.test-utils'
+import { TailwindPlugin } from './tailwind-style-plugin'
+
+const Project = `
+import React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <Scene
+      id='scene'
+      commentId='scene'
+      data-uid='scene'
+      style={{
+        width: 700,
+        height: 759,
+        position: 'absolute',
+        left: 212,
+        top: 128,
+      }}
+    >
+      <div
+        data-uid='div'
+        className=''
+        style={{
+          top: 2,
+          left: 2,
+          width: 100,
+          height: 100,
+          backgroundColor: 'blue',
+          display: 'flex',
+          flexDirection: 'row',
+          gap: '12px',
+        }}
+      />
+    </Scene>
+  </Storyboard>
+)
+
+`
+
+describe('tailwind style plugin', () => {
+  it('can normalize inline style', async () => {
+    const editor = await renderTestEditorWithCode(Project, 'await-first-dom-report')
+    const target = EP.fromString('sb/scene/div')
+    const normalizedEditor = TailwindPlugin(null).normalizeFromInlineStyle(
+      editor.getEditorState().editor,
+      [target],
+    )
+
+    const normalizedElement = getJSXElementFromProjectContents(
+      target,
+      normalizedEditor.projectContents,
+    )!
+
+    expect(jsxAttributesSlice(normalizedElement.props)).toEqual({
+      className: 'flex-row gap-[12px]',
+      'data-uid': 'div',
+      style: { backgroundColor: 'blue', display: 'flex', height: 100, left: 2, top: 2, width: 100 },
+    })
+  })
+})
+
+function jsxAttributesSlice(attributes: JSXAttributes) {
+  return attributes.reduce((acc: Record<string, unknown>, attribute) => {
+    if (attribute.type === 'JSX_ATTRIBUTES_SPREAD' || attribute.value.type !== 'ATTRIBUTE_VALUE') {
+      return acc
+    }
+    return { ...acc, [attribute.key]: attribute.value.value }
+  }, {})
+}

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
@@ -1,16 +1,12 @@
 import * as TailwindClassParser from '@xengine/tailwindcss-class-parser'
-import type { ElementPath, JSXAttributesEntry } from 'utopia-shared/src/types'
-import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import type { JSXAttributesEntry } from 'utopia-shared/src/types'
 import { isLeft } from '../../../core/shared/either'
-import type {
-  ElementInstanceMetadata,
-  ElementInstanceMetadataMap,
-} from '../../../core/shared/element-template'
 import { getClassNameAttribute } from '../../../core/tailwind/tailwind-options'
 import {
   getElementFromProjectContents,
   getJSXElementFromProjectContents,
 } from '../../editor/store/editor-state'
+import type { Parser } from '../../inspector/common/css-utils'
 import { cssParsers } from '../../inspector/common/css-utils'
 import { foldAndApplyCommandsSimple } from './../commands/commands'
 import { mapDropNulls } from '../../../core/shared/array-utils'
@@ -19,64 +15,16 @@ import * as PP from '../../../core/shared/property-path'
 import { updateClassListCommand } from './../commands/update-class-list-command'
 import * as UCL from './../commands/update-class-list-command'
 import type { StylePlugin } from './style-plugins'
-import type { FlexDirectionInfo, FlexGapInfo, StyleProperty, StylePropInfo } from '../canvas-types'
-import { flexDirectionInfo, flexGapInfo, styleProperty } from '../canvas-types'
-import { cssNumberWithRenderedValue } from '../controls/select-mode/controls-common'
+import type { WithPropertyTag } from '../canvas-types'
+import { withPropertyTag } from '../canvas-types'
+import type { Config } from 'tailwindcss/types/config'
 
-function parseTailwindGap(
-  gapValue: string | null,
-  instanceMetadata: ElementInstanceMetadata | null,
-): StyleProperty<FlexGapInfo> | null {
-  if (
-    instanceMetadata == null ||
-    instanceMetadata.specialSizeMeasurements.gap == null ||
-    gapValue == null
-  ) {
-    return null
-  }
-
-  const parsedGapValue = cssParsers.gap(gapValue, null)
-  if (isLeft(parsedGapValue)) {
-    return null
-  }
-
-  return styleProperty(
-    flexGapInfo(
-      cssNumberWithRenderedValue(
-        parsedGapValue.value,
-        instanceMetadata.specialSizeMeasurements.gap,
-      ),
-    ),
-  )
-}
-
-function parseTailwindFlexDirection(
-  directionValue: string | null,
-): StyleProperty<FlexDirectionInfo> | null {
-  if (directionValue == null) {
-    return null
-  }
-  const parsed = cssParsers.flexDirection(directionValue, null)
+function parseTailwindProperty<T>(value: unknown, parse: Parser<T>): WithPropertyTag<T> | null {
+  const parsed = parse(value, null)
   if (isLeft(parsed)) {
     return null
   }
-
-  return styleProperty(flexDirectionInfo(parsed.value))
-}
-
-function parseTailwindClass(
-  metadata: ElementInstanceMetadataMap,
-  elementPath: ElementPath,
-  { property, value }: { property: string; value: string },
-): StyleProperty<StylePropInfo> | null {
-  switch (property) {
-    case 'gap':
-      return parseTailwindGap(value, MetadataUtils.findElementByElementPath(metadata, elementPath))
-    case 'flexDirection':
-      return parseTailwindFlexDirection(value)
-    default:
-      return null
-  }
+  return withPropertyTag(parsed.value)
 }
 
 const TailwindPropertyMapping = {
@@ -99,37 +47,40 @@ function stringifiedStylePropValue(value: unknown): string | null {
   return null
 }
 
-// TODO: pass down the tailwind config
-export const TailwindPlugin: StylePlugin = {
+function getTailwindClassMapping(classes: string[], config: Config | null) {
+  const mapping: Record<string, string> = {}
+  classes.forEach((className) => {
+    const parsed = TailwindClassParser.parse(className, config ?? undefined)
+    if (parsed.kind === 'error' || !isSupportedTailwindProperty(parsed.property)) {
+      return
+    }
+    mapping[parsed.property] = parsed.value
+  })
+  return mapping
+}
+
+export const TailwindPlugin = (config: Config | null): StylePlugin => ({
   name: 'Tailwind',
   styleInfoFactory:
-    ({ metadata, projectContents }) =>
+    ({ projectContents }) =>
     (elementPath) => {
       const classList = getClassNameAttribute(
         getElementFromProjectContents(elementPath, projectContents),
       )?.value
 
       if (classList == null || typeof classList !== 'string') {
-        return []
+        return null
       }
 
-      const classes = classList.split(' ')
+      const mapping = getTailwindClassMapping(classList.split(' '), config)
 
-      const styleProps = mapDropNulls((tailwindClass) => {
-        const parsed = TailwindClassParser.parse(
-          tailwindClass /* TODO pass the tailwind config here */,
-        )
-        if (parsed.kind === 'error' || !isSupportedTailwindProperty(parsed.property)) {
-          return null
-        }
-
-        return parseTailwindClass(metadata, elementPath, {
-          property: parsed.property,
-          value: parsed.value,
-        })
-      }, classes)
-
-      return styleProps
+      return {
+        gap: parseTailwindProperty(mapping[TailwindPropertyMapping.gap], cssParsers.gap),
+        flexDirection: parseTailwindProperty(
+          mapping[TailwindPropertyMapping.flexDirection],
+          cssParsers.flexDirection,
+        ),
+      }
     },
   normalizeFromInlineStyle: (editorState, elementsToNormalize) => {
     const commands = elementsToNormalize.flatMap((elementPath) => {
@@ -167,14 +118,7 @@ export const TailwindPlugin: StylePlugin = {
           return null
         }
 
-        const tailwindClass = TailwindClassParser.classname(
-          { property: TailwindPropertyMapping[key], value: valueString },
-          /* TODO pass the tailwind config here */
-        )
-        if (tailwindClass == null) {
-          return null
-        }
-        return { tailwindClass, key }
+        return { property: TailwindPropertyMapping[key], value: valueString }
       }, styleProps)
 
       return [
@@ -183,8 +127,10 @@ export const TailwindPlugin: StylePlugin = {
           elementPath,
           Object.keys(TailwindPropertyMapping).map((prop) => PP.create('style', prop)),
         ),
-        ...stylePropConversions.map(({ tailwindClass }) =>
-          updateClassListCommand('always', elementPath, UCL.add(tailwindClass)),
+        updateClassListCommand(
+          'always',
+          elementPath,
+          stylePropConversions.map(({ property, value }) => UCL.add({ property, value })),
         ),
       ]
     })
@@ -194,4 +140,4 @@ export const TailwindPlugin: StylePlugin = {
 
     return foldAndApplyCommandsSimple(editorState, commands)
   },
-}
+})

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
@@ -1,0 +1,197 @@
+import * as TailwindClassParser from '@xengine/tailwindcss-class-parser'
+import type { ElementPath, JSXAttributesEntry } from 'utopia-shared/src/types'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { isLeft } from '../../../core/shared/either'
+import type {
+  ElementInstanceMetadata,
+  ElementInstanceMetadataMap,
+} from '../../../core/shared/element-template'
+import { getClassNameAttribute } from '../../../core/tailwind/tailwind-options'
+import {
+  getElementFromProjectContents,
+  getJSXElementFromProjectContents,
+} from '../../editor/store/editor-state'
+import { cssParsers } from '../../inspector/common/css-utils'
+import { foldAndApplyCommandsSimple } from './../commands/commands'
+import { mapDropNulls } from '../../../core/shared/array-utils'
+import { deleteProperties } from './../commands/delete-properties-command'
+import * as PP from '../../../core/shared/property-path'
+import { updateClassListCommand } from './../commands/update-class-list-command'
+import * as UCL from './../commands/update-class-list-command'
+import type { StylePlugin } from './style-plugins'
+import type { FlexDirectionInfo, FlexGapInfo, StyleProperty, StylePropInfo } from '../canvas-types'
+import { flexDirectionInfo, flexGapInfo, styleProperty } from '../canvas-types'
+import { cssNumberWithRenderedValue } from '../controls/select-mode/controls-common'
+
+function parseTailwindGap(
+  gapValue: string | null,
+  instanceMetadata: ElementInstanceMetadata | null,
+): StyleProperty<FlexGapInfo> | null {
+  if (
+    instanceMetadata == null ||
+    instanceMetadata.specialSizeMeasurements.gap == null ||
+    gapValue == null
+  ) {
+    return null
+  }
+
+  const parsedGapValue = cssParsers.gap(gapValue, null)
+  if (isLeft(parsedGapValue)) {
+    return null
+  }
+
+  return styleProperty(
+    flexGapInfo(
+      cssNumberWithRenderedValue(
+        parsedGapValue.value,
+        instanceMetadata.specialSizeMeasurements.gap,
+      ),
+    ),
+  )
+}
+
+function parseTailwindFlexDirection(
+  directionValue: string | null,
+): StyleProperty<FlexDirectionInfo> | null {
+  if (directionValue == null) {
+    return null
+  }
+  const parsed = cssParsers.flexDirection(directionValue, null)
+  if (isLeft(parsed)) {
+    return null
+  }
+
+  return styleProperty(flexDirectionInfo(parsed.value))
+}
+
+function parseTailwindClass(
+  metadata: ElementInstanceMetadataMap,
+  elementPath: ElementPath,
+  { property, value }: { property: string; value: string },
+): StyleProperty<StylePropInfo> | null {
+  switch (property) {
+    case 'gap':
+      return parseTailwindGap(value, MetadataUtils.findElementByElementPath(metadata, elementPath))
+    case 'flexDirection':
+      return parseTailwindFlexDirection(value)
+    default:
+      return null
+  }
+}
+
+const TailwindPropertyMapping = {
+  gap: 'gap',
+  flexDirection: 'flexDirection',
+} as const
+
+function isSupportedTailwindProperty(prop: unknown): prop is keyof typeof TailwindPropertyMapping {
+  return typeof prop === 'string' && prop in TailwindPropertyMapping
+}
+
+function stringifiedStylePropValue(value: unknown): string | null {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number') {
+    return `${value}px`
+  }
+
+  return null
+}
+
+// TODO: pass down the tailwind config
+export const TailwindPlugin: StylePlugin = {
+  name: 'Tailwind',
+  styleInfoFactory:
+    ({ metadata, projectContents }) =>
+    (elementPath) => {
+      const classList = getClassNameAttribute(
+        getElementFromProjectContents(elementPath, projectContents),
+      )?.value
+
+      if (classList == null || typeof classList !== 'string') {
+        return []
+      }
+
+      const classes = classList.split(' ')
+
+      const styleProps = mapDropNulls((tailwindClass) => {
+        const parsed = TailwindClassParser.parse(
+          tailwindClass /* TODO pass the tailwind config here */,
+        )
+        if (parsed.kind === 'error' || !isSupportedTailwindProperty(parsed.property)) {
+          return null
+        }
+
+        return parseTailwindClass(metadata, elementPath, {
+          property: parsed.property,
+          value: parsed.value,
+        })
+      }, classes)
+
+      return styleProps
+    },
+  normalizeFromInlineStyle: (editorState, elementsToNormalize) => {
+    const commands = elementsToNormalize.flatMap((elementPath) => {
+      const element = getJSXElementFromProjectContents(elementPath, editorState.projectContents)
+      if (element == null) {
+        return []
+      }
+
+      const styleAttribute = element.props.find(
+        (prop): prop is JSXAttributesEntry =>
+          prop.type === 'JSX_ATTRIBUTES_ENTRY' && prop.key === 'style',
+      )
+      if (styleAttribute == null) {
+        return []
+      }
+
+      const styleValue = styleAttribute.value
+      if (styleValue.type !== 'ATTRIBUTE_NESTED_OBJECT') {
+        return []
+      }
+
+      const styleProps = mapDropNulls(
+        (c): { key: keyof typeof TailwindPropertyMapping; value: unknown } | null =>
+          c.type === 'PROPERTY_ASSIGNMENT' &&
+          c.value.type === 'ATTRIBUTE_VALUE' &&
+          isSupportedTailwindProperty(c.key)
+            ? { key: c.key, value: c.value.value }
+            : null,
+        styleValue.content,
+      )
+
+      const stylePropConversions = mapDropNulls(({ key, value }) => {
+        const valueString = stringifiedStylePropValue(value)
+        if (valueString == null) {
+          return null
+        }
+
+        const tailwindClass = TailwindClassParser.classname(
+          { property: TailwindPropertyMapping[key], value: valueString },
+          /* TODO pass the tailwind config here */
+        )
+        if (tailwindClass == null) {
+          return null
+        }
+        return { tailwindClass, key }
+      }, styleProps)
+
+      return [
+        deleteProperties(
+          'always',
+          elementPath,
+          Object.keys(TailwindPropertyMapping).map((prop) => PP.create('style', prop)),
+        ),
+        ...stylePropConversions.map(({ tailwindClass }) =>
+          updateClassListCommand('always', elementPath, UCL.add(tailwindClass)),
+        ),
+      ]
+    })
+    if (commands.length === 0) {
+      return editorState
+    }
+
+    return foldAndApplyCommandsSimple(editorState, commands)
+  },
+}

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -57,6 +57,7 @@ import { isInsertMode } from '../editor-modes'
 import { patchedCreateRemixDerivedDataMemo } from './remix-derived-data'
 import { allowedToEditProject } from './collaborative-editing'
 import { canMeasurePerformance } from '../../../core/performance/performance-utils'
+import { getActivePlugin } from '../../canvas/plugins/style-plugins'
 
 interface HandleStrategiesResult {
   unpatchedEditorState: EditorState
@@ -103,7 +104,8 @@ export function interactionFinished(
             'end-interaction',
           )
         : strategyApplicationResult([], [])
-    const commandResult = foldAndApplyCommands(
+
+    const { editorState } = foldAndApplyCommands(
       newEditorState,
       storedState.patchedEditor,
       [],
@@ -111,9 +113,14 @@ export function interactionFinished(
       'end-interaction',
     )
 
+    const normalizedEditor = getActivePlugin(editorState).normalizeFromInlineStyle(
+      editorState,
+      strategyResult.elementsToRerender,
+    )
+
     const finalEditor: EditorState = applyElementsToRerenderFromStrategyResult(
       {
-        ...commandResult.editorState,
+        ...normalizedEditor,
         // TODO instead of clearing the metadata, we should save the latest valid metadata here to save a dom-walker run
         jsxMetadata: {},
         domMetadata: {},

--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -5445,7 +5445,10 @@ export const computedStyleKeys: Array<string> = Object.keys({
   ...layoutEmptyValuesNew,
 })
 
-type Parser<T> = (simpleValue: unknown, rawValue: ModifiableAttribute | null) => Either<string, T>
+export type Parser<T> = (
+  simpleValue: unknown,
+  rawValue: ModifiableAttribute | null,
+) => Either<string, T>
 
 type ParseFunction<T, K extends keyof T> = (
   prop: K,

--- a/editor/src/core/tailwind/tailwind-class-list-utils.ts
+++ b/editor/src/core/tailwind/tailwind-class-list-utils.ts
@@ -40,7 +40,7 @@ export function getClassListFromParsedClassList(
         config ?? undefined,
       )
     })
-    .filter((part) => part != null && part?.length > 0)
+    .filter((part) => part != null && part.length > 0)
     .join(' ')
 }
 

--- a/editor/src/core/tailwind/tailwind-class-list-utils.ts
+++ b/editor/src/core/tailwind/tailwind-class-list-utils.ts
@@ -40,6 +40,7 @@ export function getClassListFromParsedClassList(
         config ?? undefined,
       )
     })
+    .filter((part) => part != null && part?.length > 0)
     .join(' ')
 }
 


### PR DESCRIPTION
# [Example project with a flex gap](https://utopia.fish/p/71b4ada2-boatneck-lamp/?branch_name=feature-style-plugins)

## Problem
The canvas controls can't edit elements that are styled with Tailwind

## Fix
Add a plugin system, where each plugin provides a data source that strategies can read from (so as of this PR, either Tailwind or the inline style), and a function that takes props from the inline style, and moves them to the right place the style element. For example, the plugin that implements Tailwind styling takes the inline style props, converts them to the right tailwind classes, and adds them to the `className` prop.

The flex gap strategy and the flex gap control is updated to use the data provided by the plugin system to read the necessary data.

### Out of scope
There's one known limitation of this system as implemented in this PR: props that are removed by a strategy don't get removed by the normalization step in plugins. This is only a problem for the Tailwind plugin (since the inline style plugin leaves the inline style prop as the strategies left them, so the fix for this will come on a follow-up PR after this one (the actual fix is already implemented here for anyone interested https://github.com/concrete-utopia/utopia/pull/6510/commits/b2fc141d411d684c618792c6b4963e11c7a00f54)

### Details
- Types for the plugin system, and two concrete plugin implementations are added in the `canvas/plugins` folder
- The data provided by the plugins is added to `InteractionCanvasState` as the `styleInfoReader` function
- The normalization step provided by the plugins is hooked into the strategy lifecycle in `interactionFinished` 
- The flex gap strategy/controls are updated to use `styleInfoReader`
- `UpdateClassList` is fixed so that it can write the `className` prop even if it doesn't exist on element at the start of the command