### PR TITLE
Remove unused SetElementsToRerender action

### DIFF
--- a/editor/src/components/editor/action-types.ts
+++ b/editor/src/components/editor/action-types.ts
@@ -1104,11 +1104,6 @@ export interface RunEscapeHatch {
   setHuggingParentToFixed: SetHuggingParentToFixed
 }
 
-export interface SetElementsToRerender {
-  action: 'SET_ELEMENTS_TO_RERENDER'
-  value: ElementsToRerender
-}
-
 export type ToggleSelectionLock = {
   action: 'TOGGLE_SELECTION_LOCK'
   targets: Array<ElementPath>
@@ -1376,7 +1371,6 @@ export type EditorAction =
   | SetResizeOptionsTargetOptions
   | ForceParseFile
   | RunEscapeHatch
-  | SetElementsToRerender
   | ToggleSelectionLock
   | UpdateAgainstGithub
   | SetImageDragSessionState

--- a/editor/src/components/editor/actions/action-utils.ts
+++ b/editor/src/components/editor/actions/action-utils.ts
@@ -119,7 +119,6 @@ export function isTransientAction(action: EditorAction): boolean {
     case 'UPDATE_INTERACTION_SESSION':
     case 'UPDATE_DRAG_INTERACTION_DATA':
     case 'SET_USERS_PREFERRED_STRATEGY':
-    case 'SET_ELEMENTS_TO_RERENDER':
     case 'TOGGLE_SELECTION_LOCK':
     case 'UPDATE_GITHUB_OPERATIONS':
     case 'SET_REFRESHING_DEPENDENCIES':

--- a/editor/src/components/editor/actions/actions.tsx
+++ b/editor/src/components/editor/actions/actions.tsx
@@ -251,7 +251,6 @@ import type {
   SetCodeEditorVisibility,
   SetCurrentTheme,
   SetCursorOverlay,
-  SetElementsToRerender,
   SetFilebrowserDropTarget,
   SetFilebrowserRenamingTarget,
   SetFocusedElement,
@@ -5764,15 +5763,6 @@ export const UPDATE_FNS = {
       return foldAndApplyCommandsSimple(editor, commands)
     } else {
       return editor
-    }
-  },
-  SET_ELEMENTS_TO_RERENDER: (action: SetElementsToRerender, editor: EditorModel): EditorModel => {
-    return {
-      ...editor,
-      canvas: {
-        ...editor.canvas,
-        elementsToRerender: action.value,
-      },
     }
   },
   TOGGLE_SELECTION_LOCK: (action: ToggleSelectionLock, editor: EditorModel): EditorModel => {

--- a/editor/src/components/editor/store/editor-update.tsx
+++ b/editor/src/components/editor/store/editor-update.tsx
@@ -447,8 +447,6 @@ export function runSimpleLocalEditorAction(
       return UPDATE_FNS.FORCE_PARSE_FILE(action, state)
     case 'RUN_ESCAPE_HATCH':
       return UPDATE_FNS.RUN_ESCAPE_HATCH(action, state, builtInDependencies)
-    case 'SET_ELEMENTS_TO_RERENDER':
-      return UPDATE_FNS.SET_ELEMENTS_TO_RERENDER(action, state)
     case 'TOGGLE_SELECTION_LOCK':
       return UPDATE_FNS.TOGGLE_SELECTION_LOCK(action, state)
     case 'UPDATE_AGAINST_GITHUB':


### PR DESCRIPTION
**Problem:**
SetElementsToRerender action is not used anymore, let's delete it.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

