### PR TITLE
Preserve span when changing grid item position

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-keyboard-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-keyboard-strategy.ts
@@ -10,7 +10,7 @@ import {
   strategyApplicationResult,
 } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
-import { setGridPropsCommands } from './grid-helpers'
+import { getCommandsForGridItemPlacement } from './grid-helpers'
 import { getGridChildCellCoordBoundsFromCanvas } from './grid-cell-bounds'
 import { accumulatePresses } from './shared-keyboard-strategy-helpers'
 import { gridItemIdentifier } from '../../../editor/store/editor-state'
@@ -121,7 +121,7 @@ export function gridChangeElementLocationResizeKeyboardStrategy(
       }
 
       return strategyApplicationResult(
-        setGridPropsCommands(target, gridTemplate, {
+        getCommandsForGridItemPlacement(target, gridTemplate, {
           gridColumnStart,
           gridColumnEnd,
           gridRowStart,

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-strategy.ts
@@ -32,7 +32,7 @@ import {
   getParentGridTemplatesFromChildMeasurements,
   gridMoveStrategiesExtraCommands,
   isAutoGridPin,
-  setGridPropsCommands,
+  getCommandsForGridItemPlacement,
   sortElementsByGridPosition,
 } from './grid-helpers'
 
@@ -281,7 +281,11 @@ export function runGridChangeElementLocation(
     gridRowEnd: rowBounds.end,
   }
 
-  const gridCellMoveCommands = setGridPropsCommands(pathForCommands, gridTemplate, gridProps)
+  const gridCellMoveCommands = getCommandsForGridItemPlacement(
+    pathForCommands,
+    gridTemplate,
+    gridProps,
+  )
 
   // The siblings of the grid element being moved
   const siblings = MetadataUtils.getSiblingsUnordered(

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-strategy.ts
@@ -230,8 +230,8 @@ export function runGridChangeElementLocation(
   }
   const { targetCellCoords, targetRootCell } = targetGridCellData
 
-  const elementGridPropertiesFromProps =
-    selectedElementMetadata.specialSizeMeasurements.elementGridPropertiesFromProps
+  const elementGridProperties =
+    selectedElementMetadata.specialSizeMeasurements.elementGridProperties
 
   function getUpdatedPins(
     start: GridPositionOrSpan | null,
@@ -280,15 +280,15 @@ export function runGridChangeElementLocation(
   }
 
   const columnBounds = getUpdatedPins(
-    elementGridPropertiesFromProps.gridColumnStart,
-    elementGridPropertiesFromProps.gridColumnEnd,
+    elementGridProperties.gridColumnStart,
+    elementGridProperties.gridColumnEnd,
     'column',
     originalCellBounds.width,
   )
 
   const rowBounds = getUpdatedPins(
-    elementGridPropertiesFromProps.gridRowStart,
-    elementGridPropertiesFromProps.gridRowEnd,
+    elementGridProperties.gridRowStart,
+    elementGridProperties.gridRowEnd,
     'row',
     originalCellBounds.height,
   )

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-strategy.ts
@@ -223,41 +223,43 @@ export function runGridChangeElementLocation(
     start: GridPositionOrSpan
     end: GridPositionOrSpan
   } {
-    let result: {
-      start: GridPositionOrSpan
-      end: GridPositionOrSpan
-    } = {
-      start: cssKeyword('auto'),
-      end: cssKeyword('auto'),
-    }
-
     const isSpanning = isGridSpan(start) || isGridSpan(end)
     if (isSpanning) {
       if (isGridSpan(start)) {
         const isEndGridSpanArea = isGridSpan(end) || start.type === 'SPAN_AREA'
         if (!isEndGridSpanArea) {
-          if (isAutoGridPin(end ?? cssKeyword('auto'))) {
-            result.start = start
-            result.end = gridPositionValue(start.value + targetRootCell[axis])
-          } else {
-            result.start = start
-            result.end = gridPositionValue(start.value + targetRootCell[axis])
+          return {
+            start: start,
+            end: gridPositionValue(start.value + targetRootCell[axis]),
           }
         }
       } else if (isGridSpan(end)) {
-        result.start = gridPositionValue(targetRootCell[axis])
-        result.end = end
+        return {
+          start: gridPositionValue(targetRootCell[axis]),
+          end: end,
+        }
       }
     } else {
-      result.start = gridPositionValue(targetRootCell[axis])
       const shouldSetEndPosition = end != null && !isAutoGridPin(end)
       if (shouldSetEndPosition) {
-        result.end =
-          dimension === 1 ? cssKeyword('auto') : gridPositionValue(targetRootCell[axis] + dimension)
+        return {
+          start: gridPositionValue(targetRootCell[axis]),
+          end:
+            dimension === 1
+              ? cssKeyword('auto')
+              : gridPositionValue(targetRootCell[axis] + dimension),
+        }
+      }
+      return {
+        start: gridPositionValue(targetRootCell[axis]),
+        end: cssKeyword('auto'),
       }
     }
 
-    return result
+    return {
+      start: cssKeyword('auto'),
+      end: cssKeyword('auto'),
+    }
   }
 
   const columnBounds = getUpdatedPins(

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
@@ -43,7 +43,7 @@ import {
   getStyleAttributesForFrameInAbsolutePosition,
   updateInsertionSubjectWithAttributes,
 } from './draw-to-insert-metastrategy'
-import { setGridPropsCommands } from './grid-helpers'
+import { getCommandsForGridItemPlacement } from './grid-helpers'
 import { newReparentSubjects } from './reparent-helpers/reparent-strategy-helpers'
 import { getReparentTargetUnified } from './reparent-helpers/reparent-strategy-parent-lookup'
 import { getGridCellUnderMouseFromMetadata } from './grid-cell-bounds'
@@ -212,7 +212,7 @@ const gridDrawToInsertStrategyInner =
           [
             insertionCommand,
             ...nukeAllAbsolutePositioningPropsCommands(insertedElementPath), // do not use absolute positioning in grid cells
-            ...setGridPropsCommands(insertedElementPath, gridTemplate, {
+            ...getCommandsForGridItemPlacement(insertedElementPath, gridTemplate, {
               gridRowStart: { numericalPosition: gridCellCoordinates.row },
               gridColumnStart: { numericalPosition: gridCellCoordinates.column },
               gridRowEnd: { numericalPosition: gridCellCoordinates.row + 1 },

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-element-change-location-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-element-change-location-strategy.spec.browser2.tsx
@@ -219,6 +219,112 @@ describe('grid element change location strategy', () => {
     })
   })
 
+  it('can change the location of an element with span (from start, implicit end)', async () => {
+    const editor = await renderTestEditorWithCode(
+      ProjectCodeWithSpanningItems,
+      'await-first-dom-report',
+    )
+
+    const testId = 'pink'
+    const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } = await runMoveTest(editor, {
+      scale: 1,
+      pathString: `sb/scene/grid/${testId}`,
+      testId: testId,
+    })
+
+    expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+      gridColumnEnd: '5',
+      gridColumnStart: 'span 2',
+      gridRowEnd: 'auto',
+      gridRowStart: '2',
+    })
+  })
+
+  it('can change the location of an element with span (from start, explicit end)', async () => {
+    const editor = await renderTestEditorWithCode(
+      ProjectCodeWithSpanningItems,
+      'await-first-dom-report',
+    )
+
+    const testId = 'cyan'
+    const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } = await runMoveTest(editor, {
+      scale: 1,
+      pathString: `sb/scene/grid/${testId}`,
+      testId: testId,
+    })
+
+    expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+      gridColumnEnd: '5',
+      gridColumnStart: 'span 2',
+      gridRowEnd: 'auto',
+      gridRowStart: '2',
+    })
+  })
+
+  it('can change the location of an element with span (from end, explicit start)', async () => {
+    const editor = await renderTestEditorWithCode(
+      ProjectCodeWithSpanningItems,
+      'await-first-dom-report',
+    )
+
+    const testId = 'orange'
+    const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } = await runMoveTest(editor, {
+      scale: 1,
+      pathString: `sb/scene/grid/${testId}`,
+      testId: testId,
+      targetCell: { row: 3, column: 2 },
+    })
+
+    expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+      gridColumnEnd: 'span 3',
+      gridColumnStart: '2',
+      gridRowEnd: 'auto',
+      gridRowStart: '3',
+    })
+  })
+
+  it('can change the location of an element with span (longhand start)', async () => {
+    const editor = await renderTestEditorWithCode(
+      ProjectCodeWithSpanningItems,
+      'await-first-dom-report',
+    )
+
+    const testId = 'blue'
+    const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } = await runMoveTest(editor, {
+      scale: 1,
+      pathString: `sb/scene/grid/${testId}`,
+      testId: testId,
+    })
+
+    expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+      gridColumnEnd: '5',
+      gridColumnStart: 'span 2',
+      gridRowEnd: 'auto',
+      gridRowStart: '2',
+    })
+  })
+
+  it('can change the location of an element with span (longhand end)', async () => {
+    const editor = await renderTestEditorWithCode(
+      ProjectCodeWithSpanningItems,
+      'await-first-dom-report',
+    )
+
+    const testId = 'purple'
+    const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } = await runMoveTest(editor, {
+      scale: 1,
+      pathString: `sb/scene/grid/${testId}`,
+      testId: testId,
+    })
+
+    expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+      gridColumnEnd: 'span 2',
+      gridColumnStart: '3',
+      gridRowEnd: 'auto',
+      gridRowStart: '2',
+    })
+  })
+
   describe('grids within grids', () => {
     it('can move a grid child that is a grid itself', async () => {
       const editor = await renderTestEditorWithCode(
@@ -1555,6 +1661,102 @@ export var storyboard = (
           data-uid='blue'
 		  data-testid='blue'
           data-label='blue'
+        />
+      </div>
+    </Scene>
+  </Storyboard>
+)
+`
+
+const ProjectCodeWithSpanningItems = `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <Scene
+      id='playground-scene'
+      commentId='playground-scene'
+      style={{
+        width: 600,
+        height: 600,
+        position: 'absolute',
+        left: 0,
+        top: 0,
+      }}
+      data-label='Playground'
+      data-uid='scene'
+    >
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          width: 500,
+          height: 500,
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr 1fr 1fr',
+          gridTemplateRows: '1fr 1fr 1fr 1fr',
+          gridGap: 10,
+          padding: 10,
+        }}
+        data-testid='grid'
+        data-uid='grid'
+      >
+        <div
+          style={{
+            backgroundColor: '#f09',
+            width: '100%',
+            height: '100%',
+            gridColumn: 'span 2',
+          }}
+          data-uid='pink'
+          data-testid='pink'
+          data-label='pink'
+        />
+        <div
+          style={{
+            backgroundColor: '#f90',
+            width: '100%',
+            height: '100%',
+            gridColumn: '2 / span 3',
+          }}
+          data-uid='orange'
+          data-testid='orange'
+          data-label='orange'
+        />
+        <div
+          style={{
+            backgroundColor: '#0f9',
+            width: '100%',
+            height: '100%',
+            gridColumn: 'span 2 / 4',
+            gridRow: 3,
+          }}
+          data-uid='cyan'
+          data-testid='cyan'
+          data-label='cyan'
+        />
+        <div
+          style={{
+            backgroundColor: '#09f',
+            width: '100%',
+            height: '100%',
+            gridColumnStart: 'span 2',
+            gridRow: 4,
+          }}
+          data-uid='blue'
+          data-testid='blue'
+          data-label='blue'
+        />
+        <div
+          style={{
+            backgroundColor: '#90f',
+            width: '100%',
+            height: '100%',
+            gridColumnEnd: 'span 2',
+            gridRow: 4,
+          }}
+          data-uid='purple'
+          data-testid='purple'
+          data-label='purple'
         />
       </div>
     </Scene>

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-element-change-location-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-element-change-location-strategy.spec.browser2.tsx
@@ -174,7 +174,6 @@ describe('grid element change location strategy', () => {
       scale: 1,
       pathString: `sb/scene/grid/${testId}`,
       testId: testId,
-      tab: true,
       targetCell: { row: 3, column: 1 },
     })
 
@@ -594,9 +593,9 @@ export var storyboard = (
             child.style
           expect({ top, left, gridColumnStart, gridColumnEnd, gridRowStart, gridRowEnd }).toEqual({
             gridColumnStart: '1',
-            gridColumnEnd: '',
+            gridColumnEnd: 'auto',
             gridRowStart: '1',
-            gridRowEnd: '',
+            gridRowEnd: 'auto',
             left: '59px',
             top: '59.5px',
           })
@@ -866,13 +865,7 @@ export var storyboard = (
         'await-first-dom-report',
       )
 
-      const result = await runReorderTest(
-        editor,
-        'sb/scene/grid',
-        'orange',
-        { row: 1, column: 1 },
-        { tab: true },
-      )
+      const result = await runReorderTest(editor, 'sb/scene/grid', 'orange', { row: 1, column: 1 })
       expect({
         gridRowStart: result.gridRowStart,
         gridRowEnd: result.gridRowEnd,

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -116,7 +116,16 @@ export function setGridPropsCommands(
     startPosition: GridPositionOrSpan,
     endPosition: GridPositionOrSpan,
     axis: 'row' | 'column',
-  ): { property: string; value: string | number } {
+  ): {
+    property:
+      | 'gridColumn'
+      | 'gridColumnStart'
+      | 'gridColumnEnd'
+      | 'gridRow'
+      | 'gridRowStart'
+      | 'gridRowEnd'
+    value: string | number
+  } {
     const startValue = printPin(startPosition, axis)
     const endValue = printPin(endPosition, axis)
 
@@ -136,7 +145,7 @@ export function setGridPropsCommands(
       startValue === endValue
     ) {
       return {
-        property: axis === 'column' ? 'gridColumnStart' : 'gridRowStart',
+        property: axis === 'column' ? 'gridColumn' : 'gridRow',
         value: startValue,
       }
     }
@@ -251,7 +260,7 @@ export function sortElementsByGridPosition(gridTemplateColumns: number) {
 }
 
 function isGridPositionNumericValue(p: GridPositionOrSpan | null): p is GridPositionValue {
-  return p != null && !(isCSSKeyword(p) && !isGridSpan(p) && p.value === 'auto')
+  return p != null && !isGridSpan(p) && !(isCSSKeyword(p) && p.value === 'auto')
 }
 
 export function getGridPositionIndex(props: {
@@ -534,18 +543,22 @@ export function getGridElementPinState(
   elementGridPropertiesFromProps: GridElementProperties | null,
 ): GridElementPinState {
   if (
-    elementGridPropertiesFromProps?.gridColumnEnd == null ||
-    elementGridPropertiesFromProps?.gridColumnStart == null ||
-    elementGridPropertiesFromProps?.gridRowEnd == null ||
+    elementGridPropertiesFromProps?.gridColumnEnd == null &&
+    elementGridPropertiesFromProps?.gridColumnStart == null &&
+    elementGridPropertiesFromProps?.gridRowEnd == null &&
     elementGridPropertiesFromProps?.gridRowStart == null
   ) {
     return 'not-pinned'
   }
   if (
-    isGridPositionNumericValue(elementGridPropertiesFromProps?.gridColumnEnd ?? null) ||
-    isGridPositionNumericValue(elementGridPropertiesFromProps?.gridColumnStart ?? null) ||
-    isGridPositionNumericValue(elementGridPropertiesFromProps?.gridRowEnd ?? null) ||
-    isGridPositionNumericValue(elementGridPropertiesFromProps?.gridRowStart ?? null)
+    isGridPositionNumericValue(elementGridPropertiesFromProps?.gridColumnEnd) ||
+    isGridSpan(elementGridPropertiesFromProps?.gridColumnEnd) ||
+    isGridPositionNumericValue(elementGridPropertiesFromProps?.gridColumnStart) ||
+    isGridSpan(elementGridPropertiesFromProps?.gridColumnStart) ||
+    isGridPositionNumericValue(elementGridPropertiesFromProps?.gridRowEnd) ||
+    isGridSpan(elementGridPropertiesFromProps?.gridRowEnd) ||
+    isGridPositionNumericValue(elementGridPropertiesFromProps?.gridRowStart) ||
+    isGridSpan(elementGridPropertiesFromProps?.gridRowStart)
   ) {
     return 'pinned'
   }
@@ -553,10 +566,7 @@ export function getGridElementPinState(
 }
 
 export function isFlowGridChild(child: ElementInstanceMetadata) {
-  return (
-    getGridElementPinState(child.specialSizeMeasurements.elementGridPropertiesFromProps) !==
-    'pinned'
-  )
+  return getGridElementPinState(child.specialSizeMeasurements.elementGridProperties) !== 'pinned'
 }
 
 function restoreGridTemplateFromProps(params: {

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -93,7 +93,7 @@ export function setGridPropsCommands(
     ]),
   ]
 
-  function stringifyPin(pin: GridPositionOrSpan, axis: 'row' | 'column') {
+  function printPin(pin: GridPositionOrSpan, axis: 'row' | 'column'): string | number {
     if (isGridSpan(pin)) {
       return stringifyGridSpan(pin)
     }
@@ -109,16 +109,16 @@ export function setGridPropsCommands(
     if (maybeLineName != null) {
       return maybeLineName
     }
-    return `${pin.numericalPosition}`
+    return pin.numericalPosition ?? 'auto'
   }
 
   function serializeAxis(
     startPosition: GridPositionOrSpan,
     endPosition: GridPositionOrSpan,
     axis: 'row' | 'column',
-  ): { property: string; value: string } {
-    const startValue = stringifyPin(startPosition, axis)
-    const endValue = stringifyPin(endPosition, axis)
+  ): { property: string; value: string | number } {
+    const startValue = printPin(startPosition, axis)
+    const endValue = printPin(endPosition, axis)
 
     if (isAutoGridPin(startPosition) && !isAutoGridPin(endPosition)) {
       return {
@@ -129,6 +129,10 @@ export function setGridPropsCommands(
 
     const shorthand = !(
       (isCSSKeyword(endPosition) && endPosition.value === 'auto') ||
+      (isGridPositionNumericValue(endPosition) &&
+        isGridPositionNumericValue(startPosition) &&
+        (endPosition.numericalPosition ?? 0) >= (startPosition.numericalPosition ?? 0) &&
+        (endPosition.numericalPosition ?? 0) - (startPosition.numericalPosition ?? 0) <= 1) ||
       startValue === endValue
     )
       ? `${startValue} / ${endValue}`
@@ -203,26 +207,6 @@ function getCellCoordsDelta(
   const columnDiff = dragFrom.column - rootCell.column
 
   return gridCellCoordinates(rowDiff, columnDiff)
-}
-
-function asMaybeNamedLineOrValue(
-  grid: GridContainerProperties,
-  axis: 'row' | 'column',
-  value: number | string | null,
-): string | number {
-  if (value == null) {
-    return 1
-  } else if (typeof value === 'number') {
-    const template = axis === 'row' ? grid.gridTemplateRows : grid.gridTemplateColumns
-    if (template?.type === 'DIMENSIONS') {
-      const maybeLineStart = template.dimensions.at(value - 1)
-      if (maybeLineStart != null && maybeLineStart.lineName != null) {
-        return maybeLineStart.lineName
-      }
-    }
-    return value === 0 ? 1 : value
-  }
-  return value
 }
 
 export type SortableGridElementProperties = GridElementProperties & {

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -141,6 +141,7 @@ export function getCommandsForGridItemPlacement(
       if (isAutoPin) {
         return true
       }
+
       const printedValuedEqual = startValue === endValue
       if (printedValuedEqual) {
         return true
@@ -158,6 +159,7 @@ export function getCommandsForGridItemPlacement(
           return true
         }
       }
+
       return false
     }
     if (shouldReturnSingleValue()) {

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -76,7 +76,7 @@ export function isAutoGridPin(v: GridPositionOrSpan): boolean {
   return isCSSKeyword(v) && v.value === 'auto'
 }
 
-export function setGridPropsCommands(
+export function getCommandsForGridItemPlacement(
   elementPath: ElementPath,
   gridTemplate: GridContainerProperties,
   gridProps: Partial<GridElementProperties>,

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -127,20 +127,23 @@ export function setGridPropsCommands(
       }
     }
 
-    const shorthand = !(
+    if (
       (isCSSKeyword(endPosition) && endPosition.value === 'auto') ||
       (isGridPositionNumericValue(endPosition) &&
         isGridPositionNumericValue(startPosition) &&
         (endPosition.numericalPosition ?? 0) >= (startPosition.numericalPosition ?? 0) &&
         (endPosition.numericalPosition ?? 0) - (startPosition.numericalPosition ?? 0) <= 1) ||
       startValue === endValue
-    )
-      ? `${startValue} / ${endValue}`
-      : startValue
+    ) {
+      return {
+        property: axis === 'column' ? 'gridColumnStart' : 'gridRowStart',
+        value: startValue,
+      }
+    }
 
     return {
       property: axis === 'column' ? 'gridColumn' : 'gridRow',
-      value: shorthand,
+      value: `${startValue} / ${endValue}`,
     }
   }
 

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -136,14 +136,31 @@ export function getCommandsForGridItemPlacement(
       }
     }
 
-    if (
-      (isCSSKeyword(endPosition) && endPosition.value === 'auto') ||
-      (isGridPositionNumericValue(endPosition) &&
-        isGridPositionNumericValue(startPosition) &&
-        (endPosition.numericalPosition ?? 0) >= (startPosition.numericalPosition ?? 0) &&
-        (endPosition.numericalPosition ?? 0) - (startPosition.numericalPosition ?? 0) <= 1) ||
-      startValue === endValue
-    ) {
+    function shouldReturnSingleValue(): boolean {
+      const isAutoPin = isAutoGridPin(endPosition)
+      if (isAutoPin) {
+        return true
+      }
+      const printedValuedEqual = startValue === endValue
+      if (printedValuedEqual) {
+        return true
+      }
+
+      const positionsAreNumeric =
+        isGridPositionNumericValue(endPosition) && isGridPositionNumericValue(startPosition)
+      if (positionsAreNumeric) {
+        const startNumericPosition = startPosition.numericalPosition ?? 0
+        const endNumericPosition = endPosition.numericalPosition ?? 0
+        const positionsDeltaAtMostOne =
+          endNumericPosition >= startNumericPosition &&
+          endNumericPosition - startNumericPosition <= 1
+        if (positionsDeltaAtMostOne) {
+          return true
+        }
+      }
+      return false
+    }
+    if (shouldReturnSingleValue()) {
       return {
         property: axis === 'column' ? 'gridColumn' : 'gridRow',
         value: startValue,

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
@@ -527,8 +527,7 @@ describe('grid resize element strategy', () => {
       ['backgroundColor', '#db48f6'],
       ['width', '100%'],
       ['height', '100%'],
-      ['gridColumnStart', 7],
-      ['gridColumnEnd', 11],
+      ['gridColumn', '7 / 11'],
       ['gridRow', 2],
     ])
   })

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -21,7 +21,7 @@ import {
   strategyApplicationResult,
 } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
-import { findOriginalGrid, setGridPropsCommands } from './grid-helpers'
+import { findOriginalGrid, getCommandsForGridItemPlacement } from './grid-helpers'
 import { resizeBoundingBoxFromSide } from './resize-helpers'
 
 export const gridResizeElementStrategy: CanvasStrategyFactory = (
@@ -114,7 +114,7 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
         selectedElementMetadata.specialSizeMeasurements.parentContainerGridProperties
 
       return strategyApplicationResult(
-        setGridPropsCommands(selectedElement, gridTemplate, gridProps),
+        getCommandsForGridItemPlacement(selectedElement, gridTemplate, gridProps),
         [EP.parentPath(selectedElement)],
       )
     },

--- a/editor/src/components/inspector/flex-section.tsx
+++ b/editor/src/components/inspector/flex-section.tsx
@@ -72,7 +72,7 @@ import {
 } from '../../core/shared/element-template'
 import {
   isJustAutoGridDimension,
-  setGridPropsCommands,
+  getCommandsForGridItemPlacement,
 } from '../canvas/canvas-strategies/strategies/grid-helpers'
 import { type CanvasCommand } from '../canvas/commands/commands'
 import type { DropdownMenuItem } from '../../uuiui/radix-components'
@@ -357,7 +357,9 @@ const TemplateDimensionControl = React.memo(
             }
           }
 
-          commands.push(...setGridPropsCommands(child.elementPath, adjustedGridTemplate, updated))
+          commands.push(
+            ...getCommandsForGridItemPlacement(child.elementPath, adjustedGridTemplate, updated),
+          )
         }
 
         dispatch([applyCommandsAction(commands)])
@@ -434,7 +436,7 @@ const TemplateDimensionControl = React.memo(
         const children = MetadataUtils.getChildrenUnordered(metadataRef.current, grid.elementPath)
         for (const child of children) {
           commands.push(
-            ...setGridPropsCommands(
+            ...getCommandsForGridItemPlacement(
               child.elementPath,
               adjustedGridTemplate,
               child.specialSizeMeasurements.elementGridPropertiesFromProps,

--- a/editor/src/components/inspector/sections/style-section/container-subsection/grid-cell-subsection.tsx
+++ b/editor/src/components/inspector/sections/style-section/container-subsection/grid-cell-subsection.tsx
@@ -27,7 +27,7 @@ import {
 } from '../../../../../uuiui'
 import type { KeywordForControl } from '../../../../../uuiui/inputs/number-or-keyword-control'
 import { NumberOrKeywordControl } from '../../../../../uuiui/inputs/number-or-keyword-control'
-import { setGridPropsCommands } from '../../../../canvas/canvas-strategies/strategies/grid-helpers'
+import { getCommandsForGridItemPlacement } from '../../../../canvas/canvas-strategies/strategies/grid-helpers'
 import { applyCommandsAction } from '../../../../editor/actions/action-creators'
 import { useDispatch } from '../../../../editor/store/dispatch-context'
 import { Substores, useEditorState } from '../../../../editor/store/store-hook'
@@ -97,7 +97,7 @@ export const GridPlacementSubsection = React.memo(() => {
       return
     }
 
-    const commands = setGridPropsCommands(
+    const commands = getCommandsForGridItemPlacement(
       cell.elementPath,
       gridTemplate,
       cell.specialSizeMeasurements.elementGridProperties,
@@ -271,7 +271,11 @@ const DimensionsControls = React.memo(
               }
               break
           }
-          const commands = setGridPropsCommands(cell.elementPath, gridTemplate, newValues)
+          const commands = getCommandsForGridItemPlacement(
+            cell.elementPath,
+            gridTemplate,
+            newValues,
+          )
 
           dispatch([applyCommandsAction(commands)])
         },
@@ -395,7 +399,11 @@ const BoundariesControls = React.memo(
             ...cell.specialSizeMeasurements.elementGridProperties,
             [dimension]: value,
           }
-          const commands = setGridPropsCommands(cell.elementPath, gridTemplate, newValues)
+          const commands = getCommandsForGridItemPlacement(
+            cell.elementPath,
+            gridTemplate,
+            newValues,
+          )
 
           dispatch([applyCommandsAction(commands)])
         },


### PR DESCRIPTION
**Problem:**

`span` values for grid child positioning props are wiped when using `gridChangeElementLocationStrategy`.

**Fix:**

Rework the way grid element props are calculated when changing element location pins, so that `spans` are respected and kept in place if present.

The behavior is now so that:
- when it makes sense to do so, return shorthand versions of grid positioning props
- when moving an element with `span` values, support moving them when the span is in the starting prop as well as the ending prop

Examples for moving a item one cell to the right:

| Initial config | Result |
|------------|------------|
| `gridColumn: 'span 2'` | `gridColumn: 'span 2 / 4'` |
| `gridColumn: '2 / span 2'` | `gridColumn: '3 / span 2'` |
| `gridColumnStart: 'span 2'` | `gridColumn: 'span 2 / 4'` |
| `gridColumnEnd: 'span 2'` | `gridColumn: '3 / span 2'` |

**Note:** a subsequent PR will take care of also keepign `span` intact for the reorder strategy.

Fixes #6639 