### PR TITLE
Grid ruler resize labels sticky

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -2529,7 +2529,7 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
         <RulerMarkerIndicator
           gridRect={rulerMarkerData.gridRect}
           parentGrid={rulerMarkerData.parentGrid}
-          marker={rulerMarkerData.columnStart}
+          marker={frozenMarkers?.columnStart ?? rulerMarkerData.columnStart}
           axis={'column'}
           visible={'visible'}
           onMouseDown={columnMarkerMouseDown('column-start')}
@@ -2538,7 +2538,7 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
         <RulerMarkerIndicator
           gridRect={rulerMarkerData.gridRect}
           parentGrid={rulerMarkerData.parentGrid}
-          marker={rulerMarkerData.columnEnd}
+          marker={frozenMarkers?.columnEnd ?? rulerMarkerData.columnEnd}
           axis={'column'}
           visible={'visible'}
           onMouseDown={columnMarkerMouseDown('column-end')}
@@ -2570,7 +2570,7 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
         <RulerMarkerIndicator
           gridRect={rulerMarkerData.gridRect}
           parentGrid={rulerMarkerData.parentGrid}
-          marker={rulerMarkerData.rowStart}
+          marker={frozenMarkers?.rowStart ?? rulerMarkerData.rowStart}
           axis={'row'}
           visible={'visible'}
           onMouseDown={rowMarkerMouseDown('row-start')}
@@ -2579,7 +2579,7 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
         <RulerMarkerIndicator
           gridRect={rulerMarkerData.gridRect}
           parentGrid={rulerMarkerData.parentGrid}
-          marker={rulerMarkerData.rowEnd}
+          marker={frozenMarkers?.rowEnd ?? rulerMarkerData.rowEnd}
           axis={'row'}
           visible={'visible'}
           onMouseDown={rowMarkerMouseDown('row-end')}

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -2859,6 +2859,21 @@ const RulerMarkerIndicator = React.memo(
 
     const labelClass = 'ruler-marker-label'
 
+    const edge: GridResizeEdge =
+      props.marker.bound === 'start'
+        ? props.axis === 'column'
+          ? 'column-start'
+          : 'row-start'
+        : props.axis === 'column'
+        ? 'column-end'
+        : 'row-end'
+
+    const resizeControlRef = useRefEditorState((store) =>
+      store.editor.canvas.interactionSession?.activeControl.type !== 'GRID_RESIZE_RULER_HANDLE'
+        ? null
+        : store.editor.canvas.interactionSession.activeControl,
+    )
+
     return (
       <div
         data-testid={props.testID}
@@ -2874,7 +2889,7 @@ const RulerMarkerIndicator = React.memo(
         onMouseDown={props.onMouseDown}
         css={{
           [`> .${labelClass}`]: {
-            visibility: 'hidden',
+            visibility: resizeControlRef.current?.edge === edge ? 'visible' : 'hidden',
           },
           ':hover': {
             [`> .${labelClass}`]: {

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -2859,14 +2859,7 @@ const RulerMarkerIndicator = React.memo(
 
     const labelClass = 'ruler-marker-label'
 
-    const edge: GridResizeEdge =
-      props.marker.bound === 'start'
-        ? props.axis === 'column'
-          ? 'column-start'
-          : 'row-start'
-        : props.axis === 'column'
-        ? 'column-end'
-        : 'row-end'
+    const edge: GridResizeEdge = `${props.axis}-${props.marker.bound}`
 
     const resizeControlRef = useRefEditorState((store) =>
       store.editor.canvas.interactionSession?.activeControl.type !== 'GRID_RESIZE_RULER_HANDLE'


### PR DESCRIPTION
**Problem:**

Markers should not move while resize is in progress, and the active one's label should be visible during resize.

**Fix:**

As a followup to https://github.com/concrete-utopia/utopia/pull/6689, this PR makes sure that markers are fixed when the ruler resize strategy is active, and that the label for the marker being dragged stays visible as well.
