### PR TITLE
Remove grid element placement props

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/rearrange-grid-swap-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/rearrange-grid-swap-strategy.ts
@@ -126,7 +126,7 @@ export const rearrangeGridSwapStrategy: CanvasStrategyFactory = (
   }
 }
 
-const GridPositioningProps: Array<keyof React.CSSProperties> = [
+export const GridPositioningProps: Array<keyof React.CSSProperties> = [
   'gridColumn',
   'gridRow',
   'gridColumnStart',

--- a/editor/src/components/inspector/sections/style-section/container-subsection/grid-cell-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/grid-cell-subsection.tsx
@@ -38,6 +38,9 @@ import {
   isEmptyInputValue,
 } from '../../../common/css-utils'
 import { UIGridRow } from '../../../widgets/ui-grid-row'
+import { deleteProperties } from '../../../../canvas/commands/delete-properties-command'
+import { GridPositioningProps } from '../../../../canvas/canvas-strategies/strategies/rearrange-grid-swap-strategy'
+import { styleP } from '../../../inspector-common'
 
 type CellAdjustMode = 'dimensions' | 'boundaries'
 
@@ -100,6 +103,18 @@ export const GridPlacementSubsection = React.memo(() => {
     dispatch([applyCommandsAction(commands)])
   }, [dispatch, cell, gridTemplate])
 
+  const removePlacementProps = React.useCallback(() => {
+    if (cell == null) {
+      return
+    }
+
+    dispatch([
+      applyCommandsAction([
+        deleteProperties('always', cell.elementPath, GridPositioningProps.map(styleP)),
+      ]),
+    ])
+  }, [dispatch, cell])
+
   if (cell == null || gridTemplate == null) {
     return null
   }
@@ -120,6 +135,12 @@ export const GridPlacementSubsection = React.memo(() => {
           isAllDefaults,
           <SquareButton highlight onClick={writeDefaults}>
             <Icons.SmallPlus />
+          </SquareButton>,
+        )}
+        {unless(
+          isAllDefaults,
+          <SquareButton highlight onClick={removePlacementProps}>
+            <Icons.SmallCross />
           </SquareButton>,
         )}
       </InspectorSubsectionHeader>


### PR DESCRIPTION
**Problem:**

There should be a cross button to the side of the Grid Placement inspector subsection to clear those props when set.

**Fix:**

Add that button, shown unless all values are defaults.

![Kapture 2024-10-30 at 15 13 27](https://github.com/user-attachments/assets/0402ce1d-dc34-4cb0-9e7b-561d3fc18539)


Fixes #6600
