### PR TITLE
Removed a cyclic dependency from math-utils.ts

### DIFF
--- a/editor/src/core/shared/math-utils.ts
+++ b/editor/src/core/shared/math-utils.ts
@@ -1,4 +1,3 @@
-import { stripNulls } from './array-utils'
 import type { Either } from './either'
 import { left, right, mapEither } from './either'
 
@@ -637,6 +636,17 @@ export function combineRectangles<C extends CoordinateMarker>(
     width: first.width + second.width,
     height: first.height + second.height,
   } as Rectangle<C>
+}
+
+// Copied from array-utils.ts to prevent a cyclic dependency
+function stripNulls<T>(array: Array<T | null | undefined>): Array<T> {
+  var workingArray: Array<T> = []
+  for (const value of array) {
+    if (value !== null && value !== undefined) {
+      workingArray.push(value)
+    }
+  }
+  return workingArray
 }
 
 export function boundingRectangleArray<C extends CoordinateMarker>(


### PR DESCRIPTION
**Problem:**
There has always been a cyclic dependency between `math-utils.ts` and `array-utils.ts`, but for some reason it has started causing a runtime error over the last few days:
![image](https://github.com/user-attachments/assets/55c10392-1587-4155-9571-60cdc7e1dbfb)

**Fix:**
`math-utils.ts` was importing a function `stripNulls` from `array-utils.ts`, so I've removed the import and copied the function. The fix could have been applied in the opposite direction, but I've chosen this direction as it seems more likely that at a future date we'd want to import another math function into `array-utils` than vice versa.