### PR TITLE
Fix insertion of not yet imported component

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
@@ -240,7 +240,7 @@ const gridDrawToInsertStrategyInner =
                 : null,
             ]),
           ],
-          [targetParent],
+          [targetParent, insertedElementPath],
           {
             strategyGeneratedUidsCache: {
               [insertionSubject.uid]: maybeWrapperWithUid?.uid,


### PR DESCRIPTION
**Problem:**
When we grid-draw-to-insert a component which is not imported yet, the canvas errors out momentarily.

**Fix:**
According to this we need to one rerender-all-elements rendering to update the require fn: https://github.com/concrete-utopia/utopia/pull/2960/files#r1042121124

For reasons I don't really understand it seems enough to add the newly inserted elemenet to elements-to-rerender.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

