### PR TITLE
Fix grid resize striped area length with per-axis gap

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -532,7 +532,8 @@ export const GridRowColumnResizingControlsComponent = ({
             gap={grid.columnGap ?? grid.gap}
             padding={grid.padding}
             stripedAreaLength={
-              getStripedAreaLength(grid.gridTemplateRows, grid.gap ?? 0) ?? grid.frame.height
+              getStripedAreaLength(grid.gridTemplateRows, grid.rowGap ?? grid.gap ?? 0) ??
+              grid.frame.height
             }
             alignContent={grid.justifyContent}
             justifyContent={grid.alignContent}
@@ -550,7 +551,8 @@ export const GridRowColumnResizingControlsComponent = ({
             gap={grid.rowGap ?? grid.gap}
             padding={grid.padding}
             stripedAreaLength={
-              getStripedAreaLength(grid.gridTemplateColumns, grid.gap ?? 0) ?? grid.frame.width
+              getStripedAreaLength(grid.gridTemplateColumns, grid.columnGap ?? grid.gap ?? 0) ??
+              grid.frame.width
             }
             alignContent={grid.alignContent}
             justifyContent={grid.justifyContent}


### PR DESCRIPTION
**Problem:**

When changing the grid gap via the canvas the row/column specific gap is set (or using the split gap in the inspector), but it's not taken into account when calculating the striped area length for grid resize.

**Fix:**

Take the `rowGap` / `columnGap` props into account when calculating the striped area length in addition to the `gap` shorthand.

Fixes #6562 