### PR TITLE
Disallow changing location for components which do not support style props

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-element-change-location-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-element-change-location-strategy.spec.browser2.tsx
@@ -1011,6 +1011,35 @@ export var storyboard = (
           data-uid='aaa'
           data-testid='aaa'
         />
+        <div
+          style={{
+            minHeight: 0,
+            backgroundColor: '#23565b',
+          }}
+          data-uid='bbb'
+          data-testid='bbb'
+        />
+        <Placeholder
+          style={{
+            minHeight: 0,
+            gridColumnEnd: 5,
+            gridRowEnd: 4,
+            gridColumnStart: 1,
+            gridRowStart: 3,
+            backgroundColor: '#0074ff',
+          }}
+          data-uid='ccc'
+        />
+        <Placeholder
+          style={{
+            minHeight: 0,
+            gridColumnEnd: 9,
+            gridRowEnd: 4,
+            gridColumnStart: 5,
+            gridRowStart: 3,
+          }}
+          data-uid='ddd'
+        />
       </div>
     </Scene>
   </Storyboard>

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-element-change-location-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-element-change-location-strategy.spec.browser2.tsx
@@ -999,7 +999,7 @@ export var storyboard = (
         }}
         data-uid='grid'
       >
-        <Item
+        <div
           style={{
             minHeight: 0,
             backgroundColor: '#f3785f',

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-move-rearrange-duplicate-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-move-rearrange-duplicate-strategy.ts
@@ -51,7 +51,17 @@ export const gridMoveRearrangeDuplicateStrategy: CanvasStrategyFactory = (
     canvasState.startingMetadata,
     selectedElement,
   )
-  if (selectedElementMetadata == null) {
+  if (
+    selectedElementMetadata == null ||
+    !MetadataUtils.targetRegisteredStyleControlsOrHonoursStyleProps(
+      canvasState.projectContents,
+      selectedElementMetadata,
+      canvasState.propertyControlsInfo,
+      'layout',
+      ['gridRow', 'gridColumn', 'gridRowStart', 'gridColumnStart', 'gridRowEnd', 'gridColumnEnd'],
+      'some',
+    )
+  ) {
     return null
   }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-move-rearrange-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-move-rearrange-strategy.ts
@@ -58,9 +58,20 @@ export const gridMoveRearrangeStrategy: CanvasStrategyFactory = (
     canvasState.startingMetadata,
     selectedElement,
   )
-  if (selectedElementMetadata == null) {
+  if (
+    selectedElementMetadata == null ||
+    !MetadataUtils.targetRegisteredStyleControlsOrHonoursStyleProps(
+      canvasState.projectContents,
+      selectedElementMetadata,
+      canvasState.propertyControlsInfo,
+      'layout',
+      ['gridRow', 'gridColumn', 'gridRowStart', 'gridColumnStart', 'gridRowEnd', 'gridColumnEnd'],
+      'some',
+    )
+  ) {
     return null
   }
+
   const initialTemplates = getParentGridTemplatesFromChildMeasurements(
     selectedElementMetadata.specialSizeMeasurements,
   )

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-move-rearrange-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-move-rearrange-strategy.ts
@@ -66,7 +66,7 @@ export const gridMoveRearrangeStrategy: CanvasStrategyFactory = (
       canvasState.propertyControlsInfo,
       'layout',
       ['gridRow', 'gridColumn', 'gridRowStart', 'gridColumnStart', 'gridRowEnd', 'gridColumnEnd'],
-      'some',
+      'every',
     )
   ) {
     return null


### PR DESCRIPTION
**Problem:**
When a grid contains component items which do not support style props:
- changing location should be disabled, because we can not attach the gridRow*, gridColumn* props on the component
- reorder should still work, because that just modifies the order of the grid items as siblings

**Fix:**
I used MetadataUtils.targetRegisteredStyleControlsOrHonoursStyleProps to decide if a component supports the necessary grid placement style props:
- if `layout` inspector section is enabled in the component annotations, we should allow changing location
- if  gridRow/gridColumn/etc props are taken by the component, then we should allow changing location
- reorder does not need any constrains, it does not depend on style props

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

