### PR TITLE
Handle Nested Grid Dragging

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
+++ b/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
@@ -162,7 +162,12 @@ export interface GridControlProps {
 }
 
 export interface GridControlsProps {
+  type: 'GRID_CONTROLS_PROPS'
   targets: ElementPath[]
+}
+
+export function isGridControlsProps(props: unknown): props is GridControlsProps {
+  return (props as GridControlsProps).type === 'GRID_CONTROLS_PROPS'
 }
 
 export const GridControls = controlForStrategyMemoized<GridControlsProps>(GridControlsComponent)
@@ -193,13 +198,17 @@ export function gridEdgeToEdgePosition(edge: GridResizeEdge): EdgePosition {
 }
 
 export function controlsForGridPlaceholders(
-  gridPath: ElementPath,
+  gridPath: ElementPath | Array<ElementPath>,
   whenToShow: WhenToShowControl = 'always-visible',
+  suffix: string | null = null,
 ): ControlWithProps<any> {
   return {
     control: GridControls,
-    props: { targets: [gridPath] },
-    key: GridControlsKey(gridPath),
+    props: {
+      type: 'GRID_CONTROLS_PROPS',
+      targets: Array.isArray(gridPath) ? gridPath : [gridPath],
+    },
+    key: `GridControls${suffix == null ? '' : suffix}`,
     show: whenToShow,
     priority: 'bottom',
   }


### PR DESCRIPTION
**Problem:**
Rearranging a grid inside a grid only works if dragging a cell of the nested grid.

**Fix:**
The main fix was the removal of a `pointerEvents` property which was inadvertently preventing the mousedown from triggering as it should.

But a secondary issue was discovered while testing that, which is that the mousedown is also not handled correctly in this case:
![image](https://github.com/user-attachments/assets/076d4f39-56ed-491a-a978-eaafa4596e0a)
When the mousedown is triggered it selects the parent grid item, but this is too late as there's no handling present for the parent grid item as that gets initialised by the selection change. To fix this, ancestor grids have been added to the grids currently present so that the ancestor grids can catch the mouse down.

However, doing the above caused an issue of duplicated controls which broke some of our tests. To fix that `combineApplicableControls` was implemented to combine different instances of `GridControls`, thereby deduplicating some of the controls that would render.

**Commit Details:**
- Implemented `combineApplicableControls` to collate disparate instances of `GridControls`.
- `controlsForGridPlaceholders` has been slightly tweaked to cater for the change in the type of `GridControlsProps` and also to handle a new option suffix.
- Removed `pointerEvents` setting which was bizarrely the cause of the original issue.
- Removed spurious property.
- `GridControlsComponent` now includes ancestor paths.

**Manual Tests:**
I hereby swear that:

- [x] ] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode
