### PR TITLE
feat(import): early break on error

### DIFF
--- a/editor/src/components/editor/import-wizard/components.tsx
+++ b/editor/src/components/editor/import-wizard/components.tsx
@@ -29,8 +29,11 @@ export function OperationLine({ operation }: { operation: ImportOperation }) {
 
   const [childrenShown, serChildrenShown] = React.useState(false)
   const shouldShowChildren = React.useMemo(
-    () => childrenShown || operation.timeDone == null,
-    [childrenShown, operation.timeDone],
+    () =>
+      childrenShown ||
+      operation.timeDone == null ||
+      operation.result == ImportOperationResult.Error,
+    [childrenShown, operation.timeDone, operation.result],
   )
   const hasChildren = React.useMemo(
     () => operation.children != null && operation.children.length > 0,

--- a/editor/src/core/shared/github/operations/load-branch.ts
+++ b/editor/src/core/shared/github/operations/load-branch.ts
@@ -42,7 +42,10 @@ import {
   notifyOperationStarted,
   startImportProcess,
 } from '../../import/import-operation-service'
-import { resetRequirementsResolutions } from '../../import/proejct-health-check/utopia-requirements-service'
+import {
+  RequirementResolutionResult,
+  resetRequirementsResolutions,
+} from '../../import/proejct-health-check/utopia-requirements-service'
 import { checkAndFixUtopiaRequirements } from '../../import/proejct-health-check/check-utopia-requirements'
 import { ImportOperationResult } from '../../import/import-operation-types'
 
@@ -171,8 +174,12 @@ export const updateProjectWithBranchContent =
             notifyOperationFinished(dispatch, { type: 'parseFiles' }, ImportOperationResult.Success)
 
             resetRequirementsResolutions(dispatch)
+            const { fixedProjectContents, result: requirementResolutionResult } =
+              checkAndFixUtopiaRequirements(dispatch, parseResults)
 
-            const parsedProjectContents = checkAndFixUtopiaRequirements(dispatch, parseResults)
+            if (requirementResolutionResult === RequirementResolutionResult.Critical) {
+              return []
+            }
 
             // Update the editor with everything so that if anything else fails past this point
             // there's no loss of data from the user's perspective.
@@ -185,19 +192,19 @@ export const updateProjectWithBranchContent =
                   branchName,
                   true,
                 ),
-                updateProjectContents(parsedProjectContents),
-                updateBranchContents(parsedProjectContents),
+                updateProjectContents(fixedProjectContents),
+                updateBranchContents(fixedProjectContents),
                 truncateHistory(),
               ],
               'everyone',
             )
 
             const componentDescriptorFiles =
-              getAllComponentDescriptorFilePaths(parsedProjectContents)
+              getAllComponentDescriptorFilePaths(fixedProjectContents)
 
             // If there's a package.json file, then attempt to load the dependencies for it.
             let dependenciesPromise: Promise<void> = Promise.resolve()
-            const packageJson = packageJsonFileFromProjectContents(parsedProjectContents)
+            const packageJson = packageJsonFileFromProjectContents(fixedProjectContents)
             if (packageJson != null && isTextFile(packageJson)) {
               notifyOperationStarted(dispatch, { type: 'refreshDependencies' })
               dependenciesPromise = refreshDependencies(

--- a/editor/src/core/shared/import/proejct-health-check/check-utopia-requirements.ts
+++ b/editor/src/core/shared/import/proejct-health-check/check-utopia-requirements.ts
@@ -5,6 +5,7 @@ import type { EditorDispatch } from '../../../../components/editor/action-types'
 import CheckPackageJson from './requirements/requirement-package-json'
 import CheckLanguage from './requirements/requirement-language'
 import CheckReactVersion from './requirements/requirement-react'
+import { RequirementResolutionResult } from './utopia-requirements-types'
 import type { ProjectRequirement, RequirementCheck } from './utopia-requirements-types'
 import { notifyCheckingRequirement, notifyResolveRequirement } from './utopia-requirements-service'
 import CheckStoryboard from './requirements/requirement-storyboard'
@@ -12,7 +13,7 @@ import CheckStoryboard from './requirements/requirement-storyboard'
 export function checkAndFixUtopiaRequirements(
   dispatch: EditorDispatch,
   parsedProjectContents: ProjectContentTreeRoot,
-): ProjectContentTreeRoot {
+): { result: RequirementResolutionResult; fixedProjectContents: ProjectContentTreeRoot } {
   const checks: Record<ProjectRequirement, RequirementCheck> = {
     storyboard: new CheckStoryboard(),
     packageJsonEntries: new CheckPackageJson(),
@@ -20,11 +21,15 @@ export function checkAndFixUtopiaRequirements(
     reactVersion: new CheckReactVersion(),
   }
   let projectContents = parsedProjectContents
+  let result: RequirementResolutionResult = RequirementResolutionResult.Found
   // iterate over all checks, updating the project contents as we go
   for (const [name, check] of Object.entries(checks)) {
     const checkName = name as ProjectRequirement
     notifyCheckingRequirement(dispatch, checkName, check.getStartText())
     const checkResult = check.check(projectContents)
+    if (checkResult.resolution === RequirementResolutionResult.Critical) {
+      result = RequirementResolutionResult.Critical
+    }
     notifyResolveRequirement(
       dispatch,
       checkName,
@@ -34,7 +39,7 @@ export function checkAndFixUtopiaRequirements(
     )
     projectContents = checkResult.newProjectContents ?? projectContents
   }
-  return projectContents
+  return { result: result, fixedProjectContents: projectContents }
 }
 
 export function getPackageJson(


### PR DESCRIPTION
This PR breaks early when there is a requirement check error (for example a TS project) - without fetching dependencies or dispatching the results to the project.
For example a Next TS project - note the dependencies are not fetched and the project contents are not updated:
<video src="https://github.com/user-attachments/assets/6ef4e75a-1659-4219-b7e0-d94471a88f57"></video>

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Play mode
