### PR TITLE
refactor(editor): separate requirements checks

### DIFF
--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -398,7 +398,6 @@ import {
   trueUpChildrenOfGroupChanged,
   trueUpHuggingElement,
   trueUpGroupElementChanged,
-  getPackageJsonFromProjectContents,
   modifyUnderlyingTargetJSXElement,
   getAllComponentDescriptorErrors,
   updatePackageJsonInEditorState,
@@ -441,7 +440,6 @@ import { reorderElement } from '../../../components/canvas/commands/reorder-elem
 import type { BuiltInDependencies } from '../../../core/es-modules/package-manager/built-in-dependencies-list'
 import { fetchNodeModules } from '../../../core/es-modules/package-manager/fetch-packages'
 import { resolveModule } from '../../../core/es-modules/package-manager/module-resolution'
-import { addStoryboardFileToProject } from '../../../core/model/storyboard-utils'
 import { UTOPIA_UID_KEY } from '../../../core/model/utopia-constants'
 import { mapDropNulls, uniqBy } from '../../../core/shared/array-utils'
 import type { TreeConflicts } from '../../../core/shared/github/helpers'
@@ -630,13 +628,9 @@ import { getNavigatorTargetsFromEditorState } from '../../navigator/navigator-ut
 import { getParseCacheOptions } from '../../../core/shared/parse-cache-utils'
 import { styleP } from '../../inspector/inspector-common'
 import { getUpdateOperationResult } from '../../../core/shared/import/import-operation-service'
-import {
-  notifyCheckingRequirement,
-  notifyResolveRequirement,
-  updateRequirements,
-} from '../../../core/shared/import/proejct-health-check/utopia-requirements-service'
-import { RequirementResolutionResult } from '../../../core/shared/import/proejct-health-check/utopia-requirements-types'
+import { updateRequirements } from '../../../core/shared/import/proejct-health-check/utopia-requirements-service'
 import { applyValuesAtPath, deleteValuesAtPath } from '../../canvas/commands/utils/property-utils'
+import { createStoryboardFileIfNecessary } from '../../../core/shared/import/proejct-health-check/requirements/requirement-storyboard'
 
 export const MIN_CODE_PANE_REOPEN_WIDTH = 100
 
@@ -1593,91 +1587,6 @@ function updateCodeEditorVisibility(editor: EditorModel, codePaneVisible: boolea
       codePaneVisible: codePaneVisible,
     },
   }
-}
-
-function createStoryboardFileIfRemixProject(
-  projectContents: ProjectContentTreeRoot,
-): ProjectContentTreeRoot | null {
-  const packageJsonContents = defaultEither(
-    null,
-    getPackageJsonFromProjectContents(projectContents),
-  )
-  if (packageJsonContents == null) {
-    return null
-  }
-  const remixNotIncluded = packageJsonContents['dependencies']?.['@remix-run/react'] == null
-  if (remixNotIncluded) {
-    return null
-  }
-
-  const updatedProjectContents = addFileToProjectContents(
-    projectContents,
-    StoryboardFilePath,
-    codeFile(DefaultStoryboardWithRemix, null, 1),
-  )
-  return updatedProjectContents
-}
-
-function createStoryboardFileIfMainComponentPresent(
-  projectContents: ProjectContentTreeRoot,
-): ProjectContentTreeRoot | null {
-  return addStoryboardFileToProject(projectContents)
-}
-
-function createStoryboardFileWithPlaceholderContents(
-  projectContents: ProjectContentTreeRoot,
-  createPlaceholder: 'create-placeholder' | 'skip-creating-placeholder',
-): ProjectContentTreeRoot {
-  if (createPlaceholder === 'skip-creating-placeholder') {
-    return projectContents
-  }
-  const updatedProjectContents = addFileToProjectContents(
-    projectContents,
-    StoryboardFilePath,
-    codeFile(DefaultStoryboardContents, null, 1),
-  )
-  return updatedProjectContents
-}
-
-export function createStoryboardFileIfNecessary(
-  dispatch: EditorDispatch,
-  projectContents: ProjectContentTreeRoot,
-  createPlaceholder: 'create-placeholder' | 'skip-creating-placeholder',
-): ProjectContentTreeRoot {
-  notifyCheckingRequirement(dispatch, 'storyboard', 'Checking for storyboard.js')
-  const storyboardFile = getProjectFileByFilePath(projectContents, StoryboardFilePath)
-  if (storyboardFile != null) {
-    notifyResolveRequirement(
-      dispatch,
-      'storyboard',
-      RequirementResolutionResult.Found,
-      'Storyboard.js found',
-    )
-    return projectContents
-  }
-
-  const result =
-    createStoryboardFileIfRemixProject(projectContents) ??
-    createStoryboardFileIfMainComponentPresent(projectContents) ??
-    createStoryboardFileWithPlaceholderContents(projectContents, createPlaceholder)
-
-  if (result == projectContents) {
-    notifyResolveRequirement(
-      dispatch,
-      'storyboard',
-      RequirementResolutionResult.Partial,
-      'Storyboard.js skipped',
-    )
-  } else {
-    notifyResolveRequirement(
-      dispatch,
-      'storyboard',
-      RequirementResolutionResult.Fixed,
-      'Storyboard.js created',
-    )
-  }
-
-  return result
 }
 
 // JS Editor Actions:
@@ -4049,14 +3958,12 @@ export const UPDATE_FNS = {
     }
     return {
       ...editor,
-      projectContents: createStoryboardFileIfNecessary(
-        dispatch,
-        workingProjectContents,
-        // If we are in the process of cloning a Github repository, do not create placeholder Storyboard
+      projectContents:
+        // If we are in the process of cloning a Github repository, do not create storyboard
+        // it will be created in the requirements check phase
         userState.githubState.gitRepoToLoad != null
-          ? 'skip-creating-placeholder'
-          : 'create-placeholder',
-      ),
+          ? workingProjectContents
+          : createStoryboardFileIfNecessary(workingProjectContents),
       canvas: {
         ...editor.canvas,
         canvasContentInvalidateCount: anyParsedUpdates
@@ -6461,61 +6368,6 @@ function saveFileInProjectContents(
     return addFileToProjectContents(projectContents, filePath, saveFile(file))
   }
 }
-
-const DefaultStoryboardWithRemix = `import * as React from 'react'
-import { Storyboard, RemixScene } from 'utopia-api'
-
-export var storyboard = (
-  <Storyboard>
-    <RemixScene
-      style={{
-        position: 'absolute',
-        width: 644,
-        height: 750,
-        left: 200,
-        top: 30,
-        overflow: 'hidden',
-      }}
-      data-label='Mood Board'
-    />
-  </Storyboard>
-)
-`
-
-const DefaultStoryboardContents = `import * as React from 'react'
-import { Scene, Storyboard } from 'utopia-api'
-
-export var storyboard = (
-  <Storyboard>
-    <Scene
-      style={{
-        width: 603,
-        height: 794,
-        position: 'absolute',
-        left: 212,
-        top: 128,
-        display: 'flex',
-        flexDirection: 'column',
-        padding: '253px 101px',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <span
-        style={{
-          wordBreak: 'break-word',
-          fontSize: '25px',
-          width: 257,
-          height: 130,
-        }}
-      >
-        Open the insert menu or press the + button in the
-        toolbar to insert components
-      </span>
-    </Scene>
-  </Storyboard>
-  )
-`
 
 function addTextFile(
   editor: EditorState,

--- a/editor/src/core/shared/github/operations/load-branch.ts
+++ b/editor/src/core/shared/github/operations/load-branch.ts
@@ -33,9 +33,7 @@ import {
   saveGithubAsset,
 } from '../helpers'
 import type { GithubOperationContext } from './github-operation-context'
-import { createStoryboardFileIfNecessary } from '../../../../components/editor/actions/actions'
 import { getAllComponentDescriptorFilePaths } from '../../../property-controls/property-controls-local'
-import type { ExistingAsset } from '../../../../components/editor/server'
 import { GithubOperations } from '.'
 import { assertNever } from '../../utils'
 import { updateProjectContentsWithParseResults } from '../../parser-projectcontents-utils'
@@ -173,16 +171,8 @@ export const updateProjectWithBranchContent =
             notifyOperationFinished(dispatch, { type: 'parseFiles' }, ImportOperationResult.Success)
 
             resetRequirementsResolutions(dispatch)
-            const parsedProjectContentsInitial = createStoryboardFileIfNecessary(
-              dispatch,
-              parseResults,
-              'create-placeholder',
-            )
 
-            const parsedProjectContents = checkAndFixUtopiaRequirements(
-              dispatch,
-              parsedProjectContentsInitial,
-            )
+            const parsedProjectContents = checkAndFixUtopiaRequirements(dispatch, parseResults)
 
             // Update the editor with everything so that if anything else fails past this point
             // there's no loss of data from the user's perspective.

--- a/editor/src/core/shared/import/proejct-health-check/check-utopia-requirements.ts
+++ b/editor/src/core/shared/import/proejct-health-check/check-utopia-requirements.ts
@@ -5,16 +5,16 @@ import type { EditorDispatch } from '../../../../components/editor/action-types'
 import CheckPackageJson from './requirements/requirement-package-json'
 import CheckLanguage from './requirements/requirement-language'
 import CheckReactVersion from './requirements/requirement-react'
-import type { RequirementCheck } from './utopia-requirements-types'
+import type { ProjectRequirements, RequirementCheck } from './utopia-requirements-types'
 import { notifyCheckingRequirement, notifyResolveRequirement } from './utopia-requirements-service'
 import CheckStoryboard from './requirements/requirement-storyboard'
 
-const checks: RequirementCheck[] = [
-  new CheckStoryboard(),
-  new CheckPackageJson(),
-  new CheckLanguage(),
-  new CheckReactVersion(),
-]
+const checks: Record<keyof ProjectRequirements, RequirementCheck> = {
+  storyboard: new CheckStoryboard(),
+  packageJsonEntries: new CheckPackageJson(),
+  language: new CheckLanguage(),
+  reactVersion: new CheckReactVersion(),
+}
 
 export function checkAndFixUtopiaRequirements(
   dispatch: EditorDispatch,
@@ -22,8 +22,8 @@ export function checkAndFixUtopiaRequirements(
 ): ProjectContentTreeRoot {
   let projectContents = parsedProjectContents
   // iterate over all checks, updating the project contents as we go
-  for (const check of checks) {
-    const checkName = check.getRequirementName()
+  for (const [name, check] of Object.entries(checks)) {
+    const checkName = name as keyof ProjectRequirements
     notifyCheckingRequirement(dispatch, checkName, check.getStartText())
     const checkResult = check.check(projectContents)
     notifyResolveRequirement(

--- a/editor/src/core/shared/import/proejct-health-check/check-utopia-requirements.ts
+++ b/editor/src/core/shared/import/proejct-health-check/check-utopia-requirements.ts
@@ -1,154 +1,65 @@
-import {
-  addFileToProjectContents,
-  packageJsonFileFromProjectContents,
-} from '../../../../components/assets'
+import { getProjectFileByFilePath } from '../../../../components/assets'
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
-import { codeFile, isTextFile, RevisionsState } from '../../project-file-types'
-import { notifyCheckingRequirement, notifyResolveRequirement } from './utopia-requirements-service'
-import { RequirementResolutionResult } from './utopia-requirements-types'
-import { applyToAllUIJSFiles } from '../../../../core/model/project-file-utils'
+import { isTextFile } from '../../project-file-types'
 import type { EditorDispatch } from '../../../../components/editor/action-types'
+import CheckPackageJson from './requirements/requirement-package-json'
+import CheckLanguage from './requirements/requirement-language'
+import CheckReactVersion from './requirements/requirement-react'
+import type { RequirementCheck } from './utopia-requirements-types'
+import { notifyCheckingRequirement, notifyResolveRequirement } from './utopia-requirements-service'
+import CheckStoryboard from './requirements/requirement-storyboard'
+
+const checks: RequirementCheck[] = [
+  new CheckStoryboard(),
+  new CheckPackageJson(),
+  new CheckLanguage(),
+  new CheckReactVersion(),
+]
 
 export function checkAndFixUtopiaRequirements(
   dispatch: EditorDispatch,
   parsedProjectContents: ProjectContentTreeRoot,
 ): ProjectContentTreeRoot {
   let projectContents = parsedProjectContents
-  // check and fix package.json
-  projectContents = checkAndFixPackageJson(dispatch, projectContents)
-  // check language
-  checkProjectLanguage(dispatch, projectContents)
-  // check react version
-  checkReactVersion(dispatch, projectContents)
+  // iterate over all checks, updating the project contents as we go
+  for (const check of checks) {
+    const checkName = check.getRequirementName()
+    notifyCheckingRequirement(dispatch, checkName, check.getStartText())
+    const checkResult = check.check(projectContents)
+    notifyResolveRequirement(
+      dispatch,
+      checkName,
+      checkResult.resolution,
+      checkResult.resultText,
+      checkResult.resultValue,
+    )
+    projectContents = checkResult.newProjectContents ?? projectContents
+  }
   return projectContents
 }
 
-function getPackageJson(
+export function getPackageJson(
   projectContents: ProjectContentTreeRoot,
 ): { utopia?: Record<string, string>; dependencies?: Record<string, string> } | null {
-  const packageJson = packageJsonFileFromProjectContents(projectContents)
-  if (packageJson != null && isTextFile(packageJson)) {
-    return JSON.parse(packageJson.fileContents.code)
+  return getJsonFile<{ utopia?: Record<string, string>; dependencies?: Record<string, string> }>(
+    projectContents,
+    '/package.json',
+  )
+}
+
+export function getPackageLockJson(
+  projectContents: ProjectContentTreeRoot,
+): { dependencies?: Record<string, string> } | null {
+  return getJsonFile<{ dependencies?: Record<string, string> }>(
+    projectContents,
+    '/package-lock.json',
+  )
+}
+
+function getJsonFile<T>(projectContents: ProjectContentTreeRoot, fileName: string): T | null {
+  const file = getProjectFileByFilePath(projectContents, fileName)
+  if (file != null && isTextFile(file)) {
+    return JSON.parse(file.fileContents.code) as T
   }
   return null
-}
-
-function checkAndFixPackageJson(
-  dispatch: EditorDispatch,
-  projectContents: ProjectContentTreeRoot,
-): ProjectContentTreeRoot {
-  notifyCheckingRequirement(dispatch, 'packageJsonEntries', 'Checking package.json')
-  const parsedPackageJson = getPackageJson(projectContents)
-  if (parsedPackageJson == null) {
-    notifyResolveRequirement(
-      dispatch,
-      'packageJsonEntries',
-      RequirementResolutionResult.Critical,
-      'The file package.json was not found',
-    )
-    return projectContents
-  }
-  if (parsedPackageJson.utopia == null) {
-    parsedPackageJson.utopia = {
-      'main-ui': 'utopia/storyboard.js',
-    }
-    const result = addFileToProjectContents(
-      projectContents,
-      '/package.json',
-      codeFile(
-        JSON.stringify(parsedPackageJson, null, 2),
-        null,
-        0,
-        RevisionsState.CodeAheadButPleaseTellVSCodeAboutIt,
-      ),
-    )
-    notifyResolveRequirement(
-      dispatch,
-      'packageJsonEntries',
-      RequirementResolutionResult.Fixed,
-      'Fixed utopia entry in package.json',
-    )
-    return result
-  } else {
-    notifyResolveRequirement(
-      dispatch,
-      'packageJsonEntries',
-      RequirementResolutionResult.Found,
-      'Valid package.json found',
-    )
-  }
-
-  return projectContents
-}
-
-function checkProjectLanguage(
-  dispatch: EditorDispatch,
-  projectContents: ProjectContentTreeRoot,
-): void {
-  notifyCheckingRequirement(dispatch, 'language', 'Checking project language')
-  let jsCount = 0
-  let tsCount = 0
-  applyToAllUIJSFiles(projectContents, (filename, uiJSFile) => {
-    if ((filename.endsWith('.ts') || filename.endsWith('.tsx')) && !filename.endsWith('.d.ts')) {
-      tsCount++
-    } else if (filename.endsWith('.js') || filename.endsWith('.jsx')) {
-      jsCount++
-    }
-    return uiJSFile
-  })
-  if (tsCount > 0) {
-    notifyResolveRequirement(
-      dispatch,
-      'language',
-      RequirementResolutionResult.Critical,
-      'There are Typescript files in the project',
-      'typescript',
-    )
-  } else if (jsCount == 0) {
-    // in case it's a .coffee project, python, etc
-    notifyResolveRequirement(
-      dispatch,
-      'language',
-      RequirementResolutionResult.Critical,
-      'No JS/JSX files found',
-      'javascript',
-    )
-  } else {
-    notifyResolveRequirement(
-      dispatch,
-      'language',
-      RequirementResolutionResult.Found,
-      'Project uses JS/JSX',
-      'javascript',
-    )
-  }
-}
-
-function checkReactVersion(
-  dispatch: EditorDispatch,
-  projectContents: ProjectContentTreeRoot,
-): void {
-  notifyCheckingRequirement(dispatch, 'reactVersion', 'Checking React version')
-  const parsedPackageJson = getPackageJson(projectContents)
-  if (
-    parsedPackageJson == null ||
-    parsedPackageJson.dependencies == null ||
-    parsedPackageJson.dependencies.react == null
-  ) {
-    return notifyResolveRequirement(
-      dispatch,
-      'reactVersion',
-      RequirementResolutionResult.Critical,
-      'React is not in dependencies',
-    )
-  }
-  const reactVersion = parsedPackageJson.dependencies.react
-  // TODO: check react version
-  return notifyResolveRequirement(
-    dispatch,
-    'reactVersion',
-    RequirementResolutionResult.Found,
-    'React version is ok',
-    reactVersion,
-  )
 }

--- a/editor/src/core/shared/import/proejct-health-check/check-utopia-requirements.ts
+++ b/editor/src/core/shared/import/proejct-health-check/check-utopia-requirements.ts
@@ -9,17 +9,16 @@ import type { ProjectRequirement, RequirementCheck } from './utopia-requirements
 import { notifyCheckingRequirement, notifyResolveRequirement } from './utopia-requirements-service'
 import CheckStoryboard from './requirements/requirement-storyboard'
 
-const checks: Record<ProjectRequirement, RequirementCheck> = {
-  storyboard: new CheckStoryboard(),
-  packageJsonEntries: new CheckPackageJson(),
-  language: new CheckLanguage(),
-  reactVersion: new CheckReactVersion(),
-}
-
 export function checkAndFixUtopiaRequirements(
   dispatch: EditorDispatch,
   parsedProjectContents: ProjectContentTreeRoot,
 ): ProjectContentTreeRoot {
+  const checks: Record<ProjectRequirement, RequirementCheck> = {
+    storyboard: new CheckStoryboard(),
+    packageJsonEntries: new CheckPackageJson(),
+    language: new CheckLanguage(),
+    reactVersion: new CheckReactVersion(),
+  }
   let projectContents = parsedProjectContents
   // iterate over all checks, updating the project contents as we go
   for (const [name, check] of Object.entries(checks)) {

--- a/editor/src/core/shared/import/proejct-health-check/check-utopia-requirements.ts
+++ b/editor/src/core/shared/import/proejct-health-check/check-utopia-requirements.ts
@@ -5,11 +5,11 @@ import type { EditorDispatch } from '../../../../components/editor/action-types'
 import CheckPackageJson from './requirements/requirement-package-json'
 import CheckLanguage from './requirements/requirement-language'
 import CheckReactVersion from './requirements/requirement-react'
-import type { ProjectRequirements, RequirementCheck } from './utopia-requirements-types'
+import type { ProjectRequirement, RequirementCheck } from './utopia-requirements-types'
 import { notifyCheckingRequirement, notifyResolveRequirement } from './utopia-requirements-service'
 import CheckStoryboard from './requirements/requirement-storyboard'
 
-const checks: Record<keyof ProjectRequirements, RequirementCheck> = {
+const checks: Record<ProjectRequirement, RequirementCheck> = {
   storyboard: new CheckStoryboard(),
   packageJsonEntries: new CheckPackageJson(),
   language: new CheckLanguage(),
@@ -23,7 +23,7 @@ export function checkAndFixUtopiaRequirements(
   let projectContents = parsedProjectContents
   // iterate over all checks, updating the project contents as we go
   for (const [name, check] of Object.entries(checks)) {
-    const checkName = name as keyof ProjectRequirements
+    const checkName = name as ProjectRequirement
     notifyCheckingRequirement(dispatch, checkName, check.getStartText())
     const checkResult = check.check(projectContents)
     notifyResolveRequirement(

--- a/editor/src/core/shared/import/proejct-health-check/requirements/requirement-language.ts
+++ b/editor/src/core/shared/import/proejct-health-check/requirements/requirement-language.ts
@@ -1,5 +1,4 @@
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
-import type { ProjectRequirements } from '../utopia-requirements-types'
 import {
   RequirementResolutionResult,
   type RequirementCheck,
@@ -8,9 +7,6 @@ import {
 import { applyToAllUIJSFiles } from '../../../../model/project-file-utils'
 
 export default class CheckProjectLanguage implements RequirementCheck {
-  getRequirementName(): keyof ProjectRequirements {
-    return 'language'
-  }
   getStartText(): string {
     return 'Checking project language'
   }

--- a/editor/src/core/shared/import/proejct-health-check/requirements/requirement-language.ts
+++ b/editor/src/core/shared/import/proejct-health-check/requirements/requirement-language.ts
@@ -1,0 +1,48 @@
+import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
+import type { ProjectRequirements } from '../utopia-requirements-types'
+import {
+  RequirementResolutionResult,
+  type RequirementCheck,
+  type RequirementCheckResult,
+} from '../utopia-requirements-types'
+import { applyToAllUIJSFiles } from '../../../../model/project-file-utils'
+
+export default class CheckProjectLanguage implements RequirementCheck {
+  getRequirementName(): keyof ProjectRequirements {
+    return 'language'
+  }
+  getStartText(): string {
+    return 'Checking project language'
+  }
+  check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
+    let jsCount = 0
+    let tsCount = 0
+    applyToAllUIJSFiles(projectContents, (filename, uiJSFile) => {
+      if ((filename.endsWith('.ts') || filename.endsWith('.tsx')) && !filename.endsWith('.d.ts')) {
+        tsCount++
+      } else if (filename.endsWith('.js') || filename.endsWith('.jsx')) {
+        jsCount++
+      }
+      return uiJSFile
+    })
+    if (tsCount > 0) {
+      return {
+        resolution: RequirementResolutionResult.Critical,
+        resultText: 'There are Typescript files in the project',
+        resultValue: 'typescript',
+      }
+    } else if (jsCount == 0) {
+      // in case it's a .coffee project, python, etc
+      return {
+        resolution: RequirementResolutionResult.Critical,
+        resultText: 'No JS/JSX files found',
+      }
+    } else {
+      return {
+        resolution: RequirementResolutionResult.Found,
+        resultText: 'Project uses JS/JSX',
+        resultValue: 'javascript',
+      }
+    }
+  }
+}

--- a/editor/src/core/shared/import/proejct-health-check/requirements/requirement-package-json.ts
+++ b/editor/src/core/shared/import/proejct-health-check/requirements/requirement-package-json.ts
@@ -1,19 +1,12 @@
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
 import { RevisionsState } from 'utopia-shared/src/types'
 import { getPackageJson } from '../check-utopia-requirements'
-import type {
-  ProjectRequirements,
-  RequirementCheck,
-  RequirementCheckResult,
-} from '../utopia-requirements-types'
+import type { RequirementCheck, RequirementCheckResult } from '../utopia-requirements-types'
 import { RequirementResolutionResult } from '../utopia-requirements-types'
 import { addFileToProjectContents } from '../../../../../components/assets'
 import { codeFile } from '../../../../../core/shared/project-file-types'
 
 export default class PackageJsonCheckAndFix implements RequirementCheck {
-  getRequirementName(): keyof ProjectRequirements {
-    return 'packageJsonEntries'
-  }
   getStartText(): string {
     return 'Checking package.json'
   }

--- a/editor/src/core/shared/import/proejct-health-check/requirements/requirement-package-json.ts
+++ b/editor/src/core/shared/import/proejct-health-check/requirements/requirement-package-json.ts
@@ -1,0 +1,54 @@
+import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
+import { RevisionsState } from 'utopia-shared/src/types'
+import { getPackageJson } from '../check-utopia-requirements'
+import type {
+  ProjectRequirements,
+  RequirementCheck,
+  RequirementCheckResult,
+} from '../utopia-requirements-types'
+import { RequirementResolutionResult } from '../utopia-requirements-types'
+import { addFileToProjectContents } from '../../../../../components/assets'
+import { codeFile } from '../../../../../core/shared/project-file-types'
+
+export default class PackageJsonCheckAndFix implements RequirementCheck {
+  getRequirementName(): keyof ProjectRequirements {
+    return 'packageJsonEntries'
+  }
+  getStartText(): string {
+    return 'Checking package.json'
+  }
+  check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
+    const parsedPackageJson = getPackageJson(projectContents)
+    if (parsedPackageJson == null) {
+      return {
+        resolution: RequirementResolutionResult.Critical,
+        resultText: 'The file package.json was not found',
+      }
+    }
+    if (parsedPackageJson.utopia == null) {
+      parsedPackageJson.utopia = {
+        'main-ui': 'utopia/storyboard.js',
+      }
+      const result = addFileToProjectContents(
+        projectContents,
+        '/package.json',
+        codeFile(
+          JSON.stringify(parsedPackageJson, null, 2),
+          null,
+          0,
+          RevisionsState.CodeAheadButPleaseTellVSCodeAboutIt,
+        ),
+      )
+      return {
+        resolution: RequirementResolutionResult.Fixed,
+        resultText: 'Added utopia entry to package.json',
+        newProjectContents: result,
+      }
+    } else {
+      return {
+        resolution: RequirementResolutionResult.Found,
+        resultText: 'Valid package.json found',
+      }
+    }
+  }
+}

--- a/editor/src/core/shared/import/proejct-health-check/requirements/requirement-react.ts
+++ b/editor/src/core/shared/import/proejct-health-check/requirements/requirement-react.ts
@@ -1,5 +1,4 @@
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
-import type { ProjectRequirements } from '../utopia-requirements-types'
 import {
   RequirementResolutionResult,
   type RequirementCheck,
@@ -11,9 +10,6 @@ import Semver from 'semver'
 const SUPPORTED_REACT_VERSION_RANGE = '16.8.0 - 18.x'
 
 export default class CheckReactRequirement implements RequirementCheck {
-  getRequirementName(): keyof ProjectRequirements {
-    return 'reactVersion'
-  }
   getStartText(): string {
     return 'Checking React version'
   }

--- a/editor/src/core/shared/import/proejct-health-check/requirements/requirement-react.ts
+++ b/editor/src/core/shared/import/proejct-health-check/requirements/requirement-react.ts
@@ -1,0 +1,44 @@
+import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
+import type { ProjectRequirements } from '../utopia-requirements-types'
+import {
+  RequirementResolutionResult,
+  type RequirementCheck,
+  type RequirementCheckResult,
+} from '../utopia-requirements-types'
+import { getPackageJson, getPackageLockJson } from '../check-utopia-requirements'
+import Semver from 'semver'
+
+const SUPPORTED_REACT_VERSION_RANGE = '16.8.0 - 18.x'
+
+export default class CheckReactRequirement implements RequirementCheck {
+  getRequirementName(): keyof ProjectRequirements {
+    return 'reactVersion'
+  }
+  getStartText(): string {
+    return 'Checking React version'
+  }
+  check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
+    const parsedPackageLockJson = getPackageLockJson(projectContents)
+    // check package-lock.json first
+    let reactVersion = parsedPackageLockJson?.dependencies?.react
+    if (reactVersion == null) {
+      const parsedPackageJson = getPackageJson(projectContents)
+      // then check package.json
+      reactVersion = parsedPackageJson?.dependencies?.react
+    }
+    if (reactVersion == null) {
+      return {
+        resolution: RequirementResolutionResult.Critical,
+        resultText: 'React is not in dependencies',
+      }
+    }
+    const isMatching = Semver.intersects(reactVersion, SUPPORTED_REACT_VERSION_RANGE)
+    return {
+      resolution: isMatching
+        ? RequirementResolutionResult.Found
+        : RequirementResolutionResult.Critical,
+      resultText: isMatching ? 'React version is ok' : 'React version is not in supported range',
+      resultValue: reactVersion,
+    }
+  }
+}

--- a/editor/src/core/shared/import/proejct-health-check/requirements/requirement-storyboard.ts
+++ b/editor/src/core/shared/import/proejct-health-check/requirements/requirement-storyboard.ts
@@ -1,5 +1,5 @@
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
-import type { ProjectRequirements, RequirementCheckResult } from '../utopia-requirements-types'
+import type { RequirementCheckResult } from '../utopia-requirements-types'
 import { RequirementResolutionResult } from '../utopia-requirements-types'
 import type { RequirementCheck } from '../utopia-requirements-types'
 import { defaultEither } from '../../../../../core/shared/either'
@@ -13,9 +13,6 @@ import { codeFile } from '../../../../../core/shared/project-file-types'
 import { addStoryboardFileToProject } from '../../../../../core/model/storyboard-utils'
 
 export default class CheckStoryboard implements RequirementCheck {
-  getRequirementName(): keyof ProjectRequirements {
-    return 'storyboard'
-  }
   getStartText(): string {
     return 'Checking for storyboard.js'
   }

--- a/editor/src/core/shared/import/proejct-health-check/requirements/requirement-storyboard.ts
+++ b/editor/src/core/shared/import/proejct-health-check/requirements/requirement-storyboard.ts
@@ -1,0 +1,157 @@
+import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
+import type { ProjectRequirements, RequirementCheckResult } from '../utopia-requirements-types'
+import { RequirementResolutionResult } from '../utopia-requirements-types'
+import type { RequirementCheck } from '../utopia-requirements-types'
+import { defaultEither } from '../../../../../core/shared/either'
+import { StoryboardFilePath } from '../../../../../components/editor/store/editor-state'
+import { getPackageJsonFromProjectContents } from '../../../../../components/editor/store/editor-state'
+import {
+  addFileToProjectContents,
+  getProjectFileByFilePath,
+} from '../../../../../components/assets'
+import { codeFile } from '../../../../../core/shared/project-file-types'
+import { addStoryboardFileToProject } from '../../../../../core/model/storyboard-utils'
+
+export default class CheckStoryboard implements RequirementCheck {
+  getRequirementName(): keyof ProjectRequirements {
+    return 'storyboard'
+  }
+  getStartText(): string {
+    return 'Checking for storyboard.js'
+  }
+  check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
+    return createStoryboardFileIfNecessaryInner(projectContents)
+  }
+}
+
+export function createStoryboardFileIfNecessary(
+  projectContents: ProjectContentTreeRoot,
+): ProjectContentTreeRoot {
+  const result = createStoryboardFileIfNecessaryInner(projectContents)
+  return result.newProjectContents ?? projectContents
+}
+
+function createStoryboardFileIfNecessaryInner(
+  projectContents: ProjectContentTreeRoot,
+): RequirementCheckResult {
+  const storyboardFile = getProjectFileByFilePath(projectContents, StoryboardFilePath)
+  if (storyboardFile != null) {
+    return {
+      resolution: RequirementResolutionResult.Found,
+      resultText: 'Storyboard.js found',
+    }
+  }
+
+  const result =
+    createStoryboardFileIfRemixProject(projectContents) ??
+    createStoryboardFileIfMainComponentPresent(projectContents) ??
+    createStoryboardFileWithPlaceholderContents(projectContents)
+
+  if (result == projectContents) {
+    return {
+      resolution: RequirementResolutionResult.Partial,
+      resultText: 'Storyboard.js skipped',
+    }
+  } else {
+    return {
+      resolution: RequirementResolutionResult.Fixed,
+      resultText: 'Storyboard.js created',
+      newProjectContents: result,
+    }
+  }
+}
+
+function createStoryboardFileIfRemixProject(
+  projectContents: ProjectContentTreeRoot,
+): ProjectContentTreeRoot | null {
+  const packageJsonContents = defaultEither(
+    null,
+    getPackageJsonFromProjectContents(projectContents),
+  )
+  if (packageJsonContents == null) {
+    return null
+  }
+  const remixNotIncluded = packageJsonContents['dependencies']?.['@remix-run/react'] == null
+  if (remixNotIncluded) {
+    return null
+  }
+
+  const updatedProjectContents = addFileToProjectContents(
+    projectContents,
+    StoryboardFilePath,
+    codeFile(DefaultStoryboardWithRemix, null, 1),
+  )
+  return updatedProjectContents
+}
+
+function createStoryboardFileIfMainComponentPresent(
+  projectContents: ProjectContentTreeRoot,
+): ProjectContentTreeRoot | null {
+  return addStoryboardFileToProject(projectContents)
+}
+
+function createStoryboardFileWithPlaceholderContents(
+  projectContents: ProjectContentTreeRoot,
+): ProjectContentTreeRoot {
+  const updatedProjectContents = addFileToProjectContents(
+    projectContents,
+    StoryboardFilePath,
+    codeFile(DefaultStoryboardContents, null, 1),
+  )
+  return updatedProjectContents
+}
+
+const DefaultStoryboardWithRemix = `import * as React from 'react'
+import { Storyboard, RemixScene } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard>
+    <RemixScene
+      style={{
+        position: 'absolute',
+        width: 644,
+        height: 750,
+        left: 200,
+        top: 30,
+        overflow: 'hidden',
+      }}
+      data-label='Mood Board'
+    />
+  </Storyboard>
+)
+`
+
+const DefaultStoryboardContents = `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard>
+    <Scene
+      style={{
+        width: 603,
+        height: 794,
+        position: 'absolute',
+        left: 212,
+        top: 128,
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '253px 101px',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <span
+        style={{
+          wordBreak: 'break-word',
+          fontSize: '25px',
+          width: 257,
+          height: 130,
+        }}
+      >
+        Open the insert menu or press the + button in the
+        toolbar to insert components
+      </span>
+    </Scene>
+  </Storyboard>
+  )
+`

--- a/editor/src/core/shared/import/proejct-health-check/requirements/requirements.spec.ts
+++ b/editor/src/core/shared/import/proejct-health-check/requirements/requirements.spec.ts
@@ -1,0 +1,191 @@
+import { simpleDefaultProject } from '../../../../../sample-projects/sample-project-utils'
+import { RequirementResolutionResult } from '../utopia-requirements-types'
+import CheckProjectLanguage from './requirement-language'
+import CheckPackageJson from './requirement-package-json'
+import CheckReactVersion from './requirement-react'
+import { codeFile, textFile, textFileContents } from '../../../../../core/shared/project-file-types'
+import { RevisionsState } from '../../../../../core/shared/project-file-types'
+import { unparsed } from '../../../../../core/shared/project-file-types'
+import { contentsToTree } from '../../../../../components/assets'
+import { DefaultPackageJson } from '../../../../../components/editor/store/editor-state'
+import { getPackageJson } from '../check-utopia-requirements'
+import CheckStoryboard from './requirement-storyboard'
+
+describe('requirements checks', () => {
+  describe('project language', () => {
+    it('should return success for a project with only js files', () => {
+      const check = new CheckProjectLanguage()
+      const project = simpleDefaultProject()
+      const projectContents = project.projectContents
+      const result = check.check(projectContents)
+      expect(result.resolution).toBe(RequirementResolutionResult.Found)
+    })
+
+    it('should return failure for a project with ts files', () => {
+      const check = new CheckProjectLanguage()
+      const project = simpleDefaultProject({
+        additionalFiles: {
+          '/src/app.ts': codeFile(``, null),
+        },
+      })
+      const projectContents = project.projectContents
+      const result = check.check(projectContents)
+      expect(result.resolution).toBe(RequirementResolutionResult.Critical)
+    })
+    it('should not fail for a project with .d.ts files', () => {
+      const check = new CheckProjectLanguage()
+      const project = simpleDefaultProject({
+        additionalFiles: {
+          '/src/app.d.ts': codeFile(``, null),
+        },
+      })
+      const projectContents = project.projectContents
+      const result = check.check(projectContents)
+      expect(result.resolution).toBe(RequirementResolutionResult.Found)
+    })
+    it('should fail for a project with no js files', () => {
+      const check = new CheckProjectLanguage()
+      const projectContents = contentsToTree({
+        '/src/app.python': codeFile(``, null),
+      })
+      const result = check.check(projectContents)
+      expect(result.resolution).toBe(RequirementResolutionResult.Critical)
+    })
+  })
+
+  describe('package json', () => {
+    it('should return success for a project with a package.json and a utopia entry', () => {
+      const check = new CheckPackageJson()
+      const project = simpleDefaultProject()
+      const projectContents = project.projectContents
+      const result = check.check(projectContents)
+      expect(result.resolution).toBe(RequirementResolutionResult.Found)
+    })
+    it('should return failure for a project without a package.json', () => {
+      const check = new CheckPackageJson()
+      const project = simpleDefaultProject()
+      const projectContents = project.projectContents
+      delete projectContents['package.json']
+      const result = check.check(projectContents)
+      expect(result.resolution).toBe(RequirementResolutionResult.Critical)
+    })
+
+    it('should add a utopia entry if there is no utopia entry', () => {
+      const { utopia, ...packageJson } = DefaultPackageJson
+      const check = new CheckPackageJson()
+      const project = simpleDefaultProject({
+        additionalFiles: {
+          '/package.json': textFile(
+            textFileContents(
+              JSON.stringify(packageJson, null, 2),
+              unparsed,
+              RevisionsState.CodeAhead,
+            ),
+            null,
+            null,
+            0,
+          ),
+        },
+      })
+      const projectContents = project.projectContents
+      const result = check.check(projectContents)
+      expect(result.resolution).toBe(RequirementResolutionResult.Fixed)
+      expect(result.newProjectContents).not.toBeNull()
+      const newPackageJson = getPackageJson(result.newProjectContents!)
+      expect(newPackageJson).not.toBeNull()
+      expect(newPackageJson!.utopia?.['main-ui']).not.toBeUndefined()
+    })
+  })
+
+  describe('react version', () => {
+    it('should return success for a project with a react version 16.8 - 18.x', () => {
+      const check = new CheckReactVersion()
+      const project = simpleDefaultProject()
+      const projectContents = project.projectContents
+      const result = check.check(projectContents)
+      expect(result.resolution).toBe(RequirementResolutionResult.Found)
+    })
+    it('should return failure for a project with a react version less than 16.8', () => {
+      const check = new CheckReactVersion()
+      const project = simpleDefaultProject({
+        additionalFiles: {
+          '/package.json': textFile(
+            textFileContents(
+              JSON.stringify(
+                {
+                  ...DefaultPackageJson,
+                  dependencies: {
+                    ...DefaultPackageJson.dependencies,
+                    react: '16.7.0',
+                  },
+                },
+                null,
+                2,
+              ),
+              unparsed,
+              RevisionsState.CodeAhead,
+            ),
+            null,
+            null,
+            0,
+          ),
+        },
+      })
+      const projectContents = project.projectContents
+      const result = check.check(projectContents)
+      expect(result.resolution).toBe(RequirementResolutionResult.Critical)
+    })
+    it('should return a failure for react version 19', () => {
+      const check = new CheckReactVersion()
+      const project = simpleDefaultProject({
+        additionalFiles: {
+          '/package.json': textFile(
+            textFileContents(
+              JSON.stringify(
+                {
+                  ...DefaultPackageJson,
+                  dependencies: {
+                    ...DefaultPackageJson.dependencies,
+                    react: '19.0.0',
+                  },
+                },
+                null,
+                2,
+              ),
+              unparsed,
+              RevisionsState.CodeAhead,
+            ),
+            null,
+            null,
+            0,
+          ),
+        },
+      })
+      const projectContents = project.projectContents
+      const result = check.check(projectContents)
+      expect(result.resolution).toBe(RequirementResolutionResult.Critical)
+    })
+  })
+
+  describe('storyboard', () => {
+    it('should return success for a project with a storyboard', () => {
+      const check = new CheckStoryboard()
+      const project = simpleDefaultProject()
+      const projectContents = project.projectContents
+      const result = check.check(projectContents)
+      expect(result.resolution).toBe(RequirementResolutionResult.Found)
+    })
+    it('should create a storyboard if there is no storyboard', () => {
+      const check = new CheckStoryboard()
+      const project = simpleDefaultProject({
+        storyboardFile: null,
+      })
+      const projectContents = project.projectContents
+      delete projectContents['utopia/storyboard.js']
+      const result = check.check(projectContents)
+      expect(result.resolution).toBe(RequirementResolutionResult.Fixed)
+      expect(result.newProjectContents).not.toBeNull()
+      expect(result.newProjectContents!['utopia/storyboard.js']).not.toBeNull()
+    })
+  })
+})

--- a/editor/src/core/shared/import/proejct-health-check/utopia-requirements-types.ts
+++ b/editor/src/core/shared/import/proejct-health-check/utopia-requirements-types.ts
@@ -1,3 +1,5 @@
+import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
+
 export const RequirementResolutionResult = {
   Found: 'found',
   Fixed: 'fixed',
@@ -74,3 +76,16 @@ export function newProjectRequirements(
     reactVersion,
   }
 }
+
+export interface RequirementCheck {
+  check: (projectContents: ProjectContentTreeRoot) => {
+    resolution: RequirementResolutionResult
+    resultText: string
+    resultValue?: string
+    newProjectContents?: ProjectContentTreeRoot | null
+  }
+  getRequirementName: () => keyof ProjectRequirements
+  getStartText: () => string
+}
+
+export type RequirementCheckResult = ReturnType<RequirementCheck['check']>

--- a/editor/src/core/shared/import/proejct-health-check/utopia-requirements-types.ts
+++ b/editor/src/core/shared/import/proejct-health-check/utopia-requirements-types.ts
@@ -77,15 +77,14 @@ export function newProjectRequirements(
   }
 }
 
-export interface RequirementCheck {
-  check: (projectContents: ProjectContentTreeRoot) => {
-    resolution: RequirementResolutionResult
-    resultText: string
-    resultValue?: string
-    newProjectContents?: ProjectContentTreeRoot | null
-  }
-  getRequirementName: () => keyof ProjectRequirements
-  getStartText: () => string
+export interface RequirementCheckResult {
+  resolution: RequirementResolutionResult
+  resultText: string
+  resultValue?: string
+  newProjectContents?: ProjectContentTreeRoot | null
 }
 
-export type RequirementCheckResult = ReturnType<RequirementCheck['check']>
+export interface RequirementCheck {
+  check: (projectContents: ProjectContentTreeRoot) => RequirementCheckResult
+  getStartText: () => string
+}

--- a/editor/src/sample-projects/sample-project-utils.ts
+++ b/editor/src/sample-projects/sample-project-utils.ts
@@ -45,7 +45,7 @@ export function simpleDefaultProject({
   storyboardFile = getDefaultUIJsFile(),
   additionalFiles = {},
 }: {
-  storyboardFile?: TextFile
+  storyboardFile?: TextFile | null
   additionalFiles?: { [path: string]: TextFile }
 } = {}): PersistentModel {
   const projectContents: ProjectContents = {
@@ -61,12 +61,12 @@ export function simpleDefaultProject({
     ),
     '/src': directory(),
     '/src/app.js': appJSFile(),
-    [StoryboardFilePath]: storyboardFile,
     '/assets': directory(),
     '/public': directory(),
     '/src/index.js': getSamplePreviewFile(),
     '/public/index.html': getSamplePreviewHTMLFile(),
     ...additionalFiles,
+    ...(storyboardFile == null ? {} : { [StoryboardFilePath]: storyboardFile }),
   }
 
   let persistentModel = persistentModelForProjectContents(contentsToTree(projectContents))


### PR DESCRIPTION
This PR is mainly a refactor one, separating requirements check so it will be easy to add more.
- move every requirement check to its own file (**no logic change**, just separating them)
- move the storyboard check and creation from `actions.tsx` to its own file (**no logic change**)
- add tests for checks
- (small) use semver for React check

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Play mode
