### PR TITLE
Fix Grid Track Labels and Resize Indicators

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -219,8 +219,11 @@ const GridTrackSizeLabelForDimension = React.memo((props: GridResizingControlPro
       <div
         data-testid={labelId}
         style={{
+          position: 'absolute',
           zoom: 1 / scale,
           height: GRID_RESIZE_HANDLE_SIZE,
+          right: props.axis === 'row' ? 'calc(100% + 8px)' : undefined,
+          bottom: props.axis === 'column' ? 'calc(100% + 8px)' : undefined,
           borderRadius: 3,
           padding: '0 4px',
           border: `.1px solid ${colorTheme.white.value}`,

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -131,7 +131,7 @@ interface GridResizingControlProps {
   stripedAreaLength: number | null
 }
 
-const GridTrackSizeLabelForDimension = React.memo((props: GridResizingControlProps) => {
+const GridTrackSizeLabel = React.memo((props: GridResizingControlProps) => {
   const { setResizingIndex } = props
 
   const canvasOffset = useEditorState(
@@ -259,7 +259,7 @@ const GridTrackSizeLabelForDimension = React.memo((props: GridResizingControlPro
     </div>
   )
 })
-GridTrackSizeLabelForDimension.displayName = 'GridTrackSizeLabelForDimension'
+GridTrackSizeLabel.displayName = 'GridTrackSizeLabel'
 
 const GridResizingStripedIndicator = React.memo((props: GridResizingControlProps) => {
   const scale = useEditorState(
@@ -452,7 +452,7 @@ const GridResizing = React.memo((props: GridResizingProps) => {
           <div style={helperGridStyle}>
             {dimensions.flatMap((dimension, dimensionIndex) => {
               return (
-                <GridTrackSizeLabelForDimension
+                <GridTrackSizeLabel
                   key={`grid-resizing-label-${dimensionIndex}`}
                   dimensionIndex={dimensionIndex}
                   dimension={dimension}

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -203,6 +203,20 @@ const GridTrackSizeLabelForDimension = React.memo((props: GridResizingControlPro
   const labelId = `grid-${props.axis}-handle-${props.dimensionIndex}`
   const containerId = `${labelId}-container`
 
+  const cssProp = React.useMemo(
+    () => ({
+      backgroundColor:
+        props.resizing === 'resize-target'
+          ? colorTheme.primary.value
+          : colorTheme.primarySubdued.value,
+      '&:hover': {
+        zIndex: 1,
+        backgroundColor: colorTheme.primary.value,
+      },
+    }),
+    [props.resizing, colorTheme],
+  )
+
   return (
     <div
       key={containerId}
@@ -227,7 +241,6 @@ const GridTrackSizeLabelForDimension = React.memo((props: GridResizingControlPro
           borderRadius: 3,
           padding: '0 4px',
           border: `.1px solid ${colorTheme.white.value}`,
-          background: colorTheme.primary.value,
           color: colorTheme.white.value,
           display: 'flex',
           alignItems: 'center',
@@ -239,6 +252,7 @@ const GridTrackSizeLabelForDimension = React.memo((props: GridResizingControlPro
         }}
         onMouseDown={mouseDownHandler}
         onMouseMove={onMouseMove}
+        css={cssProp}
       >
         {getLabelForAxis(props.dimension, props.dimensionIndex, props.fromPropsAxisValues)}
       </div>

--- a/editor/src/uuiui/styles/theme/dark.ts
+++ b/editor/src/uuiui/styles/theme/dark.ts
@@ -3,6 +3,7 @@ import type { light } from './light'
 
 const darkBase = {
   primary: createUtopiColor('oklch(59% 0.25 254)'),
+  primarySubdued: createUtopiColor('oklch(43% 0.15 254)'),
   primary10solid: createUtopiColor('oklch(0.98 0.01 253.75)'),
   primary10: createUtopiColor('oklch(59% 0.25 254 / 10%)'),
   primary25: createUtopiColor('oklch(59% 0.25 254 / 25%)'),

--- a/editor/src/uuiui/styles/theme/light.ts
+++ b/editor/src/uuiui/styles/theme/light.ts
@@ -3,6 +3,7 @@ import type { dark } from './dark'
 
 const lightBase = {
   primary: createUtopiColor('oklch(59% 0.25 254)'),
+  primarySubdued: createUtopiColor('oklch(75% 0.15 254)'),
   primary10solid: createUtopiColor('oklch(0.98 0.01 253.75)'),
   primary10: createUtopiColor('oklch(59% 0.25 254 / 10%)'),
   primary25: createUtopiColor('oklch(59% 0.25 254 / 25%)'),


### PR DESCRIPTION
# **Problem:**
The grid labels and the grid resize indicators are in a state of being fucked:
![image](https://github.com/user-attachments/assets/e68f433a-93e5-4f3a-92c7-a53764357651)
![image](https://github.com/user-attachments/assets/d2347204-9ae4-48de-bc5f-31592f81e751)
![image](https://github.com/user-attachments/assets/c0105ee6-793e-48d1-b68b-b2f9eb6f64e2)

# **Goal:**
Fix the various layout issues, and make the labels subdued until hovered. The hovered label should z-index over its siblings:
![image](https://github.com/user-attachments/assets/52b0f170-6d6b-4fed-8290-1eb6f9a022c8)

# **Fix:**
<img width="566" alt="image" src="https://github.com/user-attachments/assets/ade0a053-321f-438c-a9e2-d8538f5be293">

![image](https://github.com/user-attachments/assets/9cb73a40-b205-45c8-a43f-2f1aae5ff6bf)



**Commit Details:**

- Split `GridResizingControl` into `GridTrackSizeLabelForDimension` and `GridResizingStripedIndicator`
- Render _two_ helper grids, one for the label and one for the sizing indicator. This avoids future css intermingling problems, going forward bug fixing one should not meaningfully affect the other.
- The helper grids use the blessed `getGridHelperStyleMatchingTargetGrid` style instead of manually picking an assortment of relevant grid properties. This simplifies our life 97%

**Note:**
The code could be further simplified, as this is now a copy-paste job. I tried to remove the obviously unnecessary things, but there's still a little too much div wrappers going on.

**Manual Tests:**
I hereby swear that:

- [ ] I opened a hydrogen project and it loaded
- [ ] I could navigate to various routes in Play mode


