### PR TITLE
feat(import): split checks

### DIFF
--- a/editor/src/components/canvas/canvas-loading-screen.tsx
+++ b/editor/src/components/canvas/canvas-loading-screen.tsx
@@ -3,7 +3,6 @@ import { Global, css } from '@emotion/react'
 import { useColorTheme } from '../../uuiui'
 import { useEditorState } from '../editor/store/store-hook'
 import { Substores } from '../editor/store/store-hook'
-import cx from 'classnames'
 
 export const CanvasLoadingScreen = React.memo(() => {
   const colorTheme = useColorTheme()
@@ -18,9 +17,18 @@ export const CanvasLoadingScreen = React.memo(() => {
     'CanvasLoadingScreen importWizardOpen',
   )
 
-  const importingStopped =
-    (importWizardOpen && importState.importStatus.status === 'done') ||
-    importState.importStatus.status === 'paused'
+  const importingStoppedStyleOverride = React.useMemo(
+    () =>
+      // if the importing was stopped, we want to pause the shimmer animation
+      (importWizardOpen && importState.importStatus.status === 'done') ||
+      importState.importStatus.status === 'paused'
+        ? {
+            background: colorTheme.codeEditorShimmerPrimary.value,
+            animation: 'none',
+          }
+        : {},
+    [importWizardOpen, importState.importStatus.status, colorTheme.codeEditorShimmerPrimary.value],
+  )
 
   return (
     <React.Fragment>
@@ -64,13 +72,14 @@ export const CanvasLoadingScreen = React.memo(() => {
         style={{ height: '100%', width: '100%', backgroundColor: colorTheme.bg1.value }}
       >
         <div
-          className={cx('shimmer', { 'no-shimmer': importingStopped })}
+          className='shimmer'
           style={{
             position: 'absolute',
             left: 0,
             top: 0,
             width: '100vw',
             height: '100vh',
+            ...importingStoppedStyleOverride,
           }}
         ></div>
       </div>

--- a/editor/src/components/canvas/canvas-loading-screen.tsx
+++ b/editor/src/components/canvas/canvas-loading-screen.tsx
@@ -1,9 +1,27 @@
 import React from 'react'
 import { Global, css } from '@emotion/react'
 import { useColorTheme } from '../../uuiui'
+import { useEditorState } from '../editor/store/store-hook'
+import { Substores } from '../editor/store/store-hook'
+import cx from 'classnames'
 
 export const CanvasLoadingScreen = React.memo(() => {
   const colorTheme = useColorTheme()
+  const importState = useEditorState(
+    Substores.github,
+    (store) => store.editor.importState,
+    'CanvasLoadingScreen importState',
+  )
+  const importWizardOpen = useEditorState(
+    Substores.restOfEditor,
+    (store) => store.editor.importWizardOpen,
+    'CanvasLoadingScreen importWizardOpen',
+  )
+
+  const importingStopped =
+    (importWizardOpen && importState.importStatus.status === 'done') ||
+    importState.importStatus.status === 'paused'
+
   return (
     <React.Fragment>
       <Global
@@ -34,6 +52,11 @@ export const CanvasLoadingScreen = React.memo(() => {
             background-size: 1468px 104px;
             position: relative;
           }
+
+          .no-shimmer {
+            animation: none;
+            background: ${colorTheme.codeEditorShimmerPrimary.value};
+          }
         `}
       />
       <div
@@ -41,7 +64,7 @@ export const CanvasLoadingScreen = React.memo(() => {
         style={{ height: '100%', width: '100%', backgroundColor: colorTheme.bg1.value }}
       >
         <div
-          className='shimmer'
+          className={cx('shimmer', { 'no-shimmer': importingStopped })}
           style={{
             position: 'absolute',
             left: 0,

--- a/editor/src/components/editor/import-wizard/components.tsx
+++ b/editor/src/components/editor/import-wizard/components.tsx
@@ -3,7 +3,6 @@
 import { jsx } from '@emotion/react'
 import React from 'react'
 import type {
-  ImportCheckRequirementAndFix,
   ImportFetchDependency,
   ImportOperation,
 } from '../../../core/shared/import/import-operation-types'
@@ -11,7 +10,6 @@ import { ImportOperationResult } from '../../../core/shared/import/import-operat
 import { assertNever } from '../../../core/shared/utils'
 import { Icn, Icons, useColorTheme } from '../../../uuiui'
 import { GithubSpinner } from '../../../components/navigator/left-pane/github-pane/github-spinner'
-import { RequirementResolutionResult } from '../../../core/shared/import/project-health-check/utopia-requirements-types'
 
 export function OperationLine({ operation }: { operation: ImportOperation }) {
   const operationRunningStatus = React.useMemo(() => {
@@ -82,7 +80,8 @@ function OperationChildrenList({ operation }: { operation: ImportOperation }) {
           successFn={dependenciesSuccessFn}
           successTextFn={dependenciesSuccessTextFn}
         />
-      ) : operation.type === 'checkRequirements' ? (
+      ) : operation.type === 'checkRequirementsPreParse' ||
+        operation.type === 'checkRequirementsPostParse' ? (
         operation.children.map((childOperation) => (
           <OperationLine
             key={childOperation.id ?? childOperation.type}
@@ -97,9 +96,6 @@ const dependenciesSuccessFn = (op: ImportFetchDependency) =>
   op.result === ImportOperationResult.Success
 const dependenciesSuccessTextFn = (successCount: number) =>
   `${successCount} dependencies fetched successfully`
-const requirementsSuccessFn = (op: ImportCheckRequirementAndFix) =>
-  op.resolution === RequirementResolutionResult.Passed
-const requirementsSuccessTextFn = (successCount: number) => `${successCount} requirements met`
 
 function AggregatedChildrenStatus<T extends ImportOperation>({
   childOperations,
@@ -255,7 +251,7 @@ function getImportOperationText(operation: ImportOperation): React.ReactNode {
       if (operation.branchName != null) {
         return (
           <span>
-            Loading branch{' '}
+            Fetching branch{' '}
             <strong>
               {operation.githubRepo?.owner}/{operation.githubRepo?.repository}@
               {operation.branchName}
@@ -265,7 +261,7 @@ function getImportOperationText(operation: ImportOperation): React.ReactNode {
       } else {
         return (
           <span>
-            Loading repository{' '}
+            Fetching repository{' '}
             <strong>
               {operation.githubRepo?.owner}/{operation.githubRepo?.repository}
             </strong>
@@ -278,9 +274,13 @@ function getImportOperationText(operation: ImportOperation): React.ReactNode {
       return 'Parsing files'
     case 'refreshDependencies':
       return 'Fetching dependencies'
-    case 'checkRequirements':
+    case 'checkRequirementsPreParse':
+      return 'Validating code'
+    case 'checkRequirementsPostParse':
       return 'Checking Utopia requirements'
-    case 'checkRequirementAndFix':
+    case 'checkRequirementAndFixPreParse':
+      return operation.text
+    case 'checkRequirementAndFixPostParse':
       return operation.text
     default:
       assertNever(operation)

--- a/editor/src/components/editor/import-wizard/import-wizard.tsx
+++ b/editor/src/components/editor/import-wizard/import-wizard.tsx
@@ -78,7 +78,7 @@ export const ImportWizard = React.memo(() => {
             boxShadow: UtopiaStyles.popup.boxShadow,
             borderRadius: 10,
             width: 600,
-            height: 450,
+            height: 480,
             position: 'relative',
             display: 'flex',
             flexDirection: 'column',

--- a/editor/src/components/editor/import-wizard/import-wizard.tsx
+++ b/editor/src/components/editor/import-wizard/import-wizard.tsx
@@ -100,7 +100,7 @@ export const ImportWizard = React.memo(() => {
               flex: 'none',
             }}
           >
-            <div css={{ fontSize: 16, fontWeight: 400 }}>Loading Project</div>
+            <div css={{ fontSize: 16, fontWeight: 400 }}>Cloning Project</div>
           </FlexRow>
           <div
             className='import-wizard-body'

--- a/editor/src/components/editor/import-wizard/import-wizard.tsx
+++ b/editor/src/components/editor/import-wizard/import-wizard.tsx
@@ -41,12 +41,6 @@ export const ImportWizard = React.memo(() => {
 
   const operations = importState.importOperations
 
-  const dispatch = useDispatch()
-
-  const handleDismiss = React.useCallback(() => {
-    hideImportWizard(dispatch)
-  }, [dispatch])
-
   const stopPropagation = React.useCallback((e: React.MouseEvent) => {
     e.stopPropagation()
   }, [])
@@ -107,19 +101,6 @@ export const ImportWizard = React.memo(() => {
             }}
           >
             <div css={{ fontSize: 16, fontWeight: 400 }}>Loading Project</div>
-            {when(
-              totalImportResult.importStatus.status === 'in-progress',
-              <Button
-                highlight
-                style={{
-                  padding: 15,
-                  color: colorTheme.fg6.value,
-                }}
-                onClick={handleDismiss}
-              >
-                Cancel
-              </Button>,
-            )}
           </FlexRow>
           <div
             className='import-wizard-body'

--- a/editor/src/components/editor/import-wizard/import-wizard.tsx
+++ b/editor/src/components/editor/import-wizard/import-wizard.tsx
@@ -238,33 +238,44 @@ function ActionButtons({ importResult }: { importResult: TotalImportResult }) {
       </React.Fragment>
     )
   }
-  if (
-    importResult.result == ImportOperationResult.Error ||
-    importResult.result == ImportOperationResult.CriticalError
-  ) {
+  if (importResult.result == ImportOperationResult.CriticalError) {
+    return (
+      <React.Fragment>
+        <div style={textStyle}>Error Importing Project</div>
+        <Button style={{ ...buttonStyle, marginLeft: 'auto' }} onClick={importADifferentProject}>
+          Cancel
+        </Button>
+      </React.Fragment>
+    )
+  }
+  if (importResult.result == ImportOperationResult.Error) {
     return (
       <React.Fragment>
         <div style={textStyle}>
-          {importResult.importStatus.status !== 'done' ||
-          importResult.result === ImportOperationResult.CriticalError
-            ? 'Error Importing Project'
+          {importResult.importStatus.status !== 'done'
+            ? 'Error While Importing Project'
             : 'Project Imported With Errors'}
         </div>
-        <Button style={{ ...buttonStyle, marginLeft: 'auto' }} onClick={importADifferentProject}>
-          Import A Different Project
-        </Button>
-        {unless(
-          importResult.result == ImportOperationResult.CriticalError,
+        {when(
+          importResult.importStatus.status !== 'done',
           <Button
             style={{
               cursor: 'pointer',
+              marginLeft: 'auto',
             }}
             onClick={continueAnyway}
           >
-            {importResult.importStatus.status === 'done'
-              ? 'Continue To Editor'
-              : 'Continue Importing'}
+            Continue Anyway
           </Button>,
+        )}
+        {importResult.importStatus.status === 'done' ? (
+          <Button style={{ ...buttonStyle }} onClick={hideWizard}>
+            Continue To Editor
+          </Button>
+        ) : (
+          <Button style={{ ...buttonStyle }} onClick={importADifferentProject}>
+            Cancel
+          </Button>
         )}
       </React.Fragment>
     )

--- a/editor/src/components/editor/import-wizard/import-wizard.tsx
+++ b/editor/src/components/editor/import-wizard/import-wizard.tsx
@@ -199,67 +199,66 @@ function ActionButtons({ importResult }: { importResult: TotalImportResult }) {
   ) {
     return null
   }
-  if (importResult.result == ImportOperationResult.Success) {
-    return (
-      <React.Fragment>
-        <div style={textStyle}>Project Imported Successfully</div>
-        <Button onClick={hideWizard} style={buttonStyle}>
-          Continue To Editor
-        </Button>
-      </React.Fragment>
-    )
-  }
-  if (importResult.result == ImportOperationResult.Warn) {
-    return (
-      <React.Fragment>
-        <div style={textStyle}>Project Imported With Warnings</div>
-        <Button onClick={hideWizard} style={buttonStyle}>
-          Continue To Editor
-        </Button>
-      </React.Fragment>
-    )
-  }
-  if (importResult.result == ImportOperationResult.CriticalError) {
-    return (
-      <React.Fragment>
-        <div style={textStyle}>Error Importing Project</div>
-        <Button style={{ ...buttonStyle, marginLeft: 'auto' }} onClick={importADifferentProject}>
-          Cancel
-        </Button>
-      </React.Fragment>
-    )
-  }
-  if (importResult.result == ImportOperationResult.Error) {
-    return (
-      <React.Fragment>
-        <div style={textStyle}>
-          {importResult.importStatus.status !== 'done'
-            ? 'Error While Importing Project'
-            : 'Project Imported With Errors'}
-        </div>
-        {when(
-          importResult.importStatus.status !== 'done',
-          <Button
-            style={{
-              cursor: 'pointer',
-              marginLeft: 'auto',
-            }}
-            onClick={continueAnyway}
-          >
-            Continue Anyway
-          </Button>,
-        )}
-        {importResult.importStatus.status === 'done' ? (
-          <Button style={{ ...buttonStyle }} onClick={hideWizard}>
+  switch (importResult.result) {
+    case ImportOperationResult.Success:
+      return (
+        <React.Fragment>
+          <div style={textStyle}>Project Imported Successfully</div>
+          <Button onClick={hideWizard} style={buttonStyle}>
             Continue To Editor
           </Button>
-        ) : (
-          <Button style={{ ...buttonStyle }} onClick={importADifferentProject}>
+        </React.Fragment>
+      )
+    case ImportOperationResult.Warn:
+      return (
+        <React.Fragment>
+          <div style={textStyle}>Project Imported With Warnings</div>
+          <Button onClick={hideWizard} style={buttonStyle}>
+            Continue To Editor
+          </Button>
+        </React.Fragment>
+      )
+    case ImportOperationResult.CriticalError:
+      return (
+        <React.Fragment>
+          <div style={textStyle}>Error Importing Project</div>
+          <Button style={{ ...buttonStyle, marginLeft: 'auto' }} onClick={importADifferentProject}>
             Cancel
           </Button>
-        )}
-      </React.Fragment>
-    )
+        </React.Fragment>
+      )
+    case ImportOperationResult.Error:
+      return (
+        <React.Fragment>
+          <div style={textStyle}>
+            {importResult.importStatus.status !== 'done'
+              ? 'Error While Importing Project'
+              : 'Project Imported With Errors'}
+          </div>
+          {when(
+            importResult.importStatus.status !== 'done',
+            <Button
+              style={{
+                cursor: 'pointer',
+                marginLeft: 'auto',
+              }}
+              onClick={continueAnyway}
+            >
+              Continue Anyway
+            </Button>,
+          )}
+          {importResult.importStatus.status === 'done' ? (
+            <Button style={{ ...buttonStyle }} onClick={hideWizard}>
+              Continue To Editor
+            </Button>
+          ) : (
+            <Button style={{ ...buttonStyle }} onClick={importADifferentProject}>
+              Cancel
+            </Button>
+          )}
+        </React.Fragment>
+      )
+    default:
+      assertNever(importResult.result)
   }
-  return null
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -191,13 +191,13 @@ import type { FancyError } from '../../../core/shared/code-exec-utils'
 import type { GridCellCoordinates } from '../../canvas/canvas-strategies/strategies/grid-cell-bounds'
 import {
   emptyImportState,
-  type ImportOperation,
   type ImportState,
 } from '../../../core/shared/import/import-operation-types'
 import {
   emptyProjectRequirements,
   type ProjectRequirements,
 } from '../../../core/shared/import/project-health-check/utopia-requirements-types'
+import { isFeatureEnabled } from '../../../utils/feature-switches'
 
 const ObjectPathImmutable: any = OPI
 
@@ -362,6 +362,8 @@ export function githubOperationLocksEditor(op: GithubOperation): boolean {
     case 'loadRepositories':
     case 'listPullRequestsForBranch':
       return false
+    case 'loadBranch':
+      return !isFeatureEnabled('Import Wizard')
     default:
       return true
   }

--- a/editor/src/core/shared/github/operations/load-branch.ts
+++ b/editor/src/core/shared/github/operations/load-branch.ts
@@ -52,6 +52,8 @@ import {
 import {
   RequirementResolutionResult,
   resetRequirementsResolutions,
+  startPostParseValidation,
+  startPreParseValidation,
 } from '../../import/project-health-check/utopia-requirements-service'
 import {
   checkAndFixUtopiaRequirementsParsed,
@@ -189,8 +191,9 @@ export const updateProjectWithBranchContent =
             }
             notifyOperationFinished(dispatch, { type: 'loadBranch' }, ImportOperationResult.Success)
 
+            // pre parse validation
             resetRequirementsResolutions(dispatch)
-
+            startPreParseValidation(dispatch)
             const {
               fixedProjectContents: projectContents,
               result: preParsedRequirementResolutionResult,
@@ -199,6 +202,8 @@ export const updateProjectWithBranchContent =
               // wait for the user to resume the import if they choose to
               await pauseImport(dispatch)
             }
+
+            // parse files
             notifyOperationStarted(dispatch, { type: 'parseFiles' })
             // Push any code through the parser so that the representations we end up with are in a state of `BOTH_MATCH`.
             // So that it will override any existing files that might already exist in the project when sending them to VS Code.
@@ -208,10 +213,11 @@ export const updateProjectWithBranchContent =
             )
             notifyOperationFinished(dispatch, { type: 'parseFiles' }, ImportOperationResult.Success)
 
-            const { fixedProjectContents, result: requirementResolutionResult } =
+            // post parse validation
+            startPostParseValidation(dispatch)
+            const { fixedProjectContents, result: postParsedRequirementResolutionResult } =
               checkAndFixUtopiaRequirementsParsed(dispatch, parseResults)
-
-            if (requirementResolutionResult === RequirementResolutionResult.Critical) {
+            if (postParsedRequirementResolutionResult === RequirementResolutionResult.Critical) {
               // wait for the user to resume the import if they choose to
               await pauseImport(dispatch)
             }

--- a/editor/src/core/shared/import/import-operation-service.ts
+++ b/editor/src/core/shared/import/import-operation-service.ts
@@ -22,8 +22,9 @@ export function startImportProcess(dispatch: EditorDispatch) {
     updateImportOperations(
       [
         { type: 'loadBranch' },
-        { type: 'checkRequirements' },
+        { type: 'checkRequirementsPreParse' },
         { type: 'parseFiles' },
+        { type: 'checkRequirementsPostParse' },
         { type: 'refreshDependencies' },
       ],
       ImportOperationAction.Replace,
@@ -80,7 +81,8 @@ export function areSameOperation(existing: ImportOperation, incoming: ImportOper
 }
 
 export const defaultParentTypes: Partial<Record<ImportOperationType, ImportOperationType>> = {
-  checkRequirementAndFix: 'checkRequirements',
+  checkRequirementAndFixPreParse: 'checkRequirementsPreParse',
+  checkRequirementAndFixPostParse: 'checkRequirementsPostParse',
   fetchDependency: 'refreshDependencies',
 } as const
 

--- a/editor/src/core/shared/import/import-operation-service.ts
+++ b/editor/src/core/shared/import/import-operation-service.ts
@@ -22,8 +22,8 @@ export function startImportProcess(dispatch: EditorDispatch) {
     updateImportOperations(
       [
         { type: 'loadBranch' },
-        { type: 'parseFiles' },
         { type: 'checkRequirements' },
+        { type: 'parseFiles' },
         { type: 'refreshDependencies' },
       ],
       ImportOperationAction.Replace,

--- a/editor/src/core/shared/import/import-operation-types.ts
+++ b/editor/src/core/shared/import/import-operation-types.ts
@@ -43,26 +43,48 @@ type ImportParseFiles = {
   type: 'parseFiles'
 } & ImportOperationData
 
-export type ImportCheckRequirementAndFix = ImportOperationData & {
-  type: 'checkRequirementAndFix'
+export type ImportCheckRequirementAndFixPostParse = ImportOperationData & {
+  type: 'checkRequirementAndFixPostParse'
   resolution?: RequirementResolutionResult
   text: string
   id: string
 }
 
-export function importCheckRequirementAndFix(
+export function importCheckRequirementAndFixPostParse(
   id: string,
   text: string,
-): ImportCheckRequirementAndFix {
+): ImportCheckRequirementAndFixPostParse {
   return {
-    type: 'checkRequirementAndFix',
+    type: 'checkRequirementAndFixPostParse',
     text: text,
     id: id,
   }
 }
 
-type ImportCheckRequirements = ImportOperationData & {
-  type: 'checkRequirements'
+export type ImportCheckRequirementAndFixPreParse = ImportOperationData & {
+  type: 'checkRequirementAndFixPreParse'
+  resolution?: RequirementResolutionResult
+  text: string
+  id: string
+}
+
+export function importCheckRequirementAndFixPreParse(
+  id: string,
+  text: string,
+): ImportCheckRequirementAndFixPreParse {
+  return {
+    type: 'checkRequirementAndFixPreParse',
+    text: text,
+    id: id,
+  }
+}
+
+type ImportCheckRequirementsPostParse = ImportOperationData & {
+  type: 'checkRequirementsPostParse'
+}
+
+type ImportCheckRequirementsPreParse = ImportOperationData & {
+  type: 'checkRequirementsPreParse'
 }
 
 export type ImportOperation =
@@ -70,8 +92,10 @@ export type ImportOperation =
   | ImportRefreshDependencies
   | ImportParseFiles
   | ImportFetchDependency
-  | ImportCheckRequirementAndFix
-  | ImportCheckRequirements
+  | ImportCheckRequirementAndFixPreParse
+  | ImportCheckRequirementAndFixPostParse
+  | ImportCheckRequirementsPreParse
+  | ImportCheckRequirementsPostParse
 
 export type ImportOperationType = ImportOperation['type']
 

--- a/editor/src/core/shared/import/project-health-check/check-utopia-requirements.ts
+++ b/editor/src/core/shared/import/project-health-check/check-utopia-requirements.ts
@@ -18,10 +18,10 @@ let requirementsToChecks: Record<ProjectRequirement, RequirementCheck> | undefin
 export function getChecks(): Record<ProjectRequirement, RequirementCheck> {
   if (requirementsToChecks == null) {
     requirementsToChecks = {
-      storyboard: new CheckStoryboard(),
       packageJsonEntries: new CheckPackageJson(),
       language: new CheckLanguage(),
       reactVersion: new CheckReactVersion(),
+      storyboard: new CheckStoryboard(),
       serverPackages: new CheckServerPackages(),
     }
   }

--- a/editor/src/core/shared/import/project-health-check/check-utopia-requirements.ts
+++ b/editor/src/core/shared/import/project-health-check/check-utopia-requirements.ts
@@ -5,26 +5,17 @@ import CheckLanguage from './requirements/requirement-language'
 import CheckReactVersion from './requirements/requirement-react'
 import { RequirementResolutionResult } from './utopia-requirements-types'
 import type {
-  PostParseValidationRequirement,
-  PreParseValidationRequirement,
   ProjectRequirement,
   RequirementCheck,
+  RequirementCheckStage,
+  RequirementsByStage,
 } from './utopia-requirements-types'
 import { notifyCheckingRequirement, notifyResolveRequirement } from './utopia-requirements-service'
 import CheckStoryboard from './requirements/requirement-storyboard'
 import CheckServerPackages from './requirements/requirement-server-packages'
 
-let requirementsToCheck:
-  | {
-      preParse: Record<PreParseValidationRequirement, RequirementCheck>
-      postParse: Record<PostParseValidationRequirement, RequirementCheck>
-    }
-  | undefined
-
-export function getRequirementsToCheck(): {
-  preParse: Record<PreParseValidationRequirement, RequirementCheck>
-  postParse: Record<PostParseValidationRequirement, RequirementCheck>
-} {
+let requirementsToCheck: RequirementsByStage | undefined
+export function getRequirementsToCheck(): RequirementsByStage {
   if (requirementsToCheck == null) {
     requirementsToCheck = {
       preParse: {
@@ -59,7 +50,7 @@ export function checkAndFixUtopiaRequirementsParsed(
   )
 }
 
-export function getRequirementStage(requirement: ProjectRequirement): 'preParse' | 'postParse' {
+export function getRequirementStage(requirement: ProjectRequirement): RequirementCheckStage {
   if (requirement in getRequirementsToCheck().preParse) {
     return 'preParse'
   }

--- a/editor/src/core/shared/import/project-health-check/requirements/requirement-language.ts
+++ b/editor/src/core/shared/import/project-health-check/requirements/requirement-language.ts
@@ -1,5 +1,4 @@
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
-import type { RequirementCheckStage } from '../utopia-requirements-types'
 import {
   RequirementResolutionResult,
   type RequirementCheck,
@@ -8,7 +7,7 @@ import {
 import { applyToAllUIJSFiles } from '../../../../model/project-file-utils'
 
 export default class CheckProjectLanguage implements RequirementCheck {
-  stage: RequirementCheckStage = 'pre-parsed'
+  initialText = 'Checking project language'
   check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
     let jsCount = 0
     let tsCount = 0

--- a/editor/src/core/shared/import/project-health-check/requirements/requirement-language.ts
+++ b/editor/src/core/shared/import/project-health-check/requirements/requirement-language.ts
@@ -1,4 +1,5 @@
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
+import type { RequirementCheckStage } from '../utopia-requirements-types'
 import {
   RequirementResolutionResult,
   type RequirementCheck,
@@ -7,6 +8,7 @@ import {
 import { applyToAllUIJSFiles } from '../../../../model/project-file-utils'
 
 export default class CheckProjectLanguage implements RequirementCheck {
+  stage: RequirementCheckStage = 'pre-parsed'
   check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
     let jsCount = 0
     let tsCount = 0

--- a/editor/src/core/shared/import/project-health-check/requirements/requirement-package-json.ts
+++ b/editor/src/core/shared/import/project-health-check/requirements/requirement-package-json.ts
@@ -1,12 +1,17 @@
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
 import { RevisionsState } from 'utopia-shared/src/types'
 import { getPackageJson } from '../../../../../components/assets'
-import type { RequirementCheck, RequirementCheckResult } from '../utopia-requirements-types'
+import type {
+  RequirementCheck,
+  RequirementCheckResult,
+  RequirementCheckStage,
+} from '../utopia-requirements-types'
 import { RequirementResolutionResult } from '../utopia-requirements-types'
 import { addFileToProjectContents } from '../../../../../components/assets'
 import { codeFile } from '../../../../../core/shared/project-file-types'
 
 export default class PackageJsonCheckAndFix implements RequirementCheck {
+  stage: RequirementCheckStage = 'pre-parsed'
   check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
     const parsedPackageJson = getPackageJson(projectContents)
     if (parsedPackageJson == null) {

--- a/editor/src/core/shared/import/project-health-check/requirements/requirement-package-json.ts
+++ b/editor/src/core/shared/import/project-health-check/requirements/requirement-package-json.ts
@@ -1,17 +1,13 @@
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
 import { RevisionsState } from 'utopia-shared/src/types'
 import { getPackageJson } from '../../../../../components/assets'
-import type {
-  RequirementCheck,
-  RequirementCheckResult,
-  RequirementCheckStage,
-} from '../utopia-requirements-types'
+import type { RequirementCheck, RequirementCheckResult } from '../utopia-requirements-types'
 import { RequirementResolutionResult } from '../utopia-requirements-types'
 import { addFileToProjectContents } from '../../../../../components/assets'
 import { codeFile } from '../../../../../core/shared/project-file-types'
 
 export default class PackageJsonCheckAndFix implements RequirementCheck {
-  stage: RequirementCheckStage = 'pre-parsed'
+  initialText = 'Checking for a valid package.json'
   check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
     const parsedPackageJson = getPackageJson(projectContents)
     if (parsedPackageJson == null) {

--- a/editor/src/core/shared/import/project-health-check/requirements/requirement-react.ts
+++ b/editor/src/core/shared/import/project-health-check/requirements/requirement-react.ts
@@ -1,5 +1,4 @@
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
-import type { RequirementCheckStage } from '../utopia-requirements-types'
 import {
   RequirementResolutionResult,
   type RequirementCheck,
@@ -11,7 +10,7 @@ import { getProjectDependencies } from '../../../../../components/assets'
 const SUPPORTED_REACT_VERSION_RANGE = '16.8.0 - 18.x'
 
 export default class CheckReactRequirement implements RequirementCheck {
-  stage: RequirementCheckStage = 'pre-parsed'
+  initialText = 'Checking React version'
   check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
     const projectDependencies = getProjectDependencies(projectContents)
     const reactVersion = projectDependencies?.react

--- a/editor/src/core/shared/import/project-health-check/requirements/requirement-react.ts
+++ b/editor/src/core/shared/import/project-health-check/requirements/requirement-react.ts
@@ -1,4 +1,5 @@
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
+import type { RequirementCheckStage } from '../utopia-requirements-types'
 import {
   RequirementResolutionResult,
   type RequirementCheck,
@@ -10,6 +11,7 @@ import { getProjectDependencies } from '../../../../../components/assets'
 const SUPPORTED_REACT_VERSION_RANGE = '16.8.0 - 18.x'
 
 export default class CheckReactRequirement implements RequirementCheck {
+  stage: RequirementCheckStage = 'pre-parsed'
   check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
     const projectDependencies = getProjectDependencies(projectContents)
     const reactVersion = projectDependencies?.react

--- a/editor/src/core/shared/import/project-health-check/requirements/requirement-server-packages.ts
+++ b/editor/src/core/shared/import/project-health-check/requirements/requirement-server-packages.ts
@@ -1,5 +1,4 @@
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
-import type { RequirementCheckStage } from '../utopia-requirements-types'
 import {
   RequirementResolutionResult,
   type RequirementCheck,
@@ -12,7 +11,7 @@ import builtinModules from './builtin-modules.json'
 const serverPackagesRestrictionList: RegExp[] = [/^next/, /^remix/, /^astro/, /^svelte/]
 
 export default class CheckServerPackages implements RequirementCheck {
-  stage: RequirementCheckStage = 'parsed'
+  initialText = 'Checking for server packages'
   check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
     const projectDependencies = getProjectDependencies(projectContents) ?? {}
 

--- a/editor/src/core/shared/import/project-health-check/requirements/requirement-server-packages.ts
+++ b/editor/src/core/shared/import/project-health-check/requirements/requirement-server-packages.ts
@@ -23,7 +23,7 @@ export default class CheckServerPackages implements RequirementCheck {
     if (serverPackages.length > 0) {
       return {
         resolution: RequirementResolutionResult.Critical,
-        resultText: 'Server packages found',
+        resultText: 'Unsupported server packages found',
         resultValue: serverPackages.join(', '),
       }
     }

--- a/editor/src/core/shared/import/project-health-check/requirements/requirement-server-packages.ts
+++ b/editor/src/core/shared/import/project-health-check/requirements/requirement-server-packages.ts
@@ -1,4 +1,5 @@
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
+import type { RequirementCheckStage } from '../utopia-requirements-types'
 import {
   RequirementResolutionResult,
   type RequirementCheck,
@@ -11,6 +12,7 @@ import builtinModules from './builtin-modules.json'
 const serverPackagesRestrictionList: RegExp[] = [/^next/, /^remix/, /^astro/, /^svelte/]
 
 export default class CheckServerPackages implements RequirementCheck {
+  stage: RequirementCheckStage = 'parsed'
   check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
     const projectDependencies = getProjectDependencies(projectContents) ?? {}
 

--- a/editor/src/core/shared/import/project-health-check/requirements/requirement-storyboard.ts
+++ b/editor/src/core/shared/import/project-health-check/requirements/requirement-storyboard.ts
@@ -1,5 +1,5 @@
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
-import type { RequirementCheckResult, RequirementCheckStage } from '../utopia-requirements-types'
+import type { RequirementCheckResult } from '../utopia-requirements-types'
 import { RequirementResolutionResult } from '../utopia-requirements-types'
 import type { RequirementCheck } from '../utopia-requirements-types'
 import { defaultEither } from '../../../../../core/shared/either'
@@ -13,7 +13,7 @@ import { codeFile } from '../../../../../core/shared/project-file-types'
 import { addStoryboardFileToProject } from '../../../../../core/model/storyboard-utils'
 
 export default class CheckStoryboard implements RequirementCheck {
-  stage: RequirementCheckStage = 'parsed'
+  initialText = 'Checking storyboard.js'
   check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
     return createStoryboardFileIfNecessaryInner(projectContents)
   }

--- a/editor/src/core/shared/import/project-health-check/requirements/requirement-storyboard.ts
+++ b/editor/src/core/shared/import/project-health-check/requirements/requirement-storyboard.ts
@@ -13,7 +13,7 @@ import { codeFile } from '../../../../../core/shared/project-file-types'
 import { addStoryboardFileToProject } from '../../../../../core/model/storyboard-utils'
 
 export default class CheckStoryboard implements RequirementCheck {
-  stage: RequirementCheckStage = 'pre-parsed'
+  stage: RequirementCheckStage = 'parsed'
   check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
     return createStoryboardFileIfNecessaryInner(projectContents)
   }

--- a/editor/src/core/shared/import/project-health-check/requirements/requirement-storyboard.ts
+++ b/editor/src/core/shared/import/project-health-check/requirements/requirement-storyboard.ts
@@ -1,5 +1,5 @@
 import type { ProjectContentTreeRoot } from 'utopia-shared/src/types'
-import type { RequirementCheckResult } from '../utopia-requirements-types'
+import type { RequirementCheckResult, RequirementCheckStage } from '../utopia-requirements-types'
 import { RequirementResolutionResult } from '../utopia-requirements-types'
 import type { RequirementCheck } from '../utopia-requirements-types'
 import { defaultEither } from '../../../../../core/shared/either'
@@ -13,6 +13,7 @@ import { codeFile } from '../../../../../core/shared/project-file-types'
 import { addStoryboardFileToProject } from '../../../../../core/model/storyboard-utils'
 
 export default class CheckStoryboard implements RequirementCheck {
+  stage: RequirementCheckStage = 'pre-parsed'
   check(projectContents: ProjectContentTreeRoot): RequirementCheckResult {
     return createStoryboardFileIfNecessaryInner(projectContents)
   }

--- a/editor/src/core/shared/import/project-health-check/utopia-requirements-service.ts
+++ b/editor/src/core/shared/import/project-health-check/utopia-requirements-service.ts
@@ -6,12 +6,7 @@ import {
 import { notifyOperationFinished, notifyOperationStarted } from '../import-operation-service'
 import type { EditorDispatch } from '../../../../components/editor/action-types'
 import { updateProjectRequirements } from '../../../../components/editor/actions/action-creators'
-import type {
-  PostParseValidationRequirement,
-  PreParseValidationRequirement,
-  ProjectRequirement,
-  ProjectRequirements,
-} from './utopia-requirements-types'
+import type { ProjectRequirement, ProjectRequirements } from './utopia-requirements-types'
 import {
   emptyProjectRequirements,
   RequirementResolutionResult,
@@ -19,7 +14,7 @@ import {
 } from './utopia-requirements-types'
 import { isFeatureEnabled } from '../../../../utils/feature-switches'
 import { getRequirementStage, getRequirementsToCheck } from './check-utopia-requirements'
-import { objectFilter } from '../../object-utils'
+import { objectFilter, objectKeys } from '../../object-utils'
 
 export function updateProjectRequirementsStatus(
   dispatch: EditorDispatch,
@@ -42,11 +37,8 @@ export function startPreParseValidation(dispatch: EditorDispatch) {
   const checks = getRequirementsToCheck().preParse
   notifyOperationStarted(dispatch, {
     type: 'checkRequirementsPreParse',
-    children: Object.keys(checks).map((key) =>
-      importCheckRequirementAndFixPreParse(
-        key as ProjectRequirement,
-        checks[key as PreParseValidationRequirement].initialText,
-      ),
+    children: objectKeys(checks).map((key) =>
+      importCheckRequirementAndFixPreParse(key, checks[key].initialText),
     ),
   })
 }
@@ -55,11 +47,8 @@ export function startPostParseValidation(dispatch: EditorDispatch) {
   const checks = getRequirementsToCheck().postParse
   notifyOperationStarted(dispatch, {
     type: 'checkRequirementsPostParse',
-    children: Object.keys(checks).map((key) =>
-      importCheckRequirementAndFixPostParse(
-        key as ProjectRequirement,
-        checks[key as PostParseValidationRequirement].initialText,
-      ),
+    children: objectKeys(checks).map((key) =>
+      importCheckRequirementAndFixPostParse(key, checks[key].initialText),
     ),
   })
 }

--- a/editor/src/core/shared/import/project-health-check/utopia-requirements-service.ts
+++ b/editor/src/core/shared/import/project-health-check/utopia-requirements-service.ts
@@ -8,9 +8,7 @@ import type { EditorDispatch } from '../../../../components/editor/action-types'
 import { updateProjectRequirements } from '../../../../components/editor/actions/action-creators'
 import type {
   PostParseValidationRequirement,
-  PostParseValidationRequirements,
   PreParseValidationRequirement,
-  PreParseValidationRequirements,
   ProjectRequirement,
   ProjectRequirements,
 } from './utopia-requirements-types'

--- a/editor/src/core/shared/import/project-health-check/utopia-requirements-service.ts
+++ b/editor/src/core/shared/import/project-health-check/utopia-requirements-service.ts
@@ -1,22 +1,27 @@
-import { importCheckRequirementAndFix, ImportOperationResult } from '../import-operation-types'
+import {
+  importCheckRequirementAndFixPostParse,
+  importCheckRequirementAndFixPreParse,
+  ImportOperationResult,
+} from '../import-operation-types'
 import { notifyOperationFinished, notifyOperationStarted } from '../import-operation-service'
 import type { EditorDispatch } from '../../../../components/editor/action-types'
 import { updateProjectRequirements } from '../../../../components/editor/actions/action-creators'
-import type { ProjectRequirement, ProjectRequirements } from './utopia-requirements-types'
+import type {
+  PostParseValidationRequirement,
+  PostParseValidationRequirements,
+  PreParseValidationRequirement,
+  PreParseValidationRequirements,
+  ProjectRequirement,
+  ProjectRequirements,
+} from './utopia-requirements-types'
 import {
   emptyProjectRequirements,
   RequirementResolutionResult,
   RequirementResolutionStatus,
 } from './utopia-requirements-types'
 import { isFeatureEnabled } from '../../../../utils/feature-switches'
-
-export const initialTexts: Record<ProjectRequirement, string> = {
-  packageJsonEntries: 'Checking for a valid package.json',
-  language: 'Checking project language',
-  reactVersion: 'Checking React version',
-  storyboard: 'Checking storyboard.js',
-  serverPackages: 'Checking for server packages',
-}
+import { getRequirementStage, getRequirementsToCheck } from './check-utopia-requirements'
+import { objectFilter } from '../../object-utils'
 
 export function updateProjectRequirementsStatus(
   dispatch: EditorDispatch,
@@ -33,12 +38,29 @@ export function updateProjectRequirementsStatus(
 export function resetRequirementsResolutions(dispatch: EditorDispatch) {
   let projectRequirements = emptyProjectRequirements()
   updateProjectRequirementsStatus(dispatch, projectRequirements)
+}
+
+export function startPreParseValidation(dispatch: EditorDispatch) {
+  const checks = getRequirementsToCheck().preParse
   notifyOperationStarted(dispatch, {
-    type: 'checkRequirements',
-    children: Object.keys(projectRequirements).map((key) =>
-      importCheckRequirementAndFix(
+    type: 'checkRequirementsPreParse',
+    children: Object.keys(checks).map((key) =>
+      importCheckRequirementAndFixPreParse(
         key as ProjectRequirement,
-        initialTexts[key as ProjectRequirement],
+        checks[key as PreParseValidationRequirement].initialText,
+      ),
+    ),
+  })
+}
+
+export function startPostParseValidation(dispatch: EditorDispatch) {
+  const checks = getRequirementsToCheck().postParse
+  notifyOperationStarted(dispatch, {
+    type: 'checkRequirementsPostParse',
+    children: Object.keys(checks).map((key) =>
+      importCheckRequirementAndFixPostParse(
+        key as ProjectRequirement,
+        checks[key as PostParseValidationRequirement].initialText,
       ),
     ),
   })
@@ -49,13 +71,15 @@ export function notifyCheckingRequirement(
   requirement: ProjectRequirement,
   text: string,
 ) {
+  const stage = getRequirementStage(requirement)
   updateProjectRequirementsStatus(dispatch, {
     [requirement]: {
       status: RequirementResolutionStatus.Pending,
     },
   })
   notifyOperationStarted(dispatch, {
-    type: 'checkRequirementAndFix',
+    type:
+      stage === 'preParse' ? 'checkRequirementAndFixPreParse' : 'checkRequirementAndFixPostParse',
     id: requirement,
     text: text,
   })
@@ -68,6 +92,7 @@ export function notifyResolveRequirement(
   text: string,
   value?: string,
 ) {
+  const stage = getRequirementStage(requirementName)
   updateProjectRequirementsStatus(dispatch, {
     [requirementName]: {
       status: RequirementResolutionStatus.Done,
@@ -85,7 +110,8 @@ export function notifyResolveRequirement(
   notifyOperationFinished(
     dispatch,
     {
-      type: 'checkRequirementAndFix',
+      type:
+        stage === 'preParse' ? 'checkRequirementAndFixPreParse' : 'checkRequirementAndFixPostParse',
       id: requirementName,
       text: text,
       resolution: resolution,
@@ -99,35 +125,63 @@ export function updateRequirements(
   existingRequirements: ProjectRequirements,
   incomingRequirements: Partial<ProjectRequirements>,
 ): ProjectRequirements {
-  let result = { ...existingRequirements }
+  let requirements = { ...existingRequirements }
   for (const incomingRequirement of Object.keys(incomingRequirements)) {
     const incomingRequirementName = incomingRequirement as ProjectRequirement
-    result[incomingRequirementName] = {
-      ...result[incomingRequirementName],
+    requirements[incomingRequirementName] = {
+      ...requirements[incomingRequirementName],
       ...incomingRequirements[incomingRequirementName],
     }
   }
 
-  const aggregatedDoneStatus = getAggregatedStatus(result)
-  if (aggregatedDoneStatus != null) {
-    notifyOperationFinished(dispatch, { type: 'checkRequirements' }, aggregatedDoneStatus)
+  notifyAggregatedResult(dispatch, incomingRequirements)
+
+  return requirements
+}
+
+function notifyAggregatedResult(
+  dispatch: EditorDispatch,
+  incomingRequirements: Partial<ProjectRequirements>,
+): void {
+  const incomingPreParseRequirements = objectFilter(
+    (_, key) => getRequirementStage(key as ProjectRequirement) === 'preParse',
+    incomingRequirements,
+  )
+  if (Object.keys(incomingPreParseRequirements).length > 0) {
+    const aggregatedStatus = getAggregatedStatus(incomingPreParseRequirements)
+    if (aggregatedStatus != null) {
+      notifyOperationFinished(dispatch, { type: 'checkRequirementsPreParse' }, aggregatedStatus)
+    }
   }
 
-  return result
+  const incomingPostParseRequirements = objectFilter(
+    (_, key) => getRequirementStage(key as ProjectRequirement) === 'postParse',
+    incomingRequirements,
+  )
+  if (Object.keys(incomingPostParseRequirements).length > 0) {
+    const aggregatedStatus = getAggregatedStatus(incomingPostParseRequirements)
+    if (aggregatedStatus != null) {
+      notifyOperationFinished(dispatch, { type: 'checkRequirementsPostParse' }, aggregatedStatus)
+    }
+  }
 }
 
 function getAggregatedStatus(
-  requirementsResolutions: ProjectRequirements,
+  requirementsResolutions: Partial<ProjectRequirements>,
 ): ImportOperationResult | null {
   for (const resolution of Object.values(requirementsResolutions)) {
-    if (resolution.status != RequirementResolutionStatus.Done) {
-      return null
-    }
     if (resolution.resolution == RequirementResolutionResult.Critical) {
       return ImportOperationResult.Error
     }
+  }
+  for (const resolution of Object.values(requirementsResolutions)) {
     if (resolution.resolution == RequirementResolutionResult.Partial) {
       return ImportOperationResult.Warn
+    }
+  }
+  for (const resolution of Object.values(requirementsResolutions)) {
+    if (resolution.status != RequirementResolutionStatus.Done) {
+      return null
     }
   }
   return ImportOperationResult.Success

--- a/editor/src/core/shared/import/project-health-check/utopia-requirements-service.ts
+++ b/editor/src/core/shared/import/project-health-check/utopia-requirements-service.ts
@@ -11,10 +11,10 @@ import {
 import { isFeatureEnabled } from '../../../../utils/feature-switches'
 
 export const initialTexts: Record<ProjectRequirement, string> = {
-  storyboard: 'Checking storyboard.js',
   packageJsonEntries: 'Checking for a valid package.json',
   language: 'Checking project language',
   reactVersion: 'Checking React version',
+  storyboard: 'Checking storyboard.js',
   serverPackages: 'Checking for server packages',
 }
 

--- a/editor/src/core/shared/import/project-health-check/utopia-requirements-types.ts
+++ b/editor/src/core/shared/import/project-health-check/utopia-requirements-types.ts
@@ -59,14 +59,20 @@ export function requirementResolution(
   }
 }
 
-export interface ProjectRequirements {
+export type PreParseValidationRequirements = {
   packageJsonEntries: RequirementResolution
   language: RequirementResolution
   reactVersion: RequirementResolution
+}
+export type PreParseValidationRequirement = keyof PreParseValidationRequirements
+
+export type PostParseValidationRequirements = {
   storyboard: RequirementResolution
   serverPackages: RequirementResolution
 }
+export type PostParseValidationRequirement = keyof PostParseValidationRequirements
 
+export type ProjectRequirements = PreParseValidationRequirements & PostParseValidationRequirements
 export type ProjectRequirement = keyof ProjectRequirements
 
 export function newProjectRequirements(
@@ -93,8 +99,8 @@ export interface RequirementCheckResult {
 }
 
 export interface RequirementCheck {
+  initialText: string
   check: (projectContents: ProjectContentTreeRoot) => RequirementCheckResult
-  stage: RequirementCheckStage
 }
 
 export type RequirementCheckStage = 'pre-parsed' | 'parsed'

--- a/editor/src/core/shared/import/project-health-check/utopia-requirements-types.ts
+++ b/editor/src/core/shared/import/project-health-check/utopia-requirements-types.ts
@@ -103,4 +103,8 @@ export interface RequirementCheck {
   check: (projectContents: ProjectContentTreeRoot) => RequirementCheckResult
 }
 
-export type RequirementCheckStage = 'pre-parsed' | 'parsed'
+export type RequirementCheckStage = 'preParse' | 'postParse'
+export type RequirementsByStage = {
+  preParse: Record<PreParseValidationRequirement, RequirementCheck>
+  postParse: Record<PostParseValidationRequirement, RequirementCheck>
+}

--- a/editor/src/core/shared/import/project-health-check/utopia-requirements-types.ts
+++ b/editor/src/core/shared/import/project-health-check/utopia-requirements-types.ts
@@ -94,4 +94,7 @@ export interface RequirementCheckResult {
 
 export interface RequirementCheck {
   check: (projectContents: ProjectContentTreeRoot) => RequirementCheckResult
+  stage: RequirementCheckStage
 }
+
+export type RequirementCheckStage = 'pre-parsed' | 'parsed'

--- a/editor/src/core/shared/import/project-health-check/utopia-requirements-types.ts
+++ b/editor/src/core/shared/import/project-health-check/utopia-requirements-types.ts
@@ -60,27 +60,27 @@ export function requirementResolution(
 }
 
 export interface ProjectRequirements {
-  storyboard: RequirementResolution
   packageJsonEntries: RequirementResolution
   language: RequirementResolution
   reactVersion: RequirementResolution
+  storyboard: RequirementResolution
   serverPackages: RequirementResolution
 }
 
 export type ProjectRequirement = keyof ProjectRequirements
 
 export function newProjectRequirements(
-  storyboard: RequirementResolution,
   packageJsonEntries: RequirementResolution,
   language: RequirementResolution,
   reactVersion: RequirementResolution,
+  storyboard: RequirementResolution,
   serverPackages: RequirementResolution,
 ): ProjectRequirements {
   return {
-    storyboard,
     packageJsonEntries,
     language,
     reactVersion,
+    storyboard,
     serverPackages,
   }
 }

--- a/editor/src/core/shared/object-utils.ts
+++ b/editor/src/core/shared/object-utils.ts
@@ -209,8 +209,7 @@ export function mergeObjects<T, U>(
 export type SimpleObject<T> = { [key: string]: T } & { [Symbol.iterator]?: never }
 
 export function objectValues<T>(object: { [key: string]: T }): Array<T> {
-  const objectKeys = Object.keys(object)
-  return objectKeys.map((key) => object[key])
+  return Object.keys(object).map((key) => object[key])
 }
 
 export function isEmptyObject(obj: SimpleObject<any>): boolean {
@@ -293,4 +292,8 @@ export function objectContainsAllKeys<T extends MapLike<any>>(
   keys: Array<keyof T>,
 ): boolean {
   return keys.every((key) => objectContainsKey(obj, key))
+}
+
+export function objectKeys<T extends MapLike<any>>(obj: T): Array<keyof T> {
+  return Object.keys(obj) as Array<keyof T>
 }


### PR DESCRIPTION
This PR splits the validation checks to allow an early break before parsing the files.
In the UI they are split to these phases:
- **Validating code** (which are actually the pre-parse validations)
- Parse files (as today)
- **Checking Utopia requirements** (which are the post-parse validations)

**Details:**
1. The requirements are still aggregated in the editor state, but they are separated to phases for running as well as for displaying in the wizard ([see the separation here](https://github.com/concrete-utopia/utopia/pull/6618/files#diff-15c53165ea0f64ccf6f092783f2dce88639666dd1f4fd29e46035dc96ca4f2b3R20-R30)).
2. Main changes are in [editor/src/core/shared/import/project-health-check/utopia-requirements-service.ts](https://github.com/concrete-utopia/utopia/pull/6618/files#diff-9691feb390abe09b4d2b2aca374b464cf8bcb91a10942f8f6f07a2b4e9355fa6), where the split actually happens (`startPreParseValidation` and `startPostParseValidation`).
3. Renaming the requirement phases added changes in several other files, but they are simply refactors.
4. Minor - we also remove the shimmer when pausing the wizard (to make it clearer that the import has stopped).

See here - first a successful project and then one with errors:
<video src="https://github.com/user-attachments/assets/a907fe6b-68be-44a9-8a01-7e951ed90001"></video>

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Play mode
