### PR TITLE
Grid auto cols/rows inspector control

### DIFF
--- a/editor/src/components/inspector/flex-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/flex-section.spec.browser2.tsx
@@ -2,6 +2,7 @@ import { selectComponentsForTest } from '../../utils/utils.test-utils'
 import { renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
 import * as EP from '../../core/shared/element-path'
 import { act, fireEvent, screen } from '@testing-library/react'
+import { GridAutoColsOrRowsControlTestId } from './flex-section'
 
 describe('flex section', () => {
   describe('grid dimensions', () => {
@@ -73,6 +74,41 @@ describe('flex section', () => {
       const grid = await renderResult.renderedDOM.findByTestId('grid')
       expect(grid.style.gridTemplateColumns).toEqual('[area1] 1fr 1fr 1fr 1fr 1fr')
       expect(control.value).toBe('1fr')
+    })
+  })
+  describe('auto cols/rows', () => {
+    it('can set a number', async () => {
+      const renderResult = await renderTestEditorWithCode(gridProject, 'await-first-dom-report')
+      await selectComponentsForTest(renderResult, [EP.fromString('sb/grid')])
+      const control: HTMLInputElement = await screen.findByTestId(
+        GridAutoColsOrRowsControlTestId('column'),
+      )
+      await typeIntoField(control, '50px')
+      const grid = await renderResult.renderedDOM.findByTestId('grid')
+      expect(grid.style.gridAutoColumns).toEqual('50px')
+      expect(control.value).toBe('50px')
+    })
+    it('can set a keyword', async () => {
+      const renderResult = await renderTestEditorWithCode(gridProject, 'await-first-dom-report')
+      await selectComponentsForTest(renderResult, [EP.fromString('sb/grid')])
+      const control: HTMLInputElement = await screen.findByTestId(
+        GridAutoColsOrRowsControlTestId('column'),
+      )
+      await typeIntoField(control, 'min-content')
+      const grid = await renderResult.renderedDOM.findByTestId('grid')
+      expect(grid.style.gridAutoColumns).toEqual('min-content')
+      expect(control.value).toBe('min-content')
+    })
+    it('can set an expression', async () => {
+      const renderResult = await renderTestEditorWithCode(gridProject, 'await-first-dom-report')
+      await selectComponentsForTest(renderResult, [EP.fromString('sb/grid')])
+      const control: HTMLInputElement = await screen.findByTestId(
+        GridAutoColsOrRowsControlTestId('column'),
+      )
+      await typeIntoField(control, 'minmax(50px, 1fr)')
+      const grid = await renderResult.renderedDOM.findByTestId('grid')
+      expect(grid.style.gridAutoColumns).toEqual('minmax(50px, 1fr)')
+      expect(control.value).toBe('minmax(50px, 1fr)')
     })
   })
 })

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -264,21 +264,7 @@ const TemplateDimensionControl = React.memo(
         (value: UnknownOrEmptyInput<CSSNumber | CSSKeyword<ValidGridDimensionKeyword>>) => {
           function getNewValue() {
             const gridValueAtIndex = values[index]
-            if (isCSSNumber(value)) {
-              const maybeUnit = isGridCSSNumber(gridValueAtIndex)
-                ? gridValueAtIndex.value.unit
-                : null
-              return gridCSSNumber(
-                cssNumber(value.value, value.unit ?? maybeUnit),
-                gridValueAtIndex.areaName,
-              )
-            } else if (isCSSKeyword(value)) {
-              return gridCSSKeyword(value, gridValueAtIndex.areaName)
-            } else if (isEmptyInputValue(value)) {
-              return gridCSSKeyword(cssKeyword('auto'), gridValueAtIndex.areaName)
-            } else {
-              return null
-            }
+            return parseGridDimensionInput(value, gridValueAtIndex ?? null)
           }
           const newValue = getNewValue()
           if (newValue == null) {
@@ -508,6 +494,7 @@ const TemplateDimensionControl = React.memo(
             opener={openDropdown}
           />
         ))}
+        <AutoColsOrRowsControl grid={grid} axis={axis} />
       </div>
     )
   },
@@ -588,10 +575,10 @@ function AxisDimensionControl({
           alignItems: 'center',
           gap: 6,
           gridTemplateColumns: gridExpressionInputFocused.focused
-            ? `40px auto`
+            ? '40px auto'
             : `40px auto ${UtopiaTheme.layout.inputHeight.default}px`,
           gridTemplateRows: '1fr',
-          width: `100%`,
+          width: '100%',
         }}
       >
         <Subdued
