### PR TITLE
Display Grid Template Ellipsis When Hovered

### DIFF
--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -92,8 +92,6 @@ import {
 import type { Axis } from '../canvas/gap-utils'
 import { GridExpressionInput } from '../../uuiui/inputs/grid-expression-input'
 
-const axisDropdownMenuButton = 'axisDropdownMenuButton'
-
 function getLayoutSystem(
   layoutSystem: DetectedLayoutSystem | null | undefined,
 ): 'grid' | 'flex' | null {
@@ -553,20 +551,20 @@ function AxisDimensionControl({
 
   const gridExpressionInputFocused = useGridExpressionInputFocused()
 
+  const [isHovered, setIsHovered] = React.useState(false)
+  const onMouseEnter = React.useCallback(() => {
+    setIsHovered(true)
+  }, [])
+  const onMouseLeave = React.useCallback(() => {
+    setIsHovered(false)
+  }, [])
+
   return (
     <div
       key={`col-${value}-${index}`}
       style={{ display: 'flex', alignItems: 'center', gap: 6 }}
-      css={{
-        [`& > .${axisDropdownMenuButton}`]: {
-          visibility: isOpen ? 'visible' : 'hidden',
-        },
-        ':hover': {
-          [`& > .${axisDropdownMenuButton}`]: {
-            visibility: 'visible',
-          },
-        },
-      }}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <div
         style={{
@@ -600,9 +598,9 @@ function AxisDimensionControl({
           onBlur={gridExpressionInputFocused.onBlur}
           keywords={gridDimensionDropdownKeywords}
         />
-        {unless(
-          gridExpressionInputFocused.focused,
-          <SquareButton className={axisDropdownMenuButton}>
+        {when(
+          (isHovered && !gridExpressionInputFocused.focused) || isOpen,
+          <SquareButton>
             <DropdownMenu align='end' items={items} opener={opener} onOpenChange={onOpenChange} />
           </SquareButton>,
         )}


### PR DESCRIPTION
**Problem:**
The `…` at the end of the grid template entries in the inspector should only be shown on hover of the row.

**Fix:**
Flipped around some logic and moved some CSS based visibility for the ellipsis to be purely React based.

**Recording:**
https://github.com/user-attachments/assets/598dd953-ccd2-46cc-8cef-63d50d260bfc

**Commit Details:**
- Moved the logic in `AxisDimensionControl` that governed the visibility of the ellipsis to be purely React based instead of using Emotion CSS.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode