### PR TITLE
Set the cursor when resizing a grid.

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.ts
@@ -187,6 +187,7 @@ export const resizeGridStrategy: CanvasStrategyFactory = (
           ),
           propertyValueAsString,
         ),
+        setCursorCommand(control.axis === 'column' ? CSSCursor.ColResize : CSSCursor.RowResize),
       ]
 
       return strategyApplicationResult(commands, [gridPath])


### PR DESCRIPTION
**Problem:**
When scrubbing to resize the row/columns here you should continue to see the resize cursor even after if moves away from the handle, and not get triggered by other things while you're still dragging (similar to when we had this issue with inspector inputs).

**Fix:**
The resize grid strategy now sets the cursor.

**Commit Details:**
- `resizeGridStrategy` now returns an instance of `setCursorCommand`.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode