### PR TITLE
Tailwind aware padding

### DIFF
--- a/editor/package.json
+++ b/editor/package.json
@@ -171,7 +171,7 @@
     "@types/w3c-css-typed-object-model-level-1": "20180410.0.5",
     "@use-it/interval": "0.1.3",
     "@vercel/stega": "0.1.0",
-    "@xengine/tailwindcss-class-parser": "1.1.17",
+    "@xengine/tailwindcss-class-parser": "1.1.18",
     "ajv": "6.4.0",
     "anser": "2.1.0",
     "antd": "4.3.5",

--- a/editor/pnpm-lock.yaml
+++ b/editor/pnpm-lock.yaml
@@ -150,7 +150,7 @@ specifiers:
   '@vercel/stega': 0.1.0
   '@vitejs/plugin-react': 4.0.4
   '@welldone-software/why-did-you-render': 5.0.0-rc.1
-  '@xengine/tailwindcss-class-parser': 1.1.17
+  '@xengine/tailwindcss-class-parser': 1.1.18
   ajv: 6.4.0
   anser: 2.1.0
   antd: 4.3.5
@@ -390,7 +390,7 @@ dependencies:
   '@types/w3c-css-typed-object-model-level-1': 20180410.0.5
   '@use-it/interval': 0.1.3_react@18.1.0
   '@vercel/stega': 0.1.0
-  '@xengine/tailwindcss-class-parser': 1.1.17_tailwindcss@3.4.13
+  '@xengine/tailwindcss-class-parser': 1.1.18_tailwindcss@3.4.13
   ajv: 6.4.0
   anser: 2.1.0
   antd: 4.3.5_ef5jwxihqo6n7gxfmzogljlgcm
@@ -6002,8 +6002,8 @@ packages:
       react: 18.1.0_47cciibm4ysmleigs33s763fqu
     dev: true
 
-  /@xengine/tailwindcss-class-parser/1.1.17_tailwindcss@3.4.13:
-    resolution: {integrity: sha512-LRod5tEDSpr3T2I8R3U0bRH4O18MDfAdybxQRLSbcIta4AboQEeIUrNVsz6wRmJcsrBXtQYbwP4k9zsE+QnKAg==}
+  /@xengine/tailwindcss-class-parser/1.1.18_tailwindcss@3.4.13:
+    resolution: {integrity: sha512-BUH8MY4cAV7H1mHXIF1cny63VOiI4HXQD5z2q3SJ2seE1dcMWpUH7PvJ3cq8iO8cJ1q81qDTKUp9nlmRU7Gn6A==}
     peerDependencies:
       tailwindcss: '*'
     dependencies:

--- a/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/set-padding-strategy.tsx
@@ -124,7 +124,6 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
     canvasState,
     interactionSession,
     selectedElements[0],
