### PR TITLE
Update gap when rowGap or columnGap is not specified

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
@@ -164,9 +164,17 @@ export const setGridGapStrategy: CanvasStrategyFactory = (
         return emptyStrategyApplicationResult
       }
 
+      const shouldSetGapByAxis = gridGap.row.value != null || gridGap.column.value != null
+
       const axis = interactionSession.activeControl.axis
       const shouldTearOffGapByAxis = axis === 'row' ? shouldTearOffGap.y : shouldTearOffGap.x
-      const axisStyleProp = axis === 'row' ? StyleRowGapProp : StyleColumnGapProp
+
+      const axisStyleProp = shouldSetGapByAxis
+        ? axis === 'row'
+          ? StyleRowGapProp
+          : StyleColumnGapProp
+        : StyleGapProp
+
       const gridGapMeasurement =
         axis === 'row' ? updatedGridGapMeasurement.row : updatedGridGapMeasurement.column
 


### PR DESCRIPTION
**Problem:**
When no separate rowGap or columnGap property is specified, the gap control should update the gap property.

**Fix:**
Check it in the strategy if a rowGap or columnGap exists, and if not, update the gap property

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

