### PR TITLE
feat(discord): add environment data to discord messages

### DIFF
--- a/utopia-remix/app/util/discordWebhookUtils.ts
+++ b/utopia-remix/app/util/discordWebhookUtils.ts
@@ -8,6 +8,7 @@ import { Status } from './statusCodes'
 import { ApiError } from './errors'
 import type { UserDetails } from 'prisma-client'
 import { ServerEnvironment } from '../env.server'
+import { assertNever } from './assertNever'
 
 // these need to be decimal colors (for 'discord-webhook-node')
 const colors: Record<DiscordMessageType, number> = {
@@ -43,6 +44,7 @@ export function sendDiscordMessage(
 
   const fields: Record<string, string> = {
     User: `${user.name ?? 'Unknown User'} (${user.email ?? 'Unknown Email'})`,
+    Environment: getEnvironmentText(),
     ...(messageDescriptor.fields ?? {}),
   }
 
@@ -69,4 +71,19 @@ function getWebhook(type: DiscordWebhookType) {
 
 function createDiscordWebhook(url: string) {
   return new Webhook(url)
+}
+
+function getEnvironmentText() {
+  switch (ServerEnvironment.environment) {
+    case 'local':
+      return 'Local'
+    case 'stage':
+      return 'Staging'
+    case 'prod':
+      return 'Production'
+    case 'test':
+      return 'Test'
+    default:
+      assertNever(ServerEnvironment.environment)
+  }
 }


### PR DESCRIPTION
This PR adds environment data to the messages that are being sent to Discord

<img width=400 src="https://github.com/user-attachments/assets/52702eb5-4e0e-4714-9d4d-60432d4ea99b"></img>

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Play mode