### PR TITLE
Conditional auto cols/rows input in the inspector, auto template in the advanced modal

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -83,6 +83,7 @@ import { parseFlex, printFlexAsAttributeValue } from '../../../printer-parsers/c
 import { memoize } from '../../../core/shared/memoize'
 import * as csstree from 'css-tree'
 import type { IcnProps } from '../../../uuiui'
+import { cssNumberEqual } from '../../canvas/controls/select-mode/controls-common'
 
 var combineRegExp = function (regexpList: Array<RegExp | string>, flags?: string) {
   let source: string = ''
@@ -593,6 +594,37 @@ export type GridCSSNumber = BaseGridDimension & {
 export type GridCSSKeyword = BaseGridDimension & {
   type: 'KEYWORD'
   value: CSSKeyword<ValidGridDimensionKeyword>
+}
+
+export function gridDimensionsAreEqual(a: GridDimension, b: GridDimension): boolean {
+  switch (a.type) {
+    case 'KEYWORD':
+      if (a.type !== b.type) {
+        return false
+      }
+      return a.value.type === b.value.type && a.value.value === b.value.value
+    case 'NUMBER':
+      if (a.type !== b.type) {
+        return false
+      }
+      return cssNumberEqual(a.value, b.value)
+    case 'MINMAX':
+      if (a.type !== b.type) {
+        return false
+      }
+      return gridDimensionsAreEqual(a.min, b.min) && gridDimensionsAreEqual(a.max, b.max)
+    case 'REPEAT':
+      if (a.type !== b.type) {
+        return false
+      }
+      return (
+        a.times === b.times &&
+        a.value.length === b.value.length &&
+        a.value.every((value, index) => gridDimensionsAreEqual(value, b.value[index]))
+      )
+    default:
+      assertNever(a)
+  }
 }
 
 type BaseGridCSSRepeat = {

--- a/editor/src/components/inspector/controls/advanced-grid-modal.tsx
+++ b/editor/src/components/inspector/controls/advanced-grid-modal.tsx
@@ -16,6 +16,10 @@ import {
 import { optionalMap } from '../../../core/shared/optional-utils'
 import type { FlexAlignment } from 'utopia-api/core'
 import { FlexJustifyContent } from 'utopia-api/core'
+import { GridAutoColsOrRowsControlInner } from '../grid-auto-cols-or-rows-control'
+import { Substores, useEditorState, useRefEditorState } from '../../editor/store/store-hook'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { selectedViewsSelector } from '../inpector-selectors'
 
 export interface AdvancedGridModalProps {
   id: string
@@ -103,6 +107,25 @@ export const AdvancedGridModal = React.memo((props: AdvancedGridModalProps) => {
     [alignContentLayoutInfo],
   )
 
+  const selectedViewsRef = useRefEditorState(selectedViewsSelector)
+  const grid = useEditorState(
+    Substores.metadata,
+    (store) => {
+      if (selectedViewsRef.current.length !== 1) {
+        return null
+      }
+      return MetadataUtils.findElementByElementPath(
+        store.editor.jsxMetadata,
+        selectedViewsRef.current[0],
+      )
+    },
+    'AdvancedGridModal grid',
+  )
+
+  if (grid == null) {
+    return null
+  }
+
   const advancedGridModal = (
     <InspectorModal
       offsetX={modalOffset.x}
@@ -189,6 +212,23 @@ export const AdvancedGridModal = React.memo((props: AdvancedGridModalProps) => {
             }}
             onOpenChange={toggleAlignContentDropdown}
           />
+        </UIGridRow>
+        <UIGridRow padded variant='<-------------1fr------------->'>
+          <span style={{ fontWeight: 600 }}>Template</span>
+        </UIGridRow>
+        <UIGridRow
+          padded
+          variant={rowVariant}
+          className={`ignore-react-onclickoutside-${props.id}`}
+        >
+          <GridAutoColsOrRowsControlInner grid={grid} axis='column' label='Auto Cols' />
+        </UIGridRow>
+        <UIGridRow
+          padded
+          variant={rowVariant}
+          className={`ignore-react-onclickoutside-${props.id}`}
+        >
+          <GridAutoColsOrRowsControlInner grid={grid} axis='row' label='Auto Rows' />
         </UIGridRow>
       </FlexColumn>
     </InspectorModal>

--- a/editor/src/components/inspector/flex-section.spec.browser2.tsx
+++ b/editor/src/components/inspector/flex-section.spec.browser2.tsx
@@ -2,7 +2,7 @@ import { selectComponentsForTest } from '../../utils/utils.test-utils'
 import { renderTestEditorWithCode } from '../canvas/ui-jsx.test-utils'
 import * as EP from '../../core/shared/element-path'
 import { act, fireEvent, screen } from '@testing-library/react'
-import { GridAutoColsOrRowsControlTestId } from './flex-section'
+import { GridAutoColsOrRowsControlTestId } from './grid-auto-cols-or-rows-control'
 
 describe('flex section', () => {
   describe('grid dimensions', () => {

--- a/editor/src/components/inspector/grid-auto-cols-or-rows-control.tsx
+++ b/editor/src/components/inspector/grid-auto-cols-or-rows-control.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { useDispatch } from '../editor/store/dispatch-context'
+import { UtopiaTheme } from '../../uuiui'
+import type {
+  CSSKeyword,
+  CSSNumber,
+  UnknownOrEmptyInput,
+  ValidGridDimensionKeyword,
+} from './common/css-utils'
+import {
+  cssKeyword,
+  gridCSSKeyword,
+  printArrayGridDimensions,
+  type GridDimension,
+} from './common/css-utils'
+import { applyCommandsAction } from '../editor/actions/action-creators'
+import { setProperty } from '../canvas/commands/set-property-command'
+import * as PP from '../../core/shared/property-path'
+import { type ElementInstanceMetadata } from '../../core/shared/element-template'
+import { GridExpressionInput } from '../../uuiui/inputs/grid-expression-input'
+import {
+  gridDimensionDropdownKeywords,
+  parseGridDimensionInput,
+  useGridExpressionInputFocused,
+} from './grid-helpers'
+
+export const GridAutoColsOrRowsControl = React.memo(
+  (props: { axis: 'column' | 'row'; grid: ElementInstanceMetadata; label: string }) => {
+    const autoColsOrRowsValueFocused = useGridExpressionInputFocused()
+
+    return (
+      <div
+        style={{
+          display: 'grid',
+          gridAutoFlow: 'column',
+          alignItems: 'center',
+          gap: 6,
+          gridTemplateColumns: autoColsOrRowsValueFocused.focused
+            ? '60px auto'
+            : `60px auto ${UtopiaTheme.layout.inputHeight.default}px`,
+          gridTemplateRows: '1fr',
+          width: '100%',
+        }}
+      >
+        <GridAutoColsOrRowsControlInner {...props} />
+      </div>
+    )
+  },
+)
+GridAutoColsOrRowsControl.displayName = 'GridAutoColsOrRowsControl'
+
+export const GridAutoColsOrRowsControlInner = React.memo(
+  (props: { axis: 'column' | 'row'; grid: ElementInstanceMetadata; label: string }) => {
+    const value = React.useMemo(() => {
+      const template = props.grid.specialSizeMeasurements.containerGridPropertiesFromProps
+      const data = props.axis === 'column' ? template.gridAutoColumns : template.gridAutoRows
+      if (data?.type !== 'DIMENSIONS') {
+        return null
+      }
+      return data.dimensions[0]
+    }, [props.grid, props.axis])
+
+    const dispatch = useDispatch()
+
+    const onUpdateDimension = React.useCallback(
+      (newDimension: GridDimension) => {
+        dispatch([
+          applyCommandsAction([
+            setProperty(
+              'always',
+              props.grid.elementPath,
+              PP.create('style', props.axis === 'column' ? 'gridAutoColumns' : 'gridAutoRows'),
+              printArrayGridDimensions([newDimension]),
+            ),
+          ]),
+        ])
+      },
+      [props.grid, props.axis, dispatch],
+    )
+
+    const onUpdateNumberOrKeyword = React.useCallback(
+      (newValue: UnknownOrEmptyInput<CSSNumber | CSSKeyword<ValidGridDimensionKeyword>>) => {
+        const parsed = parseGridDimensionInput(newValue, null)
+        if (parsed == null) {
+          return
+        }
+        onUpdateDimension(parsed)
+      },
+      [onUpdateDimension],
+    )
+
+    const autoColsOrRowsValueFocused = useGridExpressionInputFocused()
+
+    return (
+      <React.Fragment>
+        <div>{props.label}</div>
+        <GridExpressionInput
+          testId={GridAutoColsOrRowsControlTestId(props.axis)}
+          value={value ?? gridCSSKeyword(cssKeyword('auto'), null)}
+          onUpdateNumberOrKeyword={onUpdateNumberOrKeyword}
+          onUpdateDimension={onUpdateDimension}
+          onFocus={autoColsOrRowsValueFocused.onFocus}
+          onBlur={autoColsOrRowsValueFocused.onBlur}
+          keywords={gridDimensionDropdownKeywords}
+          defaultValue={gridCSSKeyword(cssKeyword('auto'), null)}
+        />
+      </React.Fragment>
+    )
+  },
+)
+GridAutoColsOrRowsControlInner.displayName = 'GridAutoColsOrRowsControlInner'
+
+export function GridAutoColsOrRowsControlTestId(axis: 'column' | 'row'): string {
+  return `grid-template-auto-${axis}`
+}

--- a/editor/src/components/inspector/grid-helpers.ts
+++ b/editor/src/components/inspector/grid-helpers.ts
@@ -1,0 +1,51 @@
+import React from 'react'
+import type {
+  CSSKeyword,
+  CSSNumber,
+  UnknownOrEmptyInput,
+  ValidGridDimensionKeyword,
+} from './common/css-utils'
+import {
+  cssKeyword,
+  cssNumber,
+  gridCSSKeyword,
+  gridCSSNumber,
+  isCSSKeyword,
+  isCSSNumber,
+  isEmptyInputValue,
+  isGridCSSNumber,
+  type GridDimension,
+} from './common/css-utils'
+
+export const useGridExpressionInputFocused = () => {
+  const [focused, setFocused] = React.useState(false)
+  const onFocus = React.useCallback(() => setFocused(true), [])
+  const onBlur = React.useCallback(() => setFocused(false), [])
+  return { focused, onFocus, onBlur }
+}
+
+export function parseGridDimensionInput(
+  value: UnknownOrEmptyInput<CSSNumber | CSSKeyword<ValidGridDimensionKeyword>>,
+  currentValue: GridDimension | null,
+) {
+  if (isCSSNumber(value)) {
+    const maybeUnit =
+      currentValue != null && isGridCSSNumber(currentValue) ? currentValue.value.unit : null
+    return gridCSSNumber(
+      cssNumber(value.value, value.unit ?? maybeUnit),
+      currentValue?.areaName ?? null,
+    )
+  } else if (isCSSKeyword(value)) {
+    return gridCSSKeyword(value, currentValue?.areaName ?? null)
+  } else if (isEmptyInputValue(value)) {
+    return gridCSSKeyword(cssKeyword('auto'), currentValue?.areaName ?? null)
+  } else {
+    return null
+  }
+}
+
+export const gridDimensionDropdownKeywords = [
+  { label: 'Auto', value: cssKeyword('auto') },
+  { label: 'Min-Content', value: cssKeyword('min-content') },
+  { label: 'Max-Content', value: cssKeyword('max-content') },
+]

--- a/editor/src/uuiui/inputs/grid-expression-input.tsx
+++ b/editor/src/uuiui/inputs/grid-expression-input.tsx
@@ -5,6 +5,7 @@ import type { CSSProperties } from 'react'
 import React from 'react'
 import {
   cssKeyword,
+  gridDimensionsAreEqual,
   isGridCSSNumber,
   isValidGridDimensionKeyword,
   parseCSSNumber,
@@ -27,6 +28,7 @@ import { Icons, SmallerIcons } from '../icons'
 import { NO_OP } from '../../core/shared/utils'
 import { unless } from '../../utils/react-conditionals'
 import { useColorTheme } from '../styles/theme'
+import { capitalize } from '../../core/shared/string-utils'
 
 interface GridExpressionInputProps {
   testId: string
@@ -37,6 +39,7 @@ interface GridExpressionInputProps {
   onBlur: () => void
   keywords: Array<{ label: string; value: CSSKeyword<any> }>
   style?: CSSProperties
+  defaultValue: GridDimension
 }
 
 const DropdownWidth = 25
@@ -51,11 +54,16 @@ export const GridExpressionInput = React.memo(
     onBlur,
     keywords,
     style = {},
+    defaultValue,
   }: GridExpressionInputProps) => {
     const colorTheme = useColorTheme()
 
-    const [printValue, setPrintValue] = React.useState<string>(stringifyGridDimension(value))
-    React.useEffect(() => setPrintValue(stringifyGridDimension(value)), [value])
+    function getPrintValue(dim: GridDimension): string {
+      return capitalize(stringifyGridDimension(dim))
+    }
+
+    const [printValue, setPrintValue] = React.useState<string>(getPrintValue(value))
+    React.useEffect(() => setPrintValue(getPrintValue(value)), [value])
 
     const onChange = React.useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
       setPrintValue(e.target.value)
@@ -157,6 +165,10 @@ export const GridExpressionInput = React.memo(
       onBlur()
     }, [onBlur])
 
+    const isDefault = React.useMemo(() => {
+      return gridDimensionsAreEqual(value, defaultValue)
+    }, [value, defaultValue])
+
     return (
       <div
         style={style}
@@ -190,6 +202,7 @@ export const GridExpressionInput = React.memo(
           style={{
             width: inputFocused ? '100%' : `calc(100% - ${DropdownWidth}px)`,
           }}
+          css={{ color: isDefault ? colorTheme.fg6.value : colorTheme.fg0.value }}
         />
         {unless(
           inputFocused,


### PR DESCRIPTION
This is a followup to https://github.com/concrete-utopia/utopia/pull/6533

This PR improves the previous iteration by:

1. showing the auto template input in the inspector only if there are no template dimensions, or the auto template is set explicitly to something that's not `auto`
2. showing the auto templates for both cols and rows in the advanced modal
3. support dimming `auto` values in grid expression inputs to `fg6`

https://github.com/user-attachments/assets/e3ecb7f5-36ed-4a96-80d5-d3d4278e33b1




Fixes #6540 