### PR TITLE
Correct Pin Outline Positioning

### DIFF
--- a/editor/src/components/canvas/controls/position-outline.tsx
+++ b/editor/src/components/canvas/controls/position-outline.tsx
@@ -201,12 +201,15 @@ const PinOutline = React.memo((props: PinOutlineProps): JSX.Element => {
   const borderLeft = props.isHorizontalLine
     ? 'none'
     : `${1 / props.scale}px dashed ${colorTheme.primary.value}`
+  const lineLeft = props.startX - 0.5 / props.scale
+  const lineTop = props.startY - 0.5 / props.scale
+
   return (
     <div
       style={{
         position: 'absolute',
-        left: props.startX,
-        top: props.startY,
+        left: lineLeft,
+        top: lineTop,
         width: width,
         height: height,
         borderTop: borderTop,

--- a/editor/src/components/canvas/controls/position-outline.tsx
+++ b/editor/src/components/canvas/controls/position-outline.tsx
@@ -191,18 +191,20 @@ interface PinOutlineProps {
   scale: number
 }
 
+const PinOutlineUnscaledSize = 1
+
 const PinOutline = React.memo((props: PinOutlineProps): JSX.Element => {
   const colorTheme = useColorTheme()
   const width = props.isHorizontalLine ? props.size : 0
   const height = props.isHorizontalLine ? 0 : props.size
   const borderTop = props.isHorizontalLine
-    ? `${1 / props.scale}px dashed ${colorTheme.primary.value}`
+    ? `${PinOutlineUnscaledSize / props.scale}px dashed ${colorTheme.primary.value}`
     : 'none'
   const borderLeft = props.isHorizontalLine
     ? 'none'
-    : `${1 / props.scale}px dashed ${colorTheme.primary.value}`
-  const lineLeft = props.startX - 0.5 / props.scale
-  const lineTop = props.startY - 0.5 / props.scale
+    : `${PinOutlineUnscaledSize / props.scale}px dashed ${colorTheme.primary.value}`
+  const lineLeft = props.startX - PinOutlineUnscaledSize / 2 / props.scale
+  const lineTop = props.startY - PinOutlineUnscaledSize / 2 / props.scale
 
   return (
     <div


### PR DESCRIPTION
**Problem:**
The blue dashed line indicating the positioning of the element doesn't line up with the grid cell outlines.

**Cause:**
The dashed line is a border which is slightly shifting the elements used for those.

**Fix:**
The dashed lines have been shifted back towards the origin by half the thickness of the border.

**Screenshot:**
![image](https://github.com/user-attachments/assets/c9bb47a7-51bd-47a0-87d1-75eee0299e37)

**Commit Details:**
- Shift pin outlines up and to the left by 0.5, scaled to the scale.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode