### PR TITLE
feat(import): allow continuing the import after an error

### DIFF
--- a/editor/src/core/shared/import/import-operation-service.ts
+++ b/editor/src/core/shared/import/import-operation-service.ts
@@ -147,3 +147,14 @@ export function getUpdateOperationResult(
   }
   return operations
 }
+
+export function updateImportOperationResult(
+  operation: ImportOperation,
+  updater: (operation: ImportOperation) => ImportOperationResult | undefined,
+): ImportOperation {
+  return {
+    ...operation,
+    result: updater(operation),
+    children: operation.children?.map((child) => updateImportOperationResult(child, updater)),
+  }
+}

--- a/editor/src/core/shared/import/import-operation-types.ts
+++ b/editor/src/core/shared/import/import-operation-types.ts
@@ -7,14 +7,16 @@ type ImportOperationData = {
   timeStarted?: number | null
   timeDone?: number | null
   result?: ImportOperationResult
-  error?: string
   children?: ImportOperation[]
 }
 
 export const ImportOperationResult = {
   Success: 'success',
-  Error: 'error',
   Warn: 'warn',
+  // an error that shows "continue anyway" button
+  Error: 'error',
+  // an error that we can't recover from
+  CriticalError: 'criticalError',
 } as const
 
 export type ImportOperationResult =


### PR DESCRIPTION
This PR adds the ability to continue the import process after an error (a "Continue Anyway" button that continues to update the project contents and fetch dependencies) (design pending)
<img width="693" alt="image" src="https://github.com/user-attachments/assets/a609068f-dece-4448-a31d-c266969a6341">

**Manual Tests:**
I hereby swear that:

- [ ] I opened a hydrogen project and it loaded
- [ ] I could navigate to various routes in Play mode