-    canvasState.styleInfoReader,
   )
 
   const resizeControl = controlWithProps({
@@ -174,12 +173,7 @@ export const setPaddingStrategy: CanvasStrategyFactory = (canvasState, interacti
       }
 
       const selectedElement = filteredSelectedElements[0]
-      const delta = calculateAdjustDelta(
-        canvasState,
-        interactionSession,
-        selectedElement,
-        canvasState.styleInfoReader,
-      )
+      const delta = calculateAdjustDelta(canvasState, interactionSession, selectedElement)
 
       if (delta == null) {
         return emptyStrategyApplicationResult
@@ -422,7 +416,6 @@ function paddingValueIndicatorProps(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
   selectedElement: ElementPath,
-  styleInfoReader: StyleInfoReader,
 ): FloatingIndicatorProps | null {
   const filteredSelectedElements = flattenSelection([selectedElement])
 
@@ -442,17 +435,12 @@ function paddingValueIndicatorProps(
   const padding = simplePaddingFromStyleInfo(
     canvasState.startingMetadata,
     filteredSelectedElements[0],
-    styleInfoReader(filteredSelectedElements[0]),
+    canvasState.styleInfoReader(filteredSelectedElements[0]),
   )
   const currentPadding =
     padding[paddingPropForEdge(edgePiece)] ?? unitlessCSSNumberWithRenderedValue(0)
 
-  const delta = calculateAdjustDelta(
-    canvasState,
-    interactionSession,
-    selectedElement,
-    styleInfoReader,
-  )
+  const delta = calculateAdjustDelta(canvasState, interactionSession, selectedElement)
   if (delta == null) {
     return null
   }
@@ -562,7 +550,6 @@ function calculateAdjustDelta(
   canvasState: InteractionCanvasState,
   interactionSession: InteractionSession | null,
   selectedElement: ElementPath,
-  styleInfoReader: StyleInfoReader,
 ): number | null {
   if (
     interactionSession == null ||
@@ -577,7 +564,7 @@ function calculateAdjustDelta(
   const padding = simplePaddingFromStyleInfo(
     canvasState.startingMetadata,
     selectedElement,
-    styleInfoReader(selectedElement),
+    canvasState.styleInfoReader(selectedElement),
   )
   const paddingPropInteractedWith = paddingPropForEdge(edgePiece)
   const currentPadding = padding[paddingPropForEdge(edgePiece)]?.renderedValuePx ?? 0

--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -26,7 +26,7 @@ import type {
 import { InteractionSession } from './canvas-strategies/interaction-state'
 import type { CanvasStrategyId } from './canvas-strategies/canvas-strategy-types'
 import type { MouseButtonsPressed } from '../../utils/mouse'
-import type { CSSNumber, FlexDirection } from '../inspector/common/css-utils'
+import type { CSSNumber, CSSPadding, FlexDirection } from '../inspector/common/css-utils'
 
 export const CanvasContainerID = 'canvas-container'
 
@@ -584,6 +584,8 @@ export type BottomInfo = CSSStyleProperty<CSSNumber>
 export type WidthInfo = CSSStyleProperty<CSSNumber>
 export type HeightInfo = CSSStyleProperty<CSSNumber>
 export type FlexBasisInfo = CSSStyleProperty<CSSNumber>
+export type PaddingInfo = CSSStyleProperty<CSSPadding>
+export type PaddingSideInfo = CSSStyleProperty<CSSNumber>
 
 export interface StyleInfo {
   gap: FlexGapInfo | null
@@ -595,6 +597,11 @@ export interface StyleInfo {
   width: WidthInfo | null
   height: HeightInfo | null
   flexBasis: FlexBasisInfo | null
+  padding: PaddingInfo | null
+  paddingTop: PaddingSideInfo | null
+  paddingRight: PaddingSideInfo | null
+  paddingBottom: PaddingSideInfo | null
+  paddingLeft: PaddingSideInfo | null
 }
 
 const emptyStyleInfo: StyleInfo = {
@@ -607,6 +614,11 @@ const emptyStyleInfo: StyleInfo = {
   width: null,
   height: null,
   flexBasis: null,
+  padding: null,
+  paddingTop: null,
+  paddingRight: null,
+  paddingBottom: null,
+  paddingLeft: null,
 }
 
 export const isStyleInfoKey = (key: string): key is keyof StyleInfo => key in emptyStyleInfo

--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -34,7 +34,7 @@ import {
   paddingAdjustMode,
   paddingFromSpecialSizeMeasurements,
   PaddingIndictorOffset,
-  simplePaddingFromMetadata,
+  simplePaddingFromStyleInfo,
 } from '../../padding-utils'
 import { useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
@@ -43,6 +43,7 @@ import type { CSSNumberWithRenderedValue } from './controls-common'
 import { CanvasLabel, fallbackEmptyValue, PillHandle, useHoverWithDelay } from './controls-common'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import { mapDropNulls } from '../../../../core/shared/array-utils'
+import { getActivePlugin } from '../../plugins/style-plugins'
 
 export const paddingControlTestId = (edge: EdgePiece): string => `padding-control-${edge}`
 export const paddingControlHandleTestId = (edge: EdgePiece): string =>
@@ -358,12 +359,22 @@ export const PaddingResizeControl = controlForStrategyMemoized((props: PaddingCo
     }
   }, [hoveredViews, selectedElements])
 
+  const styleInfoReaderRef = useRefEditorState((store) =>
+    getActivePlugin(store.editor).styleInfoFactory({
+      projectContents: store.editor.projectContents,
+    }),
+  )
+
   const currentPadding = React.useMemo(() => {
     return combinePaddings(
       paddingFromSpecialSizeMeasurements(elementMetadata, selectedElements[0]),
-      simplePaddingFromMetadata(elementMetadata, selectedElements[0]),
+      simplePaddingFromStyleInfo(
+        elementMetadata,
+        selectedElements[0],
+        styleInfoReaderRef.current(selectedElements[0]),
+      ),
     )
-  }, [elementMetadata, selectedElements])
+  }, [elementMetadata, selectedElements, styleInfoReaderRef])
 
   const shownByParent = selectedElementHovered || anyControlHovered
 

--- a/editor/src/components/canvas/controls/select-mode/subdued-padding-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/subdued-padding-control.tsx
@@ -2,9 +2,10 @@ import React from 'react'
 import { useColorTheme } from '../../../../uuiui'
 import { Substores, useEditorState, useRefEditorState } from '../../../editor/store/store-hook'
 import type { EdgePiece } from '../../canvas-types'
-import { paddingPropForEdge, simplePaddingFromMetadata } from '../../padding-utils'
+import { paddingPropForEdge, simplePaddingFromStyleInfo } from '../../padding-utils'
 import { useBoundingBox } from '../bounding-box-hooks'
 import { CanvasOffsetWrapper } from '../canvas-offset-wrapper'
+import { getActivePlugin } from '../../plugins/style-plugins'
 
 export interface SubduedPaddingControlProps {
   side: EdgePiece
@@ -25,9 +26,19 @@ export const SubduedPaddingControl = React.memo<SubduedPaddingControlProps>((pro
   const isVerticalPadding = !isHorizontalPadding
   const paddingKey = paddingPropForEdge(side)
 
+  const styleInfoReaderRef = useRefEditorState((store) =>
+    getActivePlugin(store.editor).styleInfoFactory({
+      projectContents: store.editor.projectContents,
+    }),
+  )
+
   // TODO Multiselect
   const sideRef = useBoundingBox(targets, (ref, boundingBox) => {
-    const padding = simplePaddingFromMetadata(elementMetadata.current, targets[0])
+    const padding = simplePaddingFromStyleInfo(
+      elementMetadata.current,
+      targets[0],
+      styleInfoReaderRef.current(targets[0]),
+    )
     const paddingValue = padding[paddingKey]?.renderedValuePx ?? 0
 
     const { x, y, width, height } = boundingBox

--- a/editor/src/components/canvas/padding-utils.tsx
+++ b/editor/src/components/canvas/padding-utils.tsx
@@ -1,9 +1,6 @@
 import { styleStringInArray } from '../../utils/common-constants'
-import { getLayoutProperty } from '../../core/layout/getLayoutProperty'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
-import { defaultEither, isLeft, right } from '../../core/shared/either'
 import type { ElementInstanceMetadataMap } from '../../core/shared/element-template'
-import { isJSXElement } from '../../core/shared/element-template'
 import type { CanvasVector, Size } from '../../core/shared/math-utils'
 import { numberIsZero, roundTo, zeroRectIfNullOrInfinity } from '../../core/shared/math-utils'
 import { optionalMap } from '../../core/shared/optional-utils'
@@ -11,7 +8,7 @@ import type { ElementPath } from '../../core/shared/project-file-types'
 import { assertNever } from '../../core/shared/utils'
 import type { CSSNumber, CSSNumberUnit, CSSPadding } from '../inspector/common/css-utils'
 import { printCSSNumber } from '../inspector/common/css-utils'
-import type { EdgePiece } from './canvas-types'
+import { maybePropertyValue, type EdgePiece, type StyleInfo } from './canvas-types'
 import type {
   AdjustPrecision,
   CSSNumberWithRenderedValue,
@@ -58,12 +55,11 @@ export function paddingFromSpecialSizeMeasurements(
   return paddingMappedMeasurements
 }
 
-export function simplePaddingFromMetadata(
+export function simplePaddingFromStyleInfo(
   metadata: ElementInstanceMetadataMap,
   elementPath: ElementPath,
+  styleInfo: StyleInfo | null,
 ): CSSPaddingMappedValues<CSSNumberWithRenderedValue | undefined> {
-  const element = MetadataUtils.findElementByElementPath(metadata, elementPath)
-
   const defaults: CSSPaddingMappedValues<CSSNumber | undefined> = {
     paddingTop: undefined,
     paddingRight: undefined,
@@ -71,39 +67,15 @@ export function simplePaddingFromMetadata(
     paddingLeft: undefined,
   }
 
-  if (element == null || isLeft(element.element) || !isJSXElement(element.element.value)) {
-    return {
-      paddingTop: undefined,
-      paddingRight: undefined,
-      paddingBottom: undefined,
-      paddingLeft: undefined,
-    }
-  }
-
   const paddingNumbers = paddingFromSpecialSizeMeasurements(metadata, elementPath)
 
-  const padding: CSSPadding | undefined = defaultEither(
-    undefined,
-    getLayoutProperty('padding', right(element.element.value.props), styleStringInArray),
-  )
+  const padding = optionalMap(maybePropertyValue, styleInfo?.padding)
 
-  const paddingLonghands: CSSPaddingMappedValues<CSSNumber | undefined> = {
-    paddingTop: defaultEither(
-      undefined,
-      getLayoutProperty('paddingTop', right(element.element.value.props), styleStringInArray),
-    ),
-    paddingBottom: defaultEither(
-      undefined,
-      getLayoutProperty('paddingBottom', right(element.element.value.props), styleStringInArray),
-    ),
-    paddingLeft: defaultEither(
-      undefined,
-      getLayoutProperty('paddingLeft', right(element.element.value.props), styleStringInArray),
-    ),
-    paddingRight: defaultEither(
-      undefined,
-      getLayoutProperty('paddingRight', right(element.element.value.props), styleStringInArray),
-    ),
+  const paddingLonghands: CSSPaddingMappedValues<CSSNumber | null> = {
+    paddingTop: optionalMap(maybePropertyValue, styleInfo?.paddingTop),
+    paddingBottom: optionalMap(maybePropertyValue, styleInfo?.paddingBottom),
+    paddingLeft: optionalMap(maybePropertyValue, styleInfo?.paddingLeft),
+    paddingRight: optionalMap(maybePropertyValue, styleInfo?.paddingRight),
   }
 
   const make = (prop: CSSPaddingKey): CSSNumberWithRenderedValue | undefined => {

--- a/editor/src/components/canvas/plugins/inline-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/inline-style-plugin.ts
@@ -68,6 +68,11 @@ export const InlineStylePlugin: StylePlugin = {
       const width = getPropertyFromInstance('width', element.props)
       const height = getPropertyFromInstance('height', element.props)
       const flexBasis = getPropertyFromInstance('flexBasis', element.props)
+      const padding = getPropertyFromInstance('padding', element.props)
+      const paddingTop = getPropertyFromInstance('paddingTop', element.props)
+      const paddingBottom = getPropertyFromInstance('paddingBottom', element.props)
+      const paddingLeft = getPropertyFromInstance('paddingLeft', element.props)
+      const paddingRight = getPropertyFromInstance('paddingRight', element.props)
 
       return {
         gap: gap,
@@ -79,6 +84,11 @@ export const InlineStylePlugin: StylePlugin = {
         width: width,
         height: height,
         flexBasis: flexBasis,
+        padding: padding,
+        paddingTop: paddingTop,
+        paddingBottom: paddingBottom,
+        paddingLeft: paddingLeft,
+        paddingRight: paddingRight,
       }
     },
   updateStyles: (editorState, elementPath, updates) => {

--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -187,6 +187,7 @@ const patchers: PropPatcher[] = [
       )
     },
   },
+  { matches: (p) => p.startsWith('padding'), patch: genericPropPatcher('0px') },
 ]
 
 function getPropertiesToZero(

--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -187,7 +187,7 @@ const patchers: PropPatcher[] = [
       )
     },
   },
-  { matches: (p) => p.startsWith('padding'), patch: genericPropPatcher('0px') },
+  { matches: (p) => PaddingLonghands.includes(p), patch: genericPropPatcher('0px') },
 ]
 
 function getPropertiesToZero(

--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -169,7 +169,25 @@ const genericPropPatcher =
     return [makeZeroProp(prop, zeroValue)]
   }
 
-const patchers: PropPatcher[] = [{ matches: (p) => p === 'gap', patch: genericPropPatcher('0px') }]
+const PaddingLonghands = ['paddingTop', 'paddingBottom', 'paddingLeft', 'paddingRight']
+
+const patchers: PropPatcher[] = [
+  { matches: (p) => p === 'gap', patch: genericPropPatcher('0px') },
+  {
+    matches: (p) => p === 'padding',
+    patch: (_, styleInfo, updatedProperties) => {
+      const propIsSetOnElement = styleInfo?.padding != null
+
+      if (!propIsSetOnElement) {
+        return []
+      }
+
+      return PaddingLonghands.filter((p) => !updatedProperties.propertiesUpdated.includes(p)).map(
+        (p) => makeZeroProp(p),
+      )
+    },
+  },
+]
 
 function getPropertiesToZero(
   styleInfo: StyleInfo | null,

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
@@ -66,7 +66,6 @@ function getTailwindClassMapping(classes: string[], config: Config | null): Reco
   return mapping
 }
 
-// TODO
 const underscoresToSpaces = (s: string | undefined) => s?.replace(/[-_]/g, ' ')
 
 export const TailwindPlugin = (config: Config | null): StylePlugin => ({

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
@@ -32,6 +32,11 @@ const TailwindPropertyMapping: Record<string, string> = {
   width: 'width',
   height: 'height',
   flexBasis: 'flexBasis',
+  padding: 'padding',
+  paddingTop: 'paddingTop',
+  paddingRight: 'paddingRight',
+  paddingBottom: 'paddingBottom',
+  paddingLeft: 'paddingLeft',
 }
 
 function isSupportedTailwindProperty(prop: unknown): prop is keyof typeof TailwindPropertyMapping {
@@ -60,6 +65,9 @@ function getTailwindClassMapping(classes: string[], config: Config | null): Reco
   })
   return mapping
 }
+
+// TODO
+const underscoresToSpaces = (s: string | undefined) => s?.replace(/[-_]/g, ' ')
 
 export const TailwindPlugin = (config: Config | null): StylePlugin => ({
   name: 'Tailwind',
@@ -91,6 +99,26 @@ export const TailwindPlugin = (config: Config | null): StylePlugin => ({
         flexBasis: parseTailwindProperty(
           mapping[TailwindPropertyMapping.flexBasis],
           cssParsers.flexBasis,
+        ),
+        padding: parseTailwindProperty(
+          underscoresToSpaces(mapping[TailwindPropertyMapping.padding]),
+          cssParsers.padding,
+        ),
+        paddingTop: parseTailwindProperty(
+          mapping[TailwindPropertyMapping.paddingTop],
+          cssParsers.paddingTop,
+        ),
+        paddingRight: parseTailwindProperty(
+          mapping[TailwindPropertyMapping.paddingRight],
+          cssParsers.paddingRight,
+        ),
+        paddingBottom: parseTailwindProperty(
+          mapping[TailwindPropertyMapping.paddingBottom],
+          cssParsers.paddingBottom,
+        ),
+        paddingLeft: parseTailwindProperty(
+          mapping[TailwindPropertyMapping.paddingLeft],
+          cssParsers.paddingLeft,
         ),
       }
     },


### PR DESCRIPTION
## Problem
The padding controls cannot be used to read/write values in projects that use Tailwind for styling.

## Fix
Use the style plugins and the `StyleInfo` system to make this possible.

Specifically,
- Add the padding shorthand prop/padding longhand prop to the `StyleInfo` interface
- Update `InlineStylePlugin` and `TailwindStylePlugin` to support the new props in `StyleInfo`
- Refactor the padding strategy, the padding control handle and the subdued padding control to read element styles through a `StyleInfoReader` instance
- Add a new property patcher in `style-plugins@patchers` to take care of patching removed padding props
- Add tests with a tailwind project to the padding strategy test suite

### Out of scope
The jump in the bounding box after the interaction ends ([video](https://screenshot.click/14-02-e9ktf-say96.mp4)) will be addressed on a follow-up PR

### Manual Tests
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode
