### PR TITLE
Tweak design when resizing grid stretching items

### DIFF
--- a/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
+++ b/editor/src/components/canvas/canvas-strategies/strategies/grid-resize-element-strategy.ts
@@ -17,6 +17,8 @@ import {
 import { gridContainerIdentifier, gridItemIdentifier } from '../../../editor/store/editor-state'
 import { cssKeyword } from '../../../inspector/common/css-utils'
 import { isFillOrStretchModeAppliedOnAnySide } from '../../../inspector/inspector-common'
+import { CSSCursor } from '../../canvas-types'
+import { setCursorCommand } from '../../commands/set-cursor-command'
 import {
   controlsForGridPlaceholders,
   gridEdgeToEdgePosition,
@@ -172,9 +174,18 @@ export const gridResizeElementStrategy: CanvasStrategyFactory = (
         ),
       }
 
+      const cursor =
+        interactionSession.activeControl.edge === 'column-start' ||
+        interactionSession.activeControl.edge === 'column-end'
+          ? CSSCursor.ColResize
+          : CSSCursor.RowResize
+
       return strategyApplicationResult(
-        getCommandsForGridItemPlacement(selectedElement, gridTemplate, gridProps),
-        [EP.parentPath(selectedElement), selectedElement],
+        [
+          ...getCommandsForGridItemPlacement(selectedElement, gridTemplate, gridProps),
+          setCursorCommand(cursor),
+        ],
+        [(EP.parentPath(selectedElement), selectedElement)],
       )
     },
   }

--- a/editor/src/components/canvas/controls/grid-controls.tsx
+++ b/editor/src/components/canvas/controls/grid-controls.tsx
@@ -1682,7 +1682,6 @@ interface GridResizeControlProps {
 
 export const GridResizeControlsComponent = ({ target }: GridResizeControlProps) => {
   const gridTarget = getGridIdentifierContainerOrComponentPath(target)
-  const colorTheme = useColorTheme()
 
   const element = useEditorState(
     Substores.metadata,
@@ -1854,7 +1853,7 @@ export const GridResizeControlsComponent = ({ target }: GridResizeControlProps) 
           left: bounds?.x ?? element.globalFrame.x,
           width: bounds?.width ?? element.globalFrame.width,
           height: bounds?.height ?? element.globalFrame.height,
-          backgroundColor: isResizing ? colorTheme.primary25.value : 'transparent',
+          backgroundColor: 'transparent',
         }}
       >
         <div


### PR DESCRIPTION
**Problem:**

When resizing a stretching grid item there should be no blue translucent overlay and the cursor should stay consistent during the interaction.

**Fix:**

Do that.

| Before | After |
|---------|--------------|
| ![Kapture 2024-12-10 at 13 18 45](https://github.com/user-attachments/assets/091ae790-ebab-4289-8345-45dd803c390d) | ![Kapture 2024-12-10 at 13 17 39](https://github.com/user-attachments/assets/2a859957-8b80-4bf9-a062-5cf524930f44) |

**Manual Tests:**
I hereby swear that:

- [x] I opened a hydrogen project and it loaded
- [x] I could navigate to various routes in Play mode

Fixes #6717 