### PR TITLE
Stringify the element path passed to data-grid-path

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -925,7 +925,7 @@ const GridControl = React.memo<GridControlProps>(({ grid, controlsVisible }) => 
       <div
         key={gridKeyFromPath(gridContainerOrComponentPath)}
         id={gridKeyFromPath(gridContainerOrComponentPath)}
-        data-grid-path={gridContainerOrComponentPath}
+        data-grid-path={EP.toString(gridContainerOrComponentPath)}
         style={style}
       >
         {placeholders.map((cell) => {


### PR DESCRIPTION
**Problem:**

`data-grid-path` is not stringified when used in the grid control's component, leading to a lovely `[object Object]` which functionally nerfs the dom walker.

**Fix:**

Fix that.

Fixes #6659 