### PR TITLE
Fix not found attribute styleInfoReader result

### DIFF
--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -765,7 +765,7 @@ export function useGetMultiselectedProps<P extends ParsedPropertiesKeys>(
       (props: JSXAttributes, prop: keyof StyleInfo): GetModifiableAttributeResult => {
         const elementStyle = getActivePlugin(store.editor).readStyleFromElementProps(props, prop)
         if (elementStyle == null) {
-          return left('not found')
+          return right({ type: 'ATTRIBUTE_NOT_FOUND' })
         }
         switch (elementStyle.type) {
           case 'not-found':


### PR DESCRIPTION
**Problem:**
StyleInfoReader returns `left('not found')` for attributes where there is no relevant tailwind classes set.
But the features expect `right({ type: 'ATTRIBUTE_NOT_FOUND' })` result in these cases.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

