### PR TITLE
Fix missing target cell highlight during grid rearrange

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -821,6 +821,8 @@ const GridControl = React.memo<GridControlProps>(({ grid, controlsVisible }) => 
     }`,
   }
 
+  const dontShowActiveCellHighlight = !targetsAreCellsWithPositioning && anyTargetAbsolute
+
   return (
     <React.Fragment>
       {/* grid lines */}
@@ -844,11 +846,12 @@ const GridControl = React.memo<GridControlProps>(({ grid, controlsVisible }) => 
             countedColumn === currentHoveredCell?.column &&
             countedRow === currentHoveredCell?.row
 
-          const activePositioningTarget = isActiveCell && targetsAreCellsWithPositioning
+          const activePositioningTarget = isActiveCell && !dontShowActiveCellHighlight // TODO: move the logic into runGridRearrangeMove and do not set targetCell prop in these cases
 
           const borderColor = activePositioningTarget
             ? colorTheme.brandNeonPink.value
             : colorTheme.grey65.value
+
           return (
             <div
               key={id}


### PR DESCRIPTION
**Problem:**
Pink target cell highlight is not shown when the dragged item is not pinned to a cell position.

**Fix:**
This is a regression, we just don't want to show the highlight when the dragged item is absolute AND not pinned to a cell position.

**Commit Details:** (< vv pls delete this section if's not relevant)

I think we should move these conditions into the strategy, and don't even set the target cell prop on the control in these cases. As a quick fix I just fixed the condition in the control.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

