### PR TITLE
Do Not Insert In Progress Insertion

### DIFF
--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -135,6 +135,7 @@ import { omitWithPredicate } from '../core/shared/object-utils'
 import { getParserWorkerCount } from '../core/workers/common/concurrency-utils'
 import { canMeasurePerformance } from '../core/performance/performance-utils'
 import { getChildGroupsForNonGroupParents } from '../components/canvas/canvas-strategies/strategies/fragment-like-helpers'
+import { EditorModes } from '../components/editor/editor-modes'
 
 if (PROBABLY_ELECTRON) {
   let { webFrame } = requireElectron()
@@ -412,7 +413,8 @@ export class Editor {
     this.boundDispatch(
       [
         EditorActions.clearHighlightedViews(),
-        CanvasActions.clearInteractionSession(true),
+        CanvasActions.clearInteractionSession(false),
+        EditorActions.switchEditorMode(EditorModes.selectMode(null, false, 'none')),
         EditorActions.updateKeys({}),
         EditorActions.closePopup(),
         EditorActions.clearPostActionData(),


### PR DESCRIPTION
**Problem:**
When an insertion was in progress but not complete, tabbing away from the editor would result in a zero-sized element being inserted.

**Cause:**
The editor onBlur handler was clearing the interaction session, but applying any inflight changes which caused the element to be inserted.

**Fix:**
Now the interaction session is cancelled without applying changes and the editor mode is reset to select mode.

**Commit Details:**
- `resetStateOnBlur` now clears the interaction session without applying changes and resets the editor mode to select mode.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode