### PR TITLE
fix(server): upgrade Node version to 20

### DIFF
--- a/server/default.nix
+++ b/server/default.nix
@@ -1,13 +1,17 @@
 let
   release = (import ../release.nix {});
   pkgs = release.pkgs;
+  recentPkgs = release.recentPkgs;
+  # we set only the running Node to be 20.x, for project dependencies
+  node = recentPkgs.nodejs_20;
+  yarn = recentPkgs.yarn.override { nodejs = node; };
   compiler = "ghc902";
   utopia-server = pkgs.haskell.packages.${compiler}.callCabal2nix "utopia-server" ./. {};
   haskell = pkgs.haskell.lib;
   trivial = pkgs.lib.trivial;
   disableProfiling = pkg: haskell.disableLibraryProfiling (haskell.disableExecutableProfiling pkg);
   disableExternalTests = pkg: haskell.appendConfigureFlag pkg "--flags -enable-external-tests";
-  withNodeTooling = pkg: haskell.addBuildTools pkg [pkgs.nodejs pkgs.yarn];
+  withNodeTooling = pkg: haskell.addBuildTools pkg [node yarn];
   serverModifications = pkg: trivial.pipe pkg [disableProfiling disableExternalTests withNodeTooling];
   overriddenHaskellPackages = pkgs.haskell.packages.${compiler}.override {
     overrides = self: super: {


### PR DESCRIPTION
**Problem:**
Today our server Node version was 18, which was no longer LTS and even broke some of the modern projects' dependencies.
<img width="1370" alt="image" src="https://github.com/user-attachments/assets/c4f6ec9c-9345-491e-9169-28142e18c392">

**Fix:**
Upgrade the server Node version to 20.
![image](https://github.com/user-attachments/assets/649d7b4d-4e47-4bc6-a830-ff6578974511)


**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Play mode
