### PR TITLE
Don't collapse grids on delete

### DIFF
--- a/editor/src/components/editor/actions/actions.spec.browser2.tsx
+++ b/editor/src/components/editor/actions/actions.spec.browser2.tsx
@@ -40,8 +40,6 @@ import {
   expectSingleUndoNSaves,
   searchInComponentPicker,
   selectComponentsForTest,
-  setFeatureForBrowserTestsUseInDescribeBlockOnly,
-  wait,
 } from '../../../utils/utils.test-utils'
 import {
   firePasteEvent,
@@ -93,11 +91,8 @@ async function deleteFromScene(
     makeTestProjectCodeWithSnippet(inputSnippet),
     'await-first-dom-report',
   )
-  await wait(1000)
   await renderResult.dispatch([selectComponents(targets, true)], true)
-  await wait(3000)
   await renderResult.dispatch([deleteSelected()], true)
-  await wait(1000)
 
   return {
     code: getPrintedUiJsCode(renderResult.getEditorState()),


### PR DESCRIPTION
**Problem:**

Deleting the last element in a grid should not collapse the empty grid to 0-sizes.

**Fix:**

If deletion would empty the grid, if the grid lacks at least one dimension then explicitly size the grid based on its frame.

| Before | After |
|-------|--------|
| https://github.com/user-attachments/assets/4160ba7d-5cb4-4d3c-ae8b-0fe43d482686 | https://github.com/user-attachments/assets/1fbf3552-f29f-42c9-9ebf-628f5df2265b |





Fixes #6518 