### PR TITLE
Do not run property patching when the inline style plugin is active

### DIFF
--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -177,9 +177,7 @@ function getPropertiesToZero(
 ): ValueAtPath[] {
   return updatedProperties.propertiesDeleted.flatMap((prop): ValueAtPath[] => {
     if (!isStyleInfoKey(prop)) {
-      if (isFeatureEnabled('Tailwind')) {
-        console.error("Trying to zero prop that's not a handled by StyleInfo:", prop)
-      }
+      console.error("Trying to zero prop that's not a handled by StyleInfo:", prop)
       return []
     }
 
@@ -192,7 +190,12 @@ function getPropertiesToZero(
 }
 
 export function patchRemovedProperties(editorState: EditorState): EditorState {
-  const styleInfoReader = getActivePlugin(editorState).styleInfoFactory({
+  const activePlugin = getActivePlugin(editorState)
+  if (activePlugin.name === InlineStylePlugin.name) {
+    return editorState
+  }
+
+  const styleInfoReader = activePlugin.styleInfoFactory({
     projectContents: editorState.projectContents,
     metadata: editorState.jsxMetadata,
     elementPathTree: editorState.elementPathTree,

--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -177,7 +177,9 @@ function getPropertiesToZero(
 ): ValueAtPath[] {
   return updatedProperties.propertiesDeleted.flatMap((prop): ValueAtPath[] => {
     if (!isStyleInfoKey(prop)) {
-      console.error("Trying to zero prop that's not a handled by StyleInfo:", prop)
+      if (isFeatureEnabled('Tailwind')) {
+        console.error("Trying to zero prop that's not a handled by StyleInfo:", prop)
+      }
       return []
     }
 


### PR DESCRIPTION
## Problem
https://github.com/concrete-utopia/utopia/blob/9e34bde077fbb324e4bb2fcbf9ffc067e680aa60/editor/src/components/canvas/plugins/style-plugins.ts#L180

Since `StyleInfo` only supports a subset of the style props that the editor updates/deletes, this error is triggered many times during normal editor use. When the inline style plugin is active (which is always the case when the Tailwind feature flag isn't expressly turned on), this error isn't signalling an actual error, since removed properties don't have to be zeroed when the project only uses inline styles.

## Fix
Do not run the zeroing code if the inline style plugin is active, since it's not actually needed in that case

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode
