### PR TITLE
Direct grid lookup.

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
+++ b/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
@@ -53,7 +53,11 @@ import {
 import { applicative4Either, defaultEither, isRight, mapEither } from '../../../core/shared/either'
 import { domRectToScaledCanvasRectangle, getRoundingFn } from '../../../core/shared/dom-utils'
 import Utils from '../../../utils/utils'
-import { useMonitorChangesToElements } from '../../../components/editor/store/store-monitor'
+import {
+  useMonitorChangesToEditor,
+  useMonitorChangesToElements,
+} from '../../../components/editor/store/store-monitor'
+import { useKeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
 
 export const GridCellTestId = (elementPath: ElementPath) => `grid-cell-${EP.toString(elementPath)}`
 
@@ -196,18 +200,18 @@ export function gridMeasurementHelperDataFromElement(
   }
 }
 
-export function useGridMeasurentHelperData(
+export function useGridMeasurementHelperData(
   elementPath: ElementPath,
 ): GridMeasurementHelperData | undefined {
   const scale = useEditorState(
     Substores.canvas,
     (store) => store.editor.canvas.scale,
-    'useGridMeasurentHelperData scale',
+    'useGridMeasurementHelperData scale',
   )
 
-  useMonitorChangesToElements([elementPath])
+  useMonitorChangesToEditor()
 
-  return getGridMeasurementHelperData(elementPath, scale)
+  return useKeepReferenceEqualityIfPossible(getGridMeasurementHelperData(elementPath, scale))
 }
 
 export type GridData = GridMeasurementHelperData & {
@@ -220,8 +224,6 @@ export function useGridData(elementPaths: ElementPath[]): GridData[] {
     (store) => store.editor.canvas.scale,
     'useGridData scale',
   )
-
-  useMonitorChangesToElements(elementPaths)
 
   const grids = useEditorState(
     Substores.metadata,
@@ -257,7 +259,7 @@ export function useGridData(elementPaths: ElementPath[]): GridData[] {
     'useGridData',
   )
 
-  return grids
+  return useKeepReferenceEqualityIfPossible(grids)
 }
 
 interface GridRowColumnResizingControlsProps {

--- a/editor/src/components/canvas/controls/grid-controls-helpers.ts
+++ b/editor/src/components/canvas/controls/grid-controls-helpers.ts
@@ -1,26 +1,18 @@
 import type { CSSProperties } from 'react'
 import type { GridMeasurementHelperData } from './grid-controls-for-strategies'
-import { getNullableAutoOrTemplateBaseString } from './grid-controls-for-strategies'
 
 export function getGridHelperStyleMatchingTargetGrid(
   grid: GridMeasurementHelperData,
 ): CSSProperties {
   let style: CSSProperties = {
+    ...grid.computedStyling,
     position: 'absolute',
     top: grid.frame.y,
     left: grid.frame.x,
     width: grid.frame.width,
     height: grid.frame.height,
     display: 'grid',
-    gridTemplateColumns: getNullableAutoOrTemplateBaseString(grid.gridTemplateColumns),
-    gridTemplateRows: getNullableAutoOrTemplateBaseString(grid.gridTemplateRows),
-    justifyContent: grid.justifyContent ?? 'initial',
-    alignContent: grid.alignContent ?? 'initial',
     pointerEvents: 'none',
-    padding:
-      grid.padding == null
-        ? 0
-        : `${grid.padding.top}px ${grid.padding.right}px ${grid.padding.bottom}px ${grid.padding.left}px`,
     borderTop: `${grid.border?.top}px solid transparent`,
     borderLeft: `${grid.border?.left}px solid transparent`,
     borderBottom: `${grid.border?.bottom}px solid transparent`,
@@ -32,16 +24,7 @@ export function getGridHelperStyleMatchingTargetGrid(
   if (grid.rowGap != null && grid.columnGap != null) {
     style.rowGap = grid.rowGap
     style.columnGap = grid.columnGap
-  } else {
-    if (grid.gap != null) {
-      style.gap = grid.gap
-    }
-    if (grid.rowGap != null) {
-      style.rowGap = grid.rowGap
-    }
-    if (grid.columnGap != null) {
-      style.columnGap = grid.columnGap
-    }
+    delete style['gap']
   }
 
   return style

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -366,12 +366,6 @@ interface GridResizingProps {
 }
 
 const GridResizing = React.memo((props: GridResizingProps) => {
-  const canvasScale = useEditorState(
-    Substores.canvasOffset,
-    (store) => store.editor.canvas.scale,
-    'GridResizing canvasScale',
-  )
-
   const fromProps = React.useMemo((): GridAutoOrTemplateDimensions | null => {
     if (props.fromPropsAxisValues?.type !== 'DIMENSIONS') {
       return null
@@ -1058,7 +1052,6 @@ export interface GridMeasurementHelperProps {
 
 const GridMeasurementHelper = React.memo<{ elementPath: ElementPath }>(({ elementPath }) => {
   const gridData = useGridMeasurentHelperData(elementPath)
-
   if (gridData == null) {
     return null
   }

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -361,8 +361,8 @@ interface GridResizingProps {
   axis: Axis
   gap: number | null
   padding: Sides | null
-  justifyContent: string | null
-  alignContent: string | null
+  justifyContent: string | undefined
+  alignContent: string | undefined
 }
 
 const GridResizing = React.memo((props: GridResizingProps) => {
@@ -588,8 +588,8 @@ export const GridRowColumnResizingControlsComponent = ({
               getStripedAreaLength(grid.gridTemplateRows, grid.rowGap ?? grid.gap ?? 0) ??
               grid.frame.height
             }
-            alignContent={grid.justifyContent}
-            justifyContent={grid.alignContent}
+            alignContent={grid.computedStyling.justifyContent}
+            justifyContent={grid.computedStyling.alignContent}
           />
         )
       })}
@@ -608,8 +608,8 @@ export const GridRowColumnResizingControlsComponent = ({
               getStripedAreaLength(grid.gridTemplateColumns, grid.columnGap ?? grid.gap ?? 0) ??
               grid.frame.width
             }
-            alignContent={grid.alignContent}
-            justifyContent={grid.justifyContent}
+            alignContent={grid.computedStyling.alignContent}
+            justifyContent={grid.computedStyling.justifyContent}
           />
         )
       })}

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -104,7 +104,7 @@ import {
   GridMeasurementHelperKey,
   GridMeasurementHelpersKey,
   useGridData,
-  useGridMeasurentHelperData,
+  useGridMeasurementHelperData,
 } from './grid-controls-for-strategies'
 import { useMaybeHighlightElement } from './select-mode/select-mode-hooks'
 import { useResizeEdges } from './select-mode/use-resize-edges'
@@ -1051,7 +1051,7 @@ export interface GridMeasurementHelperProps {
 }
 
 const GridMeasurementHelper = React.memo<{ elementPath: ElementPath }>(({ elementPath }) => {
-  const gridData = useGridMeasurentHelperData(elementPath)
+  const gridData = useGridMeasurementHelperData(elementPath)
   if (gridData == null) {
     return null
   }
@@ -1895,7 +1895,7 @@ export interface GridElementContainingBlockProps {
 }
 
 const GridElementContainingBlock = React.memo<GridElementContainingBlockProps>((props) => {
-  const gridData = useGridMeasurentHelperData(props.gridPath)
+  const gridData = useGridMeasurementHelperData(props.gridPath)
   const scale = useEditorState(
     Substores.canvas,
     (store) => store.editor.canvas.scale,

--- a/editor/src/components/canvas/controls/select-mode/grid-gap-control-component.tsx
+++ b/editor/src/components/canvas/controls/select-mode/grid-gap-control-component.tsx
@@ -198,8 +198,8 @@ export const GridPaddingOutlineForDimension = (props: {
             beingDragged={beingDragged}
             onMouseOver={onMouseOver}
             elementHovered={elementHovered}
-            gridJustifyContent={grid.justifyContent}
-            gridAlignContent={grid.alignContent}
+            gridJustifyContent={grid.computedStyling.justifyContent}
+            gridAlignContent={grid.computedStyling.alignContent}
             draggedOutlineColor={draggedOutlineColor}
           />
         )
@@ -220,8 +220,8 @@ const GridRowOrColumnHighlight = (props: {
   beingDragged: boolean
   onMouseOver: () => void
   elementHovered: boolean
-  gridJustifyContent: FlexJustifyContent | null
-  gridAlignContent: AlignContent | null
+  gridJustifyContent: string | undefined
+  gridAlignContent: string | undefined
   draggedOutlineColor?: UtopiColor
 }) => {
   const {

--- a/editor/src/components/canvas/direct-dom-lookups.ts
+++ b/editor/src/components/canvas/direct-dom-lookups.ts
@@ -3,53 +3,26 @@ import { CanvasContainerID } from './canvas-types'
 import { getDeepestPathOnDomElement } from '../../core/shared/uid-utils'
 import * as EP from '../../core/shared/element-path'
 import type { ElementPath } from 'utopia-shared/src/types'
-import type { SimpleRectangle } from '../../core/shared/math-utils'
 
-// Figure out how to include elements to be watched.
-// Figure out how to remove elements from being watched.
+export type FromElement<T> = (element: HTMLElement) => T
 
-// Do the update lazily when it is requested.
-// Have a function which clears the cache, which we trigger from the dispatch flow?
-// Probably best if the above works with elements to re-render?
-
-interface ComputedStyleAndBoundingRect {
-  computedStyle: CSSStyleDeclaration
-  boundingRectangle: SimpleRectangle
-}
-
-let elementComputedStylesAndBoundingRects: { [path: string]: ComputedStyleAndBoundingRect | null } =
-  {}
-
-export function clearComputedStylesAndBoundingRects(): void {
-  elementComputedStylesAndBoundingRects = {}
-}
-
-export function getComputedStyleAndBoundingRectFromElement(
-  path: ElementPath,
-): ComputedStyleAndBoundingRect | undefined {
+export function getFromElement<T>(path: ElementPath, fromElement: FromElement<T>): T | undefined {
   const pathString = EP.toString(path)
-  if (!(pathString in elementComputedStylesAndBoundingRects)) {
-    const elements = document.querySelectorAll(
-      `#${CanvasContainerID} [${UTOPIA_PATH_KEY}="${pathString}"]`,
-    )
-    for (const elementKey in elements) {
-      if (elements.hasOwnProperty(elementKey)) {
-        const element = elements[elementKey]
-        const pathFromElement = getDeepestPathOnDomElement(element)
-        if (EP.pathsEqual(path, pathFromElement)) {
-          const boundingRect = element.getBoundingClientRect()
-          elementComputedStylesAndBoundingRects[pathString] = {
-            computedStyle: window.getComputedStyle(element),
-            boundingRectangle: {
-              x: boundingRect.x,
-              y: boundingRect.y,
-              width: boundingRect.width,
-              height: boundingRect.height,
-            },
-          }
-        }
+  const elements = document.querySelectorAll(
+    `#${CanvasContainerID} [${UTOPIA_PATH_KEY}^="${pathString}"]`,
+  )
+  for (const element of Array.from(elements)) {
+    const pathFromElement = getDeepestPathOnDomElement(element)
+    if (
+      (EP.pathsEqual(path, pathFromElement) &&
+        pathFromElement != null &&
+        !EP.isRootElementOfInstance(pathFromElement)) ||
+      EP.isRootElementOf(pathFromElement, path)
+    ) {
+      if (element instanceof HTMLElement) {
+        return fromElement(element)
       }
     }
   }
-  return elementComputedStylesAndBoundingRects[pathString] ?? undefined
+  return undefined
 }

--- a/editor/src/components/canvas/direct-dom-lookups.ts
+++ b/editor/src/components/canvas/direct-dom-lookups.ts
@@ -1,0 +1,55 @@
+import { UTOPIA_PATH_KEY } from '../../core/model/utopia-constants'
+import { CanvasContainerID } from './canvas-types'
+import { getDeepestPathOnDomElement } from '../../core/shared/uid-utils'
+import * as EP from '../../core/shared/element-path'
+import type { ElementPath } from 'utopia-shared/src/types'
+import type { SimpleRectangle } from '../../core/shared/math-utils'
+
+// Figure out how to include elements to be watched.
+// Figure out how to remove elements from being watched.
+
+// Do the update lazily when it is requested.
+// Have a function which clears the cache, which we trigger from the dispatch flow?
+// Probably best if the above works with elements to re-render?
+
+interface ComputedStyleAndBoundingRect {
+  computedStyle: CSSStyleDeclaration
+  boundingRectangle: SimpleRectangle
+}
+
+let elementComputedStylesAndBoundingRects: { [path: string]: ComputedStyleAndBoundingRect | null } =
+  {}
+
+export function clearComputedStylesAndBoundingRects(): void {
+  elementComputedStylesAndBoundingRects = {}
+}
+
+export function getComputedStyleAndBoundingRectFromElement(
+  path: ElementPath,
+): ComputedStyleAndBoundingRect | undefined {
+  const pathString = EP.toString(path)
+  if (!(pathString in elementComputedStylesAndBoundingRects)) {
+    const elements = document.querySelectorAll(
+      `#${CanvasContainerID} [${UTOPIA_PATH_KEY}="${pathString}"]`,
+    )
+    for (const elementKey in elements) {
+      if (elements.hasOwnProperty(elementKey)) {
+        const element = elements[elementKey]
+        const pathFromElement = getDeepestPathOnDomElement(element)
+        if (EP.pathsEqual(path, pathFromElement)) {
+          const boundingRect = element.getBoundingClientRect()
+          elementComputedStylesAndBoundingRects[pathString] = {
+            computedStyle: window.getComputedStyle(element),
+            boundingRectangle: {
+              x: boundingRect.x,
+              y: boundingRect.y,
+              width: boundingRect.width,
+              height: boundingRect.height,
+            },
+          }
+        }
+      }
+    }
+  }
+  return elementComputedStylesAndBoundingRects[pathString] ?? undefined
+}

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -152,7 +152,12 @@ function isElementAContainingBlockForAbsolute(computedStyle: CSSStyleDeclaration
   return false
 }
 
-const applicativeSidesPxTransform = (t: CSSNumber, r: CSSNumber, b: CSSNumber, l: CSSNumber) =>
+export const applicativeSidesPxTransform = (
+  t: CSSNumber,
+  r: CSSNumber,
+  b: CSSNumber,
+  l: CSSNumber,
+) =>
   sides(
     t.unit === 'px' ? t.value : undefined,
     r.unit === 'px' ? r.value : undefined,
@@ -559,7 +564,7 @@ export function collectDomElementMetadataForElement(
   )
 }
 
-function getGridContainerProperties(
+export function getGridContainerProperties(
   elementStyle: CSSStyleDeclaration | null,
   options?: {
     dynamicCols: boolean
@@ -1020,7 +1025,7 @@ function getSpecialMeasurements(
   )
 }
 
-function isDynamicGridTemplate(template: GridAutoOrTemplateBase | null) {
+export function isDynamicGridTemplate(template: GridAutoOrTemplateBase | null) {
   return template?.type === 'DIMENSIONS' && template.dimensions.some((d) => isDynamicGridRepeat(d))
 }
 

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -921,8 +921,6 @@ function getSpecialMeasurements(
     globalFrame,
   )
 
-  const parentContainerGridProperties = getGridContainerProperties(parentElementStyle)
-
   const paddingValue = isRight(padding)
     ? padding.value
     : sides(undefined, undefined, undefined, undefined)
@@ -954,6 +952,7 @@ function getSpecialMeasurements(
     dynamicRows: isDynamicGridTemplate(containerGridPropertiesFromProps.gridTemplateRows),
   })
 
+  const parentContainerGridProperties = getGridContainerProperties(parentElementStyle)
   const containerElementPropertiesFromProps = getGridElementProperties(
     parentContainerGridProperties,
     element.style,

--- a/editor/src/components/editor/store/store-monitor.ts
+++ b/editor/src/components/editor/store/store-monitor.ts
@@ -1,0 +1,23 @@
+import type { ElementPath } from 'utopia-shared/src/types'
+import { Substores, useEditorState } from './store-hook'
+import { mapDropNulls } from '../../../core/shared/array-utils'
+import { withUnderlyingTarget } from './editor-state'
+
+export function useMonitorChangesToElements(elementPaths: Array<ElementPath>): void {
+  useEditorState(
+    Substores.projectContents,
+    (store) => {
+      return mapDropNulls((elementPath) => {
+        return withUnderlyingTarget(
+          elementPath,
+          store.editor.projectContents,
+          null,
+          (_, element) => {
+            return element
+          },
+        )
+      }, elementPaths)
+    },
+    'useMonitorChangesToElements elements',
+  )
+}

--- a/editor/src/components/editor/store/store-monitor.ts
+++ b/editor/src/components/editor/store/store-monitor.ts
@@ -18,6 +18,16 @@ export function useMonitorChangesToElements(elementPaths: Array<ElementPath>): v
         )
       }, elementPaths)
     },
-    'useMonitorChangesToElements elements',
+    'useMonitorChangesToElements',
+  )
+}
+
+export function useMonitorChangesToEditor(): void {
+  useEditorState(
+    Substores.fullStore,
+    (store) => {
+      return { editor: store.editor, derived: store.derived }
+    },
+    'useMonitorChangesToEditor',
   )
 }


### PR DESCRIPTION
**Problem:**
Currently with the grid controls there is a 1-frame behind problem, where they will always render one frame after their respective grids. This is because they get their data from the DOM walker which in turn relies on the rendered content of the canvas.

**Fix:**
Rather than relying on the metadata that comes from the DOM walker, this moves the lookups to be directly called by the controls themselves. The two hooks `useGridData` and `useGridMeasurementHelperData` mostly got the same information from the metadata and that data is now obtained by `gridMeasurementHelperDataFromElement`. Which is supported by `getFromElement`.

As the re-render triggering has been lost because it's not connected to the metadata, this PR adds `useMonitorChangesToElements` as a way to regain that re-render triggering.

**Commit Details:**
- Moved some fields from `GridData` up to `GridMeasurementHelperData`.
- Implemented `gridMeasurementHelperDataFromElement` and `getGridMeasurementHelperData`, which perform the calculations needed by the controls.
- `useGridMeasurementHelperData` now reimplemented to use `getGridMeasurementHelperData`.
- `useGridData` now reimplemented to use `getGridMeasurementHelperData`.
- Implemented `getFromElement` as a hopefully reusable function for similar solutions.
- Implemented `useMonitorChangesToElements` as a solution for how to trigger the re-renders.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode
