### PR TITLE
Make `AdjustCssLengthProperties` style prop-agnostic

### DIFF
--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -576,17 +576,37 @@ export function maybePropertyValue<T>(property: CSSStyleProperty<T>): T | null {
 }
 
 export type FlexGapInfo = CSSStyleProperty<CSSNumber>
-
 export type FlexDirectionInfo = CSSStyleProperty<FlexDirection>
+export type LeftInfo = CSSStyleProperty<CSSNumber>
+export type RightInfo = CSSStyleProperty<CSSNumber>
+export type TopInfo = CSSStyleProperty<CSSNumber>
+export type BottomInfo = CSSStyleProperty<CSSNumber>
+export type WidthInfo = CSSStyleProperty<CSSNumber>
+export type HeightInfo = CSSStyleProperty<CSSNumber>
+export type FlexBasisInfo = CSSStyleProperty<CSSNumber>
 
 export interface StyleInfo {
   gap: FlexGapInfo | null
   flexDirection: FlexDirectionInfo | null
+  left: LeftInfo | null
+  right: RightInfo | null
+  top: TopInfo | null
+  bottom: BottomInfo | null
+  width: WidthInfo | null
+  height: HeightInfo | null
+  flexBasis: FlexBasisInfo | null
 }
 
 const emptyStyleInfo: StyleInfo = {
   gap: null,
   flexDirection: null,
+  left: null,
+  right: null,
+  top: null,
+  bottom: null,
+  width: null,
+  height: null,
+  flexBasis: null,
 }
 
 export const isStyleInfoKey = (key: string): key is keyof StyleInfo => key in emptyStyleInfo

--- a/editor/src/components/canvas/commands/adjust-css-length-command.ts
+++ b/editor/src/components/canvas/commands/adjust-css-length-command.ts
@@ -15,15 +15,19 @@ import type { InteractionLifecycle } from '../canvas-strategies/canvas-strategy-
 
 export type CreateIfNotExistant = 'create-if-not-existing' | 'do-not-create-if-doesnt-exist'
 
+type LengthProperty = 'left' | 'right' | 'bottom' | 'top' | 'width' | 'height' | 'flexBasis'
+
+type LengthPropertyPath = PropertyPath<['style', LengthProperty]>
+
 export interface LengthPropertyToAdjust {
-  property: PropertyPath
+  property: LengthPropertyPath
   valuePx: number
   parentDimensionPx: number | undefined
   createIfNonExistant: CreateIfNotExistant
 }
 
 export function lengthPropertyToAdjust(
-  property: PropertyPath,
+  property: LengthPropertyPath,
   valuePx: number,
   parentDimensionPx: number | undefined,
   createIfNonExistant: CreateIfNotExistant,

--- a/editor/src/components/canvas/commands/adjust-css-length-command.ts
+++ b/editor/src/components/canvas/commands/adjust-css-length-command.ts
@@ -1,29 +1,17 @@
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
-import type { Either } from '../../../core/shared/either'
-import { foldEither, isLeft, isRight, left, mapEither } from '../../../core/shared/either'
 import * as EP from '../../../core/shared/element-path'
-import type { JSXAttributes, JSXElement } from '../../../core/shared/element-template'
-import {
-  emptyComments,
-  isJSXElement,
-  jsExpressionValue,
-} from '../../../core/shared/element-template'
-import type { ValueAtPath } from '../../../core/shared/jsx-attributes'
-import { setJSXValuesAtPaths, unsetJSXValuesAtPaths } from '../../../core/shared/jsx-attributes'
-import {
-  getModifiableJSXAttributeAtPath,
-  jsxSimpleAttributeToValue,
-} from '../../../core/shared/jsx-attribute-utils'
 import { roundTo, roundToNearestWhole } from '../../../core/shared/math-utils'
 import type { ElementPath, PropertyPath } from '../../../core/shared/project-file-types'
 import * as PP from '../../../core/shared/property-path'
 import type { EditorState } from '../../editor/store/editor-state'
-import { modifyUnderlyingForOpenFile } from '../../editor/store/editor-state'
 import type { CSSNumber, FlexDirection } from '../../inspector/common/css-utils'
-import { parseCSSPercent, parseCSSPx, printCSSNumber } from '../../inspector/common/css-utils'
-import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
-import { patchParseSuccessAtElementPath } from './patch-utils'
-import { deleteValuesAtPath } from './utils/property-utils'
+import { printCSSNumber } from '../../inspector/common/css-utils'
+import type { BaseCommand, CommandFunctionResult, WhenToRun } from './commands'
+import { mapDropNulls } from '../../../core/shared/array-utils'
+import { getCSSNumberFromStyleInfo, maybeCssPropertyFromInlineStyle } from './utils/property-utils'
+import type { StyleUpdate } from '../plugins/style-plugins'
+import { getActivePlugin, runStyleUpdateForStrategy } from '../plugins/style-plugins'
+import type { InteractionLifecycle } from '../canvas-strategies/canvas-strategy-types'
 
 export type CreateIfNotExistant = 'create-if-not-existing' | 'do-not-create-if-doesnt-exist'
 
@@ -70,237 +58,159 @@ export function adjustCssLengthProperties(
   }
 }
 
-interface UpdatedPropsAndCommandDescription {
-  updatedProps: JSXAttributes
-  commandDescription: string
-}
-
-export const runAdjustCssLengthProperties: CommandFunction<AdjustCssLengthProperties> = (
+export const runAdjustCssLengthProperties = (
   editorState: EditorState,
   command: AdjustCssLengthProperties,
-) => {
-  let commandDescriptions: Array<string> = []
-  const updatedEditorState: EditorState = modifyUnderlyingForOpenFile(
-    command.target,
+  interactionLifecycle: InteractionLifecycle,
+): CommandFunctionResult => {
+  const withConflictingPropertiesRemoved = deleteConflictingPropsForWidthHeight(
+    interactionLifecycle,
     editorState,
-    (element) => {
-      if (isJSXElement(element)) {
-        return command.properties.reduce((workingElement, property) => {
-          // Remove any conflicting properties...
-          const attributesWithConflictingPropsDeleted =
-            deleteConflictingPropsForWidthHeightFromAttributes(
-              workingElement.props,
-              property.property,
-              command.parentFlexDirection,
-            )
-          // ...If we were unable to remove those properties, then bail out as we could break something.
-          if (isLeft(attributesWithConflictingPropsDeleted)) {
-            commandDescriptions.push(attributesWithConflictingPropsDeleted.value)
-            return workingElement
-          }
-
-          // Get the current value of the property...
-          const currentValue = getModifiableJSXAttributeAtPath(
-            attributesWithConflictingPropsDeleted.value,
-            property.property,
-          )
-          // ...If the value is not writeable then escape out.
-          if (isLeft(currentValue)) {
-            commandDescriptions.push(
-              `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
-                property.property,
-              )} not applied as value is not writeable.`,
-            )
-            return workingElement
-          }
-
-          // ...Determine some other facts about the current value.
-          const currentModifiableValue = currentValue.value
-          const simpleValueResult = jsxSimpleAttributeToValue(currentModifiableValue)
-          const valueProbablyExpression = isLeft(simpleValueResult)
-          const targetPropertyNonExistant: boolean =
-            currentModifiableValue.type === 'ATTRIBUTE_NOT_FOUND'
-
-          // ...If the current value does not exist and we shouldn't create it if it doesn't exist
-          // then exit early from handling this property.
-          if (
-            targetPropertyNonExistant &&
-            property.createIfNonExistant === 'do-not-create-if-doesnt-exist'
-          ) {
-            commandDescriptions.push(
-              `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
-                property.property,
-              )} not applied as the property does not exist.`,
-            )
-            return workingElement
-          }
-
-          // ...If the value is an expression then we can't update it.
-          if (valueProbablyExpression) {
-            // TODO add option to override expressions!!!
-            commandDescriptions.push(
-              `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
-                property.property,
-              )} not applied as the property is an expression we did not want to override.`,
-            )
-            return workingElement
-          }
-
-          // Commonly used function for handling the updates.
-          function handleUpdateResult(
-            result: Either<string, UpdatedPropsAndCommandDescription>,
-          ): JSXElement {
-            return foldEither(
-              (error) => {
-                commandDescriptions.push(error)
-                return workingElement
-              },
-              (updatedProps) => {
-                commandDescriptions.push(updatedProps.commandDescription)
-                return {
-                  ...workingElement,
-                  props: updatedProps.updatedProps,
-                }
-              },
-              result,
-            )
-          }
-
-          // Parse the current value as a pixel value...
-          const parsePxResult = parseCSSPx(simpleValueResult.value) // TODO make type contain px
-          // ...If the value can be parsed as a pixel value then update it.
-          if (isRight(parsePxResult)) {
-            return handleUpdateResult(
-              updatePixelValueByPixel(
-                attributesWithConflictingPropsDeleted.value,
-                command.target,
-                property.property,
-                parsePxResult.value,
-                property.valuePx,
-              ),
-            )
-          }
-
-          // Parse the current value as a percentage value...
-          const parsePercentResult = parseCSSPercent(simpleValueResult.value) // TODO make type contain %
-          // ...If the value can be parsed as a percentage value then update it.
-          if (isRight(parsePercentResult)) {
-            return handleUpdateResult(
-              updatePercentageValueByPixel(
-                attributesWithConflictingPropsDeleted.value,
-                command.target,
-                property.property,
-                property.parentDimensionPx,
-                parsePercentResult.value,
-                property.valuePx,
-              ),
-            )
-          }
-
-          // Otherwise if it is permitted to create it if it doesn't exist, then do so.
-          if (property.createIfNonExistant === 'create-if-not-existing') {
-            return handleUpdateResult(
-              setPixelValue(
-                attributesWithConflictingPropsDeleted.value,
-                command.target,
-                property.property,
-                property.valuePx,
-              ),
-            )
-          }
-
-          // Updating the props fallback.
-          commandDescriptions.push(
-            `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
-              property.property,
-            )} not applied as the property is in a CSS unit we do not support. (${
-              simpleValueResult.value
-            })`,
-          )
-          return workingElement
-        }, element)
-      }
-
-      // Final fallback.
-      return element
-    },
+    command.target,
+    command.properties.map((p) => p.property),
+    command.parentFlexDirection,
   )
 
-  if (commandDescriptions.length === 0) {
-    // Cater for no updates at all happened.
+  const styleInfoReader = getActivePlugin(withConflictingPropertiesRemoved).styleInfoFactory({
+    projectContents: withConflictingPropertiesRemoved.projectContents,
+    metadata: withConflictingPropertiesRemoved.jsxMetadata,
+    elementPathTree: withConflictingPropertiesRemoved.elementPathTree,
+  })
+
+  const styleInfo = styleInfoReader(command.target)
+  if (styleInfo == null) {
     return {
       editorStatePatches: [],
-      commandDescription: `No JSXElement was found at path ${EP.toString(command.target)}.`,
-    }
-  } else {
-    if (updatedEditorState === editorState) {
-      // As the `EditorState` never changed, return an empty patch.
-      return {
-        editorStatePatches: [],
-        commandDescription: commandDescriptions.join('\n'),
-      }
-    } else {
-      // Build the patch for the changes.
-      const editorStatePatch = patchParseSuccessAtElementPath(
+      commandDescription: `Adjust CSS Length Properties: Element at ${EP.toString(
         command.target,
-        updatedEditorState,
-        (success) => {
-          return {
-            topLevelElements: {
-              $set: success.topLevelElements,
-            },
-            imports: {
-              $set: success.imports,
-            },
-          }
-        },
-      )
-      return {
-        editorStatePatches: [editorStatePatch],
-        commandDescription: commandDescriptions.join('\n'),
-      }
+      )} not found`,
     }
+  }
+
+  let commandDescriptions: Array<string> = []
+
+  const propsToUpdate: StyleUpdate[] = mapDropNulls((propertyUpdate) => {
+    const property = maybeCssPropertyFromInlineStyle(propertyUpdate.property)
+    if (property == null) {
+      commandDescriptions.push(
+        `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
+          propertyUpdate.property,
+        )} not found.`,
+      )
+      return null
+    }
+
+    const currentValue = getCSSNumberFromStyleInfo(styleInfo, property)
+    if (currentValue.type === 'not-css-number') {
+      commandDescriptions.push(
+        `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
+          propertyUpdate.property,
+        )} not applied as value is not writeable.`,
+      )
+      return null
+    }
+
+    if (
+      currentValue.type === 'not-found' &&
+      propertyUpdate.createIfNonExistant === 'do-not-create-if-doesnt-exist'
+    ) {
+      commandDescriptions.push(
+        `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
+          propertyUpdate.property,
+        )} not applied as the property does not exist.`,
+      )
+      return null
+    }
+
+    if (
+      currentValue.type === 'css-number' &&
+      (currentValue.number.unit == null || currentValue.number.unit === 'px')
+    ) {
+      const { commandDescription, styleUpdate } = updatePixelValueByPixel(
+        command.target,
+        property,
+        currentValue.number,
+        propertyUpdate.valuePx,
+      )
+      commandDescriptions.push(commandDescription)
+      return styleUpdate
+    }
+
+    if (currentValue.type === 'css-number' && currentValue.number.unit === '%') {
+      const { commandDescription, styleUpdate } = updatePercentageValueByPixel(
+        command.target,
+        property,
+        propertyUpdate.parentDimensionPx,
+        currentValue.number,
+        propertyUpdate.valuePx,
+      )
+      commandDescriptions.push(commandDescription)
+      return styleUpdate ?? null
+    }
+
+    if (
+      currentValue.type === 'not-found' &&
+      propertyUpdate.createIfNonExistant === 'create-if-not-existing'
+    ) {
+      const { commandDescription, styleUpdate } = setPixelValue(
+        command.target,
+        property,
+        propertyUpdate.valuePx,
+      )
+      commandDescriptions.push(commandDescription)
+      return styleUpdate
+    }
+
+    commandDescriptions.push(
+      `Adjust Css Length Prop: ${EP.toUid(command.target)}/${PP.toString(
+        propertyUpdate.property,
+      )} not applied as the property is in a CSS unit we do not support.`,
+    )
+    return null
+  }, command.properties)
+
+  if (propsToUpdate.length === 0) {
+    return { editorStatePatches: [], commandDescription: 'No props to update' }
+  }
+
+  const { editorStatePatches } = runStyleUpdateForStrategy(
+    interactionLifecycle,
+    withConflictingPropertiesRemoved,
+    command.target,
+    propsToUpdate,
+  )
+
+  return {
+    editorStatePatches: editorStatePatches,
+    commandDescription: commandDescriptions.join('\n'),
   }
 }
 
 function setPixelValue(
-  properties: JSXAttributes,
   targetElement: ElementPath,
-  targetProperty: PropertyPath,
+  targetProperty: string,
   value: number,
-): Either<string, UpdatedPropsAndCommandDescription> {
+): { commandDescription: string; styleUpdate: StyleUpdate } {
   const newValueCssNumber: CSSNumber = {
     value: value,
     unit: null,
   }
   const newValue = printCSSNumber(newValueCssNumber, null)
 
-  const propsToUpdate: Array<ValueAtPath> = [
-    {
-      path: targetProperty,
-      value: jsExpressionValue(newValue, emptyComments),
-    },
-  ]
-
-  const updatePropsResult = setJSXValuesAtPaths(properties, propsToUpdate)
-
-  return mapEither((updatedProps) => {
-    return {
-      updatedProps: updatedProps,
-      commandDescription: `Set css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
-        targetProperty,
-      )} to ${value}.`,
-    }
-  }, updatePropsResult)
+  return {
+    styleUpdate: { type: 'set', property: targetProperty, value: newValue },
+    commandDescription: `Set css Length Prop: ${EP.toUid(
+      targetElement,
+    )}/${targetProperty} to ${value}.`,
+  }
 }
 
 function updatePixelValueByPixel(
-  properties: JSXAttributes,
   targetElement: ElementPath,
-  targetProperty: PropertyPath,
+  targetProperty: string,
   currentValue: CSSNumber,
   byValue: number,
-): Either<string, UpdatedPropsAndCommandDescription> {
+): { commandDescription: string; styleUpdate: StyleUpdate } {
   if (currentValue.unit != null && currentValue.unit !== 'px') {
     throw new Error('updatePixelValueByPixel called with a non-pixel cssnumber')
   }
@@ -311,48 +221,37 @@ function updatePixelValueByPixel(
   }
   const newValue = printCSSNumber(newValueCssNumber, null)
 
-  const propsToUpdate: Array<ValueAtPath> = [
-    {
-      path: targetProperty,
-      value: jsExpressionValue(newValue, emptyComments),
-    },
-  ]
-  const updatePropsResult = setJSXValuesAtPaths(properties, propsToUpdate)
-
-  return mapEither((updatedProps) => {
-    return {
-      updatedProps: updatedProps,
-      commandDescription: `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
-        targetProperty,
-      )} by ${byValue}`,
-    }
-  }, updatePropsResult)
+  return {
+    styleUpdate: { type: 'set', property: targetProperty, value: newValue },
+    commandDescription: `Adjust Css Length Prop: ${EP.toUid(
+      targetElement,
+    )}/${targetProperty} by ${byValue}`,
+  }
 }
 
 function updatePercentageValueByPixel(
-  properties: JSXAttributes,
   targetElement: ElementPath,
-  targetProperty: PropertyPath,
+  targetProperty: string,
   parentDimensionPx: number | undefined,
   currentValue: CSSNumber, // TODO restrict to percentage numbers
   byValue: number,
-): Either<string, UpdatedPropsAndCommandDescription> {
+): { commandDescription: string; styleUpdate?: StyleUpdate } {
   if (currentValue.unit == null || currentValue.unit !== '%') {
     throw new Error('updatePercentageValueByPixel called with a non-percentage cssnumber')
   }
   if (parentDimensionPx == null) {
-    return left(
-      `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
-        targetProperty,
-      )} not applied because the parent dimensions are unknown for some reason.`,
-    )
+    return {
+      commandDescription: `Adjust Css Length Prop: ${EP.toUid(
+        targetElement,
+      )}/${targetProperty} not applied because the parent dimensions are unknown for some reason.`,
+    }
   }
   if (parentDimensionPx === 0) {
-    return left(
-      `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
-        targetProperty,
-      )} not applied because the parent dimension is 0.`,
-    )
+    return {
+      commandDescription: `Adjust Css Length Prop: ${EP.toUid(
+        targetElement,
+      )}/${targetProperty} not applied because the parent dimension is 0.`,
+    }
   }
   const currentValuePercent = currentValue.value
   const offsetInPercent = (byValue / parentDimensionPx) * 100
@@ -362,23 +261,12 @@ function updatePercentageValueByPixel(
   }
   const newValue = printCSSNumber(newValueCssNumber, null)
 
-  const propsToUpdate: Array<ValueAtPath> = [
-    {
-      path: targetProperty,
-      value: jsExpressionValue(newValue, emptyComments),
-    },
-  ]
-
-  const updatePropsResult = setJSXValuesAtPaths(properties, propsToUpdate)
-
-  return mapEither((updatedProps) => {
-    return {
-      updatedProps: updatedProps,
-      commandDescription: `Adjust Css Length Prop: ${EP.toUid(targetElement)}/${PP.toString(
-        targetProperty,
-      )} by ${byValue}`,
-    }
-  }, updatePropsResult)
+  return {
+    styleUpdate: { type: 'set', property: targetProperty, value: newValue },
+    commandDescription: `Adjust Css Length Prop: ${EP.toUid(
+      targetElement,
+    )}/${targetProperty} by ${byValue}`,
+  }
 }
 
 const FlexSizeProperties: Array<PropertyPath> = [
@@ -391,7 +279,7 @@ const FlexSizeProperties: Array<PropertyPath> = [
 function getConflictingPropertiesToDelete(
   parentFlexDirection: FlexDirection | null,
   propertyPath: PropertyPath,
-): Array<PropertyPath> {
+): Array<string> {
   let propertiesToDelete: Array<PropertyPath> = []
 
   const parentFlexDimension =
@@ -413,41 +301,27 @@ function getConflictingPropertiesToDelete(
       }
       break
   }
-  return propertiesToDelete
-}
-
-function deleteConflictingPropsForWidthHeightFromAttributes(
-  attributes: JSXAttributes,
-  propertyPath: PropertyPath,
-  parentFlexDirection: FlexDirection | null,
-): Either<string, JSXAttributes> {
-  const propertiesToDelete: Array<PropertyPath> = getConflictingPropertiesToDelete(
-    parentFlexDirection,
-    propertyPath,
-  )
-  return unsetJSXValuesAtPaths(attributes, propertiesToDelete)
+  return mapDropNulls(maybeCssPropertyFromInlineStyle, propertiesToDelete)
 }
 
 export function deleteConflictingPropsForWidthHeight(
+  interactionLifecycle: InteractionLifecycle,
   editorState: EditorState,
-  target: ElementPath,
-  propertyPath: PropertyPath,
+  elementPath: ElementPath,
+  propertyPaths: PropertyPath[],
   parentFlexDirection: FlexDirection | null,
 ): EditorState {
-  const propertiesToDelete: Array<PropertyPath> = getConflictingPropertiesToDelete(
-    parentFlexDirection,
-    propertyPath,
-  )
+  return propertyPaths.reduce((editor, propertyPath) => {
+    const propertiesToDelete = getConflictingPropertiesToDelete(parentFlexDirection, propertyPath)
+    if (propertiesToDelete.length === 0) {
+      return editor
+    }
 
-  if (propertiesToDelete.length === 0) {
-    return editorState
-  } else {
-    const { editorStateWithChanges: editorStateWithPropsDeleted } = deleteValuesAtPath(
-      editorState,
-      target,
-      propertiesToDelete,
-    )
-
-    return editorStateWithPropsDeleted
-  }
+    return runStyleUpdateForStrategy(
+      interactionLifecycle,
+      editor,
+      elementPath,
+      propertiesToDelete.map((p) => ({ type: 'delete', property: p })),
+    ).editorStateWithChanges
+  }, editorState)
 }

--- a/editor/src/components/canvas/commands/commands.ts
+++ b/editor/src/components/canvas/commands/commands.ts
@@ -143,7 +143,7 @@ export function runCanvasCommand(
     case 'STRATEGY_SWITCHED':
       return runStrategySwitchedCommand(command)
     case 'ADJUST_CSS_LENGTH_PROPERTY':
-      return runAdjustCssLengthProperties(editorState, command)
+      return runAdjustCssLengthProperties(editorState, command, commandLifecycle)
     case 'REPARENT_ELEMENT':
       return runReparentElement(editorState, command)
     case 'DUPLICATE_ELEMENT':
@@ -157,7 +157,7 @@ export function runCanvasCommand(
     case 'CONVERT_TO_ABSOLUTE':
       return runConvertToAbsolute(editorState, command)
     case 'SET_CSS_LENGTH_PROPERTY':
-      return runSetCssLengthProperty(editorState, command)
+      return runSetCssLengthProperty(editorState, command, commandLifecycle)
     case 'REORDER_ELEMENT':
       return runReorderElement(editorState, command)
     case 'SHOW_OUTLINE_HIGHLIGHT':

--- a/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
+++ b/editor/src/components/canvas/commands/set-css-length-command.spec.tsx
@@ -51,6 +51,7 @@ describe('setCssLengthProperty', () => {
     const result = runSetCssLengthProperty(
       renderResult.getEditorState().editor,
       setCSSPropertyCommand,
+      'end-interaction',
     )
 
     const patchedEditor = updateEditorStateWithPatches(
@@ -227,7 +228,7 @@ function runCommandUpdateEditor(
   store: EditorStorePatched,
   command: SetCssLengthProperty,
 ): EditorState {
-  const result = runSetCssLengthProperty(store.editor, command)
+  const result = runSetCssLengthProperty(store.editor, command, 'end-interaction')
 
   return updateEditorStateWithPatches(store.editor, result.editorStatePatches)
 }

--- a/editor/src/components/canvas/commands/set-css-length-command.ts
+++ b/editor/src/components/canvas/commands/set-css-length-command.ts
@@ -25,9 +25,10 @@ import {
 } from '../../inspector/common/css-utils'
 import type { CreateIfNotExistant } from './adjust-css-length-command'
 import { deleteConflictingPropsForWidthHeight } from './adjust-css-length-command'
-import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
+import type { BaseCommand, CommandFunctionResult, WhenToRun } from './commands'
 import { addToastPatch } from './show-toast-command'
 import { applyValuesAtPath } from './utils/property-utils'
+import type { InteractionLifecycle } from '../canvas-strategies/canvas-strategy-types'
 
 type CssNumberOrKeepOriginalUnit =
   | { type: 'EXPLICIT_CSS_NUMBER'; value: CSSNumber | CSSKeyword }
@@ -75,15 +76,17 @@ export function setCssLengthProperty(
   }
 }
 
-export const runSetCssLengthProperty: CommandFunction<SetCssLengthProperty> = (
+export const runSetCssLengthProperty = (
   editorState: EditorState,
   command: SetCssLengthProperty,
-) => {
+  interactionLifecycle: InteractionLifecycle,
+): CommandFunctionResult => {
   // in case of width or height change, delete min, max and flex props
   const editorStateWithPropsDeleted = deleteConflictingPropsForWidthHeight(
+    interactionLifecycle,
     editorState,
     command.target,
-    command.property,
+    [command.property],
     command.parentFlexDirection,
   )
 

--- a/editor/src/components/canvas/commands/utils/property-utils.ts
+++ b/editor/src/components/canvas/commands/utils/property-utils.ts
@@ -5,6 +5,9 @@ import { setJSXValuesAtPaths, unsetJSXValuesAtPaths } from '../../../../core/sha
 import type { EditorState, EditorStatePatch } from '../../../editor/store/editor-state'
 import { modifyUnderlyingElementForOpenFile } from '../../../editor/store/editor-state'
 import { patchParseSuccessAtElementPath } from '../patch-utils'
+import type { CSSNumber } from '../../../inspector/common/css-utils'
+import { isCSSNumber } from '../../../inspector/common/css-utils'
+import type { StyleInfo, CSSStyleProperty } from '../../canvas-types'
 
 export interface EditorStateWithPatch {
   editorStateWithChanges: EditorState
@@ -98,4 +101,25 @@ export function maybeCssPropertyFromInlineStyle(property: PropertyPath): string 
     return null
   }
   return prop
+}
+
+export type GetCSSNumberFromStyleInfoResult =
+  | { type: 'not-found' }
+  | { type: 'not-css-number' }
+  | { type: 'css-number'; number: CSSNumber }
+
+export function getCSSNumberFromStyleInfo(
+  styleInfo: StyleInfo,
+  property: string,
+): GetCSSNumberFromStyleInfoResult {
+  let styleInfoUntyped = styleInfo as any as Record<string, CSSStyleProperty<unknown>>
+  const prop = styleInfoUntyped[property]
+  if (prop == null || prop.type === 'not-found') {
+    return { type: 'not-found' }
+  }
+
+  if (prop.type === 'not-parsable' || !isCSSNumber(prop.value)) {
+    return { type: 'not-css-number' }
+  }
+  return { type: 'css-number', number: prop.value }
 }

--- a/editor/src/components/canvas/plugins/inline-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/inline-style-plugin.ts
@@ -61,10 +61,24 @@ export const InlineStylePlugin: StylePlugin = {
 
       const gap = getPropertyFromInstance('gap', element.props)
       const flexDirection = getPropertyFromInstance('flexDirection', element.props)
+      const left = getPropertyFromInstance('left', element.props)
+      const right = getPropertyFromInstance('right', element.props)
+      const top = getPropertyFromInstance('top', element.props)
+      const bottom = getPropertyFromInstance('bottom', element.props)
+      const width = getPropertyFromInstance('width', element.props)
+      const height = getPropertyFromInstance('height', element.props)
+      const flexBasis = getPropertyFromInstance('flexBasis', element.props)
 
       return {
         gap: gap,
         flexDirection: flexDirection,
+        left: left,
+        right: right,
+        top: top,
+        bottom: bottom,
+        width: width,
+        height: height,
+        flexBasis: flexBasis,
       }
     },
   updateStyles: (editorState, elementPath, updates) => {

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
@@ -25,6 +25,13 @@ function parseTailwindProperty<T>(
 const TailwindPropertyMapping: Record<string, string> = {
   gap: 'gap',
   flexDirection: 'flexDirection',
+  left: 'positionLeft',
+  right: 'positionRight',
+  top: 'positionTop',
+  bottom: 'positionBottom',
+  width: 'width',
+  height: 'height',
+  flexBasis: 'flexBasis',
 }
 
 function isSupportedTailwindProperty(prop: unknown): prop is keyof typeof TailwindPropertyMapping {
@@ -74,6 +81,16 @@ export const TailwindPlugin = (config: Config | null): StylePlugin => ({
         flexDirection: parseTailwindProperty(
           mapping[TailwindPropertyMapping.flexDirection],
           cssParsers.flexDirection,
+        ),
+        left: parseTailwindProperty(mapping[TailwindPropertyMapping.left], cssParsers.left),
+        right: parseTailwindProperty(mapping[TailwindPropertyMapping.right], cssParsers.right),
+        top: parseTailwindProperty(mapping[TailwindPropertyMapping.top], cssParsers.top),
+        bottom: parseTailwindProperty(mapping[TailwindPropertyMapping.bottom], cssParsers.bottom),
+        width: parseTailwindProperty(mapping[TailwindPropertyMapping.width], cssParsers.width),
+        height: parseTailwindProperty(mapping[TailwindPropertyMapping.height], cssParsers.height),
+        flexBasis: parseTailwindProperty(
+          mapping[TailwindPropertyMapping.flexBasis],
+          cssParsers.flexBasis,
         ),
       }
     },


### PR DESCRIPTION
## Problem
The padding strategy relies on the `AdjustCssLengthProperties` command to update elements, both for reading and writing styles. In order for that to work in Tailwind projects, where elements don't have an inline style prop, `AdjustCssLengthProperties`  needs to read element styles from the "right" property, otherwise the command wouldn't work as intended.

## Fix
Use the StyleInfo system from to read the element style info.

### Details
- Refactored `AdjustCssLengthProperties`  to read elements styles through `styleInfo`
...

### Manual Tests:
I hereby swear that:

- [ ] I opened a hydrogen project and it loaded
- [ ] I could navigate to various routes in Play mode

Fixes #[ticket_number] (<< pls delete this line if it's not relevant)
