### PR TITLE
Correct Grid Column Gap Indicator Position

### DIFF
--- a/editor/src/components/canvas/controls/select-mode/grid-gap-control-component.tsx
+++ b/editor/src/components/canvas/controls/select-mode/grid-gap-control-component.tsx
@@ -421,26 +421,21 @@ export function GridGapHandle({
     [onHandleHoverStartInner, index],
   )
 
-  const rowGapStyles =
-    axis === 'row'
-      ? ({
-          left: '50%',
-          top: '50%',
-          transform: 'translate(-50%, -50%)',
-          position: 'absolute',
-          gridArea: `1/${index + 1}/2/${index + 2}`,
-        } as const)
-      : {}
   return (
     <div
-      data-testid={`${GridGapControlHandleTestId}-${gapId}`}
+      data-testid={`${GridGapControlHandleTestId}-${gapId}-${index}`}
       style={{
         visibility: shouldShowHandle ? 'visible' : 'hidden',
         pointerEvents: 'all',
         padding: hitAreaPadding,
         cursor: axis === 'row' ? CSSCursor.GapNS : CSSCursor.GapEW,
         opacity: handleOpacity,
-        ...rowGapStyles,
+        left: '50%',
+        top: '50%',
+        transform: 'translate(-50%, -50%)',
+        position: 'absolute',
+        gridArea:
+          axis === 'row' ? `1/${index + 1}/2/${index + 2}` : `${index + 1}/1/${index + 2}/2`,
       }}
       onMouseDown={onMouseDown}
       onMouseEnter={onHandleHoverStart}


### PR DESCRIPTION
**Problem:**
Column gap controls are off-center when at ≤ 1x zoom levels.

**Fix:**
Applied the same positioning logic to column gaps, that was already there for row gaps.

**Screenshots:**
Before:
![image](https://github.com/user-attachments/assets/58e85dcb-9212-4fee-a74e-6813f3d4205f)
After:
![image](https://github.com/user-attachments/assets/68fabd15-413e-4a77-a5c1-7ef5133239a7)

**Commit Details:**
- Apply the same positioning for column gaps as was implemented for row gaps.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode