### PR TITLE
Increment/Decrement Fractional Grid Tracks

### DIFF
--- a/editor/src/components/inspector/common/css-utils.ts
+++ b/editor/src/components/inspector/common/css-utils.ts
@@ -574,6 +574,10 @@ const CSSNumberUnits: Array<CSSNumberUnit> = [
   '%',
 ]
 
+export function isFR(unit: CSSNumberUnit): unit is 'fr' {
+  return unit === 'fr'
+}
+
 export interface CSSNumber {
   value: number
   unit: CSSNumberUnit | null

--- a/editor/src/uuiui/inputs/grid-expression-input.tsx
+++ b/editor/src/uuiui/inputs/grid-expression-input.tsx
@@ -48,6 +48,8 @@ interface GridExpressionInputProps {
 
 const DropdownWidth = 25
 
+const ArrowKeyFractionalIncrement = 0.1
+
 export const GridExpressionInput = React.memo(
   ({
     testId,
@@ -111,7 +113,10 @@ export const GridExpressionInput = React.memo(
               gridNumberValueOptic.compose(fromField('value'))
             if (exists(valueUnitOptic, value)) {
               function updateFractional(fractionalValue: number): number {
-                return fractionalValue + (e.key === 'ArrowUp' ? 0.1 : -0.1)
+                return (
+                  fractionalValue +
+                  (e.key === 'ArrowUp' ? ArrowKeyFractionalIncrement : -ArrowKeyFractionalIncrement)
+                )
               }
               const updatedDimension = modify(gridNumberNumberOptic, updateFractional, value)
               onUpdateDimension(updatedDimension)


### PR DESCRIPTION
**Problem:**
It would be helpful if fractional grid track values can be incremented or decremented using the arrow keys.

**Fix:**
Modified the keyboard event handler for the columns and rows to increment and decrement just the fractional values.

**Commit Details:**
- Added `isFR` utility function.
- Modified `GridExpressionInput.onKeyDown` to handle arrow up and down but only for fractional values.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode