### PR TITLE
Restore Toast Renderer

### DIFF
--- a/editor/src/components/canvas/canvas-floating-toolbars.tsx
+++ b/editor/src/components/canvas/canvas-floating-toolbars.tsx
@@ -6,6 +6,7 @@ import { ErrorOverlayComponent } from './canvas-error-overlay'
 import { SafeModeErrorOverlay } from './canvas-wrapper-component'
 import { CanvasStrategyPicker } from './controls/select-mode/canvas-strategy-picker'
 import { TestMenu } from '../titlebar/test-menu'
+import { ToastRenderer } from '../editor/editor-component'
 
 export const CanvasFloatingToolbars = React.memo((props: { style: React.CSSProperties }) => {
   const safeMode = useEditorState(
@@ -41,6 +42,11 @@ export const CanvasFloatingToolbars = React.memo((props: { style: React.CSSPrope
         <FlexRow style={{ width: 250, alignItems: 'flex-start', gap: 10 }}>
           <CanvasToolbar />
           <CanvasStrategyPicker />
+        </FlexRow>
+      </FlexRow>
+      <FlexRow style={{ marginTop: `auto` }}>
+        <FlexRow style={{ marginBottom: '6.5px' }}>
+          <ToastRenderer />
         </FlexRow>
       </FlexRow>
       {/* The error overlays are deliberately the last here so they hide other canvas UI, except the test menu */}

--- a/editor/src/components/canvas/canvas-floating-toolbars.tsx
+++ b/editor/src/components/canvas/canvas-floating-toolbars.tsx
@@ -44,10 +44,8 @@ export const CanvasFloatingToolbars = React.memo((props: { style: React.CSSPrope
           <CanvasStrategyPicker />
         </FlexRow>
       </FlexRow>
-      <FlexRow style={{ marginTop: `auto` }}>
-        <FlexRow style={{ marginBottom: '6.5px' }}>
-          <ToastRenderer />
-        </FlexRow>
+      <FlexRow style={{ marginTop: 'auto', marginBottom: '6.5px' }}>
+        <ToastRenderer />
       </FlexRow>
       {/* The error overlays are deliberately the last here so they hide other canvas UI, except the test menu */}
       {safeMode ? <SafeModeErrorOverlay /> : <ErrorOverlayComponent />}

--- a/editor/src/components/editor/editor-component.tsx
+++ b/editor/src/components/editor/editor-component.tsx
@@ -645,6 +645,7 @@ export const ToastRenderer = React.memo(() => {
   return (
     <FlexColumn
       key={'toast-stack'}
+      data-testid={'toast-stack'}
       style={{
         zIndex: 100,
         gap: 10,


### PR DESCRIPTION
**Problem:**
Toasts aren't displaying.

**Fix:**
The `ToastRenderer` has been re-added into the editor hierarchy.

**Commit Details:**
- Readded `ToastRenderer` to `CanvasFloatingToolbars`.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode