### PR TITLE
Unify toolbar insert icons

### DIFF
--- a/editor/src/components/editor/canvas-toolbar.tsx
+++ b/editor/src/components/editor/canvas-toolbar.tsx
@@ -534,7 +534,7 @@ export const CanvasToolbar = React.memo(() => {
       {/* Insert Mode */}
       {canvasToolbarMode.primary === 'insert'
         ? wrapInSubmenu(
-            <FlexColumn style={{ padding: '3px 8px 0 8px', flexGrow: 1 }}>
+            <FlexColumn style={{ padding: '3px 8px 0 8px', flexGrow: 1, gap: 5 }}>
               <FlexRow>
                 <Tooltip title='Back' placement='bottom'>
                   <ToolbarButton
@@ -546,9 +546,11 @@ export const CanvasToolbar = React.memo(() => {
                 </Tooltip>
                 <Tooltip title='Insert div' placement='bottom'>
                   <ToolbarButton
-                    iconType='view'
+                    iconCategory='navigator-element'
+                    iconType='div'
                     secondary={canvasToolbarMode.secondary.divInsertionActive}
                     onClick={insertDivCallback}
+                    size={12}
                   />
                 </Tooltip>
                 <Tooltip title='Insert grid' placement='bottom'>
@@ -562,24 +564,30 @@ export const CanvasToolbar = React.memo(() => {
                 </Tooltip>
                 <Tooltip title='Insert image' placement='bottom'>
                   <ToolbarButton
+                    iconCategory='navigator-element'
                     iconType='image'
                     secondary={canvasToolbarMode.secondary.imageInsertionActive}
                     onClick={insertImgCallback}
+                    size={12}
                   />
                 </Tooltip>
                 <Tooltip title='Insert button' placement='bottom'>
                   <ToolbarButton
+                    iconCategory='navigator-element'
                     iconType='clickable'
                     secondary={canvasToolbarMode.secondary.buttonInsertionActive}
                     onClick={insertButtonCallback}
+                    size={12}
                   />
                 </Tooltip>
                 <Tooltip title='Insert conditional' placement='bottom'>
                   <ToolbarButton
                     testid={InsertConditionalButtonTestId}
+                    iconCategory='navigator-element'
                     iconType='conditional'
                     secondary={canvasToolbarMode.secondary.conditionalInsertionActive}
                     onClick={insertConditionalCallback}
+                    size={12}
                   />
                 </Tooltip>
               </FlexRow>

--- a/editor/src/components/navigator/navigator-item/component-picker.tsx
+++ b/editor/src/components/navigator/navigator-item/component-picker.tsx
@@ -223,6 +223,7 @@ const ComponentPickerTopSection = React.memo((props: ComponentPickerTopSectionPr
         padding: shownInToolbar ? undefined : '0px 8px 8px 8px',
         display: 'flex',
         flexDirection: 'column',
+        marginBottom: 2,
       }}
       tabIndex={0}
     >


### PR DESCRIPTION
Unifying the style of the element icons in the insert menu of the toolbar

| Before  | After |
| ------------- | ------------- |
| <img width="344" alt="Screenshot 2024-10-11 at 2 57 33 PM" src="https://github.com/user-attachments/assets/d726e461-374c-4242-805e-fa678ecd0902"> | <img width="360" alt="Screenshot 2024-10-11 at 2 56 49 PM" src="https://github.com/user-attachments/assets/3e960756-ce1e-4a38-a8cc-43cfd722a820"> | 
