### PR TITLE
Grid component support preparation

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -7,6 +7,7 @@ import type {
   EditorState,
   EditorStatePatch,
   EditorStorePatched,
+  GridIdentifier,
 } from '../../editor/store/editor-state'
 import { Substores, useEditorState, useSelectorWithCallback } from '../../editor/store/store-hook'
 import type {
@@ -676,7 +677,7 @@ export function combineApplicableControls(
   }
 
   // Sift the instances of `GridControls`, storing their targets by when they should be shown.
-  let gridControlsTargets: Map<WhenToShowControl, Array<ElementPath>> = new Map()
+  let gridControlsTargets: Map<WhenToShowControl, Array<GridIdentifier>> = new Map()
   for (const control of gridControlsInstances) {
     if (isGridControlsProps(control.props)) {
       const possibleTargets = gridControlsTargets.get(control.show)

--- a/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../../../core/shared/math-utils'
 import * as PP from '../../../../core/shared/property-path'
 import { styleStringInArray } from '../../../../utils/common-constants'
-import { trueUpGroupElementChanged } from '../../../editor/store/editor-state'
+import { gridItemIdentifier, trueUpGroupElementChanged } from '../../../editor/store/editor-state'
 import { stylePropPathMappingFn } from '../../../inspector/common/property-path-hooks'
 import { isFillOrStretchModeApplied } from '../../../inspector/inspector-common'
 import type { EdgePosition } from '../../canvas-types'
@@ -122,7 +122,7 @@ export function basicResizeStrategy(
         key: 'parent-bounds-control',
         show: 'visible-only-while-active',
       }),
-      ...(isGridCell ? [controlsForGridPlaceholders(EP.parentPath(selectedElement))] : []),
+      ...(isGridCell ? [controlsForGridPlaceholders(gridItemIdentifier(selectedElement))] : []),
     ],
     fitness:
       interactionSession != null &&

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-keyboard-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-keyboard-strategy.ts
@@ -10,9 +10,10 @@ import {
   strategyApplicationResult,
 } from '../canvas-strategy-types'
 import type { InteractionSession } from '../interaction-state'
-import { findOriginalGrid, setGridPropsCommands } from './grid-helpers'
+import { setGridPropsCommands } from './grid-helpers'
 import { getGridChildCellCoordBoundsFromCanvas } from './grid-cell-bounds'
 import { accumulatePresses } from './shared-keyboard-strategy-helpers'
+import { gridItemIdentifier } from '../../../editor/store/editor-state'
 
 export function gridChangeElementLocationResizeKeyboardStrategy(
   canvasState: InteractionCanvasState,
@@ -38,11 +39,6 @@ export function gridChangeElementLocationResizeKeyboardStrategy(
 
   const cell = MetadataUtils.findElementByElementPath(canvasState.startingMetadata, target)
   if (cell == null) {
-    return null
-  }
-
-  const parentGridPath = findOriginalGrid(canvasState.startingMetadata, EP.parentPath(target)) // TODO don't use EP.parentPath
-  if (parentGridPath == null) {
     return null
   }
 
@@ -72,7 +68,7 @@ export function gridChangeElementLocationResizeKeyboardStrategy(
       category: 'modalities',
       type: 'reorder-large',
     },
-    controlsToRender: [controlsForGridPlaceholders(parentGridPath)],
+    controlsToRender: [controlsForGridPlaceholders(gridItemIdentifier(target))],
     fitness: fitness(interactionSession),
     apply: () => {
       if (interactionSession == null || interactionSession.interactionData.type !== 'KEYBOARD') {
@@ -131,7 +127,7 @@ export function gridChangeElementLocationResizeKeyboardStrategy(
           gridRowStart,
           gridRowEnd,
         }),
-        [parentGridPath],
+        [EP.parentPath(target)],
       )
     },
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-strategy.ts
@@ -282,7 +282,7 @@ export function runGridChangeElementLocation(
   // The siblings of the grid element being moved
   const siblings = MetadataUtils.getSiblingsUnordered(
     jsxMetadata,
-    selectedElementMetadata.elementPath,
+    newPathAfterReparent ?? selectedElementMetadata.elementPath,
   )
     .filter((s) => !EP.pathsEqual(s.elementPath, selectedElementMetadata.elementPath))
     .map(

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-strategy.ts
@@ -26,7 +26,6 @@ import {
 import type { DragInteractionData, InteractionSession } from '../interaction-state'
 import type { GridCellGlobalFrames, SortableGridElementProperties } from './grid-helpers'
 import {
-  findOriginalGrid,
   getOriginalElementGridConfiguration,
   getParentGridTemplatesFromChildMeasurements,
   gridMoveStrategiesExtraCommands,
@@ -41,6 +40,7 @@ import {
   fromTypeGuard,
 } from '../../../../core/shared/optics/optic-creators'
 import { getJSXAttributesAtPath } from '../../../..//core/shared/jsx-attribute-utils'
+import { gridItemIdentifier } from '../../../editor/store/editor-state'
 
 export const gridChangeElementLocationStrategy: CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -88,22 +88,6 @@ export const gridChangeElementLocationStrategy: CanvasStrategyFactory = (
     return null
   }
 
-  const parentGridPath = findOriginalGrid(
-    canvasState.startingMetadata,
-    EP.parentPath(selectedElement),
-  ) // TODO don't use EP.parentPath
-  if (parentGridPath == null) {
-    return null
-  }
-
-  const gridFrame = MetadataUtils.findElementByElementPath(
-    canvasState.startingMetadata,
-    parentGridPath,
-  )?.globalFrame
-  if (gridFrame == null || isInfinityRectangle(gridFrame)) {
-    return null
-  }
-
   if (MetadataUtils.isPositionAbsolute(selectedElementMetadata)) {
     return null
   }
@@ -116,7 +100,9 @@ export const gridChangeElementLocationStrategy: CanvasStrategyFactory = (
       category: 'tools',
       type: 'pointer',
     },
-    controlsToRender: [controlsForGridPlaceholders(parentGridPath, 'visible-only-while-active')],
+    controlsToRender: [
+      controlsForGridPlaceholders(gridItemIdentifier(selectedElement), 'visible-only-while-active'),
+    ],
     fitness: onlyFitWhenDraggingThisControl(interactionSession, 'GRID_CELL_HANDLE', 2),
     apply: () => {
       if (
@@ -132,14 +118,13 @@ export const gridChangeElementLocationStrategy: CanvasStrategyFactory = (
         canvasState,
         interactionSession.interactionData,
         selectedElement,
-        parentGridPath,
       )
       if (commands.length === 0) {
         return emptyStrategyApplicationResult
       }
 
       const { midInteractionCommands, onCompleteCommands } = gridMoveStrategiesExtraCommands(
-        parentGridPath,
+        EP.parentPath(selectedElement), // TODO: don't use EP.parentPath
         initialTemplates,
       )
 
@@ -155,7 +140,6 @@ function getCommandsAndPatchForGridChangeElementLocation(
   canvasState: InteractionCanvasState,
   interactionData: DragInteractionData,
   selectedElement: ElementPath,
-  gridPath: ElementPath,
 ): {
   commands: CanvasCommand[]
   elementsToRerender: ElementPath[]
@@ -182,7 +166,6 @@ function getCommandsAndPatchForGridChangeElementLocation(
     canvasState.startingMetadata,
     interactionData,
     selectedElementMetadata,
-    gridPath,
     parentGridCellGlobalFrames,
     parentContainerGridProperties,
     null,
@@ -190,7 +173,7 @@ function getCommandsAndPatchForGridChangeElementLocation(
 
   return {
     commands: commands,
-    elementsToRerender: [gridPath, selectedElement],
+    elementsToRerender: [EP.parentPath(selectedElement), selectedElement],
   }
 }
 
@@ -198,7 +181,6 @@ export function runGridChangeElementLocation(
   jsxMetadata: ElementInstanceMetadataMap,
   interactionData: DragInteractionData,
   selectedElementMetadata: ElementInstanceMetadata,
-  gridPath: ElementPath,
   gridCellGlobalFrames: GridCellGlobalFrames,
   gridTemplate: GridContainerProperties,
   newPathAfterReparent: ElementPath | null,
@@ -298,7 +280,10 @@ export function runGridChangeElementLocation(
   })
 
   // The siblings of the grid element being moved
-  const siblings = MetadataUtils.getChildrenUnordered(jsxMetadata, gridPath)
+  const siblings = MetadataUtils.getSiblingsUnordered(
+    jsxMetadata,
+    selectedElementMetadata.elementPath,
+  )
     .filter((s) => !EP.pathsEqual(s.elementPath, selectedElementMetadata.elementPath))
     .map(
       (s, index): SortableGridElementProperties => ({
@@ -333,7 +318,7 @@ export function runGridChangeElementLocation(
 
   const updateGridControlsCommand = showGridControls(
     'mid-interaction',
-    gridPath,
+    gridItemIdentifier(selectedElementMetadata.elementPath),
     targetCellCoords,
     targetRootCell,
   )

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-draw-to-insert-strategy.tsx
@@ -48,6 +48,7 @@ import { newReparentSubjects } from './reparent-helpers/reparent-strategy-helper
 import { getReparentTargetUnified } from './reparent-helpers/reparent-strategy-parent-lookup'
 import { getGridCellUnderMouseFromMetadata } from './grid-cell-bounds'
 import { nukeAllAbsolutePositioningPropsCommands } from '../../../inspector/inspector-common'
+import { gridContainerIdentifier } from '../../../editor/store/editor-state'
 
 export const gridDrawToInsertText: CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -149,7 +150,7 @@ const gridDrawToInsertStrategyInner =
         category: 'tools',
         type: 'pointer',
       },
-      controlsToRender: [controlsForGridPlaceholders(targetParent)],
+      controlsToRender: [controlsForGridPlaceholders(gridContainerIdentifier(targetParent))],
       fitness: 5,
       apply: (strategyLifecycle) => {
         const canvasPointToUse =
@@ -165,7 +166,7 @@ const gridDrawToInsertStrategyInner =
               }),
               showGridControls(
                 'mid-interaction',
-                targetParent,
+                gridContainerIdentifier(targetParent),
                 newTargetCell?.gridCellCoordinates ?? null,
                 null,
               ),

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-reparent-strategy.tsx
@@ -9,7 +9,7 @@ import type { CanvasRectangle } from '../../../../core/shared/math-utils'
 import { isInfinityRectangle } from '../../../../core/shared/math-utils'
 import type { ElementPath } from '../../../../core/shared/project-file-types'
 import * as PP from '../../../../core/shared/property-path'
-import type { AllElementProps } from '../../../editor/store/editor-state'
+import { gridContainerIdentifier, type AllElementProps } from '../../../editor/store/editor-state'
 import type { InsertionPath } from '../../../editor/store/insertion-path'
 import { CSSCursor } from '../../canvas-types'
 import { setCursorCommand } from '../../commands/set-cursor-command'
@@ -130,7 +130,9 @@ export function controlsForGridReparent(reparentTarget: ReparentTarget): Control
       key: 'zero-size-control',
       show: 'visible-only-while-active',
     }),
-    controlsForGridPlaceholders(reparentTarget.newParent.intendedParentPath),
+    controlsForGridPlaceholders(
+      gridContainerIdentifier(reparentTarget.newParent.intendedParentPath),
+    ),
   ]
 }
 
@@ -287,7 +289,6 @@ function gridReparentCommands(
     jsxMetadata,
     interactionData,
     targetElement,
-    targetParent.elementPath,
     gridCellGlobalFrames,
     gridTemplate,
     newPath,

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -5,6 +5,7 @@ import {
   isInfinityRectangle,
   rectangleIntersection,
 } from '../../../../core/shared/math-utils'
+import { gridContainerIdentifier, gridItemIdentifier } from '../../../editor/store/editor-state'
 import { isFillOrStretchModeAppliedOnAnySide } from '../../../inspector/inspector-common'
 import {
   controlsForGridPlaceholders,
@@ -60,14 +61,6 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
     return null
   }
 
-  const parentGridPath = findOriginalGrid(
-    canvasState.startingMetadata,
-    EP.parentPath(selectedElement),
-  ) // TODO don't use EP.parentPath
-  if (parentGridPath == null) {
-    return null
-  }
-
   return {
     id: 'GRID-CELL-RESIZE-STRATEGY',
     name: 'Resize Grid Cell',
@@ -79,11 +72,11 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
     controlsToRender: [
       {
         control: GridResizeControls,
-        props: { target: selectedElement },
+        props: { target: gridContainerIdentifier(selectedElement) },
         key: `grid-resize-controls-${EP.toString(selectedElement)}`,
         show: 'always-visible',
       },
-      controlsForGridPlaceholders(parentGridPath),
+      controlsForGridPlaceholders(gridItemIdentifier(selectedElement)),
     ],
     fitness: onlyFitWhenDraggingThisControl(interactionSession, 'GRID_RESIZE_HANDLE', 1),
     apply: () => {
@@ -122,7 +115,7 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
 
       return strategyApplicationResult(
         setGridPropsCommands(selectedElement, gridTemplate, gridProps),
-        [parentGridPath],
+        [EP.parentPath(selectedElement)],
       )
     },
   }

--- a/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/resize-grid-strategy.ts
@@ -49,6 +49,7 @@ import { CSSCursor } from '../../canvas-types'
 import type { CanvasCommand } from '../../commands/commands'
 import type { Axis } from '../../gap-utils'
 import { getComponentDescriptorForTarget } from '../../../../core/property-controls/property-controls-utils'
+import { gridContainerIdentifier } from '../../../editor/store/editor-state'
 
 export const resizeGridStrategy: CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -105,11 +106,11 @@ export const resizeGridStrategy: CanvasStrategyFactory = (
     controlsToRender: [
       {
         control: GridRowColumnResizingControls,
-        props: { target: gridPath },
+        props: { target: gridContainerIdentifier(gridPath) },
         key: `grid-row-col-resize-controls-${EP.toString(gridPath)}`,
         show: 'always-visible',
       },
-      controlsForGridPlaceholders(gridPath),
+      controlsForGridPlaceholders(gridContainerIdentifier(gridPath)),
     ],
     fitness: supportsStyleProp
       ? onlyFitWhenDraggingThisControl(interactionSession, 'GRID_AXIS_HANDLE', 1)

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-grid-gap-strategy.tsx
@@ -45,6 +45,7 @@ import { GridGapControl } from '../../controls/select-mode/grid-gap-control'
 import type { GridControlsProps } from '../../controls/grid-controls-for-strategies'
 import { controlsForGridPlaceholders } from '../../controls/grid-controls-for-strategies'
 import { getComponentDescriptorForTarget } from '../../../../core/property-controls/property-controls-utils'
+import { gridContainerIdentifier } from '../../../editor/store/editor-state'
 
 const SetGridGapStrategyId = 'SET_GRID_GAP_STRATEGY'
 
@@ -152,7 +153,7 @@ export const setGridGapStrategy: CanvasStrategyFactory = (
 
   // when the drag is ongoing, keep showing the grid cells
   if (isDragOngoing(interactionSession)) {
-    controlsToRender.push(controlsForGridPlaceholders(selectedElement))
+    controlsToRender.push(controlsForGridPlaceholders(gridContainerIdentifier(selectedElement)))
   }
 
   return {

--- a/editor/src/components/canvas/commands/show-grid-controls-command.ts
+++ b/editor/src/components/canvas/commands/show-grid-controls-command.ts
@@ -1,18 +1,17 @@
-import type { ElementPath } from 'utopia-shared/src/types'
 import type { BaseCommand, CommandFunction, WhenToRun } from './commands'
-import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
+import type { EditorState, EditorStatePatch, GridIdentifier } from '../../editor/store/editor-state'
 import type { GridCellCoordinates } from '../canvas-strategies/strategies/grid-cell-bounds'
 
 export interface ShowGridControlsCommand extends BaseCommand {
   type: 'SHOW_GRID_CONTROLS'
-  target: ElementPath
+  target: GridIdentifier
   targetCell: GridCellCoordinates | null
   rootCell: GridCellCoordinates | null
 }
 
 export function showGridControls(
   whenToRun: WhenToRun,
-  target: ElementPath,
+  target: GridIdentifier,
   targetCell: GridCellCoordinates | null,
   rootCell: GridCellCoordinates | null,
 ): ShowGridControlsCommand {

--- a/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
+++ b/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
@@ -310,7 +310,7 @@ export function isGridControlsProps(props: unknown): props is GridControlsProps 
 export const GridControls = controlForStrategyMemoized<GridControlsProps>(GridControlsComponent)
 
 interface GridResizeControlProps {
-  target: ElementPath
+  target: GridIdentifier
 }
 
 export const GridResizeControls = controlForStrategyMemoized<GridResizeControlProps>(

--- a/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
+++ b/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
@@ -242,7 +242,7 @@ export function useGridData(gridIdentifiers: GridIdentifier[]): GridData[] {
       return mapDropNulls((view) => {
         const originalGridPath = findOriginalGrid(
           store.editor.jsxMetadata,
-          view.type === 'GRID_ITEM' ? EP.parentPath(view.path) : view.path,
+          view.type === 'GRID_ITEM' ? EP.parentPath(view.path) : view.path, // TODO: this is temporary, we will need to handle showing a grid control on the parent dom element of a grid item
         )
         if (originalGridPath == null) {
           return null

--- a/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
+++ b/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
@@ -1,6 +1,5 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
-import fastDeepEqual from 'fast-deep-equal'
 import { sides, type Sides } from 'utopia-api/core'
 import type { ElementPath } from 'utopia-shared/src/types'
 import {
@@ -11,10 +10,9 @@ import {
 import { MetadataUtils } from '../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../core/shared/array-utils'
 import * as EP from '../../../core/shared/element-path'
-import type { BorderWidths, ElementInstanceMetadata } from '../../../core/shared/element-template'
+import type { BorderWidths } from '../../../core/shared/element-template'
 import { type GridAutoOrTemplateBase } from '../../../core/shared/element-template'
 import type { CanvasRectangle } from '../../../core/shared/math-utils'
-import { isFiniteRectangle } from '../../../core/shared/math-utils'
 import { assertNever } from '../../../core/shared/utils'
 import { Substores, useEditorState } from '../../editor/store/store-hook'
 import type {
@@ -37,25 +35,16 @@ import {
   GridRowColumnResizingControlsComponent,
 } from './grid-controls'
 import { isEdgePositionOnSide } from '../canvas-utils'
-import { findOriginalGrid } from '../canvas-strategies/strategies/grid-helpers'
-import {
-  getAlignContent,
-  getFlexJustifyContent,
-  type AlignContent,
-  type FlexJustifyContent,
-} from '../../inspector/inspector-common'
 import { getFromElement } from '../direct-dom-lookups'
-import {
-  applicativeSidesPxTransform,
-  getGridContainerProperties,
-  isDynamicGridTemplate,
-} from '../dom-walker'
+import { applicativeSidesPxTransform, getGridContainerProperties } from '../dom-walker'
 import { applicative4Either, defaultEither, isRight, mapEither } from '../../../core/shared/either'
 import { domRectToScaledCanvasRectangle, getRoundingFn } from '../../../core/shared/dom-utils'
 import Utils from '../../../utils/utils'
 import { useMonitorChangesToEditor } from '../../../components/editor/store/store-monitor'
 import { useKeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
 import type { CSSProperties } from 'react'
+import { gridContainerIdentifier, type GridIdentifier } from '../../editor/store/editor-state'
+import { findOriginalGrid } from '../canvas-strategies/strategies/grid-helpers'
 
 export const GridCellTestId = (elementPath: ElementPath) => `grid-cell-${EP.toString(elementPath)}`
 
@@ -237,10 +226,10 @@ export function useGridMeasurementHelperData(
 }
 
 export type GridData = GridMeasurementHelperData & {
-  elementPath: ElementPath
+  identifier: GridIdentifier
 }
 
-export function useGridData(elementPaths: ElementPath[]): GridData[] {
+export function useGridData(gridIdentifiers: GridIdentifier[]): GridData[] {
   const scale = useEditorState(
     Substores.canvas,
     (store) => store.editor.canvas.scale,
@@ -251,11 +240,13 @@ export function useGridData(elementPaths: ElementPath[]): GridData[] {
     Substores.metadata,
     (store) => {
       return mapDropNulls((view) => {
-        const originalGridPath = findOriginalGrid(store.editor.jsxMetadata, view)
+        const originalGridPath = findOriginalGrid(
+          store.editor.jsxMetadata,
+          view.type === 'GRID_ITEM' ? EP.parentPath(view.path) : view.path,
+        )
         if (originalGridPath == null) {
           return null
         }
-
         const element = MetadataUtils.findElementByElementPath(
           store.editor.jsxMetadata,
           originalGridPath,
@@ -273,10 +264,10 @@ export function useGridData(elementPaths: ElementPath[]): GridData[] {
 
         const gridData: GridData = {
           ...helperData,
-          elementPath: view,
+          identifier: gridContainerIdentifier(originalGridPath),
         }
         return gridData
-      }, elementPaths)
+      }, gridIdentifiers)
     },
     'useGridData',
   )
@@ -285,7 +276,7 @@ export function useGridData(elementPaths: ElementPath[]): GridData[] {
 }
 
 interface GridRowColumnResizingControlsProps {
-  target: ElementPath
+  target: GridIdentifier
 }
 
 export const GridRowColumnResizingControls =
@@ -309,7 +300,7 @@ export interface GridControlProps {
 
 export interface GridControlsProps {
   type: 'GRID_CONTROLS_PROPS'
-  targets: ElementPath[]
+  targets: GridIdentifier[]
 }
 
 export function isGridControlsProps(props: unknown): props is GridControlsProps {
@@ -358,7 +349,7 @@ export function edgePositionToGridResizeEdge(position: EdgePosition): GridResize
 }
 
 export function controlsForGridPlaceholders(
-  gridPath: ElementPath | Array<ElementPath>,
+  gridPath: GridIdentifier | Array<GridIdentifier>,
   whenToShow: WhenToShowControl = 'always-visible',
   suffix: string | null = null,
 ): ControlWithProps<any> {

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -105,7 +105,11 @@ import type { PinOutlineProps } from './position-outline'
 import { PinOutline, usePropsOrJSXAttributes } from './position-outline'
 import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
 import { styleStringInArray } from '../../../utils/common-constants'
-import { gridContainerIdentifier, type GridIdentifier } from '../../editor/store/editor-state'
+import {
+  gridContainerIdentifier,
+  gridIdentifierSimilar,
+  type GridIdentifier,
+} from '../../editor/store/editor-state'
 
 const CELL_ANIMATION_DURATION = 0.15 // seconds
 
@@ -1125,13 +1129,7 @@ export const GridControlsComponent = ({ targets }: GridControlsProps) => {
   // With the lowest depth grid at the end so that it renders on top and catches the events
   // before those above it in the hierarchy.
   const grids = useGridData(
-    uniqBy(
-      [...gridsWithVisibleControls, ...ancestorGrids],
-      (a, b) =>
-        (a.type === b.type && EP.pathsEqual(a.path, b.path)) ||
-        (a.type === 'GRID_ITEM' && b.type === 'GRID_CONTAINER' && EP.isParentOf(b.path, a.path)) ||
-        (a.type === 'GRID_CONTAINER' && b.type === 'GRID_ITEM' && EP.isParentOf(a.path, b.path)),
-    ).sort((a, b) => {
+    uniqBy([...gridsWithVisibleControls, ...ancestorGrids], gridIdentifierSimilar).sort((a, b) => {
       const aDepth = a.type === 'GRID_CONTAINER' ? EP.fullDepth(a.path) : EP.fullDepth(a.path) - 1
       const bDepth = a.type === 'GRID_CONTAINER' ? EP.fullDepth(b.path) : EP.fullDepth(b.path) - 1
       return aDepth - bDepth

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -105,6 +105,7 @@ import type { PinOutlineProps } from './position-outline'
 import { PinOutline, usePropsOrJSXAttributes } from './position-outline'
 import { getLayoutProperty } from '../../../core/layout/getLayoutProperty'
 import { styleStringInArray } from '../../../utils/common-constants'
+import { gridContainerIdentifier, type GridIdentifier } from '../../editor/store/editor-state'
 
 const CELL_ANIMATION_DURATION = 0.15 // seconds
 
@@ -497,7 +498,7 @@ const GridResizing = React.memo((props: GridResizingProps) => {
 GridResizing.displayName = 'GridResizing'
 
 interface GridRowColumnResizingControlsProps {
-  target: ElementPath
+  target: GridIdentifier
 }
 
 export const GridRowColumnResizingControlsComponent = ({
@@ -567,7 +568,7 @@ export const GridRowColumnResizingControlsComponent = ({
       {gridsWithVisibleResizeControls.flatMap((grid) => {
         return (
           <GridResizing
-            key={`grid-resizing-column-${EP.toString(grid.elementPath)}`}
+            key={`grid-resizing-column-${EP.toString(grid.identifier.path)}`}
             targetGrid={grid}
             axisValues={grid.gridTemplateColumns}
             fromPropsAxisValues={grid.gridTemplateColumnsFromProps}
@@ -587,7 +588,7 @@ export const GridRowColumnResizingControlsComponent = ({
       {gridsWithVisibleResizeControls.flatMap((grid) => {
         return (
           <GridResizing
-            key={`grid-resizing-row-${EP.toString(grid.elementPath)}`}
+            key={`grid-resizing-row-${EP.toString(grid.identifier.path)}`}
             targetGrid={grid}
             axisValues={grid.gridTemplateRows}
             fromPropsAxisValues={grid.gridTemplateRowsFromProps}
@@ -730,7 +731,10 @@ const GridControl = React.memo<GridControlProps>(({ grid, controlsVisible }) => 
   )
 
   const cells = React.useMemo(() => {
-    const children = MetadataUtils.getChildrenUnordered(jsxMetadata, grid.elementPath)
+    const children =
+      grid.identifier.type === 'GRID_CONTAINER'
+        ? MetadataUtils.getChildrenUnordered(jsxMetadata, grid.identifier.path)
+        : MetadataUtils.getSiblingsUnordered(jsxMetadata, grid.identifier.path)
     return mapDropNulls((cell, index) => {
       if (cell == null || cell.globalFrame == null || !isFiniteRectangle(cell.globalFrame)) {
         return null
@@ -892,25 +896,25 @@ const GridControl = React.memo<GridControlProps>(({ grid, controlsVisible }) => 
   const dontShowActiveCellHighlight =
     (!targetsAreCellsWithPositioning && anyTargetAbsolute) ||
     (anyTargetNotPinned && !targetRootCellIsValidTarget)
-
   return (
     <React.Fragment>
       {/* grid lines */}
       <div
-        key={gridKeyFromPath(grid.elementPath)}
-        id={gridKeyFromPath(grid.elementPath)}
-        data-grid-path={EP.toString(grid.elementPath)}
+        key={gridKeyFromPath(grid.identifier.path)}
+        id={gridKeyFromPath(grid.identifier.path)}
+        data-grid-path={EP.toString(grid.identifier.path)}
         style={style}
       >
         {placeholders.map((cell) => {
           const countedRow = Math.floor(cell / grid.columns) + 1
           const countedColumn = Math.floor(cell % grid.columns) + 1
-          const id = gridCellTargetId(grid.elementPath, countedRow, countedColumn)
+          const id = gridCellTargetId(grid.identifier.path, countedRow, countedColumn)
           const borderID = `${id}-border`
 
           const isActiveGrid =
-            (dragging != null && EP.isParentOf(grid.elementPath, dragging)) ||
-            (currentHoveredGrid != null && EP.pathsEqual(grid.elementPath, currentHoveredGrid))
+            (dragging != null && EP.isParentOf(grid.identifier.path, dragging)) ||
+            (currentHoveredGrid != null &&
+              EP.pathsEqual(grid.identifier.path, currentHoveredGrid.path))
           const isActiveCell =
             isActiveGrid &&
             countedColumn === currentHoveredCell?.column &&
@@ -1085,18 +1089,20 @@ GridMeasurementHelper.displayName = 'GridMeasurementHelper'
 
 export const GridControlsComponent = ({ targets }: GridControlsProps) => {
   const ancestorPaths = React.useMemo(() => {
-    return targets.flatMap((target) => EP.getAncestors(target))
+    return targets.flatMap((target) => EP.getAncestors(target.path))
   }, [targets])
-  const ancestorGrids: Array<ElementPath> = useEditorState(
+  const ancestorGrids: Array<GridIdentifier> = useEditorState(
     Substores.metadata,
     (store) => {
-      return ancestorPaths.filter((ancestorPath) => {
-        const ancestorMetadata = MetadataUtils.findElementByElementPath(
-          store.editor.jsxMetadata,
-          ancestorPath,
-        )
-        return MetadataUtils.isGridLayoutedContainer(ancestorMetadata)
-      })
+      return ancestorPaths
+        .filter((ancestorPath) => {
+          const ancestorMetadata = MetadataUtils.findElementByElementPath(
+            store.editor.jsxMetadata,
+            ancestorPath,
+          )
+          return MetadataUtils.isGridLayoutedContainer(ancestorMetadata)
+        })
+        .map((p) => gridContainerIdentifier(p))
     },
     'GridControlsComponent ancestorGrids',
   )
@@ -1113,17 +1119,23 @@ export const GridControlsComponent = ({ targets }: GridControlsProps) => {
     'GridControlsComponent hoveredGrids',
   )
 
-  const gridsWithVisibleControls: Array<ElementPath> = [...targets, ...hoveredGrids]
+  const gridsWithVisibleControls: Array<GridIdentifier> = [...targets, ...hoveredGrids]
 
   // Uniqify the grid paths, and then sort them by depth.
   // With the lowest depth grid at the end so that it renders on top and catches the events
   // before those above it in the hierarchy.
   const grids = useGridData(
-    uniqBy([...gridsWithVisibleControls, ...ancestorGrids], (a, b) => EP.pathsEqual(a, b)).sort(
-      (a, b) => {
-        return EP.fullDepth(a) - EP.fullDepth(b)
-      },
-    ),
+    uniqBy(
+      [...gridsWithVisibleControls, ...ancestorGrids],
+      (a, b) =>
+        (a.type === b.type && EP.pathsEqual(a.path, b.path)) ||
+        (a.type === 'GRID_ITEM' && b.type === 'GRID_CONTAINER' && EP.isParentOf(b.path, a.path)) ||
+        (a.type === 'GRID_CONTAINER' && b.type === 'GRID_ITEM' && EP.isParentOf(a.path, b.path)),
+    ).sort((a, b) => {
+      const aDepth = a.type === 'GRID_CONTAINER' ? EP.fullDepth(a.path) : EP.fullDepth(a.path) - 1
+      const bDepth = a.type === 'GRID_CONTAINER' ? EP.fullDepth(b.path) : EP.fullDepth(b.path) - 1
+      return aDepth - bDepth
+    }),
   )
 
   if (grids.length === 0) {
@@ -1134,13 +1146,18 @@ export const GridControlsComponent = ({ targets }: GridControlsProps) => {
     <div id={'grid-controls'}>
       <CanvasOffsetWrapper>
         {grids.map((grid) => {
-          const shouldHaveVisibleControls = EP.containsPath(
-            grid.elementPath,
-            gridsWithVisibleControls,
-          )
+          const gridPath =
+            grid.identifier.type === 'GRID_CONTAINER'
+              ? grid.identifier.path
+              : EP.parentPath(grid.identifier.path)
+          const shouldHaveVisibleControls = gridsWithVisibleControls.some((g) => {
+            const visibleControlPath = g.type === 'GRID_CONTAINER' ? g.path : EP.parentPath(g.path)
+            return EP.pathsEqual(gridPath, visibleControlPath)
+          })
+
           return (
             <GridControl
-              key={GridControlKey(grid.elementPath)}
+              key={GridControlKey(grid.identifier.path)}
               grid={grid}
               controlsVisible={shouldHaveVisibleControls ? 'visible' : 'not-visible'}
             />

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -1599,15 +1599,16 @@ function useMouseMove(activelyDraggingOrResizingCell: string | null) {
 }
 
 interface GridResizeControlProps {
-  target: ElementPath
+  target: GridIdentifier
 }
 
 export const GridResizeControlsComponent = ({ target }: GridResizeControlProps) => {
+  const gridTarget = target.type === 'GRID_CONTAINER' ? target.path : EP.parentPath(target.path)
   const colorTheme = useColorTheme()
 
   const element = useEditorState(
     Substores.metadata,
-    (store) => MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, target),
+    (store) => MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, gridTarget),
     'GridResizeControls element',
   )
 
@@ -1720,7 +1721,7 @@ export const GridResizeControlsComponent = ({ target }: GridResizeControlProps) 
     [element, startResizeInteraction],
   )
 
-  const resizeEdges = useResizeEdges([target], {
+  const resizeEdges = useResizeEdges([gridTarget], {
     onEdgeDoubleClick: () => NO_OP,
     onEdgeMouseMove: NO_OP,
     onEdgeMouseDown: onEdgeMouseDown,

--- a/editor/src/components/canvas/controls/select-mode/grid-gap-control-component.tsx
+++ b/editor/src/components/canvas/controls/select-mode/grid-gap-control-component.tsx
@@ -27,6 +27,7 @@ import type { CSSNumberWithRenderedValue } from './controls-common'
 import { CanvasLabel, PillHandle, useHoverWithDelay } from './controls-common'
 import { startGapControlInteraction } from './grid-gap-control-helpers'
 import type { AlignContent, FlexJustifyContent } from '../../../inspector/inspector-common'
+import { gridContainerIdentifier } from '../../../editor/store/editor-state'
 
 export interface GridGapControlProps {
   selectedElement: ElementPath
@@ -67,7 +68,7 @@ export const GridGapControlComponent = React.memo<GridGapControlProps>((props) =
       'GridGapControlComponent elementHovered',
     ) ?? false
 
-  const grid = useGridData([selectedElement]).at(0)
+  const grid = useGridData([gridContainerIdentifier(selectedElement)]).at(0)
 
   const activeDraggingAxis = useEditorState(
     Substores.canvas,

--- a/editor/src/components/canvas/controls/select-mode/subdued-grid-gap-controls.tsx
+++ b/editor/src/components/canvas/controls/select-mode/subdued-grid-gap-controls.tsx
@@ -8,6 +8,7 @@ import { unitlessCSSNumberWithRenderedValue } from './controls-common'
 import { NO_OP } from '../../../../core/shared/utils'
 import * as EP from '../../../../core/shared/element-path'
 import { GridPaddingOutlineForDimension } from './grid-gap-control-component'
+import { gridContainerIdentifier } from '../../../editor/store/editor-state'
 
 export interface SubduedGridGapControlProps {
   hoveredOrFocused: 'hovered' | 'focused'
@@ -19,7 +20,7 @@ export const SubduedGridGapControl = React.memo<SubduedGridGapControlProps>((pro
   const colorTheme = useColorTheme()
   const targets = useEditorState(
     Substores.selectedViews,
-    (store) => store.editor.selectedViews,
+    (store) => store.editor.selectedViews.map(gridContainerIdentifier),
     'SubduedGridGapControl selectedViews',
   )
 
@@ -33,7 +34,7 @@ export const SubduedGridGapControl = React.memo<SubduedGridGapControlProps>((pro
     <CanvasOffsetWrapper>
       {gridRowColumnInfo.map((gridData) => {
         return (
-          <React.Fragment key={`grid-gap-${EP.toString(gridData.elementPath)}`}>
+          <React.Fragment key={`grid-gap-${EP.toString(gridData.identifier.path)}`}>
             <GridPaddingOutlineForDimension
               grid={gridData}
               dimension={'rows'}

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -822,8 +822,34 @@ export interface DragToMoveIndicatorFlags {
   ancestor: boolean
 }
 
+export type GridIdentifier = GridContainerIdentifier | GridItemIdentifier
+
+export interface GridContainerIdentifier {
+  type: 'GRID_CONTAINER'
+  path: ElementPath
+}
+
+export function gridContainerIdentifier(path: ElementPath): GridContainerIdentifier {
+  return {
+    type: 'GRID_CONTAINER',
+    path: path,
+  }
+}
+
+export interface GridItemIdentifier {
+  type: 'GRID_ITEM'
+  path: ElementPath
+}
+
+export function gridItemIdentifier(path: ElementPath): GridItemIdentifier {
+  return {
+    type: 'GRID_ITEM',
+    path: path,
+  }
+}
+
 export interface GridControlData {
-  grid: ElementPath
+  grid: GridIdentifier
   targetCell: GridCellCoordinates | null // the cell under the mouse
   rootCell: GridCellCoordinates | null // the top-left cell of the target child
 }

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -848,6 +848,14 @@ export function gridItemIdentifier(path: ElementPath): GridItemIdentifier {
   }
 }
 
+export function gridIdentifierSimilar(a: GridIdentifier, b: GridIdentifier): boolean {
+  return (
+    (a.type === b.type && EP.pathsEqual(a.path, b.path)) ||
+    (a.type === 'GRID_ITEM' && b.type === 'GRID_CONTAINER' && EP.isParentOf(b.path, a.path)) ||
+    (a.type === 'GRID_CONTAINER' && b.type === 'GRID_ITEM' && EP.isParentOf(a.path, b.path))
+  )
+}
+
 export interface GridControlData {
   grid: GridIdentifier
   targetCell: GridCellCoordinates | null // the cell under the mouse

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -368,6 +368,9 @@ import type {
   EditorRemixConfig,
   ErrorBoundaryHandling,
   GridControlData,
+  GridIdentifier,
+  GridContainerIdentifier,
+  GridItemIdentifier,
 } from './editor-state'
 import {
   trueUpGroupElementChanged,
@@ -380,6 +383,8 @@ import {
   newGithubData,
   renderedAtPropertyPath,
   renderedAtChildNode,
+  gridContainerIdentifier,
+  gridItemIdentifier,
 } from './editor-state'
 import {
   editorStateNodeModules,
@@ -2849,10 +2854,46 @@ export const GridCellCoordinatesKeepDeepEquality: KeepDeepEqualityCall<GridCellC
     (row, column) => ({ row, column }),
   )
 
-export const GridControlDataKeepDeepEquality: KeepDeepEqualityCall<GridControlData> =
+export const GridContainerIdentifierKeepDeepEquality: KeepDeepEqualityCall<GridContainerIdentifier> =
+  combine1EqualityCall(
+    (identifier) => identifier.path,
+    ElementPathKeepDeepEquality,
+    gridContainerIdentifier,
+  )
+
+export const GridItemIdentifierKeepDeepEquality: KeepDeepEqualityCall<GridItemIdentifier> =
+  combine1EqualityCall(
+    (identifier) => identifier.path,
+    ElementPathKeepDeepEquality,
+    gridItemIdentifier,
+  )
+
+export const GridIdentifierKeepDeepEquality: KeepDeepEqualityCall<GridIdentifier> = (
+  oldValue,
+  newValue,
+) => {
+  switch (oldValue.type) {
+    case 'GRID_CONTAINER':
+      if (newValue.type === oldValue.type) {
+        return GridContainerIdentifierKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    case 'GRID_ITEM':
+      if (newValue.type === oldValue.type) {
+        return GridItemIdentifierKeepDeepEquality(oldValue, newValue)
+      }
+      break
+    default:
+      const _exhaustiveCheck: never = oldValue
+      throw new Error(`Unhandled type ${JSON.stringify(oldValue)}`)
+  }
+  return keepDeepEqualityResult(newValue, false)
+}
+
+const GridControlDataKeepDeepEquality: KeepDeepEqualityCall<GridControlData> =
   combine3EqualityCalls(
     (data) => data.grid,
-    ElementPathKeepDeepEquality,
+    GridIdentifierKeepDeepEquality,
     (data) => data.targetCell,
     nullableDeepEquality(GridCellCoordinatesKeepDeepEquality),
     (data) => data.rootCell,

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -793,6 +793,19 @@ export const MetadataUtils = {
     }
     return result
   },
+  getSiblingsUnordered(
+    metadata: ElementInstanceMetadataMap,
+    target: ElementPath | null,
+  ): ElementInstanceMetadata[] {
+    if (target == null) {
+      return []
+    }
+    const parentPath = EP.parentPath(target)
+    const siblings = EP.isRootElementOfInstance(target)
+      ? MetadataUtils.getRootViewsUnordered(metadata, parentPath)
+      : MetadataUtils.getChildrenUnordered(metadata, parentPath)
+    return siblings
+  },
   getChildrenOrdered(
     elements: ElementInstanceMetadataMap,
     pathTree: ElementPathTrees,


### PR DESCRIPTION
**Problem:**
This PR is a preparation step to support strategies for grid items in the following scenario:

- the grid is in a component
- the grid renders the component's children
- the grid is not the root element of the component

The main issue is that we still identify the grid control using the element path of the grid, even though that grid doesn't have a path in this case. We need to be able to show and manage a grid control using the element path of one of its items.

**Fix:**
Instead of storing the element path of the `GridControlData`, I introduced a new type `GridIdentifier` which can identify a grid either by its container element path, or an item's element path.

I updated the strategies and commands to use this grid identifier, and also made sure the strategies for grid items identify using the item, and do not refer to the parent path as the grid. (For reparent we can not really do that, because the item is not in the grid yet. Solving that is not in scope now).

What is missing:
I still use mostly the old control implementations, it only works now because the `useGridData` hook converts GridItemIdentifier-s to a GridContainerIdentifier-s (using parentPath). So this PR is just a preparation, it does not solve the component problem yet. Next step is to make sure the control can render on the parent element when it receives a GridItemIdentifier. 

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

