### PR TITLE
Restore Metadata When Cancelling Interaction.

### DIFF
--- a/editor/src/components/editor/store/dispatch-strategies.spec.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.spec.tsx
@@ -140,7 +140,7 @@ describe('interactionCancel', () => {
         'zero-drag-not-permitted',
       ),
     )
-    const actualResult = interactionCancel(editorStore, dispatchResultFromEditorStore(editorStore))
+    const actualResult = interactionCancel(dispatchResultFromEditorStore(editorStore))
     expect(actualResult.newStrategyState.commandDescriptions).toHaveLength(0)
     expect(actualResult.newStrategyState.currentStrategyCommands).toHaveLength(0)
     expect(actualResult.newStrategyState.currentStrategy).toBeNull()

--- a/editor/src/components/editor/store/dispatch-strategies.tsx
+++ b/editor/src/components/editor/store/dispatch-strategies.tsx
@@ -407,22 +407,16 @@ export function interactionStart(
   }
 }
 
-export function interactionCancel(
-  storedState: EditorStoreFull,
-  result: EditorStoreUnpatched,
-): HandleStrategiesResult {
-  const interactionWasInProgress = interactionInProgress(
-    storedState.unpatchedEditor.canvas.interactionSession,
-  )
+export function interactionCancel(result: EditorStoreUnpatched): HandleStrategiesResult {
   const updatedEditorState: EditorState = {
     ...result.unpatchedEditor,
     canvas: {
       ...result.unpatchedEditor.canvas,
       interactionSession: null,
     },
-    jsxMetadata: interactionWasInProgress ? {} : result.unpatchedEditor.jsxMetadata,
-    domMetadata: interactionWasInProgress ? {} : result.unpatchedEditor.domMetadata,
-    spyMetadata: interactionWasInProgress ? {} : result.unpatchedEditor.spyMetadata,
+    jsxMetadata: result.unpatchedEditor.jsxMetadata,
+    domMetadata: result.unpatchedEditor.domMetadata,
+    spyMetadata: result.unpatchedEditor.spyMetadata,
   }
 
   return {
@@ -823,7 +817,7 @@ function handleStrategiesInner(
     }
   } else {
     if (cancelInteraction) {
-      return interactionCancel(storedState, result)
+      return interactionCancel(result)
     } else if (makeChangesPermanent) {
       return interactionFinished(strategies, storedState, result)
     } else {


### PR DESCRIPTION
**Problem:**
It was discovered that if a grid item drag was cancelled by pressing Escape, trying to drag it a second time would not succeed. Only by clearing selection and re-selecting the item would it be possible to drag the item again.

**Cause:**
The causal chain of events which make this happen are as follows:
- `EditorState.jsxMetadata` gets completely emptied out in `interactionCancel`.
- The `useAllGrids` hook call in `GridMeasurementHelpers` now returns an empty array as the metadata is empty.
- Every instance of `GridMeasurementHelper` gets unmounted and all of the rendered helper elements are removed because they no longer are rendered.
- The DOM walker attempts to get the frames of the grid cells in `measureGlobalFramesOfGridCells`, but doesn't find the helper elements as they've just been removed and then the function returns a null for the value assigned to `SpecialSizeMeasurements.parentGridCellGlobalFrames`.
- `getCommandsAndPatchForGridAbsoluteMove` used in the `Grid move (Abs)` strategy gets the value of `parentGridCellGlobalFrames` and because it is null does an early return with no changes to the element.

**Fix:**
Now instead of checking if an interaction was in progress in `interactionCancel` and resetting the metadata to the old value if no interaction was in progress. It now always restores the original metadata regardless.

**Commit Details:**
- `interactionCancel` now always restores the metadata regardless of the state of the interaction session.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode