### PR TITLE
Freeze Other Markers

### DIFF
--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -2455,6 +2455,8 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
     return null
   }
 
+  const frozenOrRegularMarkerData = frozenMarkers ?? rulerMarkerData
+
   return (
     <React.Fragment>
       <GridRuler
@@ -2464,7 +2466,7 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
         rulerVisible={showExtraMarkers === 'column' ? 'visible' : 'not-visible'}
       >
         {/* Other markers for unselected tracks */}
-        {rulerMarkerData.otherColumnMarkers.map((marker, index) => {
+        {frozenOrRegularMarkerData.otherColumnMarkers.map((marker, index) => {
           return (
             <RulerMarkerIndicator
               key={`ruler-marker-${index}`}
@@ -2481,7 +2483,7 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
         <RulerMarkerIndicator
           gridRect={rulerMarkerData.gridRect}
           parentGrid={rulerMarkerData.parentGrid}
-          marker={frozenMarkers?.columnStart ?? rulerMarkerData.columnStart}
+          marker={frozenOrRegularMarkerData.columnStart}
           axis={'column'}
           visible={'visible'}
           onMouseDown={columnMarkerMouseDown('column-start')}
@@ -2490,7 +2492,7 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
         <RulerMarkerIndicator
           gridRect={rulerMarkerData.gridRect}
           parentGrid={rulerMarkerData.parentGrid}
-          marker={frozenMarkers?.columnEnd ?? rulerMarkerData.columnEnd}
+          marker={frozenOrRegularMarkerData.columnEnd}
           axis={'column'}
           visible={'visible'}
           onMouseDown={columnMarkerMouseDown('column-end')}
@@ -2505,7 +2507,7 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
         rulerVisible={showExtraMarkers === 'row' ? 'visible' : 'not-visible'}
       >
         {/* Other markers for unselected tracks */}
-        {rulerMarkerData.otherRowMarkers.map((marker, index) => {
+        {frozenOrRegularMarkerData.otherRowMarkers.map((marker, index) => {
           return (
             <RulerMarkerIndicator
               key={`ruler-marker-${index}`}
@@ -2522,7 +2524,7 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
         <RulerMarkerIndicator
           gridRect={rulerMarkerData.gridRect}
           parentGrid={rulerMarkerData.parentGrid}
-          marker={frozenMarkers?.rowStart ?? rulerMarkerData.rowStart}
+          marker={frozenOrRegularMarkerData.rowStart}
           axis={'row'}
           visible={'visible'}
           onMouseDown={rowMarkerMouseDown('row-start')}
@@ -2531,7 +2533,7 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
         <RulerMarkerIndicator
           gridRect={rulerMarkerData.gridRect}
           parentGrid={rulerMarkerData.parentGrid}
-          marker={frozenMarkers?.rowEnd ?? rulerMarkerData.rowEnd}
+          marker={frozenOrRegularMarkerData.rowEnd}
           axis={'row'}
           visible={'visible'}
           onMouseDown={rowMarkerMouseDown('row-end')}


### PR DESCRIPTION
**Problem:**
When dragging the ruler markers, some may disappear as the drag nears them.

**Fix:**
The ruler marker backing data is frozen while dragging, but the frozen data was not used for the other row and other column ruler markers. Now they do by virtue of them using a new variable which holds either the frozen data or the regular data, in that order of preference.

**Result:**
https://github.com/user-attachments/assets/e221ca62-bba2-4b22-b024-582426a822a3

**Commit Details:**
- `RulerMarkers` now uses the frozen marker data for other row and other columns.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode