### PR TITLE
Remove unnecessary props from `StyleInfoFactory` context param

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -225,8 +225,6 @@ export function pickCanvasStateFromEditorState(
     propertyControlsInfo: editorState.propertyControlsInfo,
     styleInfoReader: activePlugin.styleInfoFactory({
       projectContents: editorState.projectContents,
-      metadata: editorState.jsxMetadata,
-      elementPathTree: editorState.elementPathTree,
     }),
   }
 }
@@ -254,8 +252,6 @@ export function pickCanvasStateFromEditorStateWithMetadata(
     propertyControlsInfo: editorState.propertyControlsInfo,
     styleInfoReader: activePlugin.styleInfoFactory({
       projectContents: editorState.projectContents,
-      metadata: metadata,
-      elementPathTree: editorState.elementPathTree,
     }),
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -110,8 +110,6 @@ export type StyleInfoReader = (elementPath: ElementPath) => StyleInfo | null
 
 export type StyleInfoFactory = (context: {
   projectContents: ProjectContentTreeRoot
-  metadata: ElementInstanceMetadataMap
-  elementPathTree: ElementPathTrees
 }) => StyleInfoReader
 
 export interface InteractionCanvasState {

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
@@ -139,8 +139,6 @@ export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((p
       maybeFlexGapData(
         getActivePlugin(store.editor).styleInfoFactory({
           projectContents: store.editor.projectContents,
-          metadata: metadata,
-          elementPathTree: store.editor.elementPathTree,
         })(selectedElement),
         MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, selectedElement),
       ),

--- a/editor/src/components/canvas/controls/select-mode/subdued-flex-gap-controls.tsx
+++ b/editor/src/components/canvas/controls/select-mode/subdued-flex-gap-controls.tsx
@@ -43,8 +43,6 @@ export const SubduedFlexGapControl = React.memo<SubduedFlexGapControlProps>((pro
       maybeFlexGapData(
         getActivePlugin(store.editor).styleInfoFactory({
           projectContents: store.editor.projectContents,
-          metadata: store.editor.jsxMetadata,
-          elementPathTree: store.editor.elementPathTree,
         })(selectedElement),
         MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, selectedElement),
       ),

--- a/editor/src/components/canvas/plugins/inline-style-plugin.spec.ts
+++ b/editor/src/components/canvas/plugins/inline-style-plugin.spec.ts
@@ -96,9 +96,7 @@ function getStyleInfoFromInlineStyle(editor: EditorRenderResult) {
   const { jsxMetadata, projectContents, elementPathTree } = editor.getEditorState().editor
 
   const styleInfoReader = InlineStylePlugin.styleInfoFactory({
-    metadata: jsxMetadata,
     projectContents: projectContents,
-    elementPathTree: elementPathTree,
   })
   const styleInfo = styleInfoReader(EP.fromString('sb/scene/div'))
   return styleInfo

--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -192,8 +192,6 @@ function getPropertiesToZero(
 export function patchRemovedProperties(editorState: EditorState): EditorState {
   const styleInfoReader = getActivePlugin(editorState).styleInfoFactory({
     projectContents: editorState.projectContents,
-    metadata: editorState.jsxMetadata,
-    elementPathTree: editorState.elementPathTree,
   })
 
   const propertiesUpdatedDuringInteraction = getPropertiesUpdatedDuringInteraction(editorState)


### PR DESCRIPTION
## Problem
`metadata` and `elementPathTree` are required by the context param of `StylePlugin.styleInfoFactory`, but they weren't used by the plugins. Because of this, having to pass `metadata` and `elementPathTree` in the context param created unnecessary boilerplate

## Fix
Remove `metadata` and `elementPathTree` from the context param of `StylePlugin.styleInfoFactory`, but keep the context param itself so other data can be added to the context later on.