### PR TITLE
Handle Changing Imports In Canvas

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
@@ -171,7 +171,7 @@ const gridDrawToInsertStrategyInner =
               ),
               updateHighlightedViews('mid-interaction', [targetParent]),
             ],
-            [targetParent],
+            [],
           )
         }
 

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -63,7 +63,12 @@ import type {
   HighlightBoundsForUids,
   ExportsDetail,
 } from '../../core/shared/project-file-types'
-import { isExportDefault, isParseSuccess, isTextFile } from '../../core/shared/project-file-types'
+import {
+  importsEquals,
+  isExportDefault,
+  isParseSuccess,
+  isTextFile,
+} from '../../core/shared/project-file-types'
 import {
   applyUtopiaJSXComponentsChanges,
   getDefaultExportedTopLevelElement,
@@ -140,7 +145,11 @@ import { getStoryboardUID } from '../../core/model/scene-utils'
 import { optionalMap } from '../../core/shared/optional-utils'
 import { assertNever, fastForEach } from '../../core/shared/utils'
 import type { ProjectContentTreeRoot } from '../assets'
-import { getProjectFileByFilePath } from '../assets'
+import {
+  getProjectFileByFilePath,
+  isProjectContentDirectory,
+  isProjectContentFile,
+} from '../assets'
 import type { CSSNumber } from '../inspector/common/css-utils'
 import { parseCSSLengthPercent, printCSSNumber } from '../inspector/common/css-utils'
 import { getTopLevelName, importedFromWhere } from '../editor/import-utils'
@@ -2179,4 +2188,70 @@ export function canvasPanelOffsets(): {
     left: (codeEditor?.clientWidth ?? 0) + (leftPane?.clientWidth ?? 0),
     right: inspector?.clientWidth ?? 0,
   }
+}
+
+export function projectContentsSameForRefreshRequire(
+  oldProjectContents: ProjectContentTreeRoot,
+  newProjectContents: ProjectContentTreeRoot,
+): boolean {
+  if (oldProjectContents === newProjectContents) {
+    // Identical references, so the imports are the same.
+    return true
+  } else {
+    for (const [filename, oldProjectTree] of Object.entries(oldProjectContents)) {
+      const newProjectTree = newProjectContents[filename]
+      // If the file can't be found in the other tree, the imports are not the same.
+      if (newProjectTree == null) {
+        return false
+      }
+      if (isProjectContentFile(oldProjectTree) && isProjectContentFile(newProjectTree)) {
+        // Both entries are files.
+        const oldContent = oldProjectTree.content
+        const newContent = newProjectTree.content
+        if (isTextFile(oldContent) || isTextFile(newContent)) {
+          if (isTextFile(oldContent) && isTextFile(newContent)) {
+            const oldParsed = oldContent.fileContents.parsed
+            const newParsed = newContent.fileContents.parsed
+            if (isParseSuccess(oldParsed) || isParseSuccess(newParsed)) {
+              if (isParseSuccess(oldParsed) && isParseSuccess(newParsed)) {
+                if (
+                  !importsEquals(oldParsed.imports, newParsed.imports) ||
+                  oldParsed.combinedTopLevelArbitraryBlock !==
+                    newParsed.combinedTopLevelArbitraryBlock ||
+                  oldParsed.exportsDetail !== newParsed.exportsDetail
+                ) {
+                  // For the same file the imports, combined top
+                  // level arbitrary block or exports have changed.
+                  return false
+                }
+              } else {
+                // One of the files is a parse success but the other is not.
+                return false
+              }
+            }
+          } else {
+            // One of the files is a text file but the other is not.
+            return false
+          }
+        }
+      } else if (
+        isProjectContentDirectory(oldProjectTree) &&
+        isProjectContentDirectory(newProjectTree)
+      ) {
+        // Both entries are directories.
+        if (
+          !projectContentsSameForRefreshRequire(oldProjectTree.children, newProjectTree.children)
+        ) {
+          // The imports of the subdirectories differ.
+          return false
+        }
+      } else {
+        // One of the entries is a file and the other is a directory.
+        return false
+      }
+    }
+  }
+
+  // If nothing differs, return true.
+  return true
 }

--- a/editor/src/components/canvas/canvas-utils.ts
+++ b/editor/src/components/canvas/canvas-utils.ts
@@ -2200,6 +2200,10 @@ export function projectContentsSameForRefreshRequire(
   } else {
     for (const [filename, oldProjectTree] of Object.entries(oldProjectContents)) {
       const newProjectTree = newProjectContents[filename]
+      // No need to check these further if they have the same reference.
+      if (oldProjectTree === newProjectTree) {
+        continue
+      }
       // If the file can't be found in the other tree, the imports are not the same.
       if (newProjectTree == null) {
         return false

--- a/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-code-execution.spec.browser2.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas-renderer/ui-jsx-canvas-code-execution.spec.browser2.tsx
@@ -215,13 +215,18 @@ describe('Re-mounting is avoided when', () => {
 
     await switchToLiveMode(renderResult)
 
+    function checkClicky(expectedContentText: string): void {
+      const clicky = renderResult.renderedDOM.getByTestId('clicky')
+      expect(clicky.innerText).toEqual(expectedContentText)
+    }
+
     // Ensure we can find the original text
-    expect(renderResult.renderedDOM.queryByText('Clicked 0 times')).not.toBeNull()
+    checkClicky('Clicked 0 times')
 
     await clickButton(renderResult)
 
     // Ensure it has been updated
-    expect(renderResult.renderedDOM.queryByText('Clicked 1 times')).not.toBeNull()
+    checkClicky('Clicked 1 times')
 
     // Update the top level arbitrary JS block
     await updateCode(
@@ -231,7 +236,7 @@ describe('Re-mounting is avoided when', () => {
     )
 
     // Check that it has updated without resetting the state
-    expect(renderResult.renderedDOM.queryByText('Clicked: 1 times')).not.toBeNull()
+    checkClicky('Clicked: 1 times')
 
     // Update the component itself
     await updateCode(
@@ -241,7 +246,7 @@ describe('Re-mounting is avoided when', () => {
     )
 
     // Check again that it has updated without resetting the state
-    expect(renderResult.renderedDOM.queryByText('Clicked: 1 times!')).not.toBeNull()
+    checkClicky('Clicked: 1 times!')
   })
 
   it('arbitrary JS or a component is edited in a remix project', async () => {

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -75,7 +75,11 @@ import {
 } from './ui-jsx-canvas-renderer/ui-jsx-canvas-execution-scope'
 import { applyUIDMonkeyPatch } from '../../utils/canvas-react-utils'
 import type { RemixValidPathsGenerationContext } from './canvas-utils'
-import { getParseSuccessForFilePath, getValidElementPaths } from './canvas-utils'
+import {
+  projectContentsSameForRefreshRequire,
+  getParseSuccessForFilePath,
+  getValidElementPaths,
+} from './canvas-utils'
 import { arrayEqualsByValue, fastForEach, NO_OP } from '../../core/shared/utils'
 import {
   AlwaysFalse,
@@ -98,7 +102,6 @@ import { listenForReactRouterErrors } from '../../core/shared/runtime-report-log
 import { getFilePathMappings } from '../../core/model/project-file-utils'
 import { useInvalidatedCanvasRemount } from './canvas-component-entry'
 import { useTailwindCompilation } from '../../core/tailwind/tailwind-compilation'
-import { getProjectImports } from '../editor/import-utils'
 
 applyUIDMonkeyPatch()
 
@@ -363,18 +366,11 @@ export const UiJsxCanvas = React.memo<UiJsxCanvasPropsWithErrorCallback>((props)
 
   const maybeOldProjectContents = React.useRef(projectContents)
 
-  function haveProjectImportsChanged(): boolean {
-    const oldProjectContents = maybeOldProjectContents.current
-    if (oldProjectContents === projectContents) {
-      return false
-    } else {
-      const oldImports = getProjectImports(oldProjectContents)
-      const newImports = getProjectImports(projectContents)
-      return !Utils.shallowEqual(oldImports, newImports)
-    }
-  }
-
-  if (haveProjectImportsChanged()) {
+  const projectContentsSimilarEnough = projectContentsSameForRefreshRequire(
+    maybeOldProjectContents.current,
+    projectContents,
+  )
+  if (!projectContentsSimilarEnough) {
     maybeOldProjectContents.current = projectContents
   }
 

--- a/editor/src/components/canvas/ui-jsx-canvas.tsx
+++ b/editor/src/components/canvas/ui-jsx-canvas.tsx
@@ -374,20 +374,7 @@ export const UiJsxCanvas = React.memo<UiJsxCanvasPropsWithErrorCallback>((props)
     }
   }
 
-  const elementsToRerenderRef = React.useRef(ElementsToRerenderGLOBAL.current)
-  const shouldRerenderRef = React.useRef(false)
-  shouldRerenderRef.current =
-    ElementsToRerenderGLOBAL.current === 'rerender-all-elements' ||
-    elementsToRerenderRef.current === 'rerender-all-elements' || // TODO this means the first drag frame will still be slow, figure out a nicer way to immediately switch to true. probably this should live in a dedicated a function
-    !arrayEqualsByValue(
-      ElementsToRerenderGLOBAL.current,
-      elementsToRerenderRef.current,
-      EP.pathsEqual,
-    ) || // once we get here, we know that both `ElementsToRerenderGLOBAL.current` and `elementsToRerenderRef.current` are arrays
-    haveProjectImportsChanged()
-  elementsToRerenderRef.current = ElementsToRerenderGLOBAL.current
-
-  if (shouldRerenderRef.current) {
+  if (haveProjectImportsChanged()) {
     maybeOldProjectContents.current = projectContents
   }
 

--- a/editor/src/components/editor/import-utils.ts
+++ b/editor/src/components/editor/import-utils.ts
@@ -31,7 +31,7 @@ import type {
   NodeModules,
 } from '../../core/shared/project-file-types'
 import { importAlias, importDetails, importsResolution } from '../../core/shared/project-file-types'
-import { walkContentsTreeForParseSuccess, type ProjectContentTreeRoot } from '../assets'
+import type { ProjectContentTreeRoot } from '../assets'
 import type { BuiltInDependencies } from '../../core/es-modules/package-manager/built-in-dependencies-list'
 import { withUnderlyingTarget } from './store/editor-state'
 import * as EP from '../../core/shared/element-path'
@@ -365,14 +365,4 @@ function removeImportDetails(
     importedAs: importedAs,
     importedFromWithin: importedFromWithin,
   }
-}
-
-export function getProjectImports(projectContents: ProjectContentTreeRoot): {
-  [filename: string]: Imports
-} {
-  let result: { [filename: string]: Imports } = {}
-  walkContentsTreeForParseSuccess(projectContents, (filePath, parseSuccess) => {
-    result[filePath] = parseSuccess.imports
-  })
-  return result
 }

--- a/editor/src/components/editor/import-utils.ts
+++ b/editor/src/components/editor/import-utils.ts
@@ -31,7 +31,7 @@ import type {
   NodeModules,
 } from '../../core/shared/project-file-types'
 import { importAlias, importDetails, importsResolution } from '../../core/shared/project-file-types'
-import type { ProjectContentTreeRoot } from '../assets'
+import { walkContentsTreeForParseSuccess, type ProjectContentTreeRoot } from '../assets'
 import type { BuiltInDependencies } from '../../core/es-modules/package-manager/built-in-dependencies-list'
 import { withUnderlyingTarget } from './store/editor-state'
 import * as EP from '../../core/shared/element-path'
@@ -365,4 +365,14 @@ function removeImportDetails(
     importedAs: importedAs,
     importedFromWithin: importedFromWithin,
   }
+}
+
+export function getProjectImports(projectContents: ProjectContentTreeRoot): {
+  [filename: string]: Imports
+} {
+  let result: { [filename: string]: Imports } = {}
+  walkContentsTreeForParseSuccess(projectContents, (filePath, parseSuccess) => {
+    result[filePath] = parseSuccess.imports
+  })
+  return result
 }


### PR DESCRIPTION
**Problem:**
If we do a partial canvas re-render but a necessary import is also added, then the canvas errors out momentarily.

**Cause:**
The resolved values of the imports are buried in a property called `requireResult` which originates with require and resolve functions. Those functions are only rebuilt when the elements to re-render value is `rerender-all-elements` or when it has changed between the current canvas render and the prior one. With our recent changes to the canvas strategies to make them never supply the `rerender-all-elements` value, the failure case of the imports changing but the elements to re-render value not changing has become more likely.

In the case of grid insertion, the elements to re-render becomes the target path on hover, then when the user clicks it stays with that target path but the imports are added. Since there is no change in the former, the canvas logic is unable to find the new import in the old `requireResult`.

**Fix:**
Compare the old and current project contents and if their imports, combined top level arbitrary block or exports have changed then recreate the require and resolve functions. This replaces the previous check which looked at the current and previous versions of the elements to re-render property.

**Commit Details:**
- Removed the previous handling of `shouldRerenderRef`.
- Implemented `projectContentsSameForRefreshRequire`.
- Changed out old `haveProjectImportsChanged` call to use the new
  `projectContentsSameForRefreshRequire`.