@@ -1111,4 +1098,100 @@ const useGridExpressionInputFocused = () => {
   const onFocus = React.useCallback(() => setFocused(true), [])
   const onBlur = React.useCallback(() => setFocused(false), [])
   return { focused, onFocus, onBlur }
+}
+
+function parseGridDimensionInput(
+  value: UnknownOrEmptyInput<CSSNumber | CSSKeyword<ValidGridDimensionKeyword>>,
+  currentValue: GridDimension | null,
+) {
+  if (isCSSNumber(value)) {
+    const maybeUnit =
+      currentValue != null && isGridCSSNumber(currentValue) ? currentValue.value.unit : null
+    return gridCSSNumber(
+      cssNumber(value.value, value.unit ?? maybeUnit),
+      currentValue?.areaName ?? null,
+    )
+  } else if (isCSSKeyword(value)) {
+    return gridCSSKeyword(value, currentValue?.areaName ?? null)
+  } else if (isEmptyInputValue(value)) {
+    return gridCSSKeyword(cssKeyword('auto'), currentValue?.areaName ?? null)
+  } else {
+    return null
+  }
+}
+
+const AutoColsOrRowsControl = React.memo(
+  (props: { axis: 'column' | 'row'; grid: ElementInstanceMetadata }) => {
+    const value = React.useMemo(() => {
+      const template = props.grid.specialSizeMeasurements.containerGridPropertiesFromProps
+      const data = props.axis === 'column' ? template.gridAutoColumns : template.gridAutoRows
+      if (data?.type !== 'DIMENSIONS') {
+        return null
+      }
+      return data.dimensions[0]
+    }, [props.grid, props.axis])
+
+    const dispatch = useDispatch()
+
+    const onUpdateDimension = React.useCallback(
+      (newDimension: GridDimension) => {
+        dispatch([
+          applyCommandsAction([
+            setProperty(
+              'always',
+              props.grid.elementPath,
+              PP.create('style', props.axis === 'column' ? 'gridAutoColumns' : 'gridAutoRows'),
+              printArrayGridDimensions([newDimension]),
+            ),
+          ]),
+        ])
+      },
+      [props.grid, props.axis, dispatch],
+    )
+
+    const onUpdateAutoValue = React.useCallback(
+      (newValue: UnknownOrEmptyInput<CSSNumber | CSSKeyword<ValidGridDimensionKeyword>>) => {
+        const parsed = parseGridDimensionInput(newValue, null)
+        if (parsed == null) {
+          return
+        }
+        onUpdateDimension(parsed)
+      },
+      [onUpdateDimension],
+    )
+
+    const autoColsOrRowsValueFocused = useGridExpressionInputFocused()
+
+    return (
+      <div
+        style={{
+          display: 'grid',
+          gridAutoFlow: 'column',
+          alignItems: 'center',
+          gap: 6,
+          gridTemplateColumns: autoColsOrRowsValueFocused.focused
+            ? '40px auto'
+            : `40px auto ${UtopiaTheme.layout.inputHeight.default}px`,
+          gridTemplateRows: '1fr',
+          width: '100%',
+        }}
+      >
+        <div>Default</div>
+        <GridExpressionInput
+          testId={GridAutoColsOrRowsControlTestId(props.axis)}
+          value={value ?? gridCSSKeyword(cssKeyword('auto'), null)}
+          onUpdateNumberOrKeyword={onUpdateAutoValue}
+          onUpdateDimension={onUpdateDimension}
+          onFocus={autoColsOrRowsValueFocused.onFocus}
+          onBlur={autoColsOrRowsValueFocused.onBlur}
+          keywords={gridDimensionDropdownKeywords}
+        />
+      </div>
+    )
+  },
+)
+AutoColsOrRowsControl.displayName = 'AutoColsOrRowsControl'
+
+export function GridAutoColsOrRowsControlTestId(axis: 'column' | 'row'): string {
+  return `grid-template-auto-${axis}`
 }

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -1149,7 +1149,7 @@ const AutoColsOrRowsControl = React.memo(
       [props.grid, props.axis, dispatch],
     )
 
-    const onUpdateAutoValue = React.useCallback(
+    const onUpdateNumberOrKeyword = React.useCallback(
       (newValue: UnknownOrEmptyInput<CSSNumber | CSSKeyword<ValidGridDimensionKeyword>>) => {
         const parsed = parseGridDimensionInput(newValue, null)
         if (parsed == null) {
@@ -1180,7 +1180,7 @@ const AutoColsOrRowsControl = React.memo(
         <GridExpressionInput
           testId={GridAutoColsOrRowsControlTestId(props.axis)}
           value={value ?? gridCSSKeyword(cssKeyword('auto'), null)}
-          onUpdateNumberOrKeyword={onUpdateAutoValue}
+          onUpdateNumberOrKeyword={onUpdateNumberOrKeyword}
           onUpdateDimension={onUpdateDimension}
           onFocus={autoColsOrRowsValueFocused.onFocus}
           onBlur={autoColsOrRowsValueFocused.onBlur}


### PR DESCRIPTION
**Problem:**

The inspector should offer a way to control the `gridAutoRows` and `gridAutoCols` props for a grid container.

**Fix:**

This PR adds a new control below the template cols and rows section in the inspector for a selected grid, allowing to edit the related style prop in the same way we edit other template values.


https://github.com/user-attachments/assets/93e5297d-6bfc-4b94-a6ac-276228bae4b1



Fixes #6532 