### PR TITLE
Fallback striped area size when resizing grid cols/rows

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -144,9 +144,9 @@ const GridResizingControl = React.memo((props: GridResizingControlProps) => {
   const colorTheme = useColorTheme()
 
   const canResize = React.useMemo(() => {
-    return !(
-      props.fromPropsAxisValues?.type !== 'DIMENSIONS' ||
-      props.fromPropsAxisValues.dimensions.length === 0
+    return (
+      props.fromPropsAxisValues?.type === 'DIMENSIONS' &&
+      props.fromPropsAxisValues.dimensions.length > 0
     )
   }, [props.fromPropsAxisValues])
 


### PR DESCRIPTION
**Problem:**

When resizing a grid col/row if the counterpart has no size, the striped area collapses to `0` pixels.

**Fix:**

Fallback to the frame size if the counterpart axis has no size. Also, disable the mouse event if the dimension is not set.

| Before | After |
|------|--------|
| ![Kapture 2024-10-15 at 21 19 53](https://github.com/user-attachments/assets/e9bdcceb-07a5-4b70-9f31-7e6d8dc3b6fe) | ![Kapture 2024-10-15 at 21 19 37](https://github.com/user-attachments/assets/dfa0b547-e7f7-48a5-a2ae-b3c173640ba8) | 


Fixes #6542 