### PR TITLE
Grid resize: remove shorthand, serialize other longhand when not auto

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -788,3 +788,12 @@ export function findOriginalGrid(
 
   return findOriginalGrid(metadata, parentPath)
 }
+
+// Returns whether the given dimensions are made of just one item, being a CSS keyword with value "auto".
+export function isJustAutoGridDimension(dimensions: GridDimension[]): boolean {
+  return (
+    dimensions.length === 1 &&
+    dimensions[0].type === 'KEYWORD' &&
+    dimensions[0].value.value === 'auto'
+  )
+}

--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.spec.browser2.tsx
@@ -29,7 +29,7 @@ export var storyboard = (
         height: ${params.height ?? "'max-content'"},
         ${params.columns != null ? `gridTemplateColumns: '${params.columns}',` : ''}
         ${params.rows != null ? `gridTemplateRows: '${params.rows}',` : ''}
-		${params.shorthand != null ? `gridTemplate: '${params.shorthand}',` : ''}
+        ${params.shorthand != null ? `gridTemplate: '${params.shorthand}',` : ''}
       }}
     >
       <div

--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.spec.browser2.tsx
@@ -5,7 +5,12 @@ import { CanvasControlsContainerID } from '../../controls/new-canvas-controls'
 import { mouseDownAtPoint, mouseMoveToPoint, mouseUpAtPoint } from '../../event-helpers.test-utils'
 import { canvasPoint } from '../../../../core/shared/math-utils'
 
-const makeTestProject = (columns: string, rows: string) => `
+const makeTestProject = (params: {
+  columns: string | null
+  rows: string | null
+  shorthand: string | null
+  height?: number | string
+}) => `
 import * as React from 'react'
 import { Storyboard } from 'utopia-api'
 
@@ -21,10 +26,10 @@ export var storyboard = (
         display: 'grid',
         gap: 10,
         width: 600,
-        height: 600,
-        gridTemplateColumns: '${columns}',
-        gridTemplateRows: '${rows}',
-        height: 'max-content',
+        height: ${params.height ?? "'max-content'"},
+        ${params.columns != null ? `gridTemplateColumns: '${params.columns}',` : ''}
+        ${params.rows != null ? `gridTemplateRows: '${params.rows}',` : ''}
+		${params.shorthand != null ? `gridTemplate: '${params.shorthand}',` : ''}
       }}
     >
       <div
@@ -132,7 +137,7 @@ export var storyboard = (
 describe('resize a grid', () => {
   it('update a fractionally sized column', async () => {
     const renderResult = await renderTestEditorWithCode(
-      makeTestProject('2.4fr 1fr 1fr', '99px 109px 90px'),
+      makeTestProject({ columns: '2.4fr 1fr 1fr', rows: '99px 109px 90px', shorthand: null }),
       'await-first-dom-report',
     )
     const target = EP.fromString(`sb/grid/row-1-column-2`)
@@ -171,10 +176,9 @@ export var storyboard = (
         display: 'grid',
         gap: 10,
         width: 600,
-        height: 600,
+        height: 'max-content',
         gridTemplateColumns: '2.4fr 1.8fr 1fr',
         gridTemplateRows: '99px 109px 90px',
-        height: 'max-content',
       }}
     >
       <div
@@ -287,10 +291,9 @@ export var storyboard = (
         display: 'grid',
         gap: 10,
         width: 600,
-        height: 600,
+        height: 'max-content',
         gridTemplateColumns: '2.4fr 1.8fr 1fr',
         gridTemplateRows: '99px 109px 90px',
-        height: 'max-content',
       }}
     >
       {[1, 2, 3].map((n) => {
@@ -310,7 +313,7 @@ export var storyboard = (
 
   it('update a pixel sized row', async () => {
     const renderResult = await renderTestEditorWithCode(
-      makeTestProject('2.4fr 1fr 1fr', '99px 109px 90px'),
+      makeTestProject({ columns: '2.4fr 1fr 1fr', rows: '99px 109px 90px', shorthand: null }),
       'await-first-dom-report',
     )
     const target = EP.fromString(`sb/grid/row-1-column-2`)
@@ -349,10 +352,9 @@ export var storyboard = (
         display: 'grid',
         gap: 10,
         width: 600,
-        height: 600,
+        height: 'max-content',
         gridTemplateColumns: '2.4fr 1fr 1fr',
         gridTemplateRows: '99px 129px 90px',
-        height: 'max-content',
       }}
     >
       <div
@@ -426,7 +428,7 @@ export var storyboard = (
 
   it('update a repeat (fr) sized column', async () => {
     const renderResult = await renderTestEditorWithCode(
-      makeTestProject('repeat(3, 1fr)', '99px 109px 90px'),
+      makeTestProject({ columns: 'repeat(3, 1fr)', rows: '99px 109px 90px', shorthand: null }),
       'await-first-dom-report',
     )
     const target = EP.fromString(`sb/grid/row-1-column-2`)
@@ -465,10 +467,9 @@ export var storyboard = (
         display: 'grid',
         gap: 10,
         width: 600,
-        height: 600,
+        height: 'max-content',
         gridTemplateColumns: 'repeat(3, 1.5fr)',
         gridTemplateRows: '99px 109px 90px',
-        height: 'max-content',
       }}
     >
       <div
@@ -538,5 +539,362 @@ export var storyboard = (
   </Storyboard>
 )
 `)
+  })
+
+  describe('shorthand handling', () => {
+    it('removes the shorthand and adds the longhand for both the other axii', async () => {
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProject({
+          shorthand: '99px 109px 90px / 2.4fr 1fr 1fr',
+          columns: null,
+          rows: null,
+        }),
+        'await-first-dom-report',
+      )
+      const target = EP.fromString(`sb/grid/row-1-column-2`)
+      await renderResult.dispatch(selectComponents([target], false), true)
+      await renderResult.getDispatchFollowUpActionsFinished()
+      const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+      const resizeControl = renderResult.renderedDOM.getByTestId(`grid-column-handle-1`)
+      const resizeControlRect = resizeControl.getBoundingClientRect()
+      const startPoint = canvasPoint({
+        x: resizeControlRect.x + resizeControlRect.width / 2,
+        y: resizeControlRect.y + resizeControlRect.height / 2,
+      })
+      const endPoint = canvasPoint({
+        x: startPoint.x + 100,
+        y: startPoint.y,
+      })
+      await mouseMoveToPoint(resizeControl, startPoint)
+      await mouseDownAtPoint(resizeControl, startPoint)
+      await mouseMoveToPoint(canvasControlsLayer, endPoint)
+      await mouseUpAtPoint(canvasControlsLayer, endPoint)
+      await renderResult.getDispatchFollowUpActionsFinished()
+
+      expect(getPrintedUiJsCode(renderResult.getEditorState()))
+        .toEqual(`import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-uid='grid'
+      data-testid='grid'
+      style={{
+        position: 'absolute',
+        left: 25,
+        top: 305,
+        display: 'grid',
+        gap: 10,
+        width: 600,
+        height: 'max-content',
+        gridTemplateColumns: '2.4fr 1.8fr 1fr',
+        gridTemplateRows: '99px 109px 90px',
+      }}
+    >
+      <div
+        data-uid='row-1-column-1'
+        data-testid='row-1-column-1'
+        style={{
+          backgroundColor: 'green',
+          gridColumnStart: 1,
+          gridColumnEnd: 1,
+          gridRowStart: 2,
+          gridRowEnd: 2,
+        }}
+      />
+      <div
+        data-uid='row-1-column-2'
+        data-testid='row-1-column-2'
+        style={{ backgroundColor: 'blue' }}
+      />
+      <div
+        data-uid='row-1-column-3'
+        data-testid='row-1-column-3'
+        style={{ backgroundColor: 'pink' }}
+      />
+      <div
+        data-uid='row-2-column-1'
+        data-testid='row-2-column-1'
+        style={{
+          backgroundColor: 'green',
+          gridColumnStart: 3,
+          gridColumnEnd: 4,
+          gridRowStart: 2,
+          gridRowEnd: 4,
+        }}
+      />
+      <div
+        data-uid='row-2-column-2'
+        data-testid='row-2-column-2'
+        style={{
+          backgroundColor: 'blue',
+          gridColumnStart: 2,
+          gridColumnEnd: 2,
+          gridRowStart: 2,
+          gridRowEnd: 2,
+        }}
+      />
+      <div
+        data-uid='row-2-column-3'
+        data-testid='row-2-column-3'
+        style={{ backgroundColor: 'pink' }}
+      />
+      <div
+        data-uid='row-3-column-1'
+        data-testid='row-3-column-1'
+        style={{ backgroundColor: 'green' }}
+      />
+      <div
+        data-uid='row-3-column-2'
+        data-testid='row-3-column-2'
+        style={{ backgroundColor: 'blue' }}
+      />
+      <div
+        data-uid='row-3-column-3'
+        data-testid='row-3-column-3'
+        style={{ backgroundColor: 'pink' }}
+      />
+    </div>
+  </Storyboard>
+)
+`)
+    })
+    it("removes the shorthand without adding the longhand if it's auto", async () => {
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProject({
+          shorthand: 'auto / 2.4fr 1fr 1fr',
+          columns: null,
+          rows: null,
+          height: 600,
+        }),
+        'await-first-dom-report',
+      )
+      const target = EP.fromString(`sb/grid/row-1-column-2`)
+      await renderResult.dispatch(selectComponents([target], false), true)
+      await renderResult.getDispatchFollowUpActionsFinished()
+      const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+      const resizeControl = renderResult.renderedDOM.getByTestId(`grid-column-handle-1`)
+      const resizeControlRect = resizeControl.getBoundingClientRect()
+      const startPoint = canvasPoint({
+        x: resizeControlRect.x + resizeControlRect.width / 2,
+        y: resizeControlRect.y + resizeControlRect.height / 2,
+      })
+      const endPoint = canvasPoint({
+        x: startPoint.x + 100,
+        y: startPoint.y,
+      })
+      await mouseMoveToPoint(resizeControl, startPoint)
+      await mouseDownAtPoint(resizeControl, startPoint)
+      await mouseMoveToPoint(canvasControlsLayer, endPoint)
+      await mouseUpAtPoint(canvasControlsLayer, endPoint)
+      await renderResult.getDispatchFollowUpActionsFinished()
+
+      expect(getPrintedUiJsCode(renderResult.getEditorState()))
+        .toEqual(`import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-uid='grid'
+      data-testid='grid'
+      style={{
+        position: 'absolute',
+        left: 25,
+        top: 305,
+        display: 'grid',
+        gap: 10,
+        width: 600,
+        height: 600,
+        gridTemplateColumns: '2.4fr 1.8fr 1fr',
+      }}
+    >
+      <div
+        data-uid='row-1-column-1'
+        data-testid='row-1-column-1'
+        style={{
+          backgroundColor: 'green',
+          gridColumnStart: 1,
+          gridColumnEnd: 1,
+          gridRowStart: 2,
+          gridRowEnd: 2,
+        }}
+      />
+      <div
+        data-uid='row-1-column-2'
+        data-testid='row-1-column-2'
+        style={{ backgroundColor: 'blue' }}
+      />
+      <div
+        data-uid='row-1-column-3'
+        data-testid='row-1-column-3'
+        style={{ backgroundColor: 'pink' }}
+      />
+      <div
+        data-uid='row-2-column-1'
+        data-testid='row-2-column-1'
+        style={{
+          backgroundColor: 'green',
+          gridColumnStart: 3,
+          gridColumnEnd: 4,
+          gridRowStart: 2,
+          gridRowEnd: 4,
+        }}
+      />
+      <div
+        data-uid='row-2-column-2'
+        data-testid='row-2-column-2'
+        style={{
+          backgroundColor: 'blue',
+          gridColumnStart: 2,
+          gridColumnEnd: 2,
+          gridRowStart: 2,
+          gridRowEnd: 2,
+        }}
+      />
+      <div
+        data-uid='row-2-column-3'
+        data-testid='row-2-column-3'
+        style={{ backgroundColor: 'pink' }}
+      />
+      <div
+        data-uid='row-3-column-1'
+        data-testid='row-3-column-1'
+        style={{ backgroundColor: 'green' }}
+      />
+      <div
+        data-uid='row-3-column-2'
+        data-testid='row-3-column-2'
+        style={{ backgroundColor: 'blue' }}
+      />
+      <div
+        data-uid='row-3-column-3'
+        data-testid='row-3-column-3'
+        style={{ backgroundColor: 'pink' }}
+      />
+    </div>
+  </Storyboard>
+)
+`)
+    })
+    it("does not add the other longhand if the shorthand is not defined and the other longhand it's auto", async () => {
+      const renderResult = await renderTestEditorWithCode(
+        makeTestProject({
+          shorthand: 'auto / 2.4fr 1fr 1fr',
+          columns: null,
+          rows: null,
+          height: 600,
+        }),
+        'await-first-dom-report',
+      )
+      const target = EP.fromString(`sb/grid/row-1-column-2`)
+      await renderResult.dispatch(selectComponents([target], false), true)
+      await renderResult.getDispatchFollowUpActionsFinished()
+      const canvasControlsLayer = renderResult.renderedDOM.getByTestId(CanvasControlsContainerID)
+      const resizeControl = renderResult.renderedDOM.getByTestId(`grid-column-handle-1`)
+      const resizeControlRect = resizeControl.getBoundingClientRect()
+      const startPoint = canvasPoint({
+        x: resizeControlRect.x + resizeControlRect.width / 2,
+        y: resizeControlRect.y + resizeControlRect.height / 2,
+      })
+      const endPoint = canvasPoint({
+        x: startPoint.x + 100,
+        y: startPoint.y,
+      })
+      await mouseMoveToPoint(resizeControl, startPoint)
+      await mouseDownAtPoint(resizeControl, startPoint)
+      await mouseMoveToPoint(canvasControlsLayer, endPoint)
+      await mouseUpAtPoint(canvasControlsLayer, endPoint)
+      await renderResult.getDispatchFollowUpActionsFinished()
+
+      expect(getPrintedUiJsCode(renderResult.getEditorState()))
+        .toEqual(`import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      data-uid='grid'
+      data-testid='grid'
+      style={{
+        position: 'absolute',
+        left: 25,
+        top: 305,
+        display: 'grid',
+        gap: 10,
+        width: 600,
+        height: 600,
+        gridTemplateColumns: '2.4fr 1.8fr 1fr',
+      }}
+    >
+      <div
+        data-uid='row-1-column-1'
+        data-testid='row-1-column-1'
+        style={{
+          backgroundColor: 'green',
+          gridColumnStart: 1,
+          gridColumnEnd: 1,
+          gridRowStart: 2,
+          gridRowEnd: 2,
+        }}
+      />
+      <div
+        data-uid='row-1-column-2'
+        data-testid='row-1-column-2'
+        style={{ backgroundColor: 'blue' }}
+      />
+      <div
+        data-uid='row-1-column-3'
+        data-testid='row-1-column-3'
+        style={{ backgroundColor: 'pink' }}
+      />
+      <div
+        data-uid='row-2-column-1'
+        data-testid='row-2-column-1'
+        style={{
+          backgroundColor: 'green',
+          gridColumnStart: 3,
+          gridColumnEnd: 4,
+          gridRowStart: 2,
+          gridRowEnd: 4,
+        }}
+      />
+      <div
+        data-uid='row-2-column-2'
+        data-testid='row-2-column-2'
+        style={{
+          backgroundColor: 'blue',
+          gridColumnStart: 2,
+          gridColumnEnd: 2,
+          gridRowStart: 2,
+          gridRowEnd: 2,
+        }}
+      />
+      <div
+        data-uid='row-2-column-3'
+        data-testid='row-2-column-3'
+        style={{ backgroundColor: 'pink' }}
+      />
+      <div
+        data-uid='row-3-column-1'
+        data-testid='row-3-column-1'
+        style={{ backgroundColor: 'green' }}
+      />
+      <div
+        data-uid='row-3-column-2'
+        data-testid='row-3-column-2'
+        style={{ backgroundColor: 'blue' }}
+      />
+      <div
+        data-uid='row-3-column-3'
+        data-testid='row-3-column-3'
+        style={{ backgroundColor: 'pink' }}
+      />
+    </div>
+  </Storyboard>
+)
+`)
+    })
   })
 })

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -66,7 +66,10 @@ import {
   type ElementInstanceMetadata,
   type GridElementProperties,
 } from '../../core/shared/element-template'
-import { setGridPropsCommands } from '../canvas/canvas-strategies/strategies/grid-helpers'
+import {
+  isJustAutoGridDimension,
+  setGridPropsCommands,
+} from '../canvas/canvas-strategies/strategies/grid-helpers'
 import { type CanvasCommand } from '../canvas/commands/commands'
 import type { DropdownMenuItem } from '../../uuiui/radix-components'
 import {
@@ -480,11 +483,7 @@ const TemplateDimensionControl = React.memo(
         template.dimensions.length === 0 ||
         (autoTemplate?.type === 'DIMENSIONS' &&
           autoTemplate.dimensions.length > 0 &&
-          !(
-            autoTemplate.dimensions.length === 1 &&
-            autoTemplate.dimensions[0].type === 'KEYWORD' &&
-            autoTemplate.dimensions[0].value.value === 'auto'
-          ))
+          !isJustAutoGridDimension(autoTemplate.dimensions))
       )
     }, [template, autoTemplate])
 


### PR DESCRIPTION
**Problem:**

If a grid is configured with the `gridTemplate` shorthand, resizing the grid does not handle that correctly.

**Fix:**

This PR handles `gridTemplate` shorthands during template changes via the canvas.
**An incremental PR will do the same for the inspector template editing**.

For example, if a grid is configured as follows: `gridTemplate: 1fr 2fr / 3fr 4fr`, changing its first column to `3.5fr` will result in the following style:
```
gridTemplateColumns: '3.5fr 4fr',
gridTemplateRows: '1fr 2fr'
```

If a grid has a shorthand with an axis being the default (a single `auto` keyword), for example `gridTemplate: auto / 3fr 4fr`, the same change as above will result in:
```
gridTemplateColumns: '3.5fr 4fr',
```

Fixes #6580