### PR TITLE
Fix getGridRelativeContainingBlock for flow elements

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-change-element-location-strategy.ts
@@ -34,16 +34,8 @@ import {
   isAutoGridPin,
   getCommandsForGridItemPlacement,
   sortElementsByGridPosition,
-  getGridRelativeContainingBlock,
 } from './grid-helpers'
 import type { GridCellCoordinates } from './grid-cell-bounds'
-import {
-  canvasRectangle,
-  offsetPoint,
-  offsetRect,
-  rectContainsPoint,
-  zeroCanvasRect,
-} from '../../../../core/shared/math-utils'
 
 export const gridChangeElementLocationStrategy: CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,

--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-move-absolute.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-move-absolute.ts
@@ -1,34 +1,29 @@
 import type { ElementPath } from 'utopia-shared/src/types'
 import { MetadataUtils } from '../../../../core/model/element-metadata-utils'
 import * as EP from '../../../../core/shared/element-path'
-import type { JSXElementChild } from '../../../../core/shared/element-template'
+import type {
+  JSXElementChild,
+  SpecialSizeMeasurements,
+} from '../../../../core/shared/element-template'
 import {
   isJSXElement,
   type ElementInstanceMetadata,
   type ElementInstanceMetadataMap,
   type GridContainerProperties,
 } from '../../../../core/shared/element-template'
-import type { CanvasRectangle, CanvasVector } from '../../../../core/shared/math-utils'
+import type { CanvasRectangle } from '../../../../core/shared/math-utils'
 import {
   canvasRectangle,
   canvasRectangleToLocalRectangle,
   isNotNullFiniteRectangle,
   nullIfInfinity,
-  offsetPoint,
   offsetRect,
   rectangleContainsRectangleInclusive,
-  rectContainsPoint,
-  windowPoint,
-  zeroCanvasRect,
   zeroRectIfNullOrInfinity,
-  zeroSize,
 } from '../../../../core/shared/math-utils'
 import type { CanvasCommand } from '../../commands/commands'
 import { showGridControls } from '../../commands/show-grid-controls-command'
-import {
-  controlsForGridPlaceholders,
-  GridElementChildContainingBlockKey,
-} from '../../controls/grid-controls-for-strategies'
+import { controlsForGridPlaceholders } from '../../controls/grid-controls-for-strategies'
 import type { CanvasStrategyFactory } from '../canvas-strategies'
 import { onlyFitWhenDraggingThisControl } from '../canvas-strategies'
 import type { InteractionCanvasState } from '../canvas-strategy-types'
@@ -57,8 +52,6 @@ import { getMoveCommandsForDrag } from './shared-move-strategies-helpers'
 import { toFirst } from '../../../../core/shared/optics/optic-utilities'
 import { eitherRight, fromTypeGuard } from '../../../../core/shared/optics/optic-creators'
 import { defaultEither } from '../../../../core/shared/either'
-import { forceNotNull } from '../../../..//core/shared/optional-utils'
-import { windowToCanvasCoordinates } from '../../dom-lookup'
 
 export const gridMoveAbsoluteStrategy: CanvasStrategyFactory = (
   canvasState: InteractionCanvasState,
@@ -197,8 +190,8 @@ export function getNewGridElementPropsCheckingOriginalGrid(
   // Identify the containing block position and size.
   const originalContainingBlockRectangle = getGridRelativeContainingBlock(
     originalGridMetadata,
-    selectedElementMetadata,
-    selectedElementMetadata.specialSizeMeasurements.elementGridProperties,
+    [selectedElementMetadata],
+    selectedElementMetadata.elementPath,
   )
 
   // Capture the original position of the grid child.
@@ -347,11 +340,21 @@ function runGridMoveAbsolute(
   )
 
   // Get the containing block of the grid child.
+  const patchedSpecialSizeMeasurements: SpecialSizeMeasurements = {
+    ...selectedElementMetadata.specialSizeMeasurements,
+    elementGridProperties:
+      newGridElementProps?.gridElementProperties ??
+      selectedElementMetadata.specialSizeMeasurements.elementGridProperties,
+  }
   const containingBlockRectangle = getGridRelativeContainingBlock(
     originalGrid,
-    selectedElementMetadata,
-    newGridElementProps?.gridElementProperties ??
-      selectedElementMetadata.specialSizeMeasurements.elementGridProperties,
+    [
+      {
+        ...selectedElementMetadata,
+        specialSizeMeasurements: patchedSpecialSizeMeasurements,
+      },
+    ],
+    selectedElementMetadata.elementPath,
   )
 
   // Get the appropriately shifted and typed local frame value to use.

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -2261,7 +2261,11 @@ const RulerMarkers = React.memo((props: RulerMarkersProps) => {
       }
 
       const parentGrid = elementMetadata.specialSizeMeasurements.parentContainerGridProperties
-      const cellRect = calculateGridCellRectangle(store.editor.jsxMetadata, props.path)
+      const cellRect = calculateGridCellRectangle(
+        store.editor.jsxMetadata,
+        store.editor.elementPathTree,
+        props.path,
+      )
       if (cellRect == null) {
         return null
       }


### PR DESCRIPTION
**Problem:**

`getGridRelativeContainingBlock` doesn't correctly return the item position for flow elements. It was temporarily patched with the positioning coming from `getGridChildCellCoordBoundsFromCanvas`, but this PR instead fixes it for good, which cascade-solves a bunch of other small bugs.

**Fix:**

The flow positioning requires _all_ preceding grid items to be available in the grid, so this PR does just that: inject every (ordered!) child into the temporary grid, retrieve the wanted one, and return its bounding box.

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

Fixes #6712 