### PR TITLE
Grid component support

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-element-change-location-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-element-change-location-strategy.spec.browser2.tsx
@@ -120,29 +120,6 @@ describe('grid element change location strategy', () => {
         gridRowStart: '2',
       })
     })
-
-    it('can change the location of elements in a grid component with non-root grid inside', async () => {
-      const editor = await renderTestEditorWithCode(
-        ProjectCodeComponentNonRootGrid,
-        'await-first-dom-report',
-      )
-
-      const testId = 'aaa'
-      const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } = await runGridMoveTest(
-        editor,
-        {
-          scale: 1,
-          pathString: `sb/scene/grid/${testId}`,
-          testId: testId,
-        },
-      )
-      expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
-        gridColumnEnd: '7',
-        gridColumnStart: '3',
-        gridRowEnd: '4',
-        gridRowStart: '2',
-      })
-    })
   })
 
   it('can not change location of a multicell element out of the grid', async () => {
@@ -1019,104 +996,6 @@ ${itemComponentCode}
 `
 
 const ProjectCodeGridComponent = `import * as React from 'react'
-import { Scene, Storyboard, Placeholder } from 'utopia-api'
-
-export var storyboard = (
-  <Storyboard data-uid='sb'>
-    <Scene
-      id='playground-scene'
-      commentId='playground-scene'
-      style={{
-        width: 847,
-        height: 895,
-        position: 'absolute',
-        left: 46,
-        top: 131,
-      }}
-      data-label='Playground'
-      data-uid='scene'
-    >
-      <Grid
-        style={{
-          display: 'grid',
-          gridTemplateRows: '75px 75px 75px 75px',
-          gridTemplateColumns:
-            '50px 50px 50px 50px 50px 50px 50px 50px 50px 50px 50px 50px',
-          gridGap: 16,
-          height: 482,
-          width: 786,
-          position: 'absolute',
-          left: 31,
-          top: 0,
-        }}
-        data-uid='grid'
-      >
-        <div
-          style={{
-            minHeight: 0,
-            backgroundColor: '#f3785f',
-            gridColumnEnd: 5,
-            gridColumnStart: 1,
-            gridRowEnd: 3,
-            gridRowStart: 1,
-          }}
-          data-uid='aaa'
-          data-testid='aaa'
-        />
-        <div
-          style={{
-            minHeight: 0,
-            backgroundColor: '#23565b',
-          }}
-          data-uid='bbb'
-          data-testid='bbb'
-        />
-        <Placeholder
-          style={{
-            minHeight: 0,
-            gridColumnEnd: 5,
-            gridRowEnd: 4,
-            gridColumnStart: 1,
-            gridRowStart: 3,
-            backgroundColor: '#0074ff',
-          }}
-          data-uid='ccc'
-        />
-        <Placeholder
-          style={{
-            minHeight: 0,
-            gridColumnEnd: 9,
-            gridRowEnd: 4,
-            gridColumnStart: 5,
-            gridRowStart: 3,
-          }}
-          data-uid='ddd'
-        />
-      </Grid>
-    </Scene>
-  </Storyboard>
-)
-
-export function Grid(props) {
-  return (
-    <div
-      style={{
-        ...props.style,
-        display: 'grid',
-        gridTemplateRows: '75px 75px 75px 75px',
-        gridTemplateColumns:
-          '50px 50px 50px 50px 50px 50px 50px 50px 50px 50px 50px 50px',
-        gridGap: 16,
-      }}
-      data-uid='f84914f31dbc6c5d9b44c11ae54139ef'
-    >
-      {props.children}
-    </div>
-  )
-}
-`
-
-const ProjectCodeComponentNonRootGrid = `import * as React from 'react'
 import { Scene, Storyboard, Placeholder } from 'utopia-api'
 
 export var storyboard = (

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-element-change-location-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-element-change-location-strategy.spec.browser2.tsx
@@ -5,7 +5,7 @@ import {
   offsetPoint,
   windowPoint,
 } from '../../../../core/shared/math-utils'
-import { selectComponentsForTest } from '../../../../utils/utils.test-utils'
+import { selectComponentsForTest, wait } from '../../../../utils/utils.test-utils'
 import CanvasActions from '../../canvas-actions'
 import { GridCellTestId } from '../../controls/grid-controls-for-strategies'
 import { mouseDownAtPoint, mouseMoveToPoint, mouseUpAtPoint } from '../../event-helpers.test-utils'
@@ -97,26 +97,51 @@ describe('grid element change location strategy', () => {
     })
   })
 
-  it('can change the location of elements in a grid component', async () => {
-    const editor = await renderTestEditorWithCode(
-      ProjectCodeGridComponent,
-      'await-first-dom-report',
-    )
+  describe('grid component', () => {
+    it('can change the location of elements in a grid component', async () => {
+      const editor = await renderTestEditorWithCode(
+        ProjectCodeGridComponent,
+        'await-first-dom-report',
+      )
 
-    const testId = 'aaa'
-    const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } = await runGridMoveTest(
-      editor,
-      {
-        scale: 1,
-        pathString: `sb/scene/grid/${testId}`,
-        testId: testId,
-      },
-    )
-    expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
-      gridColumnEnd: '7',
-      gridColumnStart: '3',
-      gridRowEnd: '4',
-      gridRowStart: '2',
+      const testId = 'aaa'
+      const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } = await runGridMoveTest(
+        editor,
+        {
+          scale: 1,
+          pathString: `sb/scene/grid/${testId}`,
+          testId: testId,
+        },
+      )
+      expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+        gridColumnEnd: '7',
+        gridColumnStart: '3',
+        gridRowEnd: '4',
+        gridRowStart: '2',
+      })
+    })
+
+    it('can change the location of elements in a grid component with non-root grid inside', async () => {
+      const editor = await renderTestEditorWithCode(
+        ProjectCodeComponentNonRootGrid,
+        'await-first-dom-report',
+      )
+
+      const testId = 'aaa'
+      const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } = await runGridMoveTest(
+        editor,
+        {
+          scale: 1,
+          pathString: `sb/scene/grid/${testId}`,
+          testId: testId,
+        },
+      )
+      expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+        gridColumnEnd: '7',
+        gridColumnStart: '3',
+        gridRowEnd: '4',
+        gridRowStart: '2',
+      })
     })
   })
 
@@ -1075,7 +1100,6 @@ export var storyboard = (
 export function Grid(props) {
   return (
     <div
-      {...props}
       style={{
         ...props.style,
         display: 'grid',
@@ -1087,6 +1111,104 @@ export function Grid(props) {
       data-uid='f84914f31dbc6c5d9b44c11ae54139ef'
     >
       {props.children}
+    </div>
+  )
+}
+`
+
+const ProjectCodeComponentNonRootGrid = `import * as React from 'react'
+import { Scene, Storyboard, Placeholder } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <Scene
+      id='playground-scene'
+      commentId='playground-scene'
+      style={{
+        width: 847,
+        height: 895,
+        position: 'absolute',
+        left: 46,
+        top: 131,
+      }}
+      data-label='Playground'
+      data-uid='scene'
+    >
+      <Grid
+        style={{
+          position: 'absolute',
+          left: 31,
+          top: 0,
+        }}
+        data-uid='grid'
+      >
+        <div
+          style={{
+            minHeight: 0,
+            backgroundColor: '#23565b',
+          }}
+          data-uid='bbb'
+          data-testid='bbb'
+        />
+        <div
+          style={{
+            minHeight: 0,
+            backgroundColor: '#f3785f',
+            gridColumn: '1 / 5',
+            gridRow: '1 / 3',
+          }}
+          data-uid='aaa'
+          data-testid='aaa'
+        />
+        <Placeholder
+          style={{
+            minHeight: 0,
+            gridColumnEnd: 5,
+            gridRowEnd: 4,
+            gridColumnStart: 1,
+            gridRowStart: 3,
+            backgroundColor: '#0074ff',
+          }}
+          data-uid='ccc'
+        />
+        <Placeholder
+          style={{
+            minHeight: 0,
+            gridColumnEnd: 9,
+            gridRowEnd: 4,
+            gridColumnStart: 5,
+            gridRowStart: 3,
+          }}
+          data-uid='ddd'
+        />
+      </Grid>
+    </Scene>
+  </Storyboard>
+)
+
+export function Grid(props) {
+  return (
+    <div
+      style={{
+        ...props.style,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateRows: '75px 75px 75px 75px',
+          gridTemplateColumns:
+            '50px 50px 50px 50px 50px 50px 50px 50px 50px 50px 50px 50px',
+          gridGap: 16,
+        }}
+      >
+        {props.children}
+      </div>
+      <div
+        style={{ height: 100 }}
+      />
     </div>
   )
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-element-change-location-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-element-change-location-strategy.spec.browser2.tsx
@@ -5,7 +5,7 @@ import {
   offsetPoint,
   windowPoint,
 } from '../../../../core/shared/math-utils'
-import { selectComponentsForTest, wait } from '../../../../utils/utils.test-utils'
+import { selectComponentsForTest } from '../../../../utils/utils.test-utils'
 import CanvasActions from '../../canvas-actions'
 import { GridCellTestId } from '../../controls/grid-controls-for-strategies'
 import { mouseDownAtPoint, mouseMoveToPoint, mouseUpAtPoint } from '../../event-helpers.test-utils'

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -689,22 +689,36 @@ export function gridMoveStrategiesExtraCommands(
 export function getGridIdentifierContainerOrComponentPath(identifier: GridIdentifier): ElementPath {
   switch (identifier.type) {
     case 'GRID_CONTAINER':
-      return identifier.path
+      return identifier.container
     case 'GRID_ITEM':
-      return EP.parentPath(identifier.path)
+      return EP.parentPath(identifier.item)
     default:
       assertNever(identifier)
   }
 }
 
 export function gridIdentifiersSimilar(a: GridIdentifier, b: GridIdentifier): boolean {
-  return (
-    (a.type === b.type && EP.pathsEqual(a.path, b.path)) ||
-    (a.type === 'GRID_ITEM' && b.type === 'GRID_CONTAINER' && EP.isParentOf(b.path, a.path)) ||
-    (a.type === 'GRID_CONTAINER' && b.type === 'GRID_ITEM' && EP.isParentOf(a.path, b.path))
-  )
+  switch (a.type) {
+    case 'GRID_CONTAINER':
+      return b.type === 'GRID_CONTAINER'
+        ? EP.pathsEqual(a.container, b.container)
+        : EP.isParentOf(a.container, b.item)
+    case 'GRID_ITEM':
+      return b.type === 'GRID_ITEM'
+        ? EP.pathsEqual(a.item, b.item)
+        : EP.isParentOf(b.container, a.item)
+    default:
+      assertNever(a)
+  }
 }
 
 export function gridIdentifierToString(identifier: GridIdentifier): string {
-  return `${identifier.type}-${EP.toString(identifier.path)}`
+  switch (identifier.type) {
+    case 'GRID_CONTAINER':
+      return `${identifier.type}-${EP.toString(identifier.container)}`
+    case 'GRID_ITEM':
+      return `${identifier.type}-${EP.toString(identifier.item)}`
+    default:
+      assertNever(identifier)
+  }
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -45,6 +45,7 @@ import {
   getGridChildCellCoordBoundsFromCanvas,
   gridCellCoordinates,
 } from './grid-cell-bounds'
+import type { GridIdentifier } from '../../../editor/store/editor-state'
 
 export function gridPositionToValue(
   p: GridPositionOrSpan | null | undefined,
@@ -683,4 +684,27 @@ export function gridMoveStrategiesExtraCommands(
   ]
 
   return { midInteractionCommands, onCompleteCommands }
+}
+
+export function getGridIdentifierContainerOrComponentPath(identifier: GridIdentifier): ElementPath {
+  switch (identifier.type) {
+    case 'GRID_CONTAINER':
+      return identifier.path
+    case 'GRID_ITEM':
+      return EP.parentPath(identifier.path)
+    default:
+      assertNever(identifier)
+  }
+}
+
+export function gridIdentifiersSimilar(a: GridIdentifier, b: GridIdentifier): boolean {
+  return (
+    (a.type === b.type && EP.pathsEqual(a.path, b.path)) ||
+    (a.type === 'GRID_ITEM' && b.type === 'GRID_CONTAINER' && EP.isParentOf(b.path, a.path)) ||
+    (a.type === 'GRID_CONTAINER' && b.type === 'GRID_ITEM' && EP.isParentOf(a.path, b.path))
+  )
+}
+
+export function gridIdentifierToString(identifier: GridIdentifier): string {
+  return `${identifier.type}-${EP.toString(identifier.path)}`
 }

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-reorder-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-reorder-strategy.spec.browser2.tsx
@@ -22,6 +22,23 @@ describe('grid reorder', () => {
 
     expect(cells).toEqual(['pink', 'cyan', 'orange', 'blue'])
   })
+  it('reorders an element in a grid component without setting positioning (inside contiguous area)', async () => {
+    const editor = await renderTestEditorWithCode(
+      ProjectCodeReorderGridComponent,
+      'await-first-dom-report',
+    )
+    const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd, cells } =
+      await runReorderTest(editor, 'sb/scene/grid', 'orange', { row: 1, column: 3 })
+
+    expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+      gridColumnEnd: '',
+      gridColumnStart: '',
+      gridRowEnd: '',
+      gridRowStart: '',
+    })
+
+    expect(cells).toEqual(['pink', 'cyan', 'orange', 'blue'])
+  })
   it('reorders a component (which does not take style props) inside contiguous area', async () => {
     const editor = await renderTestEditorWithCode(
       ProjectCodeReorderWithComponentItem,
@@ -337,6 +354,109 @@ export var storyboard = (
     </Scene>
   </Storyboard>
 )
+`
+
+const ProjectCodeReorderGridComponent = `import * as React from 'react'
+import { Scene, Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <Scene
+      id='playground-scene'
+      commentId='playground-scene'
+      style={{
+        width: 600,
+        height: 600,
+        position: 'absolute',
+        left: 0,
+        top: 0,
+      }}
+      data-label='Playground'
+      data-uid='scene'
+    >
+      <Grid
+        style={{
+          backgroundColor: '#aaaaaa33',
+        }}
+        data-testid='grid'
+        data-uid='grid'
+      >
+        <div
+          style={{
+            backgroundColor: '#f09',
+            width: '100%',
+            height: '100%',
+          }}
+          data-uid='pink'
+          data-testid='pink'
+          data-label='pink'
+        />
+        <div
+          style={{
+            backgroundColor: '#f90',
+            width: '100%',
+            height: '100%',
+          }}
+          data-uid='orange'
+          data-testid='orange'
+          data-label='orange'
+        />
+        <div
+          style={{
+            backgroundColor: '#0f9',
+            width: '100%',
+            height: '100%',
+          }}
+          data-uid='cyan'
+          data-testid='cyan'
+          data-label='cyan'
+        />
+        <div
+          style={{
+            backgroundColor: '#09f',
+            width: '100%',
+            height: '100%',
+          }}
+          data-uid='blue'
+          data-testid='blue'
+          data-label='blue'
+        />
+      </Grid>
+    </Scene>
+  </Storyboard>
+)
+
+export function Grid(props) {
+  return (
+    <div
+      style={{
+        ...props.style,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+      data-uid='43adc9c0cf5a0bbf66c67e2e37466c18'
+    >
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr 1fr',
+          gridTemplateRows: '1fr 1fr 1fr',
+          gridGap: 10,
+          width: 500,
+          height: 500,
+          padding: 10,
+        }}
+        data-uid='f84914f31dbc6c5d9b44c11ae54139ef'
+      >
+        {props.children}
+      </div>
+      <div
+        style={{ height: 100 }}
+        data-uid='f5827ce0f04916c792a1da2bd69b6cad'
+      />
+    </div>
+  )
+}
 `
 
 const ProjectCodeReorderWithComponentItem = `import * as React from 'react'

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
@@ -867,18 +867,26 @@ export var storyboard = (
 export function Grid(props) {
   return (
     <div
-      {...props}
       style={{
         ...props.style,
-        display: 'grid',
-        gridTemplateRows: '75px 75px 75px 75px',
-        gridTemplateColumns:
-          '50px 50px 50px 50px 50px 50px 50px 50px 50px 50px 50px 50px',
-        gridGap: 16,
+        display: 'flex',
+        flexDirection: 'column',
       }}
-      data-uid='f84914f31dbc6c5d9b44c11ae54139ef'
     >
-      {props.children}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateRows: '75px 75px 75px 75px',
+          gridTemplateColumns:
+            '50px 50px 50px 50px 50px 50px 50px 50px 50px 50px 50px 50px',
+          gridGap: 16,
+        }}
+      >
+        {props.children}
+      </div>
+      <div
+        style={{ height: 100 }}
+      />
     </div>
   )
 }

--- a/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
+++ b/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
@@ -50,6 +50,8 @@ import {
 } from '../../editor/store/editor-state'
 import { findOriginalGrid } from '../canvas-strategies/strategies/grid-helpers'
 
+export const GridMeasurementHelperMap = { current: new WeakMap<HTMLElement, string>() }
+
 export const GridCellTestId = (elementPath: ElementPath) => `grid-cell-${EP.toString(elementPath)}`
 
 function getCellsCount(template: GridAutoOrTemplateBase | null): number {
@@ -94,6 +96,7 @@ export type GridMeasurementHelperData = {
   rowGap: number | null
   columnGap: number | null
   padding: Sides
+  element: HTMLElement
 }
 
 export function getGridMeasurementHelperData(
@@ -217,12 +220,14 @@ export function gridMeasurementHelperDataFromElement(
       columns: columns,
       cells: columns * rows,
       computedStyling: computedStyling,
+      element: element,
     }
   }
 }
 
 export function useGridMeasurementHelperData(
   elementPath: ElementPath,
+  fromParent: 'fromParent' | 'fromElement' = 'fromElement',
 ): GridMeasurementHelperData | undefined {
   const scale = useEditorState(
     Substores.canvas,
@@ -232,7 +237,9 @@ export function useGridMeasurementHelperData(
 
   useMonitorChangesToEditor()
 
-  return useKeepReferenceEqualityIfPossible(getGridMeasurementHelperData(elementPath, scale))
+  return useKeepReferenceEqualityIfPossible(
+    getGridMeasurementHelperData(elementPath, scale, fromParent),
+  )
 }
 
 export type GridData = GridMeasurementHelperData & {

--- a/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
+++ b/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
@@ -35,7 +35,7 @@ import {
   GridRowColumnResizingControlsComponent,
 } from './grid-controls'
 import { isEdgePositionOnSide } from '../canvas-utils'
-import { getFromElement, getFromParent } from '../direct-dom-lookups'
+import { getFromElement } from '../direct-dom-lookups'
 import { applicativeSidesPxTransform, getGridContainerProperties } from '../dom-walker'
 import { applicative4Either, defaultEither, isRight, mapEither } from '../../../core/shared/either'
 import { domRectToScaledCanvasRectangle, getRoundingFn } from '../../../core/shared/dom-utils'
@@ -99,19 +99,14 @@ export type GridMeasurementHelperData = {
   element: HTMLElement
 }
 
-export type GridMeasurementHelperSourceElement = 'parent' | 'element'
+export type ElementOrParent = 'parent' | 'element'
 
 export function getGridMeasurementHelperData(
   elementPath: ElementPath,
   scale: number,
-  source: GridMeasurementHelperSourceElement,
+  source: ElementOrParent,
 ): GridMeasurementHelperData | undefined {
-  switch (source) {
-    case 'element':
-      return getFromElement(elementPath, gridMeasurementHelperDataFromElement(scale))
-    case 'parent':
-      return getFromParent(elementPath, gridMeasurementHelperDataFromElement(scale))
-  }
+  return getFromElement(elementPath, gridMeasurementHelperDataFromElement(scale), source)
 }
 
 function getStylingSubset(styling: CSSStyleDeclaration): CSSProperties {
@@ -229,7 +224,7 @@ export function gridMeasurementHelperDataFromElement(
 
 export function useGridMeasurementHelperData(
   elementPath: ElementPath,
-  source: GridMeasurementHelperSourceElement,
+  source: ElementOrParent,
 ): GridMeasurementHelperData | undefined {
   const scale = useEditorState(
     Substores.canvas,

--- a/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
+++ b/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
@@ -256,7 +256,7 @@ export function useGridData(gridIdentifiers: GridIdentifier[]): GridData[] {
       return mapDropNulls((view) => {
         switch (view.type) {
           case 'GRID_CONTAINER': {
-            const originalGridPath = findOriginalGrid(store.editor.jsxMetadata, view.path)
+            const originalGridPath = findOriginalGrid(store.editor.jsxMetadata, view.container)
             if (originalGridPath == null) {
               return null
             }
@@ -284,21 +284,21 @@ export function useGridData(gridIdentifiers: GridIdentifier[]): GridData[] {
             return gridData
           }
           case 'GRID_ITEM':
-            const item = MetadataUtils.isGridItem(store.editor.jsxMetadata, view.path)
-              ? MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, view.path)
+            const item = MetadataUtils.isGridItem(store.editor.jsxMetadata, view.item)
+              ? MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, view.item)
               : null
             if (item == null) {
               return null
             }
 
-            const helperData = getGridMeasurementHelperData(view.path, scale, 'parent')
+            const helperData = getGridMeasurementHelperData(view.item, scale, 'parent')
             if (helperData == null) {
               return null
             }
 
             const gridData: GridData = {
               ...helperData,
-              identifier: gridItemIdentifier(view.path),
+              identifier: gridItemIdentifier(view.item),
             }
             return gridData
           default:

--- a/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
+++ b/editor/src/components/canvas/controls/grid-controls-for-strategies.tsx
@@ -99,15 +99,17 @@ export type GridMeasurementHelperData = {
   element: HTMLElement
 }
 
+export type GridMeasurementHelperSourceElement = 'parent' | 'element'
+
 export function getGridMeasurementHelperData(
   elementPath: ElementPath,
   scale: number,
-  fromParent: 'fromParent' | 'fromElement' = 'fromElement',
+  source: GridMeasurementHelperSourceElement,
 ): GridMeasurementHelperData | undefined {
-  switch (fromParent) {
-    case 'fromElement':
+  switch (source) {
+    case 'element':
       return getFromElement(elementPath, gridMeasurementHelperDataFromElement(scale))
-    case 'fromParent':
+    case 'parent':
       return getFromParent(elementPath, gridMeasurementHelperDataFromElement(scale))
   }
 }
@@ -227,7 +229,7 @@ export function gridMeasurementHelperDataFromElement(
 
 export function useGridMeasurementHelperData(
   elementPath: ElementPath,
-  fromParent: 'fromParent' | 'fromElement' = 'fromElement',
+  source: GridMeasurementHelperSourceElement,
 ): GridMeasurementHelperData | undefined {
   const scale = useEditorState(
     Substores.canvas,
@@ -238,7 +240,7 @@ export function useGridMeasurementHelperData(
   useMonitorChangesToEditor()
 
   return useKeepReferenceEqualityIfPossible(
-    getGridMeasurementHelperData(elementPath, scale, fromParent),
+    getGridMeasurementHelperData(elementPath, scale, source),
   )
 }
 
@@ -275,7 +277,7 @@ export function useGridData(gridIdentifiers: GridIdentifier[]): GridData[] {
               return null
             }
 
-            const helperData = getGridMeasurementHelperData(originalGridPath, scale)
+            const helperData = getGridMeasurementHelperData(originalGridPath, scale, 'element')
             if (helperData == null) {
               return null
             }
@@ -294,7 +296,7 @@ export function useGridData(gridIdentifiers: GridIdentifier[]): GridData[] {
               return null
             }
 
-            const helperData = getGridMeasurementHelperData(view.path, scale, 'fromParent')
+            const helperData = getGridMeasurementHelperData(view.path, scale, 'parent')
             if (helperData == null) {
               return null
             }

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -739,9 +739,9 @@ const GridControl = React.memo<GridControlProps>(({ grid, controlsVisible }) => 
     const children = (() => {
       switch (grid.identifier.type) {
         case 'GRID_CONTAINER':
-          return MetadataUtils.getChildrenUnordered(jsxMetadata, grid.identifier.path)
+          return MetadataUtils.getChildrenUnordered(jsxMetadata, grid.identifier.container)
         case 'GRID_ITEM':
-          return MetadataUtils.getSiblingsUnordered(jsxMetadata, grid.identifier.path)
+          return MetadataUtils.getSiblingsUnordered(jsxMetadata, grid.identifier.item)
         default:
           assertNever(grid.identifier)
       }
@@ -927,7 +927,7 @@ const GridControl = React.memo<GridControlProps>(({ grid, controlsVisible }) => 
           const isActiveGrid =
             (dragging != null && EP.isParentOf(gridContainerOrComponentPath, dragging)) ||
             (currentHoveredGrid != null &&
-              EP.pathsEqual(gridContainerOrComponentPath, currentHoveredGrid.path))
+              gridIdentifiersSimilar(grid.identifier, currentHoveredGrid))
           const isActiveCell =
             isActiveGrid &&
             countedColumn === currentHoveredCell?.column &&
@@ -1114,7 +1114,9 @@ GridMeasurementHelper.displayName = 'GridMeasurementHelper'
 
 export const GridControlsComponent = ({ targets }: GridControlsProps) => {
   const ancestorPaths = React.useMemo(() => {
-    return targets.flatMap((target) => EP.getAncestors(target.path))
+    return targets.flatMap((target) =>
+      EP.getAncestors(getGridIdentifierContainerOrComponentPath(target)),
+    )
   }, [targets])
   const ancestorGrids: Array<GridIdentifier> = useEditorState(
     Substores.metadata,
@@ -1151,8 +1153,10 @@ export const GridControlsComponent = ({ targets }: GridControlsProps) => {
   // before those above it in the hierarchy.
   const grids = useGridData(
     uniqBy([...gridsWithVisibleControls, ...ancestorGrids], gridIdentifiersSimilar).sort((a, b) => {
-      const aDepth = a.type === 'GRID_CONTAINER' ? EP.fullDepth(a.path) : EP.fullDepth(a.path) - 1
-      const bDepth = a.type === 'GRID_CONTAINER' ? EP.fullDepth(b.path) : EP.fullDepth(b.path) - 1
+      const aDepth =
+        a.type === 'GRID_CONTAINER' ? EP.fullDepth(a.container) : EP.fullDepth(a.item) - 1
+      const bDepth =
+        b.type === 'GRID_CONTAINER' ? EP.fullDepth(b.container) : EP.fullDepth(b.item) - 1
       return aDepth - bDepth
     }),
   )

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -1045,14 +1045,14 @@ export const GridMeasurementHelpers = React.memo(() => {
         <GridMeasurementHelper
           key={GridMeasurementHelpersKey(grid)}
           elementPath={grid}
-          fromParent='fromElement'
+          source='element'
         />
       ))}
       {gridItems.map((gridItem) => (
         <GridMeasurementHelper
           key={GridMeasurementHelpersKey(gridItem)}
           elementPath={gridItem}
-          fromParent='fromParent'
+          source='parent'
         />
       ))}
     </CanvasOffsetWrapper>
@@ -1062,12 +1062,12 @@ GridMeasurementHelpers.displayName = 'GridMeasurementHelpers'
 
 export interface GridMeasurementHelperProps {
   elementPath: ElementPath
-  fromParent: 'fromParent' | 'fromElement'
+  source: 'parent' | 'element'
 }
 
 export const GridMeasurementHelper = React.memo<GridMeasurementHelperProps>(
-  ({ elementPath, fromParent }) => {
-    const gridData = useGridMeasurementHelperData(elementPath, fromParent)
+  ({ elementPath, source }) => {
+    const gridData = useGridMeasurementHelperData(elementPath, source)
     if (gridData == null) {
       return null
     }
@@ -1918,7 +1918,7 @@ export interface GridElementContainingBlockProps {
 }
 
 const GridElementContainingBlock = React.memo<GridElementContainingBlockProps>((props) => {
-  const gridData = useGridMeasurementHelperData(props.gridPath)
+  const gridData = useGridMeasurementHelperData(props.gridPath, 'element')
   const scale = useEditorState(
     Substores.canvas,
     (store) => store.editor.canvas.scale,

--- a/editor/src/components/canvas/controls/select-mode/subdued-grid-gap-controls.tsx
+++ b/editor/src/components/canvas/controls/select-mode/subdued-grid-gap-controls.tsx
@@ -9,6 +9,7 @@ import { NO_OP } from '../../../../core/shared/utils'
 import * as EP from '../../../../core/shared/element-path'
 import { GridPaddingOutlineForDimension } from './grid-gap-control-component'
 import { gridContainerIdentifier } from '../../../editor/store/editor-state'
+import { getGridIdentifierContainerOrComponentPath } from '../../canvas-strategies/strategies/grid-helpers'
 
 export interface SubduedGridGapControlProps {
   hoveredOrFocused: 'hovered' | 'focused'
@@ -33,8 +34,11 @@ export const SubduedGridGapControl = React.memo<SubduedGridGapControlProps>((pro
   return (
     <CanvasOffsetWrapper>
       {gridRowColumnInfo.map((gridData) => {
+        const gridContainerOrComponent = getGridIdentifierContainerOrComponentPath(
+          gridData.identifier,
+        )
         return (
-          <React.Fragment key={`grid-gap-${EP.toString(gridData.identifier.path)}`}>
+          <React.Fragment key={`grid-gap-${EP.toString(gridContainerOrComponent)}`}>
             <GridPaddingOutlineForDimension
               grid={gridData}
               dimension={'rows'}

--- a/editor/src/components/canvas/direct-dom-lookups.ts
+++ b/editor/src/components/canvas/direct-dom-lookups.ts
@@ -3,10 +3,16 @@ import { CanvasContainerID } from './canvas-types'
 import { getDeepestPathOnDomElement } from '../../core/shared/uid-utils'
 import * as EP from '../../core/shared/element-path'
 import type { ElementPath } from 'utopia-shared/src/types'
+import type { ElementOrParent } from './controls/grid-controls-for-strategies'
+import { assertNever } from '../../core/shared/utils'
 
 export type FromElement<T> = (element: HTMLElement) => T
 
-export function getFromElement<T>(path: ElementPath, fromElement: FromElement<T>): T | undefined {
+export function getFromElement<T>(
+  path: ElementPath,
+  fromElement: FromElement<T>,
+  elementOrParent: ElementOrParent,
+): T | undefined {
   const pathString = EP.toString(path)
   const elements = document.querySelectorAll(
     `#${CanvasContainerID} [${UTOPIA_PATH_KEY}^="${pathString}"]`,
@@ -20,28 +26,17 @@ export function getFromElement<T>(path: ElementPath, fromElement: FromElement<T>
       EP.isRootElementOf(pathFromElement, path)
     ) {
       if (element instanceof HTMLElement) {
-        return fromElement(element)
-      }
-    }
-  }
-  return undefined
-}
-
-export function getFromParent<T>(path: ElementPath, fromElement: FromElement<T>): T | undefined {
-  const pathString = EP.toString(path)
-  const elements = document.querySelectorAll(
-    `#${CanvasContainerID} [${UTOPIA_PATH_KEY}^="${pathString}"]`,
-  )
-  for (const element of Array.from(elements)) {
-    const pathFromElement = getDeepestPathOnDomElement(element)
-    if (
-      (EP.pathsEqual(path, pathFromElement) &&
-        pathFromElement != null &&
-        !EP.isRootElementOfInstance(pathFromElement)) ||
-      EP.isRootElementOf(pathFromElement, path)
-    ) {
-      if (element instanceof HTMLElement && element.parentElement != null) {
-        return fromElement(element.parentElement)
+        switch (elementOrParent) {
+          case 'element':
+            if (element.parentElement != null) {
+              return fromElement(element.parentElement)
+            }
+            break
+          case 'parent':
+            return fromElement(element)
+          default:
+            assertNever(elementOrParent)
+        }
       }
     }
   }

--- a/editor/src/components/canvas/direct-dom-lookups.ts
+++ b/editor/src/components/canvas/direct-dom-lookups.ts
@@ -25,18 +25,18 @@ export function getFromElement<T>(
         !EP.isRootElementOfInstance(pathFromElement)) ||
       EP.isRootElementOf(pathFromElement, path)
     ) {
-      if (element instanceof HTMLElement) {
+      const realElement = (() => {
         switch (elementOrParent) {
           case 'element':
-            if (element.parentElement != null) {
-              return fromElement(element.parentElement)
-            }
-            break
+            return element
           case 'parent':
-            return fromElement(element)
+            return element.parentElement
           default:
             assertNever(elementOrParent)
         }
+      })()
+      if (realElement instanceof HTMLElement) {
+        return fromElement(realElement)
       }
     }
   }

--- a/editor/src/components/canvas/direct-dom-lookups.ts
+++ b/editor/src/components/canvas/direct-dom-lookups.ts
@@ -26,3 +26,24 @@ export function getFromElement<T>(path: ElementPath, fromElement: FromElement<T>
   }
   return undefined
 }
+
+export function getFromParent<T>(path: ElementPath, fromElement: FromElement<T>): T | undefined {
+  const pathString = EP.toString(path)
+  const elements = document.querySelectorAll(
+    `#${CanvasContainerID} [${UTOPIA_PATH_KEY}^="${pathString}"]`,
+  )
+  for (const element of Array.from(elements)) {
+    const pathFromElement = getDeepestPathOnDomElement(element)
+    if (
+      (EP.pathsEqual(path, pathFromElement) &&
+        pathFromElement != null &&
+        !EP.isRootElementOfInstance(pathFromElement)) ||
+      EP.isRootElementOf(pathFromElement, path)
+    ) {
+      if (element instanceof HTMLElement && element.parentElement != null) {
+        return fromElement(element.parentElement)
+      }
+    }
+  }
+  return undefined
+}

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -67,7 +67,7 @@ import {
   getPathsOnDomElement,
   getPathStringsOnDomElement,
 } from '../../core/shared/uid-utils'
-import { forceNotNull } from '../../core/shared/optional-utils'
+import { forceNotNull, optionalMap } from '../../core/shared/optional-utils'
 import { fastForEach } from '../../core/shared/utils'
 import type { EditorState, EditorStorePatched } from '../editor/store/editor-state'
 import { shallowEqual } from '../../core/shared/equality-utils'
@@ -83,7 +83,7 @@ import { runDOMWalker } from '../editor/actions/action-creators'
 import { CanvasContainerOuterId } from './canvas-component-entry'
 import { ElementsToRerenderGLOBAL } from './ui-jsx-canvas'
 import type { GridCellGlobalFrames } from './canvas-strategies/strategies/grid-helpers'
-import { GridMeasurementHelperKey } from './controls/grid-controls-for-strategies'
+import { GridMeasurementHelperMap } from './controls/grid-controls-for-strategies'
 
 export const ResizeObserver =
   window.ResizeObserver ?? ResizeObserverSyntheticDefault.default ?? ResizeObserverSyntheticDefault
@@ -1079,18 +1079,12 @@ function measureGlobalFramesOfGridCells(
   containerRectLazy: CanvasPoint | (() => CanvasPoint),
   elementCanvasRectangleCache: ElementCanvasRectangleCache,
 ): GridCellGlobalFrames | null {
-  const paths = getPathsOnDomElement(element)
-
   let gridCellGlobalFrames: GridCellGlobalFrames | null = null
-  const gridControlElement = (() => {
-    for (let p of paths) {
-      const maybeGridControlElement = document.getElementById(GridMeasurementHelperKey(p))
-      if (maybeGridControlElement != null) {
-        return maybeGridControlElement
-      }
-    }
-    return null
-  })()
+
+  const gridMeasurementHelperId = GridMeasurementHelperMap.current.get(element)
+
+  const gridControlElement =
+    gridMeasurementHelperId != null ? document.getElementById(gridMeasurementHelperId) : null
 
   if (gridControlElement != null) {
     gridCellGlobalFrames = []

--- a/editor/src/components/canvas/dom-walker.ts
+++ b/editor/src/components/canvas/dom-walker.ts
@@ -62,12 +62,8 @@ import {
 import type { UtopiaStoreAPI } from '../editor/store/store-hook'
 import { UTOPIA_SCENE_ID_KEY, UTOPIA_UID_KEY } from '../../core/model/utopia-constants'
 import { emptySet } from '../../core/shared/set-utils'
-import {
-  getDeepestPathOnDomElement,
-  getPathsOnDomElement,
-  getPathStringsOnDomElement,
-} from '../../core/shared/uid-utils'
-import { forceNotNull, optionalMap } from '../../core/shared/optional-utils'
+import { getDeepestPathOnDomElement, getPathStringsOnDomElement } from '../../core/shared/uid-utils'
+import { forceNotNull } from '../../core/shared/optional-utils'
 import { fastForEach } from '../../core/shared/utils'
 import type { EditorState, EditorStorePatched } from '../editor/store/editor-state'
 import { shallowEqual } from '../../core/shared/equality-utils'

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -848,14 +848,6 @@ export function gridItemIdentifier(path: ElementPath): GridItemIdentifier {
   }
 }
 
-export function gridIdentifierSimilar(a: GridIdentifier, b: GridIdentifier): boolean {
-  return (
-    (a.type === b.type && EP.pathsEqual(a.path, b.path)) ||
-    (a.type === 'GRID_ITEM' && b.type === 'GRID_CONTAINER' && EP.isParentOf(b.path, a.path)) ||
-    (a.type === 'GRID_CONTAINER' && b.type === 'GRID_ITEM' && EP.isParentOf(a.path, b.path))
-  )
-}
-
 export interface GridControlData {
   grid: GridIdentifier
   targetCell: GridCellCoordinates | null // the cell under the mouse

--- a/editor/src/components/editor/store/editor-state.ts
+++ b/editor/src/components/editor/store/editor-state.ts
@@ -826,25 +826,25 @@ export type GridIdentifier = GridContainerIdentifier | GridItemIdentifier
 
 export interface GridContainerIdentifier {
   type: 'GRID_CONTAINER'
-  path: ElementPath
+  container: ElementPath
 }
 
 export function gridContainerIdentifier(path: ElementPath): GridContainerIdentifier {
   return {
     type: 'GRID_CONTAINER',
-    path: path,
+    container: path,
   }
 }
 
 export interface GridItemIdentifier {
   type: 'GRID_ITEM'
-  path: ElementPath
+  item: ElementPath
 }
 
 export function gridItemIdentifier(path: ElementPath): GridItemIdentifier {
   return {
     type: 'GRID_ITEM',
-    path: path,
+    item: path,
   }
 }
 

--- a/editor/src/components/editor/store/store-deep-equality-instances.ts
+++ b/editor/src/components/editor/store/store-deep-equality-instances.ts
@@ -2856,14 +2856,14 @@ export const GridCellCoordinatesKeepDeepEquality: KeepDeepEqualityCall<GridCellC
 
 export const GridContainerIdentifierKeepDeepEquality: KeepDeepEqualityCall<GridContainerIdentifier> =
   combine1EqualityCall(
-    (identifier) => identifier.path,
+    (identifier) => identifier.container,
     ElementPathKeepDeepEquality,
     gridContainerIdentifier,
   )
 
 export const GridItemIdentifierKeepDeepEquality: KeepDeepEqualityCall<GridItemIdentifier> =
   combine1EqualityCall(
-    (identifier) => identifier.path,
+    (identifier) => identifier.item,
     ElementPathKeepDeepEquality,
     gridItemIdentifier,
   )

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -416,6 +416,11 @@ export const MetadataUtils = {
       .filter((m) => MetadataUtils.isGridLayoutedContainer(m))
       .map((m) => m.elementPath)
   },
+  getAllGridItems(metadata: ElementInstanceMetadataMap): Array<ElementPath> {
+    return Object.values(metadata)
+      .filter((m) => MetadataUtils.isGridItem(metadata, m.elementPath))
+      .map((m) => m.elementPath)
+  },
   isComponentInstanceFromMetadata(
     metadata: ElementInstanceMetadataMap,
     path: ElementPath,


### PR DESCRIPTION
**Problem:**
Followup to https://github.com/concrete-utopia/utopia/pull/6636

The goal is to support interaction with grid item in the following scenario:
- the grid is in a component
- the grid renders the component's children
- the grid is not the root element of the component

**Fix:**
In https://github.com/concrete-utopia/utopia/pull/6636 I introduced a way to indentify a grid using the element path of its item (which is necessary because when the grid is in a non-focused component).

- `GridMeasurementHelper` collects the grids from the metadata. These grids in non-focused components are not in the metadata, so they are not collected. I fixed this by collecting component items from the grids too. 
- To get the measurement data for these grids which identified by their items, I added a new parameter to `getGridMeasurementHelperData` so it can get the styling of the parentElement of the item's element.
- The measurement helper was identified by its element path, and the dom-sampler could retrieve the helper from the dom using that. However, this is again not a good solution for these grids in non-focused components, so I added global WeakMap which stores the pairing between HTMLElements of grids and the id attribute of their GridMeasurementHelper.
- I updated the `path` fiels names of `GridContainerIdentifier` and `GridItemIdentifier`: it was not a good idea to use the same name in the two paths, because it was possible to not check the type and use the path field.

**Missing:**
`gridMoveStrategiesExtraCommands` still tries to set grid props on the parent, and when it is a component, those can be absolutely useless. We should detect when that is the case, and not generate these commands.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

