### PR TITLE
Ruler marker resize for non-stretching grid items

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -752,6 +752,9 @@ export function getGridRelativeContainingBlock(
   gridMetadata: ElementInstanceMetadata,
   cellMetadata: ElementInstanceMetadata,
   cellProperties: GridElementProperties,
+  options?: {
+    forcePositionRelative?: boolean
+  },
 ): LocalRectangle {
   const gridProperties = gridMetadata.specialSizeMeasurements.containerGridProperties
 
@@ -856,7 +859,9 @@ export function getGridRelativeContainingBlock(
       'row',
     )
   }
-  gridChildElement.style.position = cellMetadata.specialSizeMeasurements.position ?? 'initial'
+  gridChildElement.style.position = options?.forcePositionRelative
+    ? 'relative'
+    : cellMetadata.specialSizeMeasurements.position ?? 'initial'
   // Fill out the entire space available.
   gridChildElement.style.top = '0'
   gridChildElement.style.left = '0'

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-helpers.ts
@@ -19,7 +19,6 @@ import {
 } from '../../../../core/shared/element-template'
 import {
   localRectangle,
-  Size,
   zeroRectIfNullOrInfinity,
   type CanvasRectangle,
   type LocalRectangle,
@@ -779,17 +778,19 @@ export function getGridRelativeContainingBlock(
 
   // Gap needs to be set only if the other two are not present or we'll have rendering issues
   // due to how measurements are calculated.
-  if (
-    gridMetadata.specialSizeMeasurements.rowGap != null &&
-    gridMetadata.specialSizeMeasurements.columnGap != null
-  ) {
+  const hasRowGap = gridMetadata.specialSizeMeasurements.rowGap != null
+  if (hasRowGap) {
+    const rowGap = gridMetadata.specialSizeMeasurements.rowGap
+    gridElement.style.rowGap = `${rowGap}px`
+  }
+  const hasColumnGap = gridMetadata.specialSizeMeasurements.columnGap != null
+  if (hasColumnGap) {
+    const columnGap = gridMetadata.specialSizeMeasurements.columnGap
+    gridElement.style.columnGap = `${columnGap}px`
+  }
+  if (!hasColumnGap && !hasRowGap) {
     const gap = gridMetadata.specialSizeMeasurements.gap
     gridElement.style.gap = gap == null ? 'initial' : `${gap}px`
-  } else {
-    const rowGap = gridMetadata.specialSizeMeasurements.rowGap
-    gridElement.style.rowGap = rowGap == null ? 'initial' : `${rowGap}px`
-    const columnGap = gridMetadata.specialSizeMeasurements.columnGap
-    gridElement.style.columnGap = columnGap == null ? 'initial' : `${columnGap}px`
   }
 
   // Include the padding.

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-ruler-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-ruler-strategy.spec.browser2.tsx
@@ -197,11 +197,11 @@ export var storyboard = (
         data-uid='flow2'
         data-testid='flow2'
       />
-	  <div
+      <div
         style={{
           backgroundColor: '#f0f',
-		  width: 50,
-		  height: 50,
+          width: 50,
+          height: 50,
         }}
         data-uid='flow-fixed'
         data-testid='flow-fixed'
@@ -223,7 +223,7 @@ export var storyboard = (
           gridColumn: 1,
           gridRow: 2,
           width: 50,
-		  height: 50,
+          height: 50,
         }}
         data-uid='pinned-fixed'
         data-testid='pinned-fixed'

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-ruler-strategy.spec.browser2.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-ruler-strategy.spec.browser2.tsx
@@ -1,15 +1,15 @@
+import * as EP from '../../../../core/shared/element-path'
 import {
   selectComponentsForTest,
   setFeatureForBrowserTestsUseInDescribeBlockOnly,
 } from '../../../../utils/utils.test-utils'
-import { renderTestEditorWithCode } from '../../ui-jsx.test-utils'
-import * as EP from '../../../../core/shared/element-path'
 import {
   RulerMarkerColumnEndTestId,
   RulerMarkerRowEndTestId,
   RulerMarkerRowStartTestId,
 } from '../../controls/grid-controls'
 import { mouseDownAtPoint, mouseMoveToPoint, mouseUpAtPoint } from '../../event-helpers.test-utils'
+import { renderTestEditorWithCode } from '../../ui-jsx.test-utils'
 
 describe('grid resize element ruler strategy', () => {
   setFeatureForBrowserTestsUseInDescribeBlockOnly('Grid Ruler Markers', true)
@@ -119,6 +119,42 @@ describe('grid resize element ruler strategy', () => {
       expect(element.style.gridRowEnd).toBe('3')
     }
   })
+
+  it('can resize a non-stretching pinned element', async () => {
+    const renderResult = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')
+
+    await selectComponentsForTest(renderResult, [EP.fromString('sb/grid/pinned-fixed')])
+
+    const control = await renderResult.renderedDOM.findByTestId(RulerMarkerColumnEndTestId)
+    const controlRect = control.getBoundingClientRect()
+    const startPoint = { x: controlRect.x + 5, y: controlRect.y + 5 }
+    const endPoint = { x: controlRect.x + 200, y: controlRect.y + 5 }
+    await mouseDownAtPoint(control, startPoint)
+    await mouseMoveToPoint(control, endPoint)
+    await mouseUpAtPoint(control, endPoint)
+
+    const element = await renderResult.renderedDOM.findByTestId('pinned-fixed')
+    expect(element.style.gridColumn).toBe('1 / 3')
+    expect(element.style.gridRow).toBe('2')
+  })
+
+  it('can resize a non-stretching flow element', async () => {
+    const renderResult = await renderTestEditorWithCode(ProjectCode, 'await-first-dom-report')
+
+    await selectComponentsForTest(renderResult, [EP.fromString('sb/grid/flow-fixed')])
+
+    const control = await renderResult.renderedDOM.findByTestId(RulerMarkerColumnEndTestId)
+    const controlRect = control.getBoundingClientRect()
+    const startPoint = { x: controlRect.x + 5, y: controlRect.y + 5 }
+    const endPoint = { x: controlRect.x + 200, y: controlRect.y + 5 }
+    await mouseDownAtPoint(control, startPoint)
+    await mouseMoveToPoint(control, endPoint)
+    await mouseUpAtPoint(control, endPoint)
+
+    const element = await renderResult.renderedDOM.findByTestId('flow-fixed')
+    expect(element.style.gridColumn).toBe('span 2')
+    expect(element.style.gridRow).toBe('auto')
+  })
 })
 
 const ProjectCode = `
@@ -161,6 +197,15 @@ export var storyboard = (
         data-uid='flow2'
         data-testid='flow2'
       />
+	  <div
+        style={{
+          backgroundColor: '#f0f',
+		  width: 50,
+		  height: 50,
+        }}
+        data-uid='flow-fixed'
+        data-testid='flow-fixed'
+      />
       <div
         style={{
           backgroundColor: '#f09',
@@ -171,6 +216,17 @@ export var storyboard = (
         }}
         data-uid='pinned'
         data-testid='pinned'
+      />
+      <div
+        style={{
+          backgroundColor: '#ff0',
+          gridColumn: 1,
+          gridRow: 2,
+          width: 50,
+		  height: 50,
+        }}
+        data-uid='pinned-fixed'
+        data-testid='pinned-fixed'
       />
     </div>
   </Storyboard>

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-ruler-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-ruler-strategy.ts
@@ -11,7 +11,6 @@ import { canvasRectangle, isInfinityRectangle } from '../../../../core/shared/ma
 import { assertNever } from '../../../../core/shared/utils'
 import { gridContainerIdentifier, gridItemIdentifier } from '../../../editor/store/editor-state'
 import { isCSSKeyword } from '../../../inspector/common/css-utils'
-import { isFillOrStretchModeAppliedOnAnySide } from '../../../inspector/inspector-common'
 import {
   controlsForGridPlaceholders,
   GridResizeControls,
@@ -88,11 +87,6 @@ export const gridResizeElementRulerStrategy: CanvasStrategyFactory = (
         interactionSession.interactionData.drag == null ||
         interactionSession.activeControl.type !== 'GRID_RESIZE_RULER_HANDLE'
       ) {
-        return emptyStrategyApplicationResult
-      }
-
-      if (!isFillOrStretchModeAppliedOnAnySide(canvasState.startingMetadata, selectedElement)) {
-        // TODO this should be removed to support resizing cells that are not stretching
         return emptyStrategyApplicationResult
       }
 

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -30,7 +30,6 @@ import type { CanvasPoint, CanvasRectangle, LocalRectangle } from '../../../core
 import {
   boundingRectangleArray,
   canvasPoint,
-  canvasRectangle,
   isFiniteRectangle,
   isInfinityRectangle,
   nullIfInfinity,
@@ -80,10 +79,7 @@ import {
   gridResizeRulerHandle,
 } from '../canvas-strategies/interaction-state'
 import type { GridCellCoordinates } from '../canvas-strategies/strategies/grid-cell-bounds'
-import {
-  getGridChildCellCoordBoundsFromCanvas,
-  gridCellTargetId,
-} from '../canvas-strategies/strategies/grid-cell-bounds'
+import { gridCellTargetId } from '../canvas-strategies/strategies/grid-cell-bounds'
 import type { GridCellGlobalFrames } from '../canvas-strategies/strategies/grid-helpers'
 import {
   getGlobalFrameOfGridCellFromMetadata,
@@ -130,6 +126,7 @@ import type { RulerMarkerType } from './grid-controls-ruler-markers'
 import { rulerMarkerIcons } from './grid-controls-ruler-markers'
 import type { GridData, GridMeasurementHelperData } from './grid-measurements'
 import {
+  calculateGridCellRectangle,
   getGridElementMeasurementHelperData,
   useGridElementMeasurementHelperData,
   useGridMeasurementHelperData,
@@ -2245,11 +2242,7 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
   const rulerMarkerData: RulerMarkerData | null = useEditorState(
     Substores.metadata,
     (store) => {
-      if (gridRect == null) {
-        return null
-      }
-
-      if (parentGridCellGlobalFrames == null) {
+      if (gridRect == null || parentGridCellGlobalFrames == null) {
         return null
       }
 
@@ -2260,6 +2253,10 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
       if (elementMetadata == null) {
         return null
       }
+      if (MetadataUtils.isPositionAbsolute(elementMetadata)) {
+        // disable markers for absolute positioning, we may revisit this in the future.
+        return null
+      }
 
       const elementGridProperties = elementMetadata.specialSizeMeasurements.elementGridProperties
       if (elementGridProperties == null) {
@@ -2267,54 +2264,10 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
       }
 
       const parentGrid = elementMetadata.specialSizeMeasurements.parentContainerGridProperties
-
-      const originalGrid = findOriginalGrid(store.editor.jsxMetadata, EP.parentPath(props.path))
-      if (originalGrid == null) {
+      const cellRect = calculateGridCellRectangle(store.editor.jsxMetadata, props.path)
+      if (cellRect == null) {
         return null
       }
-
-      const cellBounds = getGridChildCellCoordBoundsFromCanvas(
-        elementMetadata,
-        parentGridCellGlobalFrames,
-      )
-      if (cellBounds == null) {
-        return null
-      }
-
-      if (parentGridCellGlobalFrames.length === 0) {
-        return null
-      }
-      const firstRow = parentGridCellGlobalFrames[0]
-      const cellBoundsColumnIndex = cellBounds.column - 1
-      const left = firstRow[cellBoundsColumnIndex].x
-      const width = getCellCanvasWidthFromBounds(
-        parentGridCellGlobalFrames,
-        cellBoundsColumnIndex,
-        cellBounds.width,
-      )
-
-      const cellBoundsRowIndex = cellBounds.row - 1
-      if (
-        parentGridCellGlobalFrames.length <= cellBoundsRowIndex ||
-        parentGridCellGlobalFrames[cellBoundsRowIndex].length === 0
-      ) {
-        return null
-      }
-      const firstColumn = parentGridCellGlobalFrames[cellBoundsRowIndex][0]
-      const top = firstColumn.y
-      const height = getCellCanvasHeightFromBounds(
-        parentGridCellGlobalFrames,
-        cellBoundsRowIndex,
-        cellBounds.height,
-      )
-
-      const cellRect = parentGridCellGlobalFrames[cellBounds.row - 1][cellBounds.column - 1]
-      const cellRectResized = canvasRectangle({
-        x: cellRect.x,
-        y: cellRect.y,
-        width: width,
-        height: height,
-      })
 
       let otherColumnMarkers: Array<RulerMarkerPositionData> = []
       let otherRowMarkers: Array<RulerMarkerPositionData> = []
@@ -2341,10 +2294,10 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
       const lastColumnIndex = parentGridCellGlobalFrames[0].length - 1
       for (let columnIndex = 0; columnIndex <= lastColumnIndex; columnIndex++) {
         const cell = parentGridCellGlobalFrames[0][columnIndex]
-        if (left !== cell.x) {
+        if (cellRect.x !== cell.x) {
           addOtherMarker('column', 'start', cell.x, gridRect.y)
         }
-        if (left + width !== cell.x + cell.width) {
+        if (cellRect.x + cellRect.width !== cell.x + cell.width) {
           addOtherMarker('column', 'end', cell.x + cell.width, gridRect.y)
         }
       }
@@ -2353,10 +2306,10 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
       const lastRowIndex = parentGridCellGlobalFrames.length - 1
       for (let rowIndex = 0; rowIndex <= lastRowIndex; rowIndex++) {
         const cell = parentGridCellGlobalFrames[rowIndex][0]
-        if (top !== cell.y) {
+        if (cellRect.y !== cell.y) {
           addOtherMarker('row', 'start', gridRect.x, cell.y)
         }
-        if (top + height !== cell.y + cell.height) {
+        if (cellRect.y + cellRect.height !== cell.y + cell.height) {
           addOtherMarker('row', 'end', gridRect.x, cell.y + cell.height)
         }
       }
@@ -2365,7 +2318,7 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
         markerType: 'selected',
         rowOrColumn: 'column',
         top: gridRect.y,
-        left: left,
+        left: cellRect.x,
         position: elementGridProperties.gridColumnStart,
         bound: 'start',
       }
@@ -2373,14 +2326,14 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
         markerType: 'selected',
         rowOrColumn: 'column',
         top: gridRect.y,
-        left: left + width,
+        left: cellRect.x + cellRect.width,
         position: elementGridProperties.gridColumnEnd,
         bound: 'end',
       }
       const rowStart: RulerMarkerPositionData = {
         markerType: 'selected',
         rowOrColumn: 'row',
-        top: top,
+        top: cellRect.y,
         left: gridRect.x,
         position: elementGridProperties.gridRowStart,
         bound: 'start',
@@ -2388,15 +2341,15 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
       const rowEnd: RulerMarkerPositionData = {
         markerType: 'selected',
         rowOrColumn: 'row',
-        top: top + height,
+        top: cellRect.y + cellRect.height,
         left: gridRect.x,
         position: elementGridProperties.gridRowEnd,
         bound: 'end',
       }
 
-      return {
+      const data: RulerMarkerData = {
         parentGrid: parentGrid,
-        cellRect: cellRectResized,
+        cellRect: cellRect,
         gridRect: gridRect,
         otherColumnMarkers: otherColumnMarkers,
         otherRowMarkers: otherRowMarkers,
@@ -2405,6 +2358,7 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
         rowStart: rowStart,
         rowEnd: rowEnd,
       }
+      return data
     },
     'RulerMarkers markers',
   )
@@ -2951,65 +2905,6 @@ function getRulerMarkerColor(colorTheme: ThemeObject, marker: RulerMarkerPositio
     default:
       assertNever(marker.markerType)
   }
-}
-
-function getCellCanvasWidthFromBounds(
-  grid: CanvasRectangle[][],
-  index: number,
-  cells: number,
-): number {
-  if (grid.length === 0) {
-    return 0
-  }
-
-  const currentRow = grid[0]
-  if (currentRow.length <= index) {
-    return 0
-  }
-  if (cells <= 1) {
-    return currentRow[index].width
-  }
-
-  function getPadding() {
-    if (currentRow.length <= 1) {
-      return 0
-    }
-    return currentRow[1].x - (currentRow[0].x + currentRow[0].width)
-  }
-  const padding = getPadding()
-
-  return currentRow.slice(index + 1, index + cells).reduce((acc, curr) => {
-    return acc + curr.width + padding
-  }, currentRow[index].width)
-}
-
-function getCellCanvasHeightFromBounds(
-  grid: CanvasRectangle[][],
-  index: number,
-  cells: number,
-): number {
-  const columns = grid.map((row) => row[0])
-  if (columns.length <= index) {
-    return 0
-  }
-
-  const currentColumn = columns[index]
-
-  if (cells <= 1) {
-    return currentColumn.height
-  }
-
-  function getPadding() {
-    if (grid.length <= 1) {
-      return 0
-    }
-    return grid[1][0].y - (grid[0][0].y + grid[0][0].height)
-  }
-  const padding = getPadding()
-
-  return columns.slice(index + 1, index + cells).reduce((acc, curr) => {
-    return acc + curr.height + padding
-  }, currentColumn.height)
 }
 
 export const GridHelperControls = () => {

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -2253,10 +2253,6 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
       if (elementMetadata == null) {
         return null
       }
-      if (MetadataUtils.isPositionAbsolute(elementMetadata)) {
-        // disable markers for absolute positioning, we may revisit this in the future.
-        return null
-      }
 
       const elementGridProperties = elementMetadata.specialSizeMeasurements.elementGridProperties
       if (elementGridProperties == null) {

--- a/editor/src/components/canvas/controls/grid-measurements.tsx
+++ b/editor/src/components/canvas/controls/grid-measurements.tsx
@@ -410,6 +410,9 @@ function getCellDimensions(
     gridMetadata,
     cellItemMetadata,
     cellItemMetadata.specialSizeMeasurements.elementGridProperties,
+    {
+      forcePositionRelative: true,
+    },
   )
   const cellRect = offsetRect(canvasRectangle(calculatedCellBounds), coordinateSystemBounds)
   const { width, height } = cellRect

--- a/editor/src/components/canvas/controls/grid-measurements.tsx
+++ b/editor/src/components/canvas/controls/grid-measurements.tsx
@@ -1,32 +1,47 @@
 import type { Property } from 'csstype'
 import type { CSSProperties } from 'react'
-import type { GridIdentifier } from '../../editor/store/editor-state'
-import type {
-  BorderWidths,
-  GridAutoOrTemplateBase,
-  GridElementProperties,
-} from '../../../core/shared/element-template'
-import type { CanvasRectangle } from '../../../core/shared/math-utils'
+import React from 'react'
 import type { Sides } from 'utopia-api/core'
 import { sides } from 'utopia-api/core'
 import type { ElementPath } from 'utopia-shared/src/types'
-import { getFromElement } from '../direct-dom-lookups'
+import { MetadataUtils } from '../../../core/model/element-metadata-utils'
+import { domRectToScaledCanvasRectangle, getRoundingFn } from '../../../core/shared/dom-utils'
+import { applicative4Either, defaultEither, isRight, mapEither } from '../../../core/shared/either'
+import * as EP from '../../../core/shared/element-path'
+import type {
+  BorderWidths,
+  ElementInstanceMetadata,
+  ElementInstanceMetadataMap,
+  GridAutoOrTemplateBase,
+  GridElementProperties,
+} from '../../../core/shared/element-template'
+import {
+  canvasRectangle,
+  offsetRect,
+  zeroCanvasRect,
+  type CanvasRectangle,
+} from '../../../core/shared/math-utils'
+import { assertNever } from '../../../core/shared/utils'
+import { useKeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
+import Utils from '../../../utils/utils'
+import type { GridIdentifier } from '../../editor/store/editor-state'
+import { Substores, useEditorState } from '../../editor/store/store-hook'
+import { useMonitorChangesToElements } from '../../editor/store/store-monitor'
+import { isStaticGridRepeat, parseCSSLength } from '../../inspector/common/css-utils'
+import { getGridChildCellCoordBoundsFromCanvas } from '../canvas-strategies/strategies/grid-cell-bounds'
+import type { GridCellGlobalFrames } from '../canvas-strategies/strategies/grid-helpers'
+import {
+  findOriginalGrid,
+  getGridRelativeContainingBlock,
+} from '../canvas-strategies/strategies/grid-helpers'
 import { CanvasContainerID } from '../canvas-types'
+import { getFromElement } from '../direct-dom-lookups'
 import {
   applicativeSidesPxTransform,
   getGridContainerProperties,
   getGridElementProperties,
 } from '../dom-walker'
-import { isStaticGridRepeat, parseCSSLength } from '../../inspector/common/css-utils'
-import { assertNever } from '../../../core/shared/utils'
-import { applicative4Either, defaultEither, isRight, mapEither } from '../../../core/shared/either'
-import { domRectToScaledCanvasRectangle, getRoundingFn } from '../../../core/shared/dom-utils'
-import Utils from '../../../utils/utils'
-import React from 'react'
-import { Substores, useEditorState } from '../../editor/store/store-hook'
 import { addChangeCallback, removeChangeCallback } from '../observers'
-import { useMonitorChangesToElements } from '../../editor/store/store-monitor'
-import { useKeepReferenceEqualityIfPossible } from '../../../utils/react-performance'
 
 export type GridElementMeasurementHelperData = {
   frame: CanvasRectangle
@@ -340,4 +355,102 @@ export function useGridElementMeasurementHelperData(
   useObserversToWatch(elementPath)
 
   return useKeepReferenceEqualityIfPossible(getGridElementMeasurementHelperData(elementPath, scale))
+}
+
+function getCellPositionFromCanvas(
+  elementMetadata: ElementInstanceMetadata,
+  parentGridCellGlobalFrames: GridCellGlobalFrames,
+): { left: number; top: number } | null {
+  const cellCoordBoundsFromCanvas = getGridChildCellCoordBoundsFromCanvas(
+    elementMetadata,
+    parentGridCellGlobalFrames,
+  )
+  if (cellCoordBoundsFromCanvas == null) {
+    return null
+  }
+
+  if (parentGridCellGlobalFrames.length === 0) {
+    return null
+  }
+
+  const firstRow = parentGridCellGlobalFrames[0]
+  const left = firstRow[cellCoordBoundsFromCanvas.column - 1].x
+
+  const cellBoundsRowIndex = cellCoordBoundsFromCanvas.row - 1
+  if (
+    parentGridCellGlobalFrames.length <= cellBoundsRowIndex ||
+    parentGridCellGlobalFrames[cellBoundsRowIndex].length === 0
+  ) {
+    return null
+  }
+  const firstColumn = parentGridCellGlobalFrames[cellBoundsRowIndex][0]
+  const top = firstColumn.y
+
+  return { left, top }
+}
+
+function getCellDimensions(
+  jsxMetadata: ElementInstanceMetadataMap,
+  cellItemMetadata: ElementInstanceMetadata,
+): { width: number; height: number } | null {
+  const originalGrid = findOriginalGrid(jsxMetadata, EP.parentPath(cellItemMetadata.elementPath))
+  if (originalGrid == null) {
+    return null
+  }
+
+  const gridMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, originalGrid)
+  if (gridMetadata == null) {
+    return null
+  }
+
+  const coordinateSystemBounds =
+    cellItemMetadata.specialSizeMeasurements.immediateParentBounds ?? zeroCanvasRect
+
+  const calculatedCellBounds = getGridRelativeContainingBlock(
+    gridMetadata,
+    cellItemMetadata,
+    cellItemMetadata.specialSizeMeasurements.elementGridProperties,
+  )
+  const cellRect = offsetRect(canvasRectangle(calculatedCellBounds), coordinateSystemBounds)
+  const { width, height } = cellRect
+
+  return { width, height }
+}
+
+/**
+ * Returns the _actual_ canvas rectangle for a grid _cell_ (not its contained item) that's rendered on the canvas.
+ * This is done by combining grabbing the position from the parent grid frames (which is required for flow elements!),
+ * with the HTML calculation of dimensions in getGridRelativeContainingBlock.
+ */
+export function calculateGridCellRectangle(
+  jsxMetadata: ElementInstanceMetadataMap,
+  path: ElementPath,
+): CanvasRectangle | null {
+  const cellItemMetadata = MetadataUtils.findElementByElementPath(jsxMetadata, path)
+  if (cellItemMetadata == null) {
+    return null
+  }
+
+  const parentGridCellGlobalFrames =
+    cellItemMetadata.specialSizeMeasurements.parentGridCellGlobalFrames
+  if (parentGridCellGlobalFrames == null) {
+    return null
+  }
+
+  const position = getCellPositionFromCanvas(cellItemMetadata, parentGridCellGlobalFrames)
+  if (position == null) {
+    return null
+  }
+
+  const dimensions = getCellDimensions(jsxMetadata, cellItemMetadata)
+  if (dimensions == null) {
+    return null
+  }
+
+  return canvasRectangle({
+    x: position.left,
+    y: position.top,
+    width: dimensions.width,
+    height: dimensions.height,
+  })
 }


### PR DESCRIPTION
**Problem:**

It should be possible to resize non-stretching grid items via the ruler markers.

**Fix:**

Because of how grids are rendered, similarly to what happened in https://github.com/concrete-utopia/utopia/pull/6691, we need to calculate the rendered dimensions of grid _cells_ (not their contained items!) after they are rendered, since for non-stretching grid items their dimensions (via `getGridChildCellCoordBoundsFromCanvas`) don't match the ones of the cell(s) they are configured to target.

This PR uses the logic introduced in https://github.com/concrete-utopia/utopia/pull/6691 to calculate the size of a grid cell starting from its item, and uses that to correctly place the ruler markers for non-stretching items.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

Fixes #6695 