### PR TITLE
Preserve justifySelf and alignSelf when resizing a fixed grid item

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
+++ b/editor/src/components/canvas/canvas-strategies/strategies/basic-resize-strategy.tsx
@@ -242,12 +242,12 @@ export function basicResizeStrategy(
             ),
           ]
 
-          if (isEdgePositionAHorizontalEdge(edgePosition)) {
+          if (isEdgePositionAHorizontalEdge(edgePosition) && !isGridCell) {
             commands.push(
               deleteProperties('always', selectedElement, [PP.create('style', 'justifySelf')]),
             )
           }
-          if (isEdgePositionAVerticalEdge(edgePosition)) {
+          if (isEdgePositionAVerticalEdge(edgePosition) && !isGridCell) {
             commands.push(
               deleteProperties('always', selectedElement, [PP.create('style', 'alignSelf')]),
             )


### PR DESCRIPTION
**Problem:**

When resizing a grid item with fixed sizes, it loses any `alignSelf` or `justifySelf` props that were defined on it.

**Fix:**

Make sure to not nuke those props when resizing grid items.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

Fixes #6710
