### PR TITLE
keep live mode on blur

### DIFF
--- a/editor/src/templates/editor.tsx
+++ b/editor/src/templates/editor.tsx
@@ -410,11 +410,15 @@ export class Editor {
   }
 
   resetStateOnBlur = (): void => {
+    const currentMode = this.storedState.patchedEditor.mode
+
     this.boundDispatch(
       [
         EditorActions.clearHighlightedViews(),
         CanvasActions.clearInteractionSession(false),
-        EditorActions.switchEditorMode(EditorModes.selectMode(null, false, 'none')),
+        ...(currentMode.type === 'insert'
+          ? [EditorActions.switchEditorMode(EditorModes.selectMode(null, false, 'none'))]
+          : []),
         EditorActions.updateKeys({}),
         EditorActions.closePopup(),
         EditorActions.clearPostActionData(),


### PR DESCRIPTION
#6593 Aggressively switches to edit mode on blur, but we only want that to happen if the user is in insert mode (which means a draw-to-insert interaction).

**Fix**
only switch to edit mode if the current mode is insert mode