### PR TITLE
Grid cell lines

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -2561,16 +2561,17 @@ function skewMarkerPosition(
   // span-end triangle, on the column
   const spanEndColumn = axis === 'column' && markerType === 'span-end'
   if (spanEndColumn) {
-    return 10
+    return 9
   }
-  const pinnedEndColumn = axis === 'column' && markerType === 'pinned'
+  // pinned triangle, on the column
+  const pinnedEndColumn = axis === 'column' && markerType === 'pinned' && bound === 'end'
   if (pinnedEndColumn) {
     return 5
   }
   // any other ending marker, on the column
   const endColumn = bound === 'end' && axis === 'column'
   if (endColumn) {
-    return 2
+    return 1
   }
 
   // span-end triangle, on the row
@@ -2581,7 +2582,7 @@ function skewMarkerPosition(
   // any other ending marker, on the row
   const endRow = bound === 'end' && axis === 'row'
   if (endRow) {
-    return 6
+    return 4
   }
 
   // span-start triangle, on the column
@@ -2589,10 +2590,14 @@ function skewMarkerPosition(
   if (spanStartColumn) {
     return 0
   }
+  const pinnedStartColumn = axis === 'column' && markerType === 'pinned' && bound === 'start'
+  if (pinnedStartColumn) {
+    return 5
+  }
   // any starting marker, on the column
   const startColumn = bound === 'start' && axis === 'column'
   if (startColumn) {
-    return 5
+    return 1
   }
 
   // span-start starting triangle, on the row

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -2341,25 +2341,25 @@ const RulerMarkers = React.memo((props: { path: ElementPath }) => {
       />
       <RulerMarkerIndicator parentGrid={markers.parentGrid} marker={markers.rowEnd} axis={'row'} />
       {/* Offset lines */}
-      <GridOffsetLine
+      <GridCellOffsetLine
         top={markers.columnStart.top}
         left={markers.columnStart.left}
         size={markers.cellRect.y - markers.gridRect.y}
         orientation='vertical'
       />
-      <GridOffsetLine
+      <GridCellOffsetLine
         top={markers.columnEnd.top}
         left={markers.columnEnd.left}
         size={markers.cellRect.y - markers.gridRect.y}
         orientation='vertical'
       />
-      <GridOffsetLine
+      <GridCellOffsetLine
         top={markers.rowStart.top}
         left={markers.rowStart.left}
         size={markers.cellRect.x - markers.gridRect.x}
         orientation='horizontal'
       />
-      <GridOffsetLine
+      <GridCellOffsetLine
         top={markers.rowEnd.top}
         left={markers.rowEnd.left}
         size={markers.cellRect.x - markers.gridRect.x}
@@ -2614,7 +2614,7 @@ function skewMarkerPosition(
   return 0
 }
 
-const GridOffsetLine = React.memo(
+const GridCellOffsetLine = React.memo(
   (props: { top: number; left: number; size: number; orientation: 'vertical' | 'horizontal' }) => {
     const colorTheme = useColorTheme()
 
@@ -2638,7 +2638,7 @@ const GridOffsetLine = React.memo(
     )
   },
 )
-GridOffsetLine.displayName = 'GridOffsetLine'
+GridCellOffsetLine.displayName = 'GridCellOffsetLine'
 
 const GridCellOutline = React.memo(
   (props: { top: number; left: number; width: number; height: number }) => {


### PR DESCRIPTION
**Problem:**

When a grid item is selected, there should be outline lines around the cell bounds, which also expand to meet the ruler markers.

**Fix:**

Implement one component to render the cell bounds outline, and one component for the lines stretching to the markers from the cell perimeter.

<img width="807" alt="Screenshot 2024-11-22 at 11 59 11" src="https://github.com/user-attachments/assets/e82672bc-f7dd-4dd2-9b24-6f2c6d286feb">

https://github.com/user-attachments/assets/9a69b131-a052-42ab-88c6-f1534c3865af

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

Fixes #6675 