### PR TITLE
Grid rearrange strategy adds selected element to elementsToRerender

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-rearrange-move-strategy.ts
@@ -163,7 +163,7 @@ function getCommandsAndPatchForGridRearrange(
 
   return {
     commands: commands,
-    elementsToRerender: [EP.parentPath(selectedElement)],
+    elementsToRerender: [EP.parentPath(selectedElement), selectedElement],
   }
 }
 


### PR DESCRIPTION
**Problem:**
Grid rearrange doesn't render the result of the rearrange during the interaction.

**Fix:**
Quick fix: It seems in some cases (remix? dragged element is component instance?) the moved element has to be in elementsToRerender to make sure it is rendered into its target position during the interaction.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

