### PR TITLE
Fix animations for Remix scenes

### DIFF
--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/animation-context.ts
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/animation-context.ts
@@ -46,21 +46,19 @@ export function useCanvasAnimation(paths: ElementPath[]) {
   )
 
   const selector = React.useMemo(() => {
+    if (uids.length === 0) {
+      return null
+    }
     return uids.map((uid) => `[data-uid='${uid}']`).join(',')
   }, [uids])
 
-  const elements = React.useMemo(
-    () => (selector === '' ? [] : document.querySelectorAll(selector)),
-    [selector],
-  )
-
   return React.useCallback(
     (keyframes: DOMKeyframesDefinition, options?: DynamicAnimationOptions) => {
-      if (ctx.animate == null || elements.length === 0) {
+      if (ctx.animate == null || selector == null) {
         return
       }
-      void ctx.animate(elements, keyframes, options)
+      void ctx.animate(selector, keyframes, options)
     },
-    [ctx, elements],
+    [ctx, selector],
   )
 }


### PR DESCRIPTION
**Problem:**

Animations don't work inside Remix scenes.

**Fix:**

The `animate` functions accepts both selectors as well as elements as a target argument. For reasons beyond my ability to comprehend, using the selector works on both the canvas as well as Remix scenes, but not the opposite. So, let's use that.

https://github.com/user-attachments/assets/9226ffe0-4bce-48c3-bd9c-f81ec0cd4de6

Fixes #6555 