### PR TITLE
Style plugin-aware `useInspectorInfo`

### DIFF
--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react'
-import type { JSExpression } from '../../core/shared/element-template'
+import type { JSExpression, PartOfJSXAttributeValue } from '../../core/shared/element-template'
 import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
 import type { PropertyPath, ElementPath } from '../../core/shared/project-file-types'
 import type { KeysPressed } from '../../utils/keyboard'
@@ -544,13 +544,13 @@ interface CSSStylePropertyNotFound {
 
 interface CSSStylePropertyNotParsable {
   type: 'not-parsable'
-  originalValue: JSExpression
+  originalValue: JSExpression | PartOfJSXAttributeValue
 }
 
 interface ParsedCSSStyleProperty<T> {
   type: 'property'
   tags: PropertyTag[]
-  propertyValue: JSExpression
+  propertyValue: JSExpression | PartOfJSXAttributeValue
   value: T
 }
 
@@ -564,14 +564,14 @@ export function cssStylePropertyNotFound(): CSSStylePropertyNotFound {
 }
 
 export function cssStylePropertyNotParsable(
-  originalValue: JSExpression,
+  originalValue: JSExpression | PartOfJSXAttributeValue,
 ): CSSStylePropertyNotParsable {
   return { type: 'not-parsable', originalValue: originalValue }
 }
 
 export function cssStyleProperty<T>(
   value: T,
-  propertyValue: JSExpression,
+  propertyValue: JSExpression | PartOfJSXAttributeValue,
 ): ParsedCSSStyleProperty<T> {
   return { type: 'property', tags: [], value: value, propertyValue: propertyValue }
 }

--- a/editor/src/components/canvas/canvas-types.ts
+++ b/editor/src/components/canvas/canvas-types.ts
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react'
+import type { JSExpression } from '../../core/shared/element-template'
 import { ElementInstanceMetadataMap } from '../../core/shared/element-template'
 import type { PropertyPath, ElementPath } from '../../core/shared/project-file-types'
 import type { KeysPressed } from '../../utils/keyboard'
@@ -543,11 +544,13 @@ interface CSSStylePropertyNotFound {
 
 interface CSSStylePropertyNotParsable {
   type: 'not-parsable'
+  originalValue: JSExpression
 }
 
 interface ParsedCSSStyleProperty<T> {
   type: 'property'
   tags: PropertyTag[]
+  propertyValue: JSExpression
   value: T
 }
 
@@ -560,12 +563,17 @@ export function cssStylePropertyNotFound(): CSSStylePropertyNotFound {
   return { type: 'not-found' }
 }
 
-export function cssStylePropertyNotParsable(): CSSStylePropertyNotParsable {
-  return { type: 'not-parsable' }
+export function cssStylePropertyNotParsable(
+  originalValue: JSExpression,
+): CSSStylePropertyNotParsable {
+  return { type: 'not-parsable', originalValue: originalValue }
 }
 
-export function cssStyleProperty<T>(value: T): ParsedCSSStyleProperty<T> {
-  return { type: 'property', tags: [], value: value }
+export function cssStyleProperty<T>(
+  value: T,
+  propertyValue: JSExpression,
+): ParsedCSSStyleProperty<T> {
+  return { type: 'property', tags: [], value: value, propertyValue: propertyValue }
 }
 
 export function maybePropertyValue<T>(property: CSSStyleProperty<T>): T | null {

--- a/editor/src/components/canvas/commands/utils/property-utils.ts
+++ b/editor/src/components/canvas/commands/utils/property-utils.ts
@@ -7,7 +7,7 @@ import { modifyUnderlyingElementForOpenFile } from '../../../editor/store/editor
 import { patchParseSuccessAtElementPath } from '../patch-utils'
 import type { CSSNumber } from '../../../inspector/common/css-utils'
 import { isCSSNumber } from '../../../inspector/common/css-utils'
-import { type StyleInfo, isStyleInfoKey } from '../../canvas-types'
+import type { StyleInfo } from '../../canvas-types'
 
 export interface EditorStateWithPatch {
   editorStateWithChanges: EditorState

--- a/editor/src/components/canvas/plugins/inline-style-plugin.spec.ts
+++ b/editor/src/components/canvas/plugins/inline-style-plugin.spec.ts
@@ -1,3 +1,4 @@
+import { emptyComments } from 'utopia-shared/src/types'
 import * as EP from '../../../core/shared/element-path'
 import { cssNumber } from '../../inspector/common/css-utils'
 import {
@@ -8,6 +9,11 @@ import {
 import type { EditorRenderResult } from '../ui-jsx.test-utils'
 import { renderTestEditorWithCode } from '../ui-jsx.test-utils'
 import { InlineStylePlugin } from './inline-style-plugin'
+import {
+  clearJSXMapExpressionUniqueIDs,
+  jsExpressionValue,
+  jsIdentifier,
+} from '../../../core/shared/element-template'
 
 describe('inline style plugin', () => {
   it('can parse style info from element', async () => {
@@ -45,8 +51,18 @@ export var storyboard = (
 
     expect(styleInfo).not.toBeNull()
     const { flexDirection, gap } = styleInfo!
-    expect(flexDirection).toEqual(cssStyleProperty('column'))
-    expect(gap).toEqual(cssStyleProperty(cssNumber(2, 'rem')))
+    expect(flexDirection).toMatchObject({
+      type: 'property',
+      tags: [],
+      value: 'column',
+      propertyValue: { value: 'column' },
+    })
+    expect(gap).toMatchObject({
+      type: 'property',
+      tags: [],
+      value: cssNumber(2, 'rem'),
+      propertyValue: { value: '2rem' },
+    })
   })
 
   it('can parse style info with missing/unparsable props', async () => {
@@ -88,7 +104,14 @@ export var storyboard = (
     expect(styleInfo).not.toBeNull()
     const { flexDirection, gap } = styleInfo!
     expect(flexDirection).toEqual(cssStylePropertyNotFound())
-    expect(gap).toEqual(cssStylePropertyNotParsable())
+    expect(gap).toMatchObject({
+      type: 'not-parsable',
+      originalValue: {
+        type: 'JS_PROPERTY_ACCESS',
+        onValue: { type: 'JS_IDENTIFIER', name: 'gap' },
+        property: 'small',
+      },
+    })
   })
 })
 

--- a/editor/src/components/canvas/plugins/inline-style-plugin.spec.ts
+++ b/editor/src/components/canvas/plugins/inline-style-plugin.spec.ts
@@ -1,19 +1,9 @@
-import { emptyComments } from 'utopia-shared/src/types'
 import * as EP from '../../../core/shared/element-path'
 import { cssNumber } from '../../inspector/common/css-utils'
-import {
-  cssStyleProperty,
-  cssStylePropertyNotFound,
-  cssStylePropertyNotParsable,
-} from '../canvas-types'
+import { cssStylePropertyNotFound } from '../canvas-types'
 import type { EditorRenderResult } from '../ui-jsx.test-utils'
 import { renderTestEditorWithCode } from '../ui-jsx.test-utils'
 import { InlineStylePlugin } from './inline-style-plugin'
-import {
-  clearJSXMapExpressionUniqueIDs,
-  jsExpressionValue,
-  jsIdentifier,
-} from '../../../core/shared/element-template'
 
 describe('inline style plugin', () => {
   it('can parse style info from element', async () => {

--- a/editor/src/components/canvas/plugins/inline-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/inline-style-plugin.ts
@@ -34,7 +34,7 @@ function getPropertyFromInstance<P extends StyleLayoutProp, T = ParsedCSSPropert
   attributes: JSXAttributes,
 ): CSSStyleProperty<NonNullable<T>> | null {
   const attribute = getPropValue(attributes, stylePropPathMappingFn(prop, ['style']))
-  if (attribute.type === 'ATTRIBUTE_NOT_FOUND' || attribute.type === 'PART_OF_ATTRIBUTE_VALUE') {
+  if (attribute.type === 'ATTRIBUTE_NOT_FOUND') {
     return cssStylePropertyNotFound()
   }
   const simpleValue = jsxSimpleAttributeToValue(attribute)

--- a/editor/src/components/canvas/plugins/inline-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/inline-style-plugin.ts
@@ -1,5 +1,4 @@
 import type { JSXAttributes, PropertyPath } from 'utopia-shared/src/types'
-import type { StyleLayoutProp } from '../../../core/layout/layout-helpers-new'
 import * as Either from '../../../core/shared/either'
 import {
   getJSXAttributesAtPath,
@@ -29,7 +28,7 @@ function getPropValue(attributes: JSXAttributes, path: PropertyPath): Modifiable
   return result.attribute
 }
 
-function getPropertyFromInstance<P extends StyleLayoutProp, T = ParsedCSSProperties[P]>(
+function getPropertyFromInstance<P extends keyof StyleInfo, T = ParsedCSSProperties[P]>(
   prop: P,
   attributes: JSXAttributes,
 ): CSSStyleProperty<NonNullable<T>> | null {
@@ -51,8 +50,11 @@ function getPropertyFromInstance<P extends StyleLayoutProp, T = ParsedCSSPropert
 
 export const InlineStylePlugin: StylePlugin = {
   name: 'Inline Style',
-  readStyleFromElementProps: <T extends keyof StyleInfo>(props: JSXAttributes, key: T) => {
-    return getPropertyFromInstance(key, props) as StyleInfo[T]
+  readStyleFromElementProps: <T extends keyof StyleInfo>(
+    attributes: JSXAttributes,
+    prop: T,
+  ): CSSStyleProperty<NonNullable<ParsedCSSProperties[T]>> | null => {
+    return getPropertyFromInstance(prop, attributes)
   },
   styleInfoFactory:
     ({ projectContents }) =>

--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -1,4 +1,4 @@
-import type { ElementPath } from 'utopia-shared/src/types'
+import type { ElementPath, JSXAttributes } from 'utopia-shared/src/types'
 import type { EditorState, EditorStatePatch } from '../../editor/store/editor-state'
 import type {
   InteractionLifecycle,
@@ -51,6 +51,10 @@ export type StyleUpdate = UpdateCSSProp | DeleteCSSProp
 export interface StylePlugin {
   name: string
   styleInfoFactory: StyleInfoFactory
+  readStyleFromElementProps: <T extends keyof StyleInfo>(
+    props: JSXAttributes,
+    cssProp: T,
+  ) => StyleInfo[T] | null
   updateStyles: (
     editorState: EditorState,
     elementPath: ElementPath,

--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -18,7 +18,9 @@ import type { EditorStateWithPatch } from '../commands/utils/property-utils'
 import { applyValuesAtPath } from '../commands/utils/property-utils'
 import * as PP from '../../../core/shared/property-path'
 import { emptyComments, jsExpressionValue } from '../../../core/shared/element-template'
+import type { CSSStyleProperty } from '../canvas-types'
 import { isStyleInfoKey, type StyleInfo } from '../canvas-types'
+import type { ParsedCSSProperties } from '../../inspector/common/css-utils'
 
 export interface UpdateCSSProp {
   type: 'set'
@@ -52,9 +54,9 @@ export interface StylePlugin {
   name: string
   styleInfoFactory: StyleInfoFactory
   readStyleFromElementProps: <T extends keyof StyleInfo>(
-    props: JSXAttributes,
-    cssProp: T,
-  ) => StyleInfo[T] | null
+    attributes: JSXAttributes,
+    prop: T,
+  ) => CSSStyleProperty<NonNullable<ParsedCSSProperties[T]>> | null
   updateStyles: (
     editorState: EditorState,
     elementPath: ElementPath,

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -1732,6 +1732,7 @@ export const UPDATE_FNS = {
   },
   UNSET_PROPERTY: (action: UnsetProperty, editor: EditorModel): EditorModel => {
     // TODO also queue group true up, just like for SET_PROP
+    // TODO this used to fire a toast if the prop couldn't be removed
     return foldAndApplyCommandsSimple(editor, [
       deleteProperties('always', action.element, [action.property]),
     ])

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -521,12 +521,12 @@ export function useInspectorInfo<P extends ParsedPropertiesKeys, T = ParsedPrope
   pathMappingFn: PathMappingFn<P>,
 ): InspectorInfo<T> {
   const propKeys = useMemoizedPropKeys(propKeysIn)
-  const multiselectAtProps: MultiselectAtProps<P> = useGetMultiselectedProps<P>( // this gets the actual prop value
+  const multiselectAtProps: MultiselectAtProps<P> = useGetMultiselectedProps<P>(
     pathMappingFn,
     propKeys,
   )
 
-  const selectedProps = useGetSpiedProps<P>(pathMappingFn, propKeys) // this gets the spied props, won't be applicable for Tailwind
+  const selectedProps = useGetSpiedProps<P>(pathMappingFn, propKeys)
 
   const selectedComputedStyles = useGetSelectedComputedStyles<P>(pathMappingFn, propKeys)
 
@@ -777,12 +777,16 @@ export function useGetMultiselectedProps<P extends ParsedPropertiesKeys>(
         const keyFn = (propKey: P) => propKey
         const mapFn = (propKey: P) => {
           return contextData.editedMultiSelectedProps.map((props) => {
-            const result = isStyleInfoKey(propKey)
-              ? styleInfoReaderRef.current(props, propKey)
-              : getModifiableJSXAttributeAtPath(
-                  props,
-                  pathMappingFn(propKey, contextData.targetPath),
-                )
+            // const result = isStyleInfoKey(propKey)
+            //   ? styleInfoReaderRef.current(props, propKey)
+            //   : getModifiableJSXAttributeAtPath(
+            //       props,
+            //       pathMappingFn(propKey, contextData.targetPath),
+            //     )
+            const result = getModifiableJSXAttributeAtPath(
+              props,
+              pathMappingFn(propKey, contextData.targetPath),
+            )
             // This wipes the uid from any `JSExpression` values we may have retrieved,
             // as that can cause the deep equality check to fail for different elements
             // with the same value for a given property.

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -517,12 +517,12 @@ export function useInspectorInfo<P extends ParsedPropertiesKeys, T = ParsedPrope
   pathMappingFn: PathMappingFn<P>,
 ): InspectorInfo<T> {
   const propKeys = useMemoizedPropKeys(propKeysIn)
-  const multiselectAtProps: MultiselectAtProps<P> = useGetMultiselectedProps<P>(
+  const multiselectAtProps: MultiselectAtProps<P> = useGetMultiselectedProps<P>( // this gets the actual prop value
     pathMappingFn,
     propKeys,
   )
 
-  const selectedProps = useGetSpiedProps<P>(pathMappingFn, propKeys)
+  const selectedProps = useGetSpiedProps<P>(pathMappingFn, propKeys) // this gets the spied props, won't be applicable for Tailwind
 
   const selectedComputedStyles = useGetSelectedComputedStyles<P>(pathMappingFn, propKeys)
 

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -679,7 +679,7 @@ export const InspectorContextProvider = React.memo<{
                 : []
             return replaceFirstChildAndDeleteSiblings(elem, children, newValue)
           }
-          return [setProp_UNSAFE(elem, path, newValue)]
+          return [setProp_UNSAFE(elem, path, newValue)] // TODO: use command here
         }),
       ]
       const actions: EditorAction[] = transient
@@ -729,7 +729,7 @@ export const InspectorContextProvider = React.memo<{
             actionsArray.push(unsetProperty(elem, p))
           })
         } else {
-          actionsArray.push(unsetProperty(elem, property))
+          actionsArray.push(unsetProperty(elem, property)) // use command here
         }
       })
 

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -679,7 +679,7 @@ export const InspectorContextProvider = React.memo<{
                 : []
             return replaceFirstChildAndDeleteSiblings(elem, children, newValue)
           }
-          return [setProp_UNSAFE(elem, path, newValue)] // TODO: use command here
+          return [setProp_UNSAFE(elem, path, newValue)]
         }),
       ]
       const actions: EditorAction[] = transient
@@ -726,10 +726,10 @@ export const InspectorContextProvider = React.memo<{
       Utils.fastForEach(refElementsToTargetForUpdates.current, (elem) => {
         if (Array.isArray(property)) {
           Utils.fastForEach(property, (p) => {
-            actionsArray.push(unsetProperty(elem, p)) // use command here
+            actionsArray.push(unsetProperty(elem, p))
           })
         } else {
-          actionsArray.push(unsetProperty(elem, property)) // use command here
+          actionsArray.push(unsetProperty(elem, property))
         }
       })
 

--- a/editor/src/components/inspector/inspector.tsx
+++ b/editor/src/components/inspector/inspector.tsx
@@ -726,7 +726,7 @@ export const InspectorContextProvider = React.memo<{
       Utils.fastForEach(refElementsToTargetForUpdates.current, (elem) => {
         if (Array.isArray(property)) {
           Utils.fastForEach(property, (p) => {
-            actionsArray.push(unsetProperty(elem, p))
+            actionsArray.push(unsetProperty(elem, p)) // use command here
           })
         } else {
           actionsArray.push(unsetProperty(elem, property)) // use command here


### PR DESCRIPTION
## Problem
`useInspectorInfo`, a widely used helper in the inspector, cannot read element styles set by Tailwind

## Fix
The fix is made up from multiple pieces:
- I extended `StylePlugin` with a new function, `readStyleFromElementProps`, which reads a given style info key from the `JSXAttributes` passed to it. I updated both `InlineStylePlugin` and `TailwindStylePlugin` to support this function, and updated all affected tests. This change was originally prototyped on the [Megaspike](https://github.com/concrete-utopia/utopia/pull/6574)
- I updated `useGetMultiselectedProps` to use `StylePlugin.readStyleFromElementProps` when a style prop is read.
- I updated `CSSStylePropertyNotParsable` and `ParsedCSSStyleProperty` to preserve the original value read from `projectContents`, in addition to the parsed representation. This way, `CSSStyleProperties` can be used by code that expect to work with this lower-level representation (such as the internals of `useInspectorInfo`)
- I updated the `SET_PROP` and `UNSET_PROP` actions to use the `setProperty` and `deleteProperty` commands under the hood. This way, any editor code using these actions will be able to use the style plugins to write element style. This change was originally prototyped on the [Megaspike](https://github.com/concrete-utopia/utopia/pull/6574)

### Out of scope
This change only touches `useGetMultiselectedProps` from the internals of `useInspectorInfo`. `useGetSpiedProps` is left unchanged, since the values element style props set through Tailwind don't show up in `allElementProps` (which is the data source for spied props)

## Manual Tests:
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

