### PR TITLE
Respect spans when resizing grid cells

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.spec.browser2.tsx
@@ -671,6 +671,185 @@ export var storyboard = (
       gridRowEnd: 'auto',
     })
   })
+
+  describe('spans', () => {
+    it('respects column start spans', async () => {
+      const editor = await renderTestEditorWithCode(
+        makeProjectCodeWithSpan({ gridColumn: 'span 2', gridRow: '2' }),
+        'await-first-dom-report',
+      )
+
+      // enlarge to the right
+      {
+        await runCellResizeTest(
+          editor,
+          'column-end',
+          gridCellTargetId(EP.fromString('sb/grid'), 2, 3),
+          EP.fromString('sb/grid/cell'),
+        )
+
+        const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } =
+          editor.renderedDOM.getByTestId('cell').style
+        expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+          gridColumnEnd: 'auto',
+          gridColumnStart: 'span 3',
+          gridRowEnd: 'auto',
+          gridRowStart: '2',
+        })
+      }
+
+      // shrink from the left
+      {
+        await runCellResizeTest(
+          editor,
+          'column-start',
+          gridCellTargetId(EP.fromString('sb/grid'), 2, 2),
+          EP.fromString('sb/grid/cell'),
+        )
+
+        const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } =
+          editor.renderedDOM.getByTestId('cell').style
+        expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+          gridColumnEnd: '4',
+          gridColumnStart: 'span 2',
+          gridRowEnd: 'auto',
+          gridRowStart: '2',
+        })
+      }
+
+      // enlarge back from the left
+      {
+        await runCellResizeTest(
+          editor,
+          'column-start',
+          gridCellTargetId(EP.fromString('sb/grid'), 2, 1),
+          EP.fromString('sb/grid/cell'),
+        )
+
+        const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } =
+          editor.renderedDOM.getByTestId('cell').style
+        expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+          gridColumnEnd: 'auto',
+          gridColumnStart: 'span 3',
+          gridRowEnd: 'auto',
+          gridRowStart: '2',
+        })
+      }
+    })
+    it('respects column end spans', async () => {
+      const editor = await renderTestEditorWithCode(
+        makeProjectCodeWithSpan({ gridColumn: '2 / span 2', gridRow: '2' }),
+        'await-first-dom-report',
+      )
+
+      // enlarge to the right
+      {
+        await runCellResizeTest(
+          editor,
+          'column-end',
+          gridCellTargetId(EP.fromString('sb/grid'), 2, 4),
+          EP.fromString('sb/grid/cell'),
+        )
+
+        const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } =
+          editor.renderedDOM.getByTestId('cell').style
+        expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+          gridColumnEnd: 'span 3',
+          gridColumnStart: '2',
+          gridRowEnd: 'auto',
+          gridRowStart: '2',
+        })
+      }
+    })
+    it('respects row start spans', async () => {
+      const editor = await renderTestEditorWithCode(
+        makeProjectCodeWithSpan({ gridColumn: '2', gridRow: 'span 2' }),
+        'await-first-dom-report',
+      )
+
+      // enlarge to the bottom
+      {
+        await runCellResizeTest(
+          editor,
+          'row-end',
+          gridCellTargetId(EP.fromString('sb/grid'), 3, 2),
+          EP.fromString('sb/grid/cell'),
+        )
+
+        const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } =
+          editor.renderedDOM.getByTestId('cell').style
+        expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+          gridColumnEnd: 'auto',
+          gridColumnStart: '2',
+          gridRowEnd: 'auto',
+          gridRowStart: 'span 3',
+        })
+      }
+
+      // shrink from the top
+      {
+        await runCellResizeTest(
+          editor,
+          'row-start',
+          gridCellTargetId(EP.fromString('sb/grid'), 2, 2),
+          EP.fromString('sb/grid/cell'),
+        )
+
+        const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } =
+          editor.renderedDOM.getByTestId('cell').style
+        expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+          gridColumnEnd: 'auto',
+          gridColumnStart: '2',
+          gridRowEnd: '4',
+          gridRowStart: 'span 2',
+        })
+      }
+
+      // enlarge back from the top
+      {
+        await runCellResizeTest(
+          editor,
+          'row-start',
+          gridCellTargetId(EP.fromString('sb/grid'), 1, 2),
+          EP.fromString('sb/grid/cell'),
+        )
+
+        const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } =
+          editor.renderedDOM.getByTestId('cell').style
+        expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+          gridColumnEnd: 'auto',
+          gridColumnStart: '2',
+          gridRowEnd: 'auto',
+          gridRowStart: 'span 3',
+        })
+      }
+    })
+    it('respects row end spans', async () => {
+      const editor = await renderTestEditorWithCode(
+        makeProjectCodeWithSpan({ gridColumn: '2', gridRow: '2 / span 2' }),
+        'await-first-dom-report',
+      )
+
+      // enlarge to the bottom
+      {
+        await runCellResizeTest(
+          editor,
+          'row-end',
+          gridCellTargetId(EP.fromString('sb/grid'), 4, 2),
+          EP.fromString('sb/grid/cell'),
+        )
+
+        const { gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd } =
+          editor.renderedDOM.getByTestId('cell').style
+        expect({ gridRowStart, gridRowEnd, gridColumnStart, gridColumnEnd }).toEqual({
+          gridColumnEnd: 'auto',
+          gridColumnStart: '2',
+          gridRowEnd: 'span 3',
+          gridRowStart: '2',
+        })
+      }
+    })
+  })
 })
 
 const ProjectCode = `import * as React from 'react'
@@ -947,4 +1126,40 @@ export var storyboard = (
 
 function unsafeCast<T>(a: unknown): T {
   return a as T
+}
+
+function makeProjectCodeWithSpan(params: { gridColumn: string; gridRow: string }): string {
+  return `import * as React from 'react'
+import { Storyboard } from 'utopia-api'
+
+export var storyboard = (
+  <Storyboard data-uid='sb'>
+    <div
+      style={{
+        backgroundColor: '#aaaaaa33',
+        position: 'absolute',
+        width: 600,
+        height: 400,
+        display: 'grid',
+        gap: 10,
+        gridTemplateColumns: '1fr 1fr 1fr 1fr',
+        gridTemplateRows: '1fr 1fr 1fr 1fr',
+      }}
+      data-uid='grid'
+    >
+      <div
+        style={{
+          backgroundColor: '#aaaaaa33',
+          alignSelf: 'stretch',
+          justifySelf: 'stretch',
+          gridColumn: '${params.gridColumn}',
+          gridRow: '${params.gridRow}',
+        }}
+        data-uid='cell'
+		data-testid='cell'
+      />
+    </div>
+  </Storyboard>
+)
+`
 }


### PR DESCRIPTION
**Problem:**

Resizing grid cells always forces explicit numerical placement pins, chomping any `span`s that may have been defined on the cell.

**Fix:**

After determining the right numerical positions for the resized cell bounds, do a normalization pass so that the new grid props are rewritten to respect the new bounds but also to express them with `spans` if the original pins were spans in the first place.

For example, assuming enlarging to the right by 1 cell:

| Initial | Result |
|--------|----------|
| `gridColumn: span 2` | `gridColumn: span 3` |
| `gridColumn 3 / span 2` | `gridColumn: 3 / span 3` |

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

Fixes #6683 