### PR TITLE
feat(editor): pass scene size to style plugins

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategies.tsx
@@ -228,6 +228,7 @@ export function pickCanvasStateFromEditorState(
     propertyControlsInfo: editorState.propertyControlsInfo,
     styleInfoReader: activePlugin.styleInfoFactory({
       projectContents: editorState.projectContents,
+      jsxMetadata: editorState.jsxMetadata,
     }),
   }
 }
@@ -255,6 +256,7 @@ export function pickCanvasStateFromEditorStateWithMetadata(
     propertyControlsInfo: editorState.propertyControlsInfo,
     styleInfoReader: activePlugin.styleInfoFactory({
       projectContents: editorState.projectContents,
+      jsxMetadata: editorState.jsxMetadata,
     }),
   }
 }

--- a/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
+++ b/editor/src/components/canvas/canvas-strategies/canvas-strategy-types.ts
@@ -112,9 +112,11 @@ export function controlWithProps<P>(value: ControlWithProps<P>): ControlWithProp
 
 export type StyleInfoReader = (elementPath: ElementPath) => StyleInfo | null
 
-export type StyleInfoFactory = (context: {
+export type StyleInfoContext = {
   projectContents: ProjectContentTreeRoot
-}) => StyleInfoReader
+  jsxMetadata: ElementInstanceMetadataMap
+}
+export type StyleInfoFactory = (context: StyleInfoContext) => StyleInfoReader
 
 export interface InteractionCanvasState {
   interactionTarget: InteractionTarget

--- a/editor/src/components/canvas/commands/adjust-css-length-command.ts
+++ b/editor/src/components/canvas/commands/adjust-css-length-command.ts
@@ -78,6 +78,7 @@ export const runAdjustCssLengthProperties = (
 
   const styleInfoReader = getActivePlugin(withConflictingPropertiesRemoved).styleInfoFactory({
     projectContents: withConflictingPropertiesRemoved.projectContents,
+    jsxMetadata: withConflictingPropertiesRemoved.jsxMetadata,
   })
 
   const styleInfo = styleInfoReader(command.target)

--- a/editor/src/components/canvas/commands/set-css-length-command.ts
+++ b/editor/src/components/canvas/commands/set-css-length-command.ts
@@ -87,6 +87,7 @@ export const runSetCssLengthProperty = (
 
   const styleInfo = getActivePlugin(editorStateWithPropsDeleted).styleInfoFactory({
     projectContents: editorStateWithPropsDeleted.projectContents,
+    jsxMetadata: editorStateWithPropsDeleted.jsxMetadata,
   })(command.target)
 
   if (styleInfo == null) {

--- a/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/border-radius-control.tsx
@@ -63,6 +63,7 @@ const borderRadiusSelector = createCachedSelector(
   (store: StyleInfoSubstate) =>
     getActivePlugin(store.editor).styleInfoFactory({
       projectContents: store.editor.projectContents,
+      jsxMetadata: store.editor.jsxMetadata,
     }),
   (_: MetadataSubstate, x: ElementPath) => x,
   (metadata, styleInfoReader, selectedElement) => {

--- a/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/flex-gap-control.tsx
@@ -139,6 +139,7 @@ export const FlexGapControl = controlForStrategyMemoized<FlexGapControlProps>((p
       maybeFlexGapData(
         getActivePlugin(store.editor).styleInfoFactory({
           projectContents: store.editor.projectContents,
+          jsxMetadata: store.editor.jsxMetadata,
         })(selectedElement),
         MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, selectedElement),
       ),

--- a/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/padding-resize-control.tsx
@@ -362,6 +362,7 @@ export const PaddingResizeControl = controlForStrategyMemoized((props: PaddingCo
   const styleInfoReaderRef = useRefEditorState((store) =>
     getActivePlugin(store.editor).styleInfoFactory({
       projectContents: store.editor.projectContents,
+      jsxMetadata: store.editor.jsxMetadata,
     }),
   )
 

--- a/editor/src/components/canvas/controls/select-mode/subdued-flex-gap-controls.tsx
+++ b/editor/src/components/canvas/controls/select-mode/subdued-flex-gap-controls.tsx
@@ -43,6 +43,7 @@ export const SubduedFlexGapControl = React.memo<SubduedFlexGapControlProps>((pro
       maybeFlexGapData(
         getActivePlugin(store.editor).styleInfoFactory({
           projectContents: store.editor.projectContents,
+          jsxMetadata: store.editor.jsxMetadata,
         })(selectedElement),
         MetadataUtils.findElementByElementPath(store.editor.jsxMetadata, selectedElement),
       ),

--- a/editor/src/components/canvas/controls/select-mode/subdued-padding-control.tsx
+++ b/editor/src/components/canvas/controls/select-mode/subdued-padding-control.tsx
@@ -29,6 +29,7 @@ export const SubduedPaddingControl = React.memo<SubduedPaddingControlProps>((pro
   const styleInfoReaderRef = useRefEditorState((store) =>
     getActivePlugin(store.editor).styleInfoFactory({
       projectContents: store.editor.projectContents,
+      jsxMetadata: store.editor.jsxMetadata,
     }),
   )
 

--- a/editor/src/components/canvas/plugins/inline-style-plugin.spec.ts
+++ b/editor/src/components/canvas/plugins/inline-style-plugin.spec.ts
@@ -110,6 +110,7 @@ function getStyleInfoFromInlineStyle(editor: EditorRenderResult) {
 
   const styleInfoReader = InlineStylePlugin.styleInfoFactory({
     projectContents: projectContents,
+    jsxMetadata: jsxMetadata,
   })
   const styleInfo = styleInfoReader(EP.fromString('sb/scene/div'))
   return styleInfo

--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -51,8 +51,18 @@ export function deleteCSSProp(property: string): DeleteCSSProp {
 
 export type StyleUpdate = UpdateCSSProp | DeleteCSSProp
 
+export type SceneSize = { type: 'no-scene' } | { type: 'scene'; width: number }
+export function noSceneSize(): SceneSize {
+  return { type: 'no-scene' }
+}
+export function sceneSize(width: number | undefined | null): SceneSize {
+  if (width == null) {
+    return noSceneSize()
+  }
+  return { type: 'scene', width: width }
+}
 export type StylePluginContext = {
-  sceneWidth?: number
+  sceneSize: SceneSize
 }
 
 export interface StylePlugin {

--- a/editor/src/components/canvas/plugins/style-plugins.ts
+++ b/editor/src/components/canvas/plugins/style-plugins.ts
@@ -51,12 +51,17 @@ export function deleteCSSProp(property: string): DeleteCSSProp {
 
 export type StyleUpdate = UpdateCSSProp | DeleteCSSProp
 
+export type StylePluginContext = {
+  sceneWidth?: number
+}
+
 export interface StylePlugin {
   name: string
   styleInfoFactory: StyleInfoFactory
   readStyleFromElementProps: <T extends keyof StyleInfo>(
     attributes: JSXAttributes,
     prop: T,
+    context: StylePluginContext,
   ) => CSSStyleProperty<NonNullable<ParsedCSSProperties[T]>> | null
   updateStyles: (
     editorState: EditorState,
@@ -248,6 +253,7 @@ export function patchRemovedProperties(editorState: EditorState): EditorState {
 
   const styleInfoReader = activePlugin.styleInfoFactory({
     projectContents: editorState.projectContents,
+    jsxMetadata: editorState.jsxMetadata,
   })
 
   const propertiesUpdatedDuringInteraction = getPropertiesUpdatedDuringInteraction(editorState)

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
@@ -134,10 +134,7 @@ export const TailwindPlugin = (config: Config | null): StylePlugin => ({
 
       const mapping = getTailwindClassMapping(classList.split(' '), config)
       const parseTailwindProperty = parseTailwindPropertyFactory(config, {
-        sceneSize: getContainingSceneSize({
-          selectedViews: [elementPath],
-          jsxMetadata: jsxMetadata,
-        }),
+        sceneSize: getContainingSceneSize(elementPath, jsxMetadata),
       })
 
       return {

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
@@ -134,7 +134,10 @@ export const TailwindPlugin = (config: Config | null): StylePlugin => ({
 
       const mapping = getTailwindClassMapping(classList.split(' '), config)
       const parseTailwindProperty = parseTailwindPropertyFactory(config, {
-        sceneWidth: getContainingSceneWidth(elementPath, jsxMetadata),
+        sceneWidth: getContainingSceneWidth({
+          selectedViews: [elementPath],
+          jsxMetadata: jsxMetadata,
+        }),
       })
 
       return {

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
@@ -5,7 +5,7 @@ import { getElementFromProjectContents } from '../../editor/store/editor-state'
 import type { ParsedCSSProperties } from '../../inspector/common/css-utils'
 import { cssParsers } from '../../inspector/common/css-utils'
 import { mapDropNulls } from '../../../core/shared/array-utils'
-import type { StylePlugin } from './style-plugins'
+import type { StylePlugin, StylePluginContext } from './style-plugins'
 import type { Config } from 'tailwindcss/types/config'
 import type { StyleInfo } from '../canvas-types'
 import { cssStyleProperty, type CSSStyleProperty } from '../canvas-types'
@@ -18,17 +18,20 @@ import {
 import { emptyComments, type JSXAttributes } from 'utopia-shared/src/types'
 import * as PP from '../../../core/shared/property-path'
 import { jsExpressionValue } from '../../../core/shared/element-template'
+import { getContainingSceneWidth } from '../responsive-utils'
 
-function parseTailwindProperty<T extends keyof StyleInfo>(
-  value: string | number | undefined,
-  prop: T,
-): CSSStyleProperty<NonNullable<ParsedCSSProperties[T]>> | null {
-  const parsed = cssParsers[prop](value, null)
-  if (isLeft(parsed) || parsed.value == null) {
-    return null
+const parseTailwindPropertyFactory =
+  (config: Config | null, context: StylePluginContext) =>
+  <T extends keyof StyleInfo>(
+    value: string | number | undefined,
+    prop: T,
+  ): CSSStyleProperty<NonNullable<ParsedCSSProperties[T]>> | null => {
+    const parsed = cssParsers[prop](value, null)
+    if (isLeft(parsed) || parsed.value == null) {
+      return null
+    }
+    return cssStyleProperty(parsed.value, jsExpressionValue(value, emptyComments))
   }
-  return cssStyleProperty(parsed.value, jsExpressionValue(value, emptyComments))
-}
 
 const TailwindPropertyMapping: Record<string, string> = {
   left: 'positionLeft',
@@ -100,6 +103,7 @@ export const TailwindPlugin = (config: Config | null): StylePlugin => ({
   readStyleFromElementProps: <P extends keyof StyleInfo>(
     attributes: JSXAttributes,
     prop: P,
+    context: StylePluginContext,
   ): CSSStyleProperty<NonNullable<ParsedCSSProperties[P]>> | null => {
     const classNameAttribute = defaultEither(
       null,
@@ -114,10 +118,11 @@ export const TailwindPlugin = (config: Config | null): StylePlugin => ({
     }
 
     const mapping = getTailwindClassMapping(classNameAttribute.split(' '), config)
+    const parseTailwindProperty = parseTailwindPropertyFactory(config, context)
     return parseTailwindProperty(mapping[TailwindPropertyMapping[prop]], prop)
   },
   styleInfoFactory:
-    ({ projectContents }) =>
+    ({ projectContents, jsxMetadata }) =>
     (elementPath) => {
       const classList = getClassNameAttribute(
         getElementFromProjectContents(elementPath, projectContents),
@@ -128,6 +133,9 @@ export const TailwindPlugin = (config: Config | null): StylePlugin => ({
       }
 
       const mapping = getTailwindClassMapping(classList.split(' '), config)
+      const parseTailwindProperty = parseTailwindPropertyFactory(config, {
+        sceneWidth: getContainingSceneWidth(elementPath, jsxMetadata),
+      })
 
       return {
         gap: parseTailwindProperty(mapping[TailwindPropertyMapping.gap], 'gap'),

--- a/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
+++ b/editor/src/components/canvas/plugins/tailwind-style-plugin.ts
@@ -18,7 +18,7 @@ import {
 import { emptyComments, type JSXAttributes } from 'utopia-shared/src/types'
 import * as PP from '../../../core/shared/property-path'
 import { jsExpressionValue } from '../../../core/shared/element-template'
-import { getContainingSceneWidth } from '../responsive-utils'
+import { getContainingSceneSize } from '../responsive-utils'
 
 const parseTailwindPropertyFactory =
   (config: Config | null, context: StylePluginContext) =>
@@ -134,7 +134,7 @@ export const TailwindPlugin = (config: Config | null): StylePlugin => ({
 
       const mapping = getTailwindClassMapping(classList.split(' '), config)
       const parseTailwindProperty = parseTailwindPropertyFactory(config, {
-        sceneWidth: getContainingSceneWidth({
+        sceneSize: getContainingSceneSize({
           selectedViews: [elementPath],
           jsxMetadata: jsxMetadata,
         }),

--- a/editor/src/components/canvas/responsive-utils.ts
+++ b/editor/src/components/canvas/responsive-utils.ts
@@ -10,6 +10,10 @@ export function getContainingSceneWidth({
   jsxMetadata: ElementInstanceMetadataMap
 }): number | undefined {
   // TODO: support multiple selected elements in different scenes?
-  const containingScene = MetadataUtils.getParentSceneMetadata(jsxMetadata, selectedViews[0])
+  const selectedElement = selectedViews[0]
+  if (selectedElement == null) {
+    return undefined
+  }
+  const containingScene = MetadataUtils.getParentSceneMetadata(jsxMetadata, selectedElement)
   return containingScene?.specialSizeMeasurements?.clientWidth
 }

--- a/editor/src/components/canvas/responsive-utils.ts
+++ b/editor/src/components/canvas/responsive-utils.ts
@@ -1,19 +1,20 @@
 import type { ElementPath } from '../../core/shared/project-file-types'
 import type { ElementInstanceMetadataMap } from '../../core/shared/element-template'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
+import { noSceneSize, sceneSize, type SceneSize } from './plugins/style-plugins'
 
-export function getContainingSceneWidth({
+export function getContainingSceneSize({
   selectedViews,
   jsxMetadata,
 }: {
   selectedViews: ElementPath[]
   jsxMetadata: ElementInstanceMetadataMap
-}): number | undefined {
+}): SceneSize {
   // TODO: support multiple selected elements in different scenes?
   const selectedElement = selectedViews.at(0)
   if (selectedElement == null) {
-    return undefined
+    return noSceneSize()
   }
   const containingScene = MetadataUtils.getParentSceneMetadata(jsxMetadata, selectedElement)
-  return containingScene?.specialSizeMeasurements?.clientWidth
+  return sceneSize(containingScene?.specialSizeMeasurements?.clientWidth)
 }

--- a/editor/src/components/canvas/responsive-utils.ts
+++ b/editor/src/components/canvas/responsive-utils.ts
@@ -2,19 +2,28 @@ import type { ElementPath } from '../../core/shared/project-file-types'
 import type { ElementInstanceMetadataMap } from '../../core/shared/element-template'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 import { noSceneSize, sceneSize, type SceneSize } from './plugins/style-plugins'
+import type { EditorState } from '../editor/store/editor-state'
 
-export function getContainingSceneSize({
-  selectedViews,
-  jsxMetadata,
-}: {
-  selectedViews: ElementPath[]
-  jsxMetadata: ElementInstanceMetadataMap
-}): SceneSize {
-  // TODO: support multiple selected elements in different scenes?
-  const selectedElement = selectedViews.at(0)
+export function getContainingSceneSize(
+  selectedElement: ElementPath,
+  jsxMetadata: ElementInstanceMetadataMap,
+): SceneSize {
   if (selectedElement == null) {
     return noSceneSize()
   }
   const containingScene = MetadataUtils.getParentSceneMetadata(jsxMetadata, selectedElement)
   return sceneSize(containingScene?.specialSizeMeasurements?.clientWidth)
+}
+
+export function getContainingSceneSizeFromEditorState(editor: EditorState): SceneSize {
+  if (editor == null) {
+    return noSceneSize()
+  }
+  // we're taking the first selected element because we're assuming elements are in the same scene
+  // TODO: support multiple selected elements that are in different scenes?
+  const selectedElement = editor.selectedViews.at(0)
+  if (selectedElement == null) {
+    return noSceneSize()
+  }
+  return getContainingSceneSize(selectedElement, editor.jsxMetadata)
 }

--- a/editor/src/components/canvas/responsive-utils.ts
+++ b/editor/src/components/canvas/responsive-utils.ts
@@ -1,0 +1,11 @@
+import type { ElementPath } from '../../core/shared/project-file-types'
+import type { ElementInstanceMetadataMap } from '../../core/shared/element-template'
+import { MetadataUtils } from '../../core/model/element-metadata-utils'
+
+export function getContainingSceneWidth(
+  elementPath: ElementPath,
+  jsxMetadata: ElementInstanceMetadataMap,
+): number | undefined {
+  const containingScene = MetadataUtils.getParentSceneMetadata(jsxMetadata, elementPath)
+  return containingScene?.specialSizeMeasurements?.clientWidth
+}

--- a/editor/src/components/canvas/responsive-utils.ts
+++ b/editor/src/components/canvas/responsive-utils.ts
@@ -10,7 +10,7 @@ export function getContainingSceneWidth({
   jsxMetadata: ElementInstanceMetadataMap
 }): number | undefined {
   // TODO: support multiple selected elements in different scenes?
-  const selectedElement = selectedViews[0]
+  const selectedElement = selectedViews.at(0)
   if (selectedElement == null) {
     return undefined
   }

--- a/editor/src/components/canvas/responsive-utils.ts
+++ b/editor/src/components/canvas/responsive-utils.ts
@@ -2,10 +2,14 @@ import type { ElementPath } from '../../core/shared/project-file-types'
 import type { ElementInstanceMetadataMap } from '../../core/shared/element-template'
 import { MetadataUtils } from '../../core/model/element-metadata-utils'
 
-export function getContainingSceneWidth(
-  elementPath: ElementPath,
-  jsxMetadata: ElementInstanceMetadataMap,
-): number | undefined {
-  const containingScene = MetadataUtils.getParentSceneMetadata(jsxMetadata, elementPath)
+export function getContainingSceneWidth({
+  selectedViews,
+  jsxMetadata,
+}: {
+  selectedViews: ElementPath[]
+  jsxMetadata: ElementInstanceMetadataMap
+}): number | undefined {
+  // TODO: support multiple selected elements in different scenes?
+  const containingScene = MetadataUtils.getParentSceneMetadata(jsxMetadata, selectedViews[0])
   return containingScene?.specialSizeMeasurements?.clientWidth
 }

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -92,11 +92,11 @@ import type { EditorAction } from '../../editor/action-types'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { eitherRight, fromTypeGuard } from '../../../core/shared/optics/optic-creators'
 import { modify } from '../../../core/shared/optics/optic-utilities'
-import { getActivePlugin } from '../../canvas/plugins/style-plugins'
+import { getActivePlugin, noSceneSize } from '../../canvas/plugins/style-plugins'
 import { isStyleInfoKey, type StyleInfo } from '../../canvas/canvas-types'
 import { assertNever } from '../../../core/shared/utils'
 import { maybeCssPropertyFromInlineStyle } from '../../canvas/commands/utils/property-utils'
-import { getContainingSceneWidth } from '../../canvas/responsive-utils'
+import { getContainingSceneSize } from '../../canvas/responsive-utils'
 
 export interface InspectorPropsContextData {
   selectedViews: Array<ElementPath>
@@ -764,8 +764,10 @@ export function useGetMultiselectedProps<P extends ParsedPropertiesKeys>(
   const styleInfoReaderRef = useRefEditorState(
     (store) =>
       (props: JSXAttributes, prop: keyof StyleInfo): GetModifiableAttributeResult => {
+        const containingSceneSize =
+          store.editor != null ? getContainingSceneSize(store.editor) : noSceneSize()
         const elementStyle = getActivePlugin(store.editor).readStyleFromElementProps(props, prop, {
-          sceneWidth: store.editor != null ? getContainingSceneWidth(store.editor) : undefined,
+          sceneSize: containingSceneSize,
         })
         if (elementStyle == null) {
           return right({ type: 'ATTRIBUTE_NOT_FOUND' })

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -1,5 +1,4 @@
 import * as PP from '../../../core/shared/property-path'
-import * as EP from '../../../core/shared/element-path'
 
 import deepEqual from 'fast-deep-equal'
 import * as ObjectPath from 'object-path'
@@ -92,11 +91,11 @@ import type { EditorAction } from '../../editor/action-types'
 import { useDispatch } from '../../editor/store/dispatch-context'
 import { eitherRight, fromTypeGuard } from '../../../core/shared/optics/optic-creators'
 import { modify } from '../../../core/shared/optics/optic-utilities'
-import { getActivePlugin, noSceneSize } from '../../canvas/plugins/style-plugins'
+import { getActivePlugin } from '../../canvas/plugins/style-plugins'
 import { isStyleInfoKey, type StyleInfo } from '../../canvas/canvas-types'
 import { assertNever } from '../../../core/shared/utils'
 import { maybeCssPropertyFromInlineStyle } from '../../canvas/commands/utils/property-utils'
-import { getContainingSceneSize } from '../../canvas/responsive-utils'
+import { getContainingSceneSizeFromEditorState } from '../../canvas/responsive-utils'
 
 export interface InspectorPropsContextData {
   selectedViews: Array<ElementPath>
@@ -764,10 +763,8 @@ export function useGetMultiselectedProps<P extends ParsedPropertiesKeys>(
   const styleInfoReaderRef = useRefEditorState(
     (store) =>
       (props: JSXAttributes, prop: keyof StyleInfo): GetModifiableAttributeResult => {
-        const containingSceneSize =
-          store.editor != null ? getContainingSceneSize(store.editor) : noSceneSize()
         const elementStyle = getActivePlugin(store.editor).readStyleFromElementProps(props, prop, {
-          sceneSize: containingSceneSize,
+          sceneSize: getContainingSceneSizeFromEditorState(store.editor),
         })
         if (elementStyle == null) {
           return right({ type: 'ATTRIBUTE_NOT_FOUND' })

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -764,13 +764,21 @@ export function useGetMultiselectedProps<P extends ParsedPropertiesKeys>(
   const styleInfoReaderRef = useRefEditorState(
     (store) =>
       (props: JSXAttributes, prop: keyof StyleInfo): GetModifiableAttributeResult => {
-        const elementStyle = getActivePlugin(store.editor).readStyleFromElementProps(props, prop, {
-          sceneWidth: getContainingSceneWidth(
-            // TODO: support multiple selected elements in different scenes?
-            store.editor.selectedViews[0],
-            store.editor.jsxMetadata,
-          ),
-        })
+        const pluginContext =
+          store.editor != null
+            ? {
+                sceneWidth: getContainingSceneWidth(
+                  // TODO: support multiple selected elements in different scenes?
+                  store.editor.selectedViews[0],
+                  store.editor.jsxMetadata,
+                ),
+              }
+            : {}
+        const elementStyle = getActivePlugin(store.editor).readStyleFromElementProps(
+          props,
+          prop,
+          pluginContext,
+        )
         if (elementStyle == null) {
           return right({ type: 'ATTRIBUTE_NOT_FOUND' })
         }

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -766,7 +766,7 @@ export function useGetMultiselectedProps<P extends ParsedPropertiesKeys>(
       (props: JSXAttributes, prop: keyof StyleInfo): GetModifiableAttributeResult => {
         const elementStyle = getActivePlugin(store.editor).readStyleFromElementProps(props, prop, {
           sceneWidth: getContainingSceneWidth(
-            // TODO: support multiple selected elements?
+            // TODO: support multiple selected elements in different scenes?
             store.editor.selectedViews[0],
             store.editor.jsxMetadata,
           ),

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -96,6 +96,7 @@ import { getActivePlugin } from '../../canvas/plugins/style-plugins'
 import { isStyleInfoKey, type StyleInfo } from '../../canvas/canvas-types'
 import { assertNever } from '../../../core/shared/utils'
 import { maybeCssPropertyFromInlineStyle } from '../../canvas/commands/utils/property-utils'
+import { getContainingSceneWidth } from '../../canvas/responsive-utils'
 
 export interface InspectorPropsContextData {
   selectedViews: Array<ElementPath>
@@ -763,7 +764,13 @@ export function useGetMultiselectedProps<P extends ParsedPropertiesKeys>(
   const styleInfoReaderRef = useRefEditorState(
     (store) =>
       (props: JSXAttributes, prop: keyof StyleInfo): GetModifiableAttributeResult => {
-        const elementStyle = getActivePlugin(store.editor).readStyleFromElementProps(props, prop)
+        const elementStyle = getActivePlugin(store.editor).readStyleFromElementProps(props, prop, {
+          sceneWidth: getContainingSceneWidth(
+            // todo: support multiple selected elements
+            store.editor.selectedViews[0],
+            store.editor.jsxMetadata,
+          ),
+        })
         if (elementStyle == null) {
           return right({ type: 'ATTRIBUTE_NOT_FOUND' })
         }

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -766,7 +766,7 @@ export function useGetMultiselectedProps<P extends ParsedPropertiesKeys>(
       (props: JSXAttributes, prop: keyof StyleInfo): GetModifiableAttributeResult => {
         const elementStyle = getActivePlugin(store.editor).readStyleFromElementProps(props, prop, {
           sceneWidth: getContainingSceneWidth(
-            // todo: support multiple selected elements
+            // TODO: support multiple selected elements?
             store.editor.selectedViews[0],
             store.editor.jsxMetadata,
           ),

--- a/editor/src/components/inspector/common/property-path-hooks.ts
+++ b/editor/src/components/inspector/common/property-path-hooks.ts
@@ -764,21 +764,9 @@ export function useGetMultiselectedProps<P extends ParsedPropertiesKeys>(
   const styleInfoReaderRef = useRefEditorState(
     (store) =>
       (props: JSXAttributes, prop: keyof StyleInfo): GetModifiableAttributeResult => {
-        const pluginContext =
-          store.editor != null
-            ? {
-                sceneWidth: getContainingSceneWidth(
-                  // TODO: support multiple selected elements in different scenes?
-                  store.editor.selectedViews[0],
-                  store.editor.jsxMetadata,
-                ),
-              }
-            : {}
-        const elementStyle = getActivePlugin(store.editor).readStyleFromElementProps(
-          props,
-          prop,
-          pluginContext,
-        )
+        const elementStyle = getActivePlugin(store.editor).readStyleFromElementProps(props, prop, {
+          sceneWidth: store.editor != null ? getContainingSceneWidth(store.editor) : undefined,
+        })
         if (elementStyle == null) {
           return right({ type: 'ATTRIBUTE_NOT_FOUND' })
         }

--- a/editor/src/core/model/element-metadata-utils.ts
+++ b/editor/src/core/model/element-metadata-utils.ts
@@ -1061,6 +1061,13 @@ export const MetadataUtils = {
     const elementMetadata = MetadataUtils.findElementByElementPath(metadata, path)
     return elementMetadata != null && isSceneFromMetadata(elementMetadata)
   },
+  getParentSceneMetadata(
+    metadata: ElementInstanceMetadataMap,
+    path: ElementPath,
+  ): ElementInstanceMetadata | null {
+    const parentPath = MetadataUtils.findSceneOfTarget(path, metadata)
+    return parentPath == null ? null : MetadataUtils.findElementByElementPath(metadata, parentPath)
+  },
   overflows(allElementProps: AllElementProps, path: ElementPath): boolean {
     const elementProps = allElementProps[EP.toString(path)] ?? {}
     const styleProps = elementProps.style ?? null


### PR DESCRIPTION
This prep PR adds the ability to pass the Scene size to the Tailwind plugin/
This was extracted from the spike since it added small changes in many files.

**Details:**

- We need the Scene size in [tailwind-style-plugin.ts](https://github.com/concrete-utopia/utopia/pull/6715/files#diff-ad30d4bf205861b9efac9bb4bdb2bb68707cace215f64915244c46dbfab0607dR23-R25) to be able (in the next PR) to calculate the matching breakpoint.
- We get the Scene size in `getContainingSceneWidth` in [responsive-utils.ts](https://github.com/concrete-utopia/utopia/pull/6715/files#diff-4f8de694cb6cb8852ff046766f5015a01f9567d4c3b7472bbac36358b52932aaR7-R16) and we pass it to the Tailwind plugin.
- The rest of the changes are just passing down this data.

This PR doesn't change any functionality, but is merely a prep PR for the next, functional one.

**Manual Tests:**
I hereby swear that:

- [X] I opened a hydrogen project and it loaded
- [X] I could navigate to various routes in Play mode
