### PR TITLE
Clicking On Advanced Grid Modal Does Not Deselect.

### DIFF
--- a/editor/src/components/inspector/widgets/inspector-modal.tsx
+++ b/editor/src/components/inspector/widgets/inspector-modal.tsx
@@ -94,6 +94,7 @@ export const InspectorModal: React.FunctionComponent<
         >
           <div
             style={{
+              pointerEvents: 'all',
               position: 'absolute',
               left: cssOffset.left,
               top: cssOffset.top,


### PR DESCRIPTION
**Problem:**
In the grid advanced modal open a dropdown and then click outside the menu, on the advanced menu itself: the menu closes down.

**Cause:**
The dropdown was setting `pointerEvents: 'none'` on the `body` of the page which meant that the various pointer events were passing through the advanced modal.

**Fix:**
The modal is now catching the events by switching that handling back on by adding `pointerEvents: 'all'` to the content div of the modal.

**Commit Details:**
- Added `pointerEvents: 'all'` to the modal div so that it can catch mouse events and not pass them through to the elements below.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode