### PR TITLE
Move normalization step into the dispatch flow

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-flex-gap-strategy.spec.browser2.tsx
@@ -772,6 +772,14 @@ export var storyboard = (
       const div = editor.renderedDOM.getByTestId(DivTestId)
       expect(div.className).toEqual('top-10 left-10 absolute flex flex-row gap-16')
     })
+
+    it('can remove tailwind gap by dragging past threshold', async () => {
+      const editor = await renderTestEditorWithModel(Project, 'await-first-dom-report')
+      await selectComponentsForTest(editor, [EP.fromString('sb/scene/div')])
+      await doGapResize(editor, canvasPoint({ x: -100, y: 0 }))
+      const div = editor.renderedDOM.getByTestId(DivTestId)
+      expect(div.className).toEqual('top-10 left-10 absolute flex flex-row')
+    })
   })
 })
 

--- a/editor/src/components/canvas/plugins/inline-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/inline-style-plugin.ts
@@ -7,8 +7,6 @@ import { isJSXElement } from '../../../core/shared/element-template'
 import { styleStringInArray } from '../../../utils/common-constants'
 import type { ParsedCSSProperties } from '../../inspector/common/css-utils'
 import { withPropertyTag, type WithPropertyTag } from '../canvas-types'
-import { foldAndApplyCommandsSimple } from '../commands/commands'
-import { propertyToDelete, updateBulkProperties } from '../commands/set-property-command'
 import type { StylePlugin } from './style-plugins'
 
 function getPropertyFromInstance<P extends StyleLayoutProp, T = ParsedCSSProperties[P]>(

--- a/editor/src/components/canvas/plugins/inline-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/inline-style-plugin.ts
@@ -7,6 +7,8 @@ import { isJSXElement } from '../../../core/shared/element-template'
 import { styleStringInArray } from '../../../utils/common-constants'
 import type { ParsedCSSProperties } from '../../inspector/common/css-utils'
 import { withPropertyTag, type WithPropertyTag } from '../canvas-types'
+import { foldAndApplyCommandsSimple } from '../commands/commands'
+import { propertyToDelete, updateBulkProperties } from '../commands/set-property-command'
 import type { StylePlugin } from './style-plugins'
 
 function getPropertyFromInstance<P extends StyleLayoutProp, T = ParsedCSSProperties[P]>(
@@ -37,5 +39,11 @@ export const InlineStylePlugin: StylePlugin = {
         flexDirection: flexDirection,
       }
     },
-  normalizeFromInlineStyle: (editor) => editor,
+  normalizeFromInlineStyle: (editor, _, propertiesToRemove) =>
+    foldAndApplyCommandsSimple(
+      editor,
+      propertiesToRemove.map(({ elementPath, properties }) =>
+        updateBulkProperties('always', elementPath, properties.map(propertyToDelete)),
+      ),
+    ),
 }

--- a/editor/src/components/canvas/plugins/inline-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/inline-style-plugin.ts
@@ -39,11 +39,5 @@ export const InlineStylePlugin: StylePlugin = {
         flexDirection: flexDirection,
       }
     },
-  normalizeFromInlineStyle: (editor, _, propertiesToRemove) =>
-    foldAndApplyCommandsSimple(
-      editor,
-      propertiesToRemove.map(({ elementPath, properties }) =>
-        updateBulkProperties('always', elementPath, properties.map(propertyToDelete)),
-      ),
-    ),
+  normalizeFromInlineStyle: (editor) => editor,
 }

--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -8,6 +8,7 @@ import {
   isTailwindEnabled,
 } from '../../../core/tailwind/tailwind-compilation'
 import type { PropertiesToUnsetForElement } from '../../editor/actions/action-utils'
+import { isFeatureEnabled } from '../../../utils/feature-switches'
 
 export interface StylePlugin {
   name: string
@@ -25,7 +26,7 @@ export const Plugins = {
 } as const
 
 export function getActivePlugin(editorState: EditorState): StylePlugin {
-  if (isTailwindEnabled()) {
+  if (isFeatureEnabled('Tailwind') && isTailwindEnabled()) {
     return TailwindPlugin(getTailwindConfigCached(editorState))
   }
   return InlineStylePlugin

--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -7,6 +7,7 @@ import {
   getTailwindConfigCached,
   isTailwindEnabled,
 } from '../../../core/tailwind/tailwind-compilation'
+import type { PropertiesToUnsetForElement } from '../../editor/actions/action-utils'
 
 export interface StylePlugin {
   name: string
@@ -14,6 +15,7 @@ export interface StylePlugin {
   normalizeFromInlineStyle: (
     editorState: EditorState,
     elementsToNormalize: ElementPath[],
+    propertiesToRemove: PropertiesToUnsetForElement[],
   ) => EditorState
 }
 

--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -7,7 +7,7 @@ import {
   getTailwindConfigCached,
   isTailwindEnabled,
 } from '../../../core/tailwind/tailwind-compilation'
-import type { PropertiesToUnsetForElement } from '../../editor/actions/action-utils'
+import type { PropertiesWithElementPath } from '../../editor/actions/action-utils'
 import { isFeatureEnabled } from '../../../utils/feature-switches'
 
 export interface StylePlugin {
@@ -16,7 +16,7 @@ export interface StylePlugin {
   normalizeFromInlineStyle: (
     editorState: EditorState,
     elementsToNormalize: ElementPath[],
-    propertiesToRemove: PropertiesToUnsetForElement[],
+    propertiesToRemove: PropertiesWithElementPath[],
   ) => EditorState
 }
 

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.spec.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.spec.ts
@@ -66,6 +66,7 @@ describe('tailwind style plugin', () => {
     const normalizedEditor = TailwindPlugin(null).normalizeFromInlineStyle(
       editor.getEditorState().editor,
       [target],
+      [],
     )
 
     const normalizedElement = getJSXElementFromProjectContents(
@@ -96,7 +97,7 @@ describe('tailwind style plugin', () => {
     const target = EP.fromString('sb/scene/div')
     const normalizedEditor = TailwindPlugin(
       getTailwindConfigCached(editor.getEditorState().editor),
-    ).normalizeFromInlineStyle(editor.getEditorState().editor, [target])
+    ).normalizeFromInlineStyle(editor.getEditorState().editor, [target], [])
 
     const normalizedElement = getJSXElementFromProjectContents(
       target,

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
@@ -48,7 +48,7 @@ function stringifiedStylePropValue(value: unknown): string | null {
   return null
 }
 
-function getTailwindClassMapping(classes: string[], config: Config | null) {
+function getTailwindClassMapping(classes: string[], config: Config | null): Record<string, string> {
   const mapping: Record<string, string> = {}
   classes.forEach((className) => {
     const parsed = TailwindClassParser.parse(className, config ?? undefined)
@@ -85,7 +85,7 @@ function getStylePropContents(
   return null
 }
 
-function getRemoveUpdates(properties: PropertyPath[]) {
+function getRemoveUpdates(properties: PropertyPath[]): UCL.ClassListUpdate[] {
   return mapDropNulls((property) => {
     const [maybeStyle, maybeCSSProp] = property.propertyElements
     if (

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
@@ -18,7 +18,7 @@ import type { StylePlugin } from './style-plugins'
 import type { WithPropertyTag } from '../canvas-types'
 import { withPropertyTag } from '../canvas-types'
 import type { Config } from 'tailwindcss/types/config'
-import type { PropertiesToUnsetForElement } from '../../editor/actions/action-utils'
+import type { PropertiesWithElementPath } from '../../editor/actions/action-utils'
 
 function parseTailwindProperty<T>(value: unknown, parse: Parser<T>): WithPropertyTag<T> | null {
   const parsed = parse(value, null)
@@ -99,7 +99,7 @@ function getRemoveUpdates(properties: PropertyPath[]) {
   }, properties)
 }
 
-function getPropertyCleanupCommands(propertiesToRemove: PropertiesToUnsetForElement[]) {
+function getPropertyCleanupCommands(propertiesToRemove: PropertiesWithElementPath[]) {
   return mapDropNulls(({ elementPath, properties }) => {
     const removeUpdates = getRemoveUpdates(properties)
     if (removeUpdates.length === 0) {

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -389,6 +389,8 @@ export function getElementsToNormalizeFromActions(actions: EditorAction[]): Elem
     switch (action.action) {
       case 'APPLY_COMMANDS':
         return getElementsToNormalizeFromCommands(action.commands)
+      // TODO: extends this switch when we add support to non-canvas
+      // command-based edits
       default:
         return []
     }

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -397,14 +397,14 @@ export function getElementsToNormalizeFromActions(actions: EditorAction[]): Elem
   })
 }
 
-export interface PropertiesToUnsetForElement {
+export interface PropertiesWithElementPath {
   elementPath: ElementPath
   properties: PropertyPath[]
 }
 
 export function getPropertiesToRemoveFromCommands(
   commands: CanvasCommand[],
-): PropertiesToUnsetForElement[] {
+): PropertiesWithElementPath[] {
   return mapDropNulls((command) => {
     switch (command.type) {
       case 'DELETE_PROPERTIES':
@@ -425,7 +425,7 @@ export function getPropertiesToRemoveFromCommands(
 
 export function getPropertiesToRemoveFromActions(
   actions: EditorAction[],
-): PropertiesToUnsetForElement[] {
+): PropertiesWithElementPath[] {
   return actions.flatMap((action) => {
     switch (action.action) {
       case 'APPLY_COMMANDS':

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -376,6 +376,7 @@ export function getElementsToNormalizeFromCommands(commands: CanvasCommand[]): E
         return command.target
       case 'ADD_CONTAIN_LAYOUT_IF_NEEDED':
       case 'SET_PROPERTY':
+      case 'UPDATE_BULK_PROPERTIES':
         return command.element
       default:
         return null
@@ -399,26 +400,34 @@ export interface PropertiesToUnsetForElement {
   properties: PropertyPath[]
 }
 
-export function getPropertiesToUnsetFromCommands(
+export function getPropertiesToRemoveFromCommands(
   commands: CanvasCommand[],
 ): PropertiesToUnsetForElement[] {
   return mapDropNulls((command) => {
     switch (command.type) {
       case 'DELETE_PROPERTIES':
         return { elementPath: command.element, properties: command.properties }
+      case 'UPDATE_BULK_PROPERTIES':
+        return {
+          elementPath: command.element,
+          properties: mapDropNulls(
+            (p) => (p.type === 'DELETE' ? p.path : null),
+            command.properties,
+          ),
+        }
       default:
         return null
     }
   }, commands)
 }
 
-export function getPropertiesToUnsetFromActions(
+export function getPropertiesToRemoveFromActions(
   actions: EditorAction[],
 ): PropertiesToUnsetForElement[] {
   return actions.flatMap((action) => {
     switch (action.action) {
       case 'APPLY_COMMANDS':
-        return getPropertiesToUnsetFromCommands(action.commands)
+        return getPropertiesToRemoveFromCommands(action.commands)
       default:
         return []
     }

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -689,7 +689,7 @@ function handleUpdate(
       ),
       newStrategyState: newStrategyState,
       elementsToNormalize: [],
-      propertiesToRemove: [],
+      propertiesToRemove: getPropertiesToUnsetFromCommands(strategyResult.commands),
     }
   } else {
     return {

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -1034,6 +1034,7 @@ function editorDispatchInner(
         ? patchedEditorState
         : patchRemovedProperties(patchedEditorState, propertiesToRemove)
 
+    // TODO: disentangle normalizing from actions and normalizing from strategies
     const { patchedEditor, unpatchedEditor } = runNormalization(
       {
         patchedEditor: editorStateWithRemovedPropsPatched,

--- a/editor/src/components/editor/store/dispatch.tsx
+++ b/editor/src/components/editor/store/dispatch.tsx
@@ -103,7 +103,6 @@ type DispatchResultFields = {
 }
 
 export type DispatchResult = EditorStoreFull & DispatchResultFields
-import type { ElementPath } from '../../../core/shared/project-file-types'
 
 const cannotUndoRedoToastId = 'cannot-undo-or-redo'
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/d184b155-e18a-42d6-ba84-1532f6ebd280

## Problem
The tailwind style plugin can't differentiate between a prop being removed from the inline style prop, and that prop never having been there at all. For example, when a flex gap is removed by dragging it in the negative direction, it goes from positive -> 0 -> being removed from the style prop. When the normalisation step kicks in, there's no gap prop in the inline style, so the tailwind plugin doesn't do anything. To make matters worse, when the gap property is removed while the interaction is in progress, the value coming from the generated tailwind class takes precedence, so the flex gap jumps back to its original size.

## Fix
The problem of removing props in the normalization step is fixed by
1. moving the normalization step in the display flow
2. making the normalization step aware that some props need to be removed
3. find out which elements to normalize/which props to remove from the dispatched actions and the strategies, and running the normalization on those elements and prop.

The problem of prevent the CSS classes to kick in when a prop is removed (for example, when the inline `gap` prop is removed in the flex gap strategy), this PR adds a postprocessing step alongside the normalization step, that patches an allowlisted set of props to a "zero" value, which simulates the prop not being there at all

### Details
- added a test for removing the gap prop set from Tailwind
- added a `propertiesToRemove` param to `normalizeFromInlineStyle`, and updated the tailwind style plugin to use that prop to remove classes from the `className` prop
- added the code that finds out which elements/props to normalize from the dispatched actions
- added the code that finds out which elements/props to normalize from the strategies, and that tells which elements to patch during an interaction

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

Fixes #[ticket_number] (<< pls delete this line if it's not relevant)
