### PR TITLE
github actions: updating actions/cache to v4

### DIFF
--- a/.github/workflows/cache-pnpm-install.yml
+++ b/.github/workflows/cache-pnpm-install.yml
@@ -30,7 +30,7 @@ jobs:
         id: capture-pnpm-store-path
         run: nix-shell --arg includeServerBuildSupport false --arg includeRunLocallySupport false --run 'echo "pnpm-store-path=$(pnpm store path)" >> "$GITHUB_OUTPUT"'
       - name: Cache pnpm store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.capture-pnpm-store-path.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location

--- a/.github/workflows/check-staging.yml
+++ b/.github/workflows/check-staging.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Cache .pnpm-store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
@@ -87,7 +87,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Cache .pnpm-store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location

--- a/.github/workflows/editor-sharded-tests.yml
+++ b/.github/workflows/editor-sharded-tests.yml
@@ -28,13 +28,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Cache editor test result
         id: cache-editor-tests
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # For the tests it doesn't really matter what we cache
           path: editor/lib
           key: ${{ runner.os }}-editor-karma-tests-shard-${{ inputs.shard_number }}-${{ inputs.branch }}-${{ hashFiles('editor/src/**') }}-${{ hashFiles('utopia-api/src/**') }}-${{ hashFiles('editor/package.json') }}-${{ hashFiles('utopia-api/package.json') }}
       - name: Cache .pnpm-store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ inputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location

--- a/.github/workflows/master-pushes.yml
+++ b/.github/workflows/master-pushes.yml
@@ -25,13 +25,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Cache editor test result
         id: cache-editor-tests
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # For the tests it doesn't really matter what we cache
           path: editor/lib
           key: ${{ runner.os }}-editor-code-tests-master-${{ hashFiles('editor/src/**') }}-${{ hashFiles('utopia-api/src/**') }}-${{ hashFiles('editor/package.json') }}-${{ hashFiles('utopia-api/package.json') }}
       - name: Cache .pnpm-store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
@@ -59,13 +59,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Cache editor test result
         id: cache-editor-tests
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # For the tests it doesn't really matter what we cache
           path: editor/lib
           key: ${{ runner.os }}-editor-jest-tests-master-${{ hashFiles('editor/src/**') }}-${{ hashFiles('utopia-api/src/**') }}-${{ hashFiles('editor/package.json') }}-${{ hashFiles('utopia-api/package.json') }}
       - name: Cache .pnpm-store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
@@ -107,23 +107,23 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Cache .cabal/packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .cabal/packages
           key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-packages-2
       - name: Cache .cabal/store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .cabal/store
           key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-store-2
       - name: Cache dist-newstyle
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: server/dist-newstyle
           key: ${{ runner.os }}-${{ matrix.ghc }}-server-dist-newstyle-2
       - name: Cache server test result
         id: cache-server-tests
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # For the tests it doesn't really matter what we cache
           path: server/src

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -23,13 +23,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Cache editor test result
         id: cache-editor-tests
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # For the tests it doesn't really matter what we cache
           path: editor/lib
           key: ${{ runner.os }}-editor-code-tests-PR-${{ hashFiles('editor/src/**') }}-${{ hashFiles('utopia-api/src/**') }}-${{ hashFiles('editor/package.json') }}-${{ hashFiles('utopia-api/package.json') }}
       - name: Cache pnpm store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
@@ -59,13 +59,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Cache editor test result
         id: cache-editor-tests
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # For the tests it doesn't really matter what we cache
           path: editor/lib
           key: ${{ runner.os }}-editor-jest-tests-PR-${{ hashFiles('editor/src/**') }}-${{ hashFiles('utopia-api/src/**') }}-${{ hashFiles('editor/package.json') }}-${{ hashFiles('utopia-api/package.json') }}
       - name: Cache .pnpm-store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
@@ -107,23 +107,23 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Cache .cabal/packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .cabal/packages
           key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-packages-2
       - name: Cache .cabal/store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .cabal/store
           key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-store-2
       - name: Cache dist-newstyle
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: server/dist-newstyle
           key: ${{ runner.os }}-${{ matrix.ghc }}-server-dist-newstyle-2
       - name: Cache server test result
         id: cache-server-tests
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # For the tests it doesn't really matter what we cache
           path: server/src
@@ -178,7 +178,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Cache .pnpm-store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
@@ -279,7 +279,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Cache .pnpm-store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
@@ -382,7 +382,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Cache .pnpm-store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
@@ -427,7 +427,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Cache .pnpm-store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location
@@ -474,7 +474,7 @@ jobs:
           version: 7.14.2
           run_install: false
       - name: Cache .pnpm-store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location

--- a/.github/workflows/screenshot-production.yml
+++ b/.github/workflows/screenshot-production.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Cache .pnpm-store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location

--- a/.github/workflows/tag-release-automated.yml
+++ b/.github/workflows/tag-release-automated.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Cache .pnpm-store
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ needs.cache-pnpm-store.outputs.pnpm-store-path }}
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-captured-location


### PR DESCRIPTION
**Problem:**
actions/cache@v2 has been deprecated and removed since February

**Fix:**
Bumping to actions/cache@v4. in theory it's a seamless upgrade, let's see if it is true in reality too