### PR TITLE
Include border widths when measuring grid templates for controls

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
+++ b/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
@@ -7,7 +7,7 @@ import { isStaticGridRepeat, printGridAutoOrTemplateBase } from '../../inspector
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../core/shared/array-utils'
 import * as EP from '../../../core/shared/element-path'
-import type { ElementInstanceMetadata } from '../../../core/shared/element-template'
+import type { BorderWidths, ElementInstanceMetadata } from '../../../core/shared/element-template'
 import { type GridAutoOrTemplateBase } from '../../../core/shared/element-template'
 import type { CanvasRectangle } from '../../../core/shared/math-utils'
 import { isFiniteRectangle } from '../../../core/shared/math-utils'
@@ -76,6 +76,7 @@ export type GridMeasurementHelperData = {
   padding: Sides
   columns: number
   cells: number
+  border: BorderWidths
 }
 
 export function useGridMeasurentHelperData(
@@ -117,6 +118,7 @@ export function useGridMeasurentHelperData(
         padding: targetGridContainer.specialSizeMeasurements.padding,
         columns: columns,
         cells: rows * columns,
+        border: targetGridContainer.specialSizeMeasurements.borderWidths,
       }
     },
     'useGridMeasurentHelperData',
@@ -194,6 +196,7 @@ export function useGridData(elementPaths: ElementPath[]): GridData[] {
           rows: rows,
           columns: columns,
           cells: rows * columns,
+          border: targetGridContainer.specialSizeMeasurements.borderWidths,
         }
       }, elementPaths)
     },

--- a/editor/src/components/canvas/controls/grid-controls-helpers.ts
+++ b/editor/src/components/canvas/controls/grid-controls-helpers.ts
@@ -21,6 +21,10 @@ export function getGridHelperStyleMatchingTargetGrid(
       grid.padding == null
         ? 0
         : `${grid.padding.top}px ${grid.padding.right}px ${grid.padding.bottom}px ${grid.padding.left}px`,
+    borderTop: `${grid.border?.top}px solid transparent`,
+    borderLeft: `${grid.border?.left}px solid transparent`,
+    borderBottom: `${grid.border?.bottom}px solid transparent`,
+    borderRight: `${grid.border?.right}px solid transparent`,
   }
 
   // Gap needs to be set only if the other two are not present or we'll have rendering issues

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -10,6 +10,7 @@ import type {
   GridElementProperties,
   DomElementMetadata,
   GridAutoOrTemplateBase,
+  BorderWidths,
 } from '../../core/shared/element-template'
 import {
   specialSizeMeasurements,
@@ -803,7 +804,7 @@ function getSpecialMeasurements(
   const borderRightWidth = parseCSSLength(elementStyle.borderRightWidth)
   const borderBottomWidth = parseCSSLength(elementStyle.borderBottomWidth)
   const borderLeftWidth = parseCSSLength(elementStyle.borderLeftWidth)
-  const border = {
+  const border: BorderWidths = {
     top: isRight(borderTopWidth) ? borderTopWidth.value.value : 0,
     right: isRight(borderRightWidth) ? borderRightWidth.value.value : 0,
     bottom: isRight(borderBottomWidth) ? borderBottomWidth.value.value : 0,
@@ -1015,6 +1016,7 @@ function getSpecialMeasurements(
     parentGridCellGlobalFrames,
     justifySelf,
     alignSelf,
+    border,
   )
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -151,6 +151,7 @@ import type {
   GridAutoOrTemplateBase,
   GridAutoOrTemplateDimensions,
   GridAutoOrTemplateFallback,
+  BorderWidths,
 } from '../../../core/shared/element-template'
 import {
   elementInstanceMetadata,
@@ -2178,6 +2179,20 @@ export function GridElementPropertiesKeepDeepEquality(): KeepDeepEqualityCall<Gr
   )
 }
 
+export function BorderWidthsKeepDeepEquality(): KeepDeepEqualityCall<BorderWidths> {
+  return combine4EqualityCalls(
+    (p) => p.bottom,
+    NumberKeepDeepEquality,
+    (p) => p.left,
+    NumberKeepDeepEquality,
+    (p) => p.right,
+    NumberKeepDeepEquality,
+    (p) => p.top,
+    NumberKeepDeepEquality,
+    (bottom, left, right, top) => ({ bottom, left, right, top }),
+  )
+}
+
 export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<SpecialSizeMeasurements> {
   return (oldSize, newSize) => {
     const offsetResult = LocalPointKeepDeepEquality(oldSize.offset, newSize.offset)
@@ -2298,6 +2313,11 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       arrayDeepEquality(arrayDeepEquality(CanvasRectangleKeepDeepEquality)),
     )(oldSize.gridCellGlobalFrames, newSize.gridCellGlobalFrames).areEqual
 
+    const borderWidthsEqual = BorderWidthsKeepDeepEquality()(
+      oldSize.borderWidths,
+      newSize.borderWidths,
+    ).areEqual
+
     const areEqual =
       offsetResult.areEqual &&
       coordinateSystemBoundsResult.areEqual &&
@@ -2352,7 +2372,8 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
       justifySelfEquals &&
       alignSelfEquals &&
       gridCellGlobalFramesEqual &&
-      parentGridCellGlobalFramesEqual
+      parentGridCellGlobalFramesEqual &&
+      borderWidthsEqual
     if (areEqual) {
       return keepDeepEqualityResult(oldSize, true)
     } else {
@@ -2412,6 +2433,7 @@ export function SpecialSizeMeasurementsKeepDeepEquality(): KeepDeepEqualityCall<
         newSize.parentGridCellGlobalFrames,
         newSize.justifySelf,
         newSize.alignSelf,
+        newSize.borderWidths,
       )
       return keepDeepEqualityResult(sizeMeasurements, false)
     }

--- a/editor/src/core/shared/element-template.ts
+++ b/editor/src/core/shared/element-template.ts
@@ -2783,6 +2783,13 @@ export function gridElementProperties(
   }
 }
 
+export type BorderWidths = {
+  top: number
+  right: number
+  bottom: number
+  left: number
+}
+
 export interface SpecialSizeMeasurements {
   offset: LocalPoint
   coordinateSystemBounds: CanvasRectangle | null
@@ -2839,6 +2846,7 @@ export interface SpecialSizeMeasurements {
   columnGap: number | null
   gridCellGlobalFrames: GridCellGlobalFrames | null
   parentGridCellGlobalFrames: GridCellGlobalFrames | null
+  borderWidths: BorderWidths
 }
 
 export function specialSizeMeasurements(
@@ -2897,6 +2905,7 @@ export function specialSizeMeasurements(
   parentGridCellGlobalFrames: GridCellGlobalFrames | null,
   justifySelf: SelfAlignment | null,
   alignSelf: SelfAlignment | null,
+  borderWidths: BorderWidths,
 ): SpecialSizeMeasurements {
   return {
     offset,
@@ -2954,6 +2963,7 @@ export function specialSizeMeasurements(
     parentGridCellGlobalFrames,
     justifySelf,
     alignSelf,
+    borderWidths,
   }
 }
 
@@ -3050,6 +3060,12 @@ export const emptySpecialSizeMeasurements = specialSizeMeasurements(
   null,
   null,
   null,
+  {
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
 )
 
 export function walkElement(


### PR DESCRIPTION
**Problem:**

Border width is not taken into account when calculating grid template measurements, which results in the grid placeholders being misplaced.

**Fix:**

Include the border widths in the special size measurements and use them (transparent) for the grid placeholder styles.

Fixes #6619 